### PR TITLE
feat: move time params from validator params to State datum

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs
@@ -22,9 +22,9 @@ import Cardano.MPFS.Types (Coin)
 data CageConfig = CageConfig
     { cageScriptBytes :: !ShortByteString
     -- ^ Raw PlutusV3 script bytes (from blueprint)
-    , processTime :: !Integer
+    , defaultProcessTime :: !Integer
     -- ^ Phase 1 window (ms) for oracle processing
-    , retractTime :: !Integer
+    , defaultRetractTime :: !Integer
     -- ^ Phase 2 window (ms) for requester retract
     , defaultMaxFee :: !Coin
     -- ^ Default max fee for newly booted tokens

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
@@ -312,6 +312,10 @@ bootTokenImpl cfg prov addr = do
                                 let Coin c =
                                         defaultMaxFee cfg
                                 in  c
+                            , stateProcessTime =
+                                defaultProcessTime cfg
+                            , stateRetractTime =
+                                defaultRetractTime cfg
                             }
                 datumData = toPlcData stateDatum
             -- 4. Build output with ada + token

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Types.hs
@@ -113,6 +113,10 @@ data TokenState = TokenState
     -- ^ Current root hash of the token's trie
     , maxFee :: !Coin
     -- ^ Maximum fee charged per request
+    , processTime :: !Integer
+    -- ^ Duration (ms) of the oracle processing window
+    , retractTime :: !Integer
+    -- ^ Duration (ms) of the requester retract window
     }
     deriving (Eq, Show)
 

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Generators.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Generators.hs
@@ -102,14 +102,22 @@ genTxIn = do
 genCoin :: Gen Coin
 genCoin = Coin <$> choose (0, 10_000_000)
 
+-- | Generate a POSIXTime (ms).
+genPosixTime :: Gen Integer
+genPosixTime =
+    fromIntegral
+        <$> choose (0 :: Int, 2_000_000_000)
+
 -- | Generate a 'TokenState' with random owner,
--- root, and maxFee.
+-- root, maxFee, processTime, and retractTime.
 genTokenState :: Gen TokenState
 genTokenState =
     TokenState
         <$> genKeyHash
         <*> genRoot
         <*> genCoin
+        <*> genPosixTime
+        <*> genPosixTime
 
 -- | Generate a random 'Operation'.
 genOperation :: Gen Operation

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -129,8 +129,8 @@ testCageConfig :: CageConfig
 testCageConfig =
     CageConfig
         { cageScriptBytes = SBS.toShort "dummy"
-        , processTime = 300_000
-        , retractTime = 600_000
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 600_000
         , defaultMaxFee = Coin 1_000_000
         , network = Testnet
         }
@@ -316,8 +316,8 @@ bootTokenWithScript scriptBytes = do
     let cfg =
             CageConfig
                 { cageScriptBytes = scriptBytes
-                , processTime = 300_000
-                , retractTime = 600_000
+                , defaultProcessTime = 300_000
+                , defaultRetractTime = 600_000
                 , defaultMaxFee = Coin 1_000_000
                 , network = Testnet
                 }
@@ -436,6 +436,8 @@ mkTestFixture = do
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
                 , maxFee = Coin 1_000_000
+                , processTime = 300_000
+                , retractTime = 600_000
                 }
     putToken (tokens st) testTid ts
     txIn <- generate genTxIn

--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1771414143,
-        "narHash": "sha256-YIQ9Iz9mgj09eV6u4cXDvzO56seoDWFo/s6TGG1KlcY=",
+        "lastModified": 1771492622,
+        "narHash": "sha256-vAfvFfcYajsxHYlAFOKyVIIRWWD8EMLBGAFLNyEeYSY=",
         "owner": "paolino",
         "repo": "cardano-mpfs-onchain",
-        "rev": "043c218364c4990ac0d3533b4904300a70e8c0a1",
+        "rev": "6a992157e7a238a2429f17574edecee929de41aa",
         "type": "github"
       },
       "original": {

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,4 +1,5 @@
-{ CHaP, indexState, pkgs, mkdocs, asciinema, cardano-node-pkgs, mpfs-blueprint, ... }:
+{ CHaP, indexState, pkgs, mkdocs, asciinema, cardano-node-pkgs, mpfs-blueprint
+, ... }:
 
 let
   indexTool = { index-state = indexState; };


### PR DESCRIPTION
## Summary

- Move `processTime` and `retractTime` from validator parameters into the `State` datum, aligning with on-chain PR #23
- `Retract` redeemer now carries an `OutputReference` to the State UTxO (for reference input)
- Rename `CageConfig` fields to `defaultProcessTime`/`defaultRetractTime` (used only for initial boot values)
- Update `cageScriptHash` to match new validator
- Update `cardano-mpfs-onchain` flake input to post-merge main

## Test plan

- [x] All 114 offchain unit tests pass
- [x] All 80 MPF unit tests pass
- [x] Blueprint compliance tests pass (all types + script hash match)
- [x] PlutusData roundtrip tests pass for updated types
- [x] Format check and hlint clean