### PR TITLE
feat: add simple balanceTx for fee-paying UTxO

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -34,11 +34,14 @@ library
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
+    , cardano-strict-containers
     , containers                             >=0.6  && <0.8
     , merkle-patricia-forestry
     , merkle-patricia-forestry:mpf-test-lib
+    , microlens
 
   exposed-modules:
+    Cardano.MPFS.Balance
     Cardano.MPFS.Context
     Cardano.MPFS.Indexer
     Cardano.MPFS.Mock.Context
@@ -67,15 +70,18 @@ test-suite unit-tests
     , base
     , bytestring
     , cardano-crypto-class
+    , cardano-ledger-api
     , cardano-ledger-core
     , cardano-mpfs-offchain
     , containers
     , hspec                                  >=2.11 && <2.12
     , merkle-patricia-forestry
     , merkle-patricia-forestry:mpf-test-lib
+    , microlens
     , QuickCheck                             >=2.14 && <2.18
 
   other-modules:
+    Cardano.MPFS.BalanceSpec
     Cardano.MPFS.Generators
     Cardano.MPFS.ProofSpec
     Cardano.MPFS.StateSpec

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Balance.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Balance.hs
@@ -1,0 +1,111 @@
+-- |
+-- Module      : Cardano.MPFS.Balance
+-- Description : Simple transaction balancing
+-- License     : Apache-2.0
+--
+-- Balance a transaction by adding a fee-paying UTxO
+-- and a change output. The fee is estimated via
+-- 'setMinFeeTx' from @cardano-ledger-api@.
+module Cardano.MPFS.Balance
+    ( -- * Balancing
+      balanceTx
+
+      -- * Errors
+    , BalanceError (..)
+    ) where
+
+import Data.Sequence.Strict ((|>))
+import Data.Set qualified as Set
+import Lens.Micro ((&), (.~), (^.))
+
+import Cardano.Ledger.Api.Tx
+    ( Tx
+    , bodyTxL
+    , setMinFeeTx
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( feeTxBodyL
+    , inputsTxBodyL
+    , outputsTxBodyL
+    )
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , coinTxOutL
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.BaseTypes (Inject (..))
+
+import Cardano.MPFS.Types
+    ( Addr
+    , Coin (..)
+    , ConwayEra
+    , PParams
+    , TxIn
+    )
+
+-- | Fee-paying UTxO has insufficient ada.
+data BalanceError
+    = -- | @InsufficientFee required available@
+      InsufficientFee !Coin !Coin
+    deriving (Eq, Show)
+
+-- | Balance a transaction by adding a fee-paying
+-- UTxO and a change output.
+--
+-- One additional key witness is assumed for the fee
+-- input. The fee is estimated with a placeholder
+-- change output carrying the full input value, so
+-- the actual fee may be marginally lower than
+-- charged (the change output shrinks).
+balanceTx
+    :: PParams ConwayEra
+    -> (TxIn, TxOut ConwayEra)
+    -- ^ Fee-paying UTxO
+    -> Addr
+    -- ^ Change address
+    -> Tx ConwayEra
+    -- ^ Unbalanced transaction
+    -> Either BalanceError (Tx ConwayEra)
+balanceTx pp (feeInput, feeUtxo) changeAddr tx =
+    let body = tx ^. bodyTxL
+        inputCoin = feeUtxo ^. coinTxOutL
+        newInputs =
+            Set.insert
+                feeInput
+                (body ^. inputsTxBodyL)
+        origOutputs = body ^. outputsTxBodyL
+        placeholder =
+            mkBasicTxOut changeAddr (inject inputCoin)
+        draftBody =
+            body
+                & inputsTxBodyL .~ newInputs
+                & outputsTxBodyL
+                    .~ (origOutputs |> placeholder)
+        draftTx = tx & bodyTxL .~ draftBody
+        -- One extra key witness for the fee input
+        feeEstTx = setMinFeeTx pp draftTx 1
+        fee = feeEstTx ^. bodyTxL . feeTxBodyL
+        Coin available = inputCoin
+        Coin required = fee
+        changeAmount = available - required
+    in  if changeAmount < 0
+            then
+                Left (InsufficientFee fee inputCoin)
+            else
+                let changeOut =
+                        mkBasicTxOut
+                            changeAddr
+                            ( inject
+                                (Coin changeAmount)
+                            )
+                    finalBody =
+                        body
+                            & inputsTxBodyL
+                                .~ newInputs
+                            & outputsTxBodyL
+                                .~ ( origOutputs
+                                        |> changeOut
+                                   )
+                            & feeTxBodyL .~ fee
+                in  Right
+                        (tx & bodyTxL .~ finalBody)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Types.hs
@@ -13,6 +13,7 @@ module Cardano.MPFS.Types
     , Addr
     , TxId
     , TxIn
+    , TxOut
     , Coin (..)
     , MaryValue
     , PolicyID (..)
@@ -47,6 +48,7 @@ module Cardano.MPFS.Types
 import Data.ByteString (ByteString)
 
 import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Api.Tx.Out (TxOut)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/BalanceSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/BalanceSpec.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.MPFS.BalanceSpec (spec) where
+
+import Lens.Micro ((&), (.~), (^.))
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    )
+import Test.QuickCheck
+    ( Property
+    , forAll
+    , property
+    )
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Api.PParams
+    ( emptyPParams
+    , ppMinFeeBL
+    )
+import Cardano.Ledger.Api.Tx
+    ( Tx
+    , bodyTxL
+    , mkBasicTx
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( feeTxBodyL
+    , mkBasicTxBody
+    , outputsTxBodyL
+    )
+import Cardano.Ledger.Api.Tx.Out
+    ( coinTxOutL
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , Network (..)
+    )
+import Cardano.Ledger.Credential
+    ( Credential (..)
+    , StakeReference (..)
+    )
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+
+import Cardano.MPFS.Balance
+    ( BalanceError (..)
+    , balanceTx
+    )
+import Cardano.MPFS.Generators
+    ( genKeyHash
+    , genTxIn
+    )
+import Cardano.MPFS.Types
+    ( Coin (..)
+    , ConwayEra
+    , PParams
+    )
+
+-- | Testnet address from a payment key hash.
+testAddr :: KeyHash 'Payment -> Addr
+testAddr kh =
+    Addr Testnet (KeyHashObj kh) StakeRefNull
+
+-- | Empty transaction.
+emptyTx :: Tx ConwayEra
+emptyTx = mkBasicTx mkBasicTxBody
+
+-- | Protocol params with zero fees.
+zeroPP :: PParams ConwayEra
+zeroPP = emptyPParams
+
+-- | Protocol params with a large constant fee.
+highFeePP :: PParams ConwayEra
+highFeePP =
+    emptyPParams & ppMinFeeBL .~ Coin 5_000_000
+
+spec :: Spec
+spec = describe "Cardano.MPFS.Balance" $ do
+    describe "balanceTx" $ do
+        it "succeeds when fee UTxO has enough ada"
+            $ property propSucceeds
+
+        it "change output value = input - fee"
+            $ property propChangeCorrect
+
+        it "fee field is set on the balanced tx"
+            $ property propFeeSet
+
+        it "returns InsufficientFee for too little ada"
+            $ property propInsufficient
+
+-- | With zero-fee PParams, balanceTx always succeeds.
+propSucceeds :: Property
+propSucceeds =
+    forAll
+        ((,,) <$> genTxIn <*> genKeyHash <*> genKeyHash)
+        $ \(txIn, feeKh, chgKh) ->
+            let feeAddr = testAddr feeKh
+                changeAddr = testAddr chgKh
+                inputCoin = Coin 10_000_000
+                feeUtxo =
+                    mkBasicTxOut
+                        feeAddr
+                        (inject inputCoin)
+                result =
+                    balanceTx
+                        zeroPP
+                        (txIn, feeUtxo)
+                        changeAddr
+                        emptyTx
+            in  case result of
+                    Right _ -> True
+                    Left _ -> False
+
+-- | change = input - fee.
+propChangeCorrect :: Property
+propChangeCorrect =
+    forAll
+        ((,,) <$> genTxIn <*> genKeyHash <*> genKeyHash)
+        $ \(txIn, feeKh, chgKh) ->
+            let feeAddr = testAddr feeKh
+                changeAddr = testAddr chgKh
+                inputCoin = Coin 10_000_000
+                feeUtxo =
+                    mkBasicTxOut
+                        feeAddr
+                        (inject inputCoin)
+                result =
+                    balanceTx
+                        zeroPP
+                        (txIn, feeUtxo)
+                        changeAddr
+                        emptyTx
+            in  case result of
+                    Left _ -> False
+                    Right tx ->
+                        let fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                            outs =
+                                tx
+                                    ^. bodyTxL
+                                        . outputsTxBodyL
+                            lastOut =
+                                outs `seq`
+                                    last
+                                        (foldr (:) [] outs)
+                            changeCoin =
+                                lastOut ^. coinTxOutL
+                            Coin inp = inputCoin
+                            Coin f = fee
+                        in  changeCoin
+                                == Coin (inp - f)
+
+-- | Fee field is non-negative on the balanced tx.
+propFeeSet :: Property
+propFeeSet =
+    forAll
+        ((,,) <$> genTxIn <*> genKeyHash <*> genKeyHash)
+        $ \(txIn, feeKh, chgKh) ->
+            let feeAddr = testAddr feeKh
+                changeAddr = testAddr chgKh
+                inputCoin = Coin 10_000_000
+                feeUtxo =
+                    mkBasicTxOut
+                        feeAddr
+                        (inject inputCoin)
+                result =
+                    balanceTx
+                        zeroPP
+                        (txIn, feeUtxo)
+                        changeAddr
+                        emptyTx
+            in  case result of
+                    Left _ -> False
+                    Right tx ->
+                        let fee =
+                                tx
+                                    ^. bodyTxL
+                                        . feeTxBodyL
+                        in  fee >= Coin 0
+
+-- | Insufficient ada with high-fee PParams.
+propInsufficient :: Property
+propInsufficient =
+    forAll
+        ((,,) <$> genTxIn <*> genKeyHash <*> genKeyHash)
+        $ \(txIn, feeKh, chgKh) ->
+            let feeAddr = testAddr feeKh
+                changeAddr = testAddr chgKh
+                inputCoin = Coin 1
+                feeUtxo =
+                    mkBasicTxOut
+                        feeAddr
+                        (inject inputCoin)
+                result =
+                    balanceTx
+                        highFeePP
+                        (txIn, feeUtxo)
+                        changeAddr
+                        emptyTx
+            in  case result of
+                    Left (InsufficientFee _ _) -> True
+                    _ -> False

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -12,6 +12,7 @@ import Cardano.MPFS.Trie.PureManager
     ( mkPureTrieManager
     )
 
+import Cardano.MPFS.BalanceSpec qualified as BalanceSpec
 import Cardano.MPFS.ProofSpec qualified as ProofSpec
 import Cardano.MPFS.StateSpec qualified as StateSpec
 import Cardano.MPFS.TrieManagerSpec qualified as TrieManagerSpec
@@ -19,6 +20,7 @@ import Cardano.MPFS.TrieSpec qualified as TrieSpec
 
 main :: IO ()
 main = hspec $ do
+    BalanceSpec.spec
     TrieSpec.spec mkPureTrie
     TrieManagerSpec.spec mkPureTrieManager
     StateSpec.spec


### PR DESCRIPTION
## Summary

- Add `Cardano.MPFS.Balance` module with `balanceTx` — pure function that adds a fee-paying UTxO as input, estimates fee via `setMinFeeTx`, and returns change to a specified address
- Re-export `TxOut` from `Cardano.MPFS.Types`
- 4 property tests covering success, change correctness, fee field, and insufficient-fee error

## Test plan

- [x] `just ci` passes (build, 61 tests, format-check, hlint)