### PR TITLE
refactor: rename haskell-mpfs to merkle-patricia-forestry

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -20,7 +20,7 @@ resolution surprises.
 
 ```mermaid
 flowchart TD
-    http["haskell-mpfs — HTTP service (Servant)"]
+    http["mpfs-service — HTTP service (Servant)"]
     mpf["MPF trie (haskell-mpf) ✓ DONE\nProofs, insertion, deletion"]
     txb["Transaction building interface\nCoin selection, fee estimation\n(record of functions)"]
     csmt["cardano-utxo-csmt (embedded)\nUTxO queries via address prefix\nMithril bootstrap, ChainSync\n(replaces Yaci Store)"]
@@ -224,7 +224,7 @@ cleanup (close connections, flush DB) on exit.
 
 ### 1. MPF Library ✓ DONE
 
-Repository: `paolino/haskell-mpf` (this repo, to be renamed haskell-mpfs)
+Repository: `paolino/cardano-mpfs-offchain` (package: merkle-patricia-forestry)
 
 - 16-ary Merkle Patricia Forestry
 - Blake2b-256, Aiken-compatible

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# haskell-mpfs
+# merkle-patricia-forestry
 
 Merkle Patricia Forestry (MPF) implementation in Haskell.
 

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -26,17 +26,17 @@ library
   default-language: GHC2021
   hs-source-dirs:   lib
   build-depends:
-    , base                       >=4.18 && <5
-    , bytestring                 >=0.11 && <0.13
+    , base                                   >=4.18 && <5
+    , bytestring                             >=0.11 && <0.13
     , cardano-crypto-class
     , cardano-ledger-api
     , cardano-ledger-binary
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
-    , containers                 >=0.6  && <0.8
-    , haskell-mpfs
-    , haskell-mpfs:mpf-test-lib
+    , containers                             >=0.6  && <0.8
+    , merkle-patricia-forestry
+    , merkle-patricia-forestry:mpf-test-lib
 
   exposed-modules:
     Cardano.MPFS.Context
@@ -70,10 +70,10 @@ test-suite unit-tests
     , cardano-ledger-core
     , cardano-mpfs-offchain
     , containers
-    , haskell-mpfs
-    , haskell-mpfs:mpf-test-lib
-    , hspec                      >=2.11 && <2.12
-    , QuickCheck                 >=2.14 && <2.18
+    , hspec                                  >=2.11 && <2.12
+    , merkle-patricia-forestry
+    , merkle-patricia-forestry:mpf-test-lib
+    , QuickCheck                             >=2.14 && <2.18
 
   other-modules:
     Cardano.MPFS.Generators

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs
@@ -2,7 +2,7 @@
 
 -- |
 -- Module      : Cardano.MPFS.Trie.Pure
--- Description : Pure in-memory Trie backed by haskell-mpfs
+-- Description : Pure in-memory Trie backed by merkle-patricia-forestry
 -- License     : Apache-2.0
 --
 -- Provides a 'Trie IO' implementation backed by an

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TrieSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TrieSpec.hs
@@ -165,7 +165,7 @@ trieSpec newTrie = do
         isNothing mProof `shouldBe` True
 
 -- -----------------------------------------------------------------
--- Properties (via haskell-mpfs pure backend)
+-- Properties (via merkle-patricia-forestry pure backend)
 -- -----------------------------------------------------------------
 
 propertySpec :: Spec

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
               inherit (project.packages)
                 unit-tests offchain-tests
                 cardano-mpfs-offchain;
-              default = project.packages.haskell-mpfs;
+              default = project.packages.merkle-patricia-forestry;
             };
             inherit (project) devShells;
           };

--- a/merkle-patricia-forestry.cabal
+++ b/merkle-patricia-forestry.cabal
@@ -1,5 +1,5 @@
 cabal-version:   3.4
-name:            haskell-mpfs
+name:            merkle-patricia-forestry
 version:         0.1.0.0
 synopsis:        Merkle Patricia Forestry implementation in Haskell
 description:
@@ -12,8 +12,8 @@ license:         Apache-2.0
 license-file:    LICENSE
 author:          Paolo Veronelli
 maintainer:      paolo.veronelli@gmail.com
-homepage:        https://github.com/paolino/haskell-mpfs
-bug-reports:     https://github.com/paolino/haskell-mpfs/issues
+homepage:        https://github.com/paolino/cardano-mpfs-offchain
+bug-reports:     https://github.com/paolino/cardano-mpfs-offchain/issues
 category:        Cryptography, Data
 stability:       experimental
 build-type:      Simple
@@ -91,8 +91,8 @@ library mpf-test-lib
   build-depends:
     , base
     , bytestring
-    , haskell-mpfs
     , lens
+    , merkle-patricia-forestry
     , rocksdb-kv-transactions:kv-transactions
     , text                                     >=2.0 && <2.2
 
@@ -108,10 +108,10 @@ test-suite unit-tests
     , bytestring
     , cereal
     , containers
-    , haskell-mpfs
-    , haskell-mpfs:mpf-test-lib
-    , hspec                      >=2.11 && <2.12
-    , QuickCheck                 >=2.14 && <2.18
+    , hspec                                  >=2.11 && <2.12
+    , merkle-patricia-forestry
+    , merkle-patricia-forestry:mpf-test-lib
+    , QuickCheck                             >=2.14 && <2.18
 
   build-tool-depends: hspec-discover:hspec-discover >=2.11 && <2.12
   type:               exitcode-stdio-1.0
@@ -135,9 +135,9 @@ executable mpf-bench
   build-depends:
     , base
     , bytestring
-    , haskell-mpfs
-    , haskell-mpfs:mpf-test-lib
-    , time                       >=1.12 && <1.14
+    , merkle-patricia-forestry
+    , merkle-patricia-forestry:mpf-test-lib
+    , time                                   >=1.12 && <1.14
 
 executable mpf-bench-rocksdb
   import:           warnings
@@ -149,7 +149,7 @@ executable mpf-bench-rocksdb
     , base
     , bytestring
     , directory                                >=1.3  && <1.4
-    , haskell-mpfs
     , lens
+    , merkle-patricia-forestry
     , rocksdb-kv-transactions:kv-transactions
     , time                                     >=1.12 && <1.14

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -31,12 +31,12 @@ let
       pkgs.asciinema
     ];
     shellHook = ''
-      echo "Entering haskell-mpfs dev shell"
+      echo "Entering merkle-patricia-forestry dev shell"
     '';
   };
 
   mkProject = ctx@{ lib, pkgs, ... }: {
-    name = "haskell-mpfs";
+    name = "merkle-patricia-forestry";
     src = ./..;
     compiler-nix-name = "ghc984";
     shell = shell { inherit pkgs; };
@@ -49,10 +49,10 @@ let
 in {
   devShells.default = project.shell;
   inherit project;
-  packages.haskell-mpfs =
-    project.hsPkgs.haskell-mpfs.components.library;
+  packages.merkle-patricia-forestry =
+    project.hsPkgs.merkle-patricia-forestry.components.library;
   packages.unit-tests =
-    project.hsPkgs.haskell-mpfs.components.tests.unit-tests;
+    project.hsPkgs.merkle-patricia-forestry.components.tests.unit-tests;
   packages.cardano-mpfs-offchain =
     project.hsPkgs.cardano-mpfs-offchain.components.library;
   packages.offchain-tests =


### PR DESCRIPTION
## Summary

- Rename cabal package `haskell-mpfs` to `merkle-patricia-forestry`
- Update all references in cabal files, flake.nix, nix/project.nix, README, PLAN, source comments

## Test plan

- [x] `just ci` passes (137 tests, hlint, format-check)

Closes #12