### PR TITLE
feat: add Haskell singleton interfaces for offchain service

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ index-state:
 
 packages:
   .
+  cardano-mpfs-offchain/
 
 source-repository-package
   type: git

--- a/cardano-mpfs-offchain/LICENSE
+++ b/cardano-mpfs-offchain/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -1,0 +1,40 @@
+cabal-version:   3.4
+name:            cardano-mpfs-offchain
+version:         0.0.0
+synopsis:        Offchain service interfaces for Cardano MPFS
+description:
+  Record-of-functions interfaces for the Cardano Merkle
+  Patricia Forestry offchain service. Contains only type
+  definitions and singleton interface records with no
+  implementations.
+
+license:         Apache-2.0
+license-file:    LICENSE
+author:          Paolo Veronelli
+maintainer:      paolo.veronelli@gmail.com
+category:        Cardano
+build-type:      Simple
+
+common warnings
+  ghc-options: -Wall
+  default-extensions:
+    DuplicateRecordFields
+    StrictData
+
+library
+  import:           warnings
+  default-language: GHC2021
+  hs-source-dirs:   lib
+  build-depends:
+    , base        >=4.18 && <5
+    , bytestring  >=0.11 && <0.13
+
+  exposed-modules:
+    Cardano.MPFS.Context
+    Cardano.MPFS.Indexer
+    Cardano.MPFS.Provider
+    Cardano.MPFS.State
+    Cardano.MPFS.Submitter
+    Cardano.MPFS.Trie
+    Cardano.MPFS.TxBuilder
+    Cardano.MPFS.Types

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
@@ -1,0 +1,33 @@
+{- |
+Module      : Cardano.MPFS.Context
+Description : Facade bundling all singleton interfaces
+License     : Apache-2.0
+-}
+module Cardano.MPFS.Context
+    ( -- * Context
+      Context (..)
+    ) where
+
+import Cardano.MPFS.Indexer (Indexer)
+import Cardano.MPFS.Provider (Provider)
+import Cardano.MPFS.State (State)
+import Cardano.MPFS.Submitter (Submitter)
+import Cardano.MPFS.Trie (TrieManager)
+import Cardano.MPFS.TxBuilder (TxBuilder)
+
+-- | Top-level context bundling all service
+-- interfaces. Parametric in the effect @m@.
+data Context m = Context
+    { provider :: Provider m
+    -- ^ Blockchain query operations
+    , trieManager :: TrieManager m
+    -- ^ Per-token trie management
+    , state :: State m
+    -- ^ Token and request state tracking
+    , indexer :: Indexer m
+    -- ^ Chain sync follower
+    , submitter :: Submitter m
+    -- ^ Transaction submission
+    , txBuilder :: TxBuilder m
+    -- ^ Transaction construction
+    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer.hs
@@ -1,0 +1,26 @@
+{- |
+Module      : Cardano.MPFS.Indexer
+Description : Chain sync follower interface
+License     : Apache-2.0
+-}
+module Cardano.MPFS.Indexer
+    ( -- * Indexer interface
+      Indexer (..)
+    ) where
+
+import Cardano.MPFS.Types (SlotNo)
+
+-- | Interface for the chain sync indexer that
+-- follows the blockchain and updates local state.
+data Indexer m = Indexer
+    { start :: m ()
+    -- ^ Start the indexer
+    , stop :: m ()
+    -- ^ Stop the indexer
+    , pause :: m ()
+    -- ^ Pause indexing
+    , resume :: m ()
+    -- ^ Resume indexing after a pause
+    , getTip :: m SlotNo
+    -- ^ Get the current chain tip slot
+    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
@@ -1,0 +1,41 @@
+{- |
+Module      : Cardano.MPFS.Provider
+Description : Blockchain query interface
+License     : Apache-2.0
+-}
+module Cardano.MPFS.Provider
+    ( -- * Provider interface
+      Provider (..)
+
+      -- * Placeholder types
+    , Address
+    , UTxO
+    , Tx
+    , ProtocolParams
+    , ExUnits
+    ) where
+
+-- | Blockchain address (placeholder).
+type Address = ()
+
+-- | Unspent transaction output (placeholder).
+type UTxO = ()
+
+-- | Serialised transaction (placeholder).
+type Tx = ()
+
+-- | Protocol parameters (placeholder).
+type ProtocolParams = ()
+
+-- | Execution units (placeholder).
+type ExUnits = ()
+
+-- | Interface for querying the blockchain.
+data Provider m = Provider
+    { queryUTxOs :: Address -> m [UTxO]
+    -- ^ Look up UTxOs at an address
+    , queryProtocolParams :: m ProtocolParams
+    -- ^ Fetch current protocol parameters
+    , evaluateTx :: Tx -> m ExUnits
+    -- ^ Evaluate execution units for a transaction
+    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
@@ -1,0 +1,75 @@
+{- |
+Module      : Cardano.MPFS.State
+Description : Token and request state tracking interface
+License     : Apache-2.0
+-}
+module Cardano.MPFS.State
+    ( -- * Combined state
+      State (..)
+
+      -- * Token state
+    , Tokens (..)
+
+      -- * Request state
+    , Requests (..)
+
+      -- * Checkpoint state
+    , Checkpoints (..)
+    ) where
+
+import Cardano.MPFS.Types
+    ( BlockId
+    , OutputRef
+    , Request
+    , SlotNo
+    , TokenId
+    , TokenState
+    )
+
+-- | Combined state interface bundling token,
+-- request, and checkpoint tracking.
+data State m = State
+    { tokens :: Tokens m
+    -- ^ Token state operations
+    , requests :: Requests m
+    -- ^ Request state operations
+    , checkpoints :: Checkpoints m
+    -- ^ Checkpoint operations
+    }
+
+-- | Interface for managing token state.
+data Tokens m = Tokens
+    { getToken :: TokenId -> m (Maybe TokenState)
+    -- ^ Look up a token's current state
+    , putToken :: TokenId -> TokenState -> m ()
+    -- ^ Store or update a token's state
+    , removeToken :: TokenId -> m ()
+    -- ^ Remove a token
+    , listTokens :: m [TokenId]
+    -- ^ List all known tokens
+    }
+
+-- | Interface for managing pending requests.
+data Requests m = Requests
+    { getRequest
+        :: OutputRef -> m (Maybe Request)
+    -- ^ Look up a request by its UTxO reference
+    , putRequest
+        :: OutputRef -> Request -> m ()
+    -- ^ Store a new request
+    , removeRequest :: OutputRef -> m ()
+    -- ^ Remove a fulfilled or retracted request
+    , requestsByToken
+        :: TokenId -> m [Request]
+    -- ^ List all pending requests for a token
+    }
+
+-- | Interface for chain sync checkpoints.
+data Checkpoints m = Checkpoints
+    { getCheckpoint
+        :: m (Maybe (SlotNo, BlockId))
+    -- ^ Get the last processed checkpoint
+    , putCheckpoint
+        :: SlotNo -> BlockId -> m ()
+    -- ^ Store a new checkpoint
+    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs
@@ -1,0 +1,24 @@
+{- |
+Module      : Cardano.MPFS.Submitter
+Description : Transaction submission interface
+License     : Apache-2.0
+-}
+module Cardano.MPFS.Submitter
+    ( -- * Submitter interface
+      Submitter (..)
+
+      -- * Placeholder types
+    , SubmitResult
+    ) where
+
+import Cardano.MPFS.Provider (Tx)
+
+-- | Result of submitting a transaction (placeholder).
+type SubmitResult = ()
+
+-- | Interface for submitting transactions to the
+-- blockchain.
+data Submitter m = Submitter
+    { submitTx :: Tx -> m SubmitResult
+    -- ^ Submit a signed transaction
+    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE RankNTypes #-}
+
+{- |
+Module      : Cardano.MPFS.Trie
+Description : Per-token MPF trie management interface
+License     : Apache-2.0
+-}
+module Cardano.MPFS.Trie
+    ( -- * Trie manager
+      TrieManager (..)
+
+      -- * Single trie operations
+    , Trie (..)
+
+      -- * Placeholder types
+    , Proof
+    ) where
+
+import Data.ByteString (ByteString)
+
+import Cardano.MPFS.Types (Root, TokenId)
+
+-- | Merkle proof (placeholder).
+type Proof = ()
+
+-- | Manager for per-token tries.
+data TrieManager m = TrieManager
+    { withTrie
+        :: forall a. TokenId -> (Trie m -> m a) -> m a
+    -- ^ Run an action with access to a token's trie
+    , createTrie :: TokenId -> m ()
+    -- ^ Create a new empty trie for a token
+    , deleteTrie :: TokenId -> m ()
+    -- ^ Delete a token's trie
+    }
+
+-- | Operations on a single trie.
+data Trie m = Trie
+    { insert
+        :: ByteString -> ByteString -> m Root
+    -- ^ Insert a key-value pair, returning new root
+    , delete :: ByteString -> m Root
+    -- ^ Delete a key, returning new root
+    , lookup :: ByteString -> m (Maybe ByteString)
+    -- ^ Look up a value by key
+    , getRoot :: m Root
+    -- ^ Get current root hash
+    , getProof :: ByteString -> m Proof
+    -- ^ Generate a Merkle proof for a key
+    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
@@ -1,0 +1,44 @@
+{- |
+Module      : Cardano.MPFS.TxBuilder
+Description : Transaction construction interface
+License     : Apache-2.0
+-}
+module Cardano.MPFS.TxBuilder
+    ( -- * Transaction builder interface
+      TxBuilder (..)
+    ) where
+
+import Data.ByteString (ByteString)
+
+import Cardano.MPFS.Provider (Address, Tx)
+import Cardano.MPFS.Types (OutputRef, TokenId)
+
+-- | Interface for constructing transactions for
+-- all MPFS protocol operations.
+data TxBuilder m = TxBuilder
+    { bootToken
+        :: Address -> m Tx
+    -- ^ Create a new MPFS token
+    , requestInsert
+        :: TokenId
+        -> ByteString
+        -> ByteString
+        -> Address
+        -> m Tx
+    -- ^ Request inserting a key-value pair
+    , requestDelete
+        :: TokenId
+        -> ByteString
+        -> Address
+        -> m Tx
+    -- ^ Request deleting a key
+    , updateToken
+        :: TokenId -> Address -> m Tx
+    -- ^ Process pending requests for a token
+    , retractRequest
+        :: OutputRef -> Address -> m Tx
+    -- ^ Cancel a pending request
+    , endToken
+        :: TokenId -> Address -> m Tx
+    -- ^ Retire an MPFS token
+    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Types.hs
@@ -1,0 +1,99 @@
+{- |
+Module      : Cardano.MPFS.Types
+Description : Core domain types for the MPFS offchain service
+License     : Apache-2.0
+-}
+module Cardano.MPFS.Types
+    ( -- * Token identification
+      TokenId (..)
+
+      -- * Transaction references
+    , OutputRef (..)
+
+      -- * Merkle Patricia Forestry
+    , Root (..)
+    , Operation (..)
+
+      -- * Requests
+    , Request (..)
+
+      -- * Token state
+    , TokenState (..)
+
+      -- * Facts
+    , Fact (..)
+
+      -- * Chain position
+    , SlotNo (..)
+    , BlockId (..)
+    ) where
+
+import Data.ByteString (ByteString)
+import Data.Word (Word64)
+
+-- | Unique identifier for a token managed by the
+-- MPFS service.
+newtype TokenId = TokenId
+    { unTokenId :: ByteString
+    }
+
+-- | Reference to a specific UTxO on chain.
+data OutputRef = OutputRef
+    { txId :: !ByteString
+    -- ^ Transaction hash
+    , index :: !Word64
+    -- ^ Output index within the transaction
+    }
+
+-- | MPF root hash representing the current state
+-- of a trie.
+newtype Root = Root
+    { unRoot :: ByteString
+    }
+
+-- | An operation to perform on a key in the trie.
+data Operation
+    = -- | Insert a new key-value pair
+      Insert !ByteString
+    | -- | Delete a key
+      Delete !ByteString
+    | -- | Update an existing key with a new value
+      Update !ByteString !ByteString
+
+-- | A request to modify a token's trie.
+data Request = Request
+    { requestToken :: !TokenId
+    -- ^ The token whose trie is being modified
+    , requestOwner :: !ByteString
+    -- ^ The owner's credential
+    , requestKey :: !ByteString
+    -- ^ The key to operate on
+    , requestValue :: !Operation
+    -- ^ The operation to perform
+    }
+
+-- | Current on-chain state of a token.
+data TokenState = TokenState
+    { owner :: !ByteString
+    -- ^ Owner's credential
+    , root :: !Root
+    -- ^ Current root hash of the token's trie
+    }
+
+-- | A key-value fact stored in a trie.
+data Fact = Fact
+    { key :: !ByteString
+    -- ^ The fact's key
+    , value :: !ByteString
+    -- ^ The fact's value
+    }
+
+-- | Slot number on the Cardano blockchain.
+newtype SlotNo = SlotNo
+    { unSlotNo :: Word64
+    }
+
+-- | Block identifier.
+newtype BlockId = BlockId
+    { unBlockId :: ByteString
+    }

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,8 @@
               project.hsPkgs.haskell-mpfs.components.library;
             unit-tests =
               project.hsPkgs.haskell-mpfs.components.tests.unit-tests;
+            cardano-mpfs-offchain =
+              project.hsPkgs.cardano-mpfs-offchain.components.library;
           };
           devShells.default = project.shell;
         };


### PR DESCRIPTION
## Summary

- Define record-of-functions interfaces for all offchain service components: Provider, TrieManager, State, Indexer, Submitter, TxBuilder, and Context facade
- Core domain types: TokenId, OutputRef, Root, Operation, Request, TokenState, Fact, SlotNo, BlockId
- Nix flake with haskell.nix (GHC 9.8.4), CHaP input, iohk-nix crypto overlays
- Cabal file targeting GHC2021 with base + bytestring deps only
- Fourmolu config (70-char column, leading commas/arrows), justfile, .gitignore

Library compiles with `nix build`. All functions are left undefined -- only types and interface records are exported.