### PR TITLE
feat: add CIP-57 blueprint validation for on-chain types

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -18,7 +18,9 @@ build-type:    Simple
 common warnings
   ghc-options:        -Wall
   default-extensions:
+    DerivingStrategies
     DuplicateRecordFields
+    RecordWildCards
     StrictData
 
 library
@@ -26,6 +28,7 @@ library
   default-language: GHC2021
   hs-source-dirs:   lib
   build-depends:
+    , aeson                                  >=2.1  && <2.3
     , base                                   >=4.18 && <5
     , bytestring                             >=0.11 && <0.13
     , cardano-crypto-class
@@ -36,12 +39,18 @@ library
     , cardano-ledger-mary
     , cardano-strict-containers
     , containers                             >=0.6  && <0.8
+    , crypton
+    , memory
     , merkle-patricia-forestry
     , merkle-patricia-forestry:mpf-test-lib
     , microlens
+    , plutus-core
+    , plutus-tx
+    , text                                   >=2.0  && <2.2
 
   exposed-modules:
     Cardano.MPFS.Balance
+    Cardano.MPFS.Blueprint
     Cardano.MPFS.Context
     Cardano.MPFS.Indexer
     Cardano.MPFS.Mock.Context
@@ -50,6 +59,7 @@ library
     Cardano.MPFS.Mock.State
     Cardano.MPFS.Mock.Submitter
     Cardano.MPFS.Mock.TxBuilder
+    Cardano.MPFS.OnChain
     Cardano.MPFS.Proof
     Cardano.MPFS.Provider
     Cardano.MPFS.State
@@ -78,11 +88,15 @@ test-suite unit-tests
     , merkle-patricia-forestry
     , merkle-patricia-forestry:mpf-test-lib
     , microlens
+    , plutus-core
+    , plutus-tx
     , QuickCheck                             >=2.14 && <2.18
+    , text
 
   other-modules:
     Cardano.MPFS.BalanceSpec
     Cardano.MPFS.Generators
