### PR TITLE
fix: apply fourmolu and cabal-fmt formatting

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -1,21 +1,21 @@
-cabal-version:   3.4
-name:            cardano-mpfs-offchain
-version:         0.0.0
-synopsis:        Offchain service interfaces for Cardano MPFS
+cabal-version: 3.4
+name:          cardano-mpfs-offchain
+version:       0.0.0
+synopsis:      Offchain service interfaces for Cardano MPFS
 description:
   Record-of-functions interfaces for the Cardano Merkle
   Patricia Forestry offchain service. Uses real
   cardano-ledger types for all Cardano primitives.
 
-license:         Apache-2.0
-license-file:    LICENSE
-author:          Paolo Veronelli
-maintainer:      paolo.veronelli@gmail.com
-category:        Cardano
-build-type:      Simple
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Paolo Veronelli
+maintainer:    paolo.veronelli@gmail.com
+category:      Cardano
+build-type:    Simple
 
 common warnings
-  ghc-options: -Wall
+  ghc-options:        -Wall
   default-extensions:
     DuplicateRecordFields
     StrictData
@@ -25,14 +25,14 @@ library
   default-language: GHC2021
   hs-source-dirs:   lib
   build-depends:
-    , base                  >=4.18 && <5
-    , bytestring            >=0.11 && <0.13
-    , cardano-ledger-api
-    , cardano-ledger-core
-    , cardano-ledger-conway
-    , cardano-ledger-mary
-    , cardano-ledger-binary
+    , base                   >=4.18 && <5
+    , bytestring             >=0.11 && <0.13
     , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-binary
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
 
   exposed-modules:
     Cardano.MPFS.Context
@@ -53,15 +53,14 @@ test-suite unit-tests
   build-depends:
     , base
     , bytestring
-    , containers
-    , cardano-mpfs-offchain
-    , cardano-ledger-core
     , cardano-crypto-class
-    , hspec                >=2.11 && <2.12
-    , QuickCheck           >=2.14 && <2.18
+    , cardano-ledger-core
+    , cardano-mpfs-offchain
+    , containers
+    , hspec                  >=2.11 && <2.12
+    , QuickCheck             >=2.14 && <2.18
 
-  build-tool-depends:
-    hspec-discover:hspec-discover >=2.11 && <2.12
+  build-tool-depends: hspec-discover:hspec-discover >=2.11 && <2.12
   other-modules:
     Cardano.MPFS.Generators
     Cardano.MPFS.StateSpec

--- a/haskell-mpfs.cabal
+++ b/haskell-mpfs.cabal
@@ -18,14 +18,13 @@ category:        Cryptography, Data
 stability:       experimental
 build-type:      Simple
 extra-doc-files:
-    CHANGELOG.md
-    README.md
+  CHANGELOG.md
+  README.md
 
 common warnings
   ghc-options:
-    -Wall -Wunused-imports -Wunused-packages
-    -Wmissing-export-lists -Wname-shadowing
-    -Wdeferred-out-of-scope-variables
+    -Wall -Wunused-imports -Wunused-packages -Wmissing-export-lists
+    -Wname-shadowing -Wdeferred-out-of-scope-variables
     -Wpartial-type-signatures -Wredundant-constraints
 
   default-extensions:
@@ -68,19 +67,19 @@ library
     MPF.Proof.Insertion
 
   build-depends:
-    , async                                  >=2.2   && <2.3
-    , base                                   >=4.19  && <5
-    , bytestring                             >=0.12  && <0.13
-    , cereal                                 >=0.5   && <0.6
-    , containers                             >=0.6   && <0.7
-    , crypton                                >=1.0   && <1.1
-    , exceptions                             >=0.10  && <0.11
-    , lens                                   >=5.3   && <5.4
-    , memory                                 >=0.18  && <0.19
-    , rocksdb-haskell-jprupp                 >=2.1   && <2.2
-    , rocksdb-kv-transactions                >=0.1   && <0.2
+    , async                                    >=2.2  && <2.3
+    , base                                     >=4.19 && <5
+    , bytestring                               >=0.12 && <0.13
+    , cereal                                   >=0.5  && <0.6
+    , containers                               >=0.6  && <0.7
+    , crypton                                  >=1.0  && <1.1
+    , exceptions                               >=0.10 && <0.11
+    , lens                                     >=5.3  && <5.4
+    , memory                                   >=0.18 && <0.19
+    , rocksdb-haskell-jprupp                   >=2.1  && <2.2
+    , rocksdb-kv-transactions                  >=0.1  && <0.2
     , rocksdb-kv-transactions:kv-transactions