+    Cardano.MPFS.OnChainSpec
     Cardano.MPFS.ProofSpec
     Cardano.MPFS.StateSpec
     Cardano.MPFS.TrieManagerSpec

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Blueprint.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Blueprint.hs
@@ -1,0 +1,225 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.Blueprint
+-- Description : CIP-57 blueprint schema validation
+-- License     : Apache-2.0
+--
+-- Minimal CIP-57 Plutus blueprint parser and
+-- validator. Loads a @plutus.json@ blueprint file,
+-- extracts type schemas and script hashes, and
+-- validates 'PlutusCore.Data.Data' values against
+-- the declared schemas.
+module Cardano.MPFS.Blueprint
+    ( -- * Schema types
+      Blueprint (..)
+    , Validator (..)
+    , Schema (..)
+    , Constructor (..)
+
+      -- * Loading
+    , loadBlueprint
+
+      -- * Validation
+    , validateData
+
+      -- * Script hash extraction
+    , extractScriptHash
+    ) where
+
+import Data.Aeson
+    ( FromJSON (..)
+    , withObject
+    , (.:)
+    , (.:?)
+    )
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types (Parser)
+import Data.ByteString qualified as BS
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import PlutusCore.Data (Data (..))
+
+-- | A single constructor alternative in a schema.
+data Constructor = Constructor
+    { conIndex :: Integer
+    , conFields :: [Schema]
+    }
+    deriving stock (Show, Eq)
+
+-- | CIP-57 schema for a Plutus data type.
+data Schema
+    = -- | @{"dataType": "bytes"}@
+      SBytes
+    | -- | @{"dataType": "integer"}@
+      SInteger
+    | -- | @{"dataType": "list", "items": ...}@
+      SList Schema
+    | -- | @{"anyOf": [...constructors...]}@
+      SConstructors [Constructor]
+    | -- | @{"$ref": "#/definitions/..."}@
+      SRef Text
+    deriving stock (Show, Eq)
+
+-- | A validator entry in the blueprint.
+data Validator = Validator
+    { vTitle :: Text
+    , vDatum :: Maybe Schema
+    , vRedeemer :: Schema
+    , vHash :: Text
+    }
+    deriving stock (Show, Eq)
+
+-- | A parsed CIP-57 blueprint.
+data Blueprint = Blueprint
+    { validators :: [Validator]
+    , definitions :: Map Text Schema
+    }
+    deriving stock (Show, Eq)
+
+-- ---------------------------------------------------------
+-- JSON parsing
+-- ---------------------------------------------------------
+
+instance FromJSON Constructor where
+    parseJSON = withObject "Constructor" $ \o -> do
+        idx <- o .: "index"
+        fields <- o .: "fields"
+        pure Constructor{conIndex = idx, conFields = fields}
+
+instance FromJSON Schema where
+    parseJSON = withObject "Schema" $ \o -> do
+        mRef <- o .:? "$ref"
+        case mRef of
+            Just ref -> pure $ SRef (parseRef ref)
+            Nothing -> do
+                mAnyOf <- o .:? "anyOf"
+                case mAnyOf of
+                    Just cs ->
+                        pure $ SConstructors cs
+                    Nothing -> do
+                        mDataType <-
+                            o .:? "dataType"
+                                :: Parser
+                                    (Maybe Text)
+                        case mDataType of
+                            Just "bytes" ->
+                                pure SBytes
+                            Just "integer" ->
+                                pure SInteger
+                            Just "list" -> do
+                                items <- o .: "items"
+                                pure $ SList items
+                            Just "constructor" -> do
+                                idx <- o .: "index"
+                                fields <-
+                                    o .: "fields"
+                                pure
+                                    $ SConstructors
+                                        [ Constructor
+                                            idx
+                                            fields
+                                        ]
+                            _ -> pure SBytes
+
+instance FromJSON Validator where
+    parseJSON = withObject "Validator" $ \o -> do
+        title <- o .: "title"
+        datumObj <- o .:? "datum"
+        datum <- case datumObj of
+            Just d -> do
+                s <- d .: "schema"
+                pure (Just s)
+            Nothing -> pure Nothing
+        redeemerObj <- o .: "redeemer"
+        redeemer <- redeemerObj .: "schema"
+        h <- o .: "hash"
+        pure
+            Validator
+                { vTitle = title
+                , vDatum = datum
+                , vRedeemer = redeemer
+                , vHash = h
+                }
+
+instance FromJSON Blueprint where
+    parseJSON = withObject "Blueprint" $ \o -> do
+        vs <- o .: "validators"
+        defs <- o .: "definitions"
+        pure Blueprint{validators = vs, definitions = defs}
+
+-- | Strip the @#/definitions/@ prefix and unescape
+-- tilde-encoded slashes (@~1@ -> @/@).
+parseRef :: Text -> Text
+parseRef =
+    T.replace "~1" "/"
+        . T.replace "~0" "~"
+        . stripPrefix "#/definitions/"
+
+stripPrefix :: Text -> Text -> Text
+stripPrefix pfx t =
+    fromMaybe t (T.stripPrefix pfx t)
+
+-- ---------------------------------------------------------
+-- Loading
+-- ---------------------------------------------------------
+
+-- | Load and parse a CIP-57 blueprint from a file
+-- path.
+loadBlueprint
+    :: FilePath -> IO (Either String Blueprint)
+loadBlueprint path = do
+    bs <- BS.readFile path
+    pure $ Aeson.eitherDecodeStrict' bs
+
+-- ---------------------------------------------------------
+-- Validation
+-- ---------------------------------------------------------
+
+-- | Validate a 'Data' value against a 'Schema',
+-- resolving @$ref@ through the definitions map.
+validateData
+    :: Map Text Schema -> Schema -> Data -> Bool
+validateData defs schema d = case (schema, d) of
+    (SBytes, B _) -> True
+    (SInteger, I _) -> True
+    (SList s, List xs) ->
+        all (validateData defs s) xs
+    (SRef ref, _) ->
+        case Map.lookup ref defs of
+            Just s -> validateData defs s d
+            Nothing -> False
+    (SConstructors cs, Constr ix fields) ->
+        any
+            ( \c ->
+                conIndex c
+                    == ix
+                    && length (conFields c)
+                        == length fields
+                    && and
+                        ( zipWith
+                            (validateData defs)
+                            (conFields c)
+                            fields
+                        )
+            )
+            cs
+    _ -> False
+
+-- ---------------------------------------------------------
+-- Script hash extraction
+-- ---------------------------------------------------------
+
+-- | Find the first validator whose title starts with
+-- the given prefix and return its hash.
+extractScriptHash
+    :: Text -> Blueprint -> Maybe Text
+extractScriptHash prefix bp =
+    case filter
+        (T.isPrefixOf prefix . vTitle)
+        (validators bp) of
+        (v : _) -> Just (vHash v)
+        [] -> Nothing

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/OnChain.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/OnChain.hs
@@ -1,0 +1,640 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.OnChain
+-- Description : On-chain type encodings for the MPFS cage validator
+-- License     : Apache-2.0
+--
+-- Haskell types matching the Aiken on-chain datum\/redeemer
+-- structures, their PlutusData encoding, script identity,
+-- and asset-name derivation.
+--
+-- These types use Plutus primitives directly (not
+-- cardano-ledger types) because they model the exact
+-- on-chain data layout expected by the Aiken validator.
+module Cardano.MPFS.OnChain
+    ( -- * On-chain datum\/redeemer types
+      CageDatum (..)
+    , MintRedeemer (..)
+    , Mint (..)
+    , UpdateRedeemer (..)
+
+      -- * On-chain domain types
+    , OnChainTokenId (..)
+    , OnChainOperation (..)
+    , OnChainRoot (..)
+    , OnChainRequest (..)
+    , OnChainTokenState (..)
+    , OnChainTxOutRef (..)
+
+      -- * Proof steps (Aiken MPF proof encoding)
+    , ProofStep (..)
+    , Neighbor (..)
+
+      -- * Script identity
+    , cageScriptHash
+
+      -- * Asset-name derivation
+    , deriveAssetName
+
+      -- * Blueprint loading
+    , Blueprint (..)
+    , loadCageScript
+    ) where
+
+import Cardano.MPFS.Blueprint
+    ( Blueprint (..)
+    , loadBlueprint
+    )
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.Bits (shiftR)
+import Data.ByteArray (convert)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Word (Word16)
+import PlutusCore.Data (Data (..))
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    , BuiltinData (..)
+    )
+import PlutusTx.IsData.Class
+    ( FromData (..)
+    , ToData (..)
+    , UnsafeFromData (..)
+    )
+
+-- ---------------------------------------------------------
+-- On-chain domain types (Plutus primitives)
+-- ---------------------------------------------------------
+
+-- | On-chain token identifier (asset name as raw
+-- bytes). Matches Aiken @lib/TokenId@.
+newtype OnChainTokenId = OnChainTokenId
+    { unOnChainTokenId :: BuiltinByteString
+    }
+    deriving stock (Show, Eq)
+
+-- | On-chain output reference. Matches Aiken
+-- @cardano/transaction/OutputReference@.
+data OnChainTxOutRef = OnChainTxOutRef
+    { txOutRefId :: !BuiltinByteString
+    , txOutRefIdx :: !Integer
+    }
+    deriving stock (Show, Eq)
+
+-- | On-chain MPF root hash (raw bytes).
+newtype OnChainRoot = OnChainRoot
+    { unOnChainRoot :: ByteString
+    }
+    deriving stock (Show, Eq)
+
+-- | On-chain operation on a key in the trie.
+-- Matches Aiken @types/Operation@.
+data OnChainOperation
+    = -- | Insert a new key-value pair (Constr 0)
+      OpInsert !ByteString
+    | -- | Delete a key (Constr 1)
+      OpDelete !ByteString
+    | -- | Update an existing key (Constr 2)
+      OpUpdate !ByteString !ByteString
+    deriving stock (Show, Eq)
+
+-- | On-chain request to modify a token's trie.
+-- Matches Aiken @types/Request@.
+data OnChainRequest = OnChainRequest
+    { requestToken :: !OnChainTokenId
+    , requestOwner :: !BuiltinByteString
+    , requestKey :: !ByteString
+    , requestValue :: !OnChainOperation
+    }
+    deriving stock (Show, Eq)
+
+-- | On-chain token state. Matches Aiken
+-- @types/State@.
+data OnChainTokenState = OnChainTokenState
+    { stateOwner :: !BuiltinByteString
+    , stateRoot :: !OnChainRoot
+    }
+    deriving stock (Show, Eq)
+
+-- ---------------------------------------------------------
+-- On-chain-only types (datum / redeemer wrappers)
+-- ---------------------------------------------------------
+
+-- | Cage datum: either a pending request or a token
+-- state. Matches Aiken @types/CageDatum@.
+data CageDatum
+    = -- | A pending operation request (Constr 0)
+      RequestDatum !OnChainRequest
+    | -- | Current token state (Constr 1)
+      StateDatum !OnChainTokenState
+    deriving stock (Show, Eq)
+
+-- | Minting redeemer. Matches Aiken
+-- @types/MintRedeemer@.
+data MintRedeemer
+    = -- | Mint a new cage token (Constr 0)
+      Minting !Mint
+    | -- | Burn a cage token (Constr 1)
+      Burning
+    deriving stock (Show, Eq)
+
+-- | Minting parameters. Matches Aiken
+-- @types/Mint@.
+newtype Mint = Mint
+    { mintAsset :: OnChainTxOutRef
+    }
+    deriving stock (Show, Eq)
+
+-- | Spending redeemer. Matches Aiken
+-- @types/UpdateRedeemer@.
+data UpdateRedeemer
+    = -- | End the token (Constr 0)
+      End
+    | -- | Link a request to a state UTxO (Constr 1)
+      Contribute !OnChainTxOutRef
+    | -- | Fold requests with proofs (Constr 2)
+      Modify ![[ProofStep]]
+    | -- | Reclaim a pending request (Constr 3)
+      Retract
+    deriving stock (Show, Eq)
+
+-- | A single step in an MPF Merkle proof, matching
+-- the Aiken @ProofStep@ type from
+-- @aiken-lang\/merkle-patricia-forestry@.
+data ProofStep
+    = -- | Branch step (Constr 0)
+      Branch
+        { branchSkip :: !Integer
+        , branchNeighbors :: !ByteString
+        }
+    | -- | Fork step (Constr 1)
+      Fork
+        { forkSkip :: !Integer
+        , forkNeighbor :: !Neighbor
+        }
+    | -- | Leaf step (Constr 2)
+      Leaf
+        { leafSkip :: !Integer
+        , leafKey :: !ByteString
+        , leafValue :: !ByteString
+        }
+    deriving stock (Show, Eq)
+
+-- | Neighbor node in a fork proof step.
+data Neighbor = Neighbor
+    { neighborNibble :: !Integer
+    , neighborPrefix :: !ByteString
+    , neighborRoot :: !ByteString
+    }
+    deriving stock (Show, Eq)
+
+-- ---------------------------------------------------------
+-- Helpers for manual Data construction
+-- ---------------------------------------------------------
+
+mkD :: Data -> BuiltinData
+mkD = BuiltinData
+
+unD :: BuiltinData -> Data
+unD (BuiltinData d) = d
+
+bsToD :: ByteString -> Data
+bsToD = B
+
+bsFromD :: Data -> Maybe ByteString
+bsFromD (B bs) = Just bs
+bsFromD _ = Nothing
+
+bbsToD :: BuiltinByteString -> Data
+bbsToD (BuiltinByteString bs) = B bs
+
+bbsFromD :: Data -> Maybe BuiltinByteString
+bbsFromD (B bs) = Just (BuiltinByteString bs)
+bbsFromD _ = Nothing
+
+-- ---------------------------------------------------------
+-- ToData / FromData instances
+-- ---------------------------------------------------------
+
+instance ToData OnChainTokenId where
+    toBuiltinData (OnChainTokenId bbs) =
+        mkD $ Constr 0 [bbsToD bbs]
+
+instance FromData OnChainTokenId where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [x] ->
+            OnChainTokenId <$> bbsFromD x
+        _ -> Nothing
+
+instance UnsafeFromData OnChainTokenId where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [x] -> case bbsFromD x of
+            Just bbs -> OnChainTokenId bbs
+            _ ->
+                error
+                    "unsafeFromBuiltinData: OnChainTokenId"
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainTokenId"
+
+instance ToData OnChainTxOutRef where
+    toBuiltinData OnChainTxOutRef{..} =
+        mkD
+            $ Constr
+                0
+                [bbsToD txOutRefId, I txOutRefIdx]
+
+instance FromData OnChainTxOutRef where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [tid, I idx] ->
+            OnChainTxOutRef
+                <$> bbsFromD tid
+                <*> pure idx
+        _ -> Nothing
+
+instance UnsafeFromData OnChainTxOutRef where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [B tid, I idx] ->
+            OnChainTxOutRef
+                (BuiltinByteString tid)
+                idx
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainTxOutRef"
+
+instance ToData OnChainOperation where
+    toBuiltinData (OpInsert v) =
+        mkD $ Constr 0 [bsToD v]
+    toBuiltinData (OpDelete v) =
+        mkD $ Constr 1 [bsToD v]
+    toBuiltinData (OpUpdate old new) =
+        mkD $ Constr 2 [bsToD old, bsToD new]
+
+instance FromData OnChainOperation where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [v] -> OpInsert <$> bsFromD v
+        Constr 1 [v] -> OpDelete <$> bsFromD v
+        Constr 2 [o, n] ->
+            OpUpdate <$> bsFromD o <*> bsFromD n
+        _ -> Nothing
+
+instance UnsafeFromData OnChainOperation where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [B v] -> OpInsert v
+        Constr 1 [B v] -> OpDelete v
+        Constr 2 [B o, B n] -> OpUpdate o n
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainOperation"
+
+instance ToData OnChainRoot where
+    toBuiltinData (OnChainRoot bs) = mkD $ bsToD bs
+
+instance FromData OnChainRoot where
+    fromBuiltinData bd =
+        OnChainRoot <$> bsFromD (unD bd)
+
+instance UnsafeFromData OnChainRoot where
+    unsafeFromBuiltinData bd = case unD bd of
+        B bs -> OnChainRoot bs
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainRoot"
+
+instance ToData OnChainRequest where
+    toBuiltinData OnChainRequest{..} =
+        mkD
+            $ Constr
+                0
+                [ unD (toBuiltinData requestToken)
+                , bbsToD requestOwner
+                , bsToD requestKey
+                , unD (toBuiltinData requestValue)
+                ]
+
+instance FromData OnChainRequest where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [tok, own, k, val] -> do
+            requestToken <-
+                fromBuiltinData (mkD tok)
+            requestOwner <- bbsFromD own
+            requestKey <- bsFromD k
+            requestValue <-
+                fromBuiltinData (mkD val)
+            Just OnChainRequest{..}
+        _ -> Nothing
+
+instance UnsafeFromData OnChainRequest where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [tok, B own, B k, val] ->
+            OnChainRequest
+                { requestToken =
+                    unsafeFromBuiltinData (mkD tok)
+                , requestOwner =
+                    BuiltinByteString own
+                , requestKey = k
+                , requestValue =
+                    unsafeFromBuiltinData (mkD val)
+                }
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainRequest"
+
+instance ToData OnChainTokenState where
+    toBuiltinData OnChainTokenState{..} =
+        mkD
+            $ Constr
+                0
+                [ bbsToD stateOwner
+                , unD (toBuiltinData stateRoot)
+                ]
+
+instance FromData OnChainTokenState where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [own, r] -> do
+            stateOwner <- bbsFromD own
+            stateRoot <- fromBuiltinData (mkD r)
+            Just OnChainTokenState{..}
+        _ -> Nothing
+
+instance UnsafeFromData OnChainTokenState where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [B own, r] ->
+            OnChainTokenState
+                { stateOwner =
+                    BuiltinByteString own
+                , stateRoot =
+                    unsafeFromBuiltinData (mkD r)
+                }
+        _ ->
+            error
+                "unsafeFromBuiltinData:\
+                \ OnChainTokenState"
+
+instance ToData CageDatum where
+    toBuiltinData (RequestDatum r) =
+        mkD
+            $ Constr 0 [unD (toBuiltinData r)]
+    toBuiltinData (StateDatum s) =
+        mkD
+            $ Constr 1 [unD (toBuiltinData s)]
+
+instance FromData CageDatum where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            RequestDatum
+                <$> fromBuiltinData (mkD d)
+        Constr 1 [d] ->
+            StateDatum
+                <$> fromBuiltinData (mkD d)
+        _ -> Nothing
+
+instance UnsafeFromData CageDatum where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            RequestDatum
+                $ unsafeFromBuiltinData (mkD d)
+        Constr 1 [d] ->
+            StateDatum
+                $ unsafeFromBuiltinData (mkD d)
+        _ -> error "unsafeFromBuiltinData: CageDatum"
+
+instance ToData Mint where
+    toBuiltinData (Mint ref) =
+        mkD $ Constr 0 [unD (toBuiltinData ref)]
+
+instance FromData Mint where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            Mint <$> fromBuiltinData (mkD d)
+        _ -> Nothing
+
+instance UnsafeFromData Mint where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            Mint $ unsafeFromBuiltinData (mkD d)
+        _ -> error "unsafeFromBuiltinData: Mint"
+
+instance ToData MintRedeemer where
+    toBuiltinData (Minting m) =
+        mkD $ Constr 0 [unD (toBuiltinData m)]
+    toBuiltinData Burning =
+        mkD $ Constr 1 []
+
+instance FromData MintRedeemer where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            Minting <$> fromBuiltinData (mkD d)
+        Constr 1 [] -> Just Burning
+        _ -> Nothing
+
+instance UnsafeFromData MintRedeemer where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            Minting $ unsafeFromBuiltinData (mkD d)
+        Constr 1 [] -> Burning
+        _ ->
+            error "unsafeFromBuiltinData: MintRedeemer"
+
+instance ToData Neighbor where
+    toBuiltinData Neighbor{..} =
+        mkD
+            $ Constr
+                0
+                [ I neighborNibble
+                , bsToD neighborPrefix
+                , bsToD neighborRoot
+                ]
+
+instance FromData Neighbor where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [I nib, pfx, rt] ->
+            Neighbor nib
+                <$> bsFromD pfx
+                <*> bsFromD rt
+        _ -> Nothing
+
+instance UnsafeFromData Neighbor where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [I nib, B pfx, B rt] ->
+            Neighbor nib pfx rt
+        _ -> error "unsafeFromBuiltinData: Neighbor"
+
+instance ToData ProofStep where
+    toBuiltinData Branch{..} =
+        mkD
+            $ Constr
+                0
+                [ I branchSkip
+                , bsToD branchNeighbors
+                ]
+    toBuiltinData Fork{..} =
+        mkD
+            $ Constr
+                1
+                [ I forkSkip
+                , unD (toBuiltinData forkNeighbor)
+                ]
+    toBuiltinData Leaf{..} =
+        mkD
+            $ Constr
+                2
+                [ I leafSkip
+                , bsToD leafKey
+                , bsToD leafValue
+                ]
+
+instance FromData ProofStep where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [I sk, nb] ->
+            Branch sk <$> bsFromD nb
+        Constr 1 [I sk, nd] ->
+            Fork sk
+                <$> fromBuiltinData (mkD nd)
+        Constr 2 [I sk, k, v] ->
+            Leaf sk <$> bsFromD k <*> bsFromD v
+        _ -> Nothing
+
+instance UnsafeFromData ProofStep where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [I sk, B nb] -> Branch sk nb
+        Constr 1 [I sk, nd] ->
+            Fork sk
+                $ unsafeFromBuiltinData (mkD nd)
+        Constr 2 [I sk, B k, B v] -> Leaf sk k v
+        _ ->
+            error "unsafeFromBuiltinData: ProofStep"
+
+instance ToData UpdateRedeemer where
+    toBuiltinData End = mkD $ Constr 0 []
+    toBuiltinData (Contribute ref) =
+        mkD $ Constr 1 [unD (toBuiltinData ref)]
+    toBuiltinData (Modify proofs) =
+        mkD
+            $ Constr
+                2
+                [ List
+                    ( map
+                        ( List
+                            . map
+                                (unD . toBuiltinData)
+                        )
+                        proofs
+                    )
+                ]
+    toBuiltinData Retract = mkD $ Constr 3 []
+
+instance FromData UpdateRedeemer where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [] -> Just End
+        Constr 1 [d] ->
+            Contribute <$> fromBuiltinData (mkD d)
+        Constr 2 [List ps] ->
+            Modify <$> traverse parseProof ps
+          where
+            parseProof (List steps) =
+                traverse
+                    (fromBuiltinData . mkD)
+                    steps
+            parseProof _ = Nothing
+        Constr 3 [] -> Just Retract
+        _ -> Nothing
+
+instance UnsafeFromData UpdateRedeemer where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [] -> End
+        Constr 1 [d] ->
+            Contribute
+                $ unsafeFromBuiltinData (mkD d)
+        Constr 2 [List ps] ->
+            Modify $ map parseProof ps
+          where
+            parseProof (List steps) =
+                map (unsafeFromBuiltinData . mkD) steps
+            parseProof _ =
+                error
+                    "unsafeFromBuiltinData:\
+                    \ UpdateRedeemer"
+        Constr 3 [] -> Retract
+        _ ->
+            error
+                "unsafeFromBuiltinData: UpdateRedeemer"
+
+-- ---------------------------------------------------------
+-- Script identity
+-- ---------------------------------------------------------
+
+-- | The cage validator script hash (raw 28 bytes).
+-- Versioned with @cardano-mpfs-onchain v0.1.0@.
+cageScriptHash :: ByteString
+cageScriptHash =
+    BS.pack
+        [ 0xc1
+        , 0xe3
+        , 0x92
+        , 0xee
+        , 0x7d
+        , 0xa9
+        , 0x41
+        , 0x5f
+        , 0x94
+        , 0x6d
+        , 0xe9
+        , 0xd2
+        , 0xae
+        , 0xf9
+        , 0x60
+        , 0x73
+        , 0x22
+        , 0xb4
+        , 0x7d
+        , 0x6e
+        , 0x84
+        , 0xe8
+        , 0x14
+        , 0x2e
+        , 0xf0
+        , 0xc3
+        , 0x40
+        , 0xbf
+        ]
+
+-- ---------------------------------------------------------
+-- Asset-name derivation
+-- ---------------------------------------------------------
+
+-- | Derive the asset name from an output reference,
+-- matching Aiken's @lib.assetName@:
+--
+-- @SHA2-256(txId ++ bigEndian16(outputIndex))@
+deriveAssetName :: OnChainTxOutRef -> ByteString
+deriveAssetName OnChainTxOutRef{txOutRefId, txOutRefIdx} =
+    convert digest
+  where
+    digest :: Digest SHA256
+    digest = hash (txIdBytes <> indexBytes)
+
+    txIdBytes :: ByteString
+    txIdBytes =
+        let BuiltinByteString bs = txOutRefId
+        in  bs
+
+    indexBytes :: ByteString
+    indexBytes =
+        let w16 =
+                fromIntegral txOutRefIdx :: Word16
+        in  BS.pack
+                [ fromIntegral (w16 `shiftR` 8)
+                , fromIntegral w16
+                ]
+
+-- ---------------------------------------------------------
+-- Blueprint loading
+-- ---------------------------------------------------------
+
+-- | Load and parse a CIP-57 blueprint from a file
+-- path. Returns the parsed 'Blueprint' on success.
+loadCageScript
+    :: FilePath -> IO (Either String Blueprint)
+loadCageScript = loadBlueprint

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
@@ -1,0 +1,383 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.MPFS.OnChainSpec (spec) where
+
+import Cardano.MPFS.Blueprint
+    ( Blueprint (..)
+    , extractScriptHash
+    , loadBlueprint
+    , validateData
+    )
+import Cardano.MPFS.OnChain
+    ( CageDatum (..)
+    , Mint (..)
+    , MintRedeemer (..)
+    , Neighbor (..)
+    , OnChainOperation (..)
+    , OnChainRequest (..)
+    , OnChainRoot (..)
+    , OnChainTokenId (..)
+    , OnChainTokenState (..)
+    , OnChainTxOutRef (..)
+    , ProofStep (..)
+    , UpdateRedeemer (..)
+    , cageScriptHash
+    , deriveAssetName
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import PlutusCore.Data (Data (..))
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    , BuiltinData (..)
+    )
+import PlutusTx.IsData.Class
+    ( FromData (..)
+    , ToData (..)
+    )
+import System.Environment (lookupEnv)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , runIO
+    , shouldBe
+    )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , Property
+    , elements
+    , listOf
+    , oneof
+    , property
+    , vectorOf
+    , (===)
+    )
+
+-- ---------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------
+
+toData' :: (ToData a) => a -> Data
+toData' x =
+    let BuiltinData d = toBuiltinData x in d
+
+fromData' :: (FromData a) => Data -> Maybe a
+fromData' d = fromBuiltinData (BuiltinData d)
+
+roundtrip
+    :: (ToData a, FromData a, Eq a, Show a)
+    => a
+    -> Property
+roundtrip x = fromData' (toData' x) === Just x
+
+toHex :: ByteString -> Text
+toHex =
+    T.pack
+        . concatMap
+            ( \w ->
+                let (hi, lo) = w `divMod` 16
+                in  [hexChar hi, hexChar lo]
+            )
+        . BS.unpack
+  where
+    hexChar n
+        | n < 10 = toEnum (fromIntegral n + 48)
+        | otherwise =
+            toEnum (fromIntegral n + 87)
+
+-- ---------------------------------------------------------
+-- Arbitrary instances
+-- ---------------------------------------------------------
+
+genBS :: Int -> Gen ByteString
+genBS n = BS.pack <$> vectorOf n arbitrary
+
+genBBS :: Int -> Gen BuiltinByteString
+genBBS n = BuiltinByteString <$> genBS n
+
+instance Arbitrary OnChainTokenId where
+    arbitrary =
+        OnChainTokenId <$> genBBS 32
+
+instance Arbitrary OnChainOperation where
+    arbitrary =
+        oneof
+            [ OpInsert <$> genBS 32
+            , OpDelete <$> genBS 32
+            , OpUpdate <$> genBS 32 <*> genBS 32
+            ]
+
+instance Arbitrary OnChainRoot where
+    arbitrary = OnChainRoot <$> genBS 32
+
+instance Arbitrary OnChainTxOutRef where
+    arbitrary =
+        OnChainTxOutRef
+            <$> genBBS 32
+            <*> ( fromIntegral
+                    <$> (arbitrary :: Gen Int)
+                )
+
+instance Arbitrary OnChainRequest where
+    arbitrary =
+        OnChainRequest
+            <$> arbitrary
+            <*> genBBS 28
+            <*> genBS 32
+            <*> arbitrary
+
+instance Arbitrary OnChainTokenState where
+    arbitrary =
+        OnChainTokenState
+            <$> genBBS 28
+            <*> arbitrary
+
+instance Arbitrary CageDatum where
+    arbitrary =
+        oneof
+            [ RequestDatum <$> arbitrary
+            , StateDatum <$> arbitrary
+            ]
+
+instance Arbitrary Mint where
+    arbitrary = Mint <$> arbitrary
+
+instance Arbitrary MintRedeemer where
+    arbitrary =
+        oneof
+            [ Minting <$> arbitrary
+            , pure Burning
+            ]
+
+instance Arbitrary Neighbor where
+    arbitrary =
+        Neighbor
+            <$> elements [0 .. 15]
+            <*> genBS 4
+            <*> genBS 32
+
+instance Arbitrary ProofStep where
+    arbitrary =
+        oneof
+            [ Branch
+                <$> elements [0 .. 30]
+                <*> genBS 64
+            , Fork
+                <$> elements [0 .. 30]
+                <*> arbitrary
+            , Leaf
+                <$> elements [0 .. 30]
+                <*> genBS 32
+                <*> genBS 32
+            ]
+
+instance Arbitrary UpdateRedeemer where
+    arbitrary =
+        oneof
+            [ pure End
+            , Contribute <$> arbitrary
+            , Modify
+                <$> listOf
+                    (listOf arbitrary)
+            , pure Retract
+            ]
+
+-- ---------------------------------------------------------
+-- Spec
+-- ---------------------------------------------------------
+
+spec :: Spec
+spec = do
+    describe "PlutusData roundtrip" $ do
+        it "OnChainTokenId" $ property $ \x ->
+            roundtrip (x :: OnChainTokenId)
+        it "OnChainOperation" $ property $ \x ->
+            roundtrip (x :: OnChainOperation)
+        it "OnChainRoot" $ property $ \x ->
+            roundtrip (x :: OnChainRoot)
+        it "OnChainTxOutRef" $ property $ \x ->
+            roundtrip (x :: OnChainTxOutRef)
+        it "OnChainRequest" $ property $ \x ->
+            roundtrip (x :: OnChainRequest)
+        it "OnChainTokenState" $ property $ \x ->
+            roundtrip (x :: OnChainTokenState)
+        it "CageDatum" $ property $ \x ->
+            roundtrip (x :: CageDatum)
+        it "Mint" $ property $ \x ->
+            roundtrip (x :: Mint)
+        it "MintRedeemer" $ property $ \x ->
+            roundtrip (x :: MintRedeemer)
+        it "Neighbor" $ property $ \x ->
+            roundtrip (x :: Neighbor)
+        it "ProofStep" $ property $ \x ->
+            roundtrip (x :: ProofStep)
+        it "UpdateRedeemer" $ property $ \x ->
+            roundtrip (x :: UpdateRedeemer)
+
+    describe "Known value encoding" $ do
+        it "Burning encodes to Constr 1 []"
+            $ toData' Burning
+            `shouldBe` Constr 1 []
+        it "End encodes to Constr 0 []"
+            $ toData' End
+            `shouldBe` Constr 0 []
+        it "Retract encodes to Constr 3 []"
+            $ toData' Retract
+            `shouldBe` Constr 3 []
+        it "OpInsert encodes to Constr 0 [B v]"
+            $ toData' (OpInsert "hello")
+            `shouldBe` Constr 0 [B "hello"]
+        it "StateDatum wraps Constr 1" $ do
+            let st =
+                    OnChainTokenState
+                        { stateOwner =
+                            BuiltinByteString "own"
+                        , stateRoot =
+                            OnChainRoot "rt"
+                        }
+            toData' (StateDatum st)
+                `shouldBe` Constr
+                    1
+                    [Constr 0 [B "own", B "rt"]]
+
+    describe "Asset-name derivation" $ do
+        it "produces 32 bytes"
+            $ let ref =
+                    OnChainTxOutRef
+                        (BuiltinByteString $ BS.replicate 32 0)
+                        0
+              in  BS.length (deriveAssetName ref)
+                    `shouldBe` 32
+        it "differs for different indices" $ do
+            let txid =
+                    BuiltinByteString
+                        $ BS.replicate 32 0xAB
+                ref0 = OnChainTxOutRef txid 0
+                ref1 = OnChainTxOutRef txid 1
+            deriveAssetName ref0
+                `shouldBe` deriveAssetName ref0
+            (deriveAssetName ref0 /= deriveAssetName ref1)
+                `shouldBe` True
+
+    describe "Script hash" $ do
+        it "is 28 bytes"
+            $ BS.length cageScriptHash
+            `shouldBe` 28
+
+    describe "Blueprint compliance" $ do
+        mPath <- runIO $ lookupEnv "MPFS_BLUEPRINT"
+        case mPath of
+            Nothing ->
+                it
+                    "skipped (MPFS_BLUEPRINT not set)"
+                    (pure () :: IO ())
+            Just path -> do
+                ebp <- runIO $ loadBlueprint path
+                case ebp of
+                    Left err ->
+                        it
+                            ( "loads blueprint: "
+                                <> err
+                            )
+                            ( error
+                                "blueprint parse failed"
+                                :: IO ()
+                            )
+                    Right bp -> do
+                        let defs = definitions bp
+                            check
+                                :: (ToData a)
+                                => Text
+                                -> a
+                                -> Property
+                            check defKey x =
+                                let schema =
+                                        defs
+                                            Map.! defKey
+                                in  validateData
+                                        defs
+                                        schema
+                                        (toData' x)
+                                        === True
+                        it "CageDatum"
+                            $ property
+                            $ \x ->
+                                check
+                                    "types/CageDatum"
+                                    (x :: CageDatum)
+                        it "MintRedeemer"
+                            $ property
+                            $ \x ->
+                                check
+                                    "types/MintRedeemer"
+                                    (x :: MintRedeemer)
+                        it "UpdateRedeemer"
+                            $ property
+                            $ \x ->
+                                check
+                                    "types/UpdateRedeemer"
+                                    (x :: UpdateRedeemer)
+                        it "Operation"
+                            $ property
+                            $ \x ->
+                                check
+                                    "types/Operation"
+                                    (x :: OnChainOperation)
+                        it "Request"
+                            $ property
+                            $ \x ->
+                                check
+                                    "types/Request"
+                                    (x :: OnChainRequest)
+                        it "TokenState"
+                            $ property
+                            $ \x ->
+                                check
+                                    "types/State"
+                                    (x :: OnChainTokenState)
+                        it "Mint"
+                            $ property
+                            $ \x ->
+                                check
+                                    "types/Mint"
+                                    (x :: Mint)
+                        it "TokenId"
+                            $ property
+                            $ \x ->
+                                check
+                                    "lib/TokenId"
+                                    (x :: OnChainTokenId)
+                        it "ProofStep"
+                            $ property
+                            $ \x ->
+                                check
+                                    "aiken/merkle_patricia_forestry/ProofStep"
+                                    (x :: ProofStep)
+                        it "Neighbor"
+                            $ property
+                            $ \x ->
+                                check
+                                    "aiken/merkle_patricia_forestry/Neighbor"
+                                    (x :: Neighbor)
+                        it "TxOutRef"
+                            $ property
+                            $ \x ->
+                                check
+                                    "cardano/transaction/OutputReference"
+                                    (x :: OnChainTxOutRef)
+                        it "script hash matches"
+                            $ let mHash =
+                                    extractScriptHash
+                                        "cage."
+                                        bp
+                              in  mHash
+                                    `shouldBe` Just
+                                        ( toHex
+                                            cageScriptHash
+                                        )

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -13,6 +13,7 @@ import Cardano.MPFS.Trie.PureManager
     )
 
 import Cardano.MPFS.BalanceSpec qualified as BalanceSpec
+import Cardano.MPFS.OnChainSpec qualified as OnChainSpec
 import Cardano.MPFS.ProofSpec qualified as ProofSpec
 import Cardano.MPFS.StateSpec qualified as StateSpec
 import Cardano.MPFS.TrieManagerSpec qualified as TrieManagerSpec
@@ -28,3 +29,4 @@ main = hspec $ do
         mkMockRequests
         mkMockCheckpoints
     ProofSpec.spec
+    OnChainSpec.spec


### PR DESCRIPTION
## Summary

- Add `Cardano.MPFS.Blueprint` module: CIP-57 schema parser and PlutusData validator
- Add `Cardano.MPFS.OnChain` module: self-contained Plutus-native types with ToData/FromData instances for all cage contract types
- Add `OnChainSpec` with roundtrip property tests, known-value encoding tests, and blueprint compliance tests (via `MPFS_BLUEPRINT` env var)

## Test plan

- [x] All 82 unit tests pass
- [x] Builds with `-Werror`
- [x] hlint clean
- [x] fourmolu format check passes
- [ ] CI green