-    , transformers                           >=0.6   && <0.7
+    , transformers                             >=0.6  && <0.7
 
   hs-source-dirs:   lib
   default-language: Haskell2010
@@ -95,7 +94,7 @@ library mpf-test-lib
     , haskell-mpfs
     , lens
     , rocksdb-kv-transactions:kv-transactions
-    , text                                    >=2.0 && <2.2
+    , text                                     >=2.0 && <2.2
 
   hs-source-dirs:   test-lib
   default-language: Haskell2010
@@ -110,8 +109,8 @@ test-suite unit-tests
     , containers
     , haskell-mpfs
     , haskell-mpfs:mpf-test-lib
-    , hspec                     >=2.11 && <2.12
-    , QuickCheck                >=2.14 && <2.18
+    , hspec                      >=2.11 && <2.12
+    , QuickCheck                 >=2.14 && <2.18
 
   build-tool-depends: hspec-discover:hspec-discover >=2.11 && <2.12
   type:               exitcode-stdio-1.0
@@ -134,7 +133,7 @@ executable mpf-bench
     , bytestring
     , haskell-mpfs
     , haskell-mpfs:mpf-test-lib
-    , time                      >=1.12 && <1.14
+    , time                       >=1.12 && <1.14
 
 executable mpf-bench-rocksdb
   import:           warnings
@@ -145,8 +144,8 @@ executable mpf-bench-rocksdb
   build-depends:
     , base
     , bytestring
-    , directory                              >=1.3 && <1.4
+    , directory                                >=1.3  && <1.4
     , haskell-mpfs
     , lens
     , rocksdb-kv-transactions:kv-transactions
-    , time                                   >=1.12 && <1.14
+    , time                                     >=1.12 && <1.14

--- a/test/MPF/PropertySpec.hs
+++ b/test/MPF/PropertySpec.hs
@@ -77,30 +77,33 @@ spec = do
         describe "insert-verify roundtrip" $ do
             it "inserted key-value can be verified" $ property propInsertVerify
 
-            it "multiple inserts all verifiable" $ property propMultipleInsertVerify
+            it "multiple inserts all verifiable"
+                $ property propMultipleInsertVerify
 
         describe "batch insert" $ do
-            it "batch insert equals sequential inserts" $
-                property propBatchEqualsSequential
+            it "batch insert equals sequential inserts"
+                $ property propBatchEqualsSequential
 
-            it "chunked insert equals sequential inserts" $
-                property propChunkedEqualsSequential
+            it "chunked insert equals sequential inserts"
+                $ property propChunkedEqualsSequential
 
         describe "insertion order independence" $ do
-            it "same keys in any order produce same root hash" $
-                property propInsertionOrderIndependence
+            it "same keys in any order produce same root hash"
+                $ property propInsertionOrderIndependence
 
         describe "deletion properties" $ do
             it "deleted key cannot be verified" $ property propDeleteRemovesKey
 
-            it "deletion preserves sibling proofs" $ property propDeletePreservesSiblings
+            it "deletion preserves sibling proofs"
+                $ property propDeletePreservesSiblings
 
         describe "root hash properties" $ do
             it "empty tree has no root hash" $ do
                 let (mRoot, _) = runMPFPure' getRootHashM
                 mRoot `shouldBe` Nothing
 
-            it "single insert produces root hash" $ property propSingleInsertHasRoot
+            it "single insert produces root hash"
+                $ property propSingleInsertHasRoot
 
 -- | Property: inserted key-value can be verified
 propInsertVerify :: TestKV -> Bool


### PR DESCRIPTION
## Summary
- Fix fourmolu `$` placement in `test/MPF/PropertySpec.hs`
- Apply cabal-fmt to both `.cabal` files