### PR TITLE
feat: implement rollback handling with inverse operations

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -83,6 +83,7 @@ library
     Cardano.MPFS.Indexer.Codecs
     Cardano.MPFS.Indexer.Columns
     Cardano.MPFS.Indexer.Persistent
+    Cardano.MPFS.Indexer.Rollback
     Cardano.MPFS.Indexer.Skeleton
     Cardano.MPFS.Mock.Context
     Cardano.MPFS.Mock.Indexer
@@ -153,6 +154,7 @@ test-suite unit-tests
     Cardano.MPFS.Indexer.CodecsSpec
     Cardano.MPFS.Indexer.InverseSpec
     Cardano.MPFS.Indexer.PersistentSpec
+    Cardano.MPFS.Indexer.RollbackSpec
     Cardano.MPFS.OnChainSpec
     Cardano.MPFS.ProofSpec
     Cardano.MPFS.StateSpec

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -88,12 +88,13 @@ dbConfig =
 -- | Column family names and configs for the cage
 -- indexer. Order must match the 'AllColumns' GADT
 -- constructor order: CageTokens, CageRequests,
--- CageCfg, TrieNodes, TrieKV.
+-- CageCfg, CageRollbacks, TrieNodes, TrieKV.
 cageColumnFamilies :: [(String, Config)]
 cageColumnFamilies =
     [ ("tokens", dbConfig)
     , ("requests", dbConfig)
     , ("cage-cfg", dbConfig)
+    , ("cage-rollbacks", dbConfig)
     , ("trie-nodes", dbConfig)
     , ("trie-kv", dbConfig)
     ]
@@ -120,8 +121,8 @@ withApplication cfg action =
                     mkRocksDBDatabase db columns
             rt <- newRunTransaction database
             let st = mkPersistentState rt
-            -- Extract trie column families (4th and 5th)
-            case drop 3 (columnFamilies db) of
+            -- Extract trie column families (5th and 6th)
+            case drop 4 (columnFamilies db) of
                 (nodesCF : kvCF : _) -> do
                     tm <-
                         mkPersistentTrieManager
@@ -166,5 +167,5 @@ withApplication cfg action =
                     pure result
                 _ ->
                     error
-                        "Expected at least 5 \
+                        "Expected at least 6 \
                         \column families"

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageEvent.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageEvent.hs
@@ -22,6 +22,7 @@ module Cardano.MPFS.Indexer.CageEvent
     , inversesOf
     ) where
 
+import Data.ByteString (ByteString)
 import Data.ByteString.Short qualified as SBS
 import Data.Foldable (toList)
 import Data.Map.Strict qualified as Map
@@ -132,6 +133,10 @@ data CageInverseOp
       InvRemoveRequest !TxIn
     | -- | Restore a token's previous root
       InvRestoreRoot !TokenId !Root
+    | -- | Restore key→value in token's trie (undo delete/update)
+      InvTrieInsert !TokenId !ByteString !ByteString
+    | -- | Remove key from token's trie (undo insert)
+      InvTrieDelete !TokenId !ByteString
     deriving stock (Eq, Show)
 
 -- | Detect cage events from a transaction.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs
@@ -138,9 +138,10 @@ mkCheckpoints RunTransaction{runTransaction = run} =
                     Just
                         ( checkpointSlot
                         , checkpointBlockId
+                        , rollbackSlots
                         )
-        , putCheckpoint = \s b ->
+        , putCheckpoint = \s b slots ->
             run
                 $ insert CageCfg ()
-                $ CageCheckpoint s b
+                $ CageCheckpoint s b slots
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs
@@ -1,0 +1,113 @@
+-- |
+-- Module      : Cardano.MPFS.Indexer.Rollback
+-- Description : Rollback to a previous slot
+-- License     : Apache-2.0
+--
+-- Implements slot-based rollback by replaying inverse
+-- operations stored per block. Uses the rollbackSlots
+-- list in the checkpoint to find which slots need
+-- reverting (all slots > targetSlot).
+module Cardano.MPFS.Indexer.Rollback
+    ( -- * Rollback
+      rollbackToSlot
+
+      -- * Rollback storage
+    , storeRollback
+    , loadRollback
+    , deleteRollback
+    ) where
+
+import Control.Monad (forM_)
+
+import Cardano.MPFS.Indexer.CageEvent
+    ( CageInverseOp
+    )
+import Cardano.MPFS.Indexer.CageFollower
+    ( applyCageInverses
+    )
+import Cardano.MPFS.Indexer.Columns
+    ( AllColumns (..)
+    , CageRollbackEntry (..)
+    )
+import Cardano.MPFS.State
+    ( Checkpoints (..)
+    , State (..)
+    )
+import Cardano.MPFS.Trie (TrieManager)
+import Cardano.MPFS.Types (BlockId (..), SlotNo)
+import Database.KV.Transaction
+    ( RunTransaction (..)
+    , delete
+    , insert
+    , query
+    )
+
+-- | Store inverse ops for a block at a given slot.
+storeRollback
+    :: RunTransaction IO cf AllColumns op
+    -> SlotNo
+    -> [CageInverseOp]
+    -> IO ()
+storeRollback RunTransaction{runTransaction = run} slot invs =
+    run
+        $ insert
+            CageRollbacks
+            slot
+            (CageRollbackEntry invs)
+
+-- | Load inverse ops for a given slot.
+loadRollback
+    :: RunTransaction IO cf AllColumns op
+    -> SlotNo
+    -> IO (Maybe [CageInverseOp])
+loadRollback RunTransaction{runTransaction = run} slot =
+    run $ do
+        mEntry <- query CageRollbacks slot
+        pure $ fmap unRollbackEntry mEntry
+
+-- | Delete stored inverse ops for a given slot.
+deleteRollback
+    :: RunTransaction IO cf AllColumns op
+    -> SlotNo
+    -> IO ()
+deleteRollback RunTransaction{runTransaction = run} slot =
+    run $ delete CageRollbacks slot
+
+-- | Roll back cage state to a target slot by replaying
+-- inverse operations for all slots after the target.
+-- Processes slots in reverse order (most recent first).
+-- Updates the checkpoint to reflect the new position.
+rollbackToSlot
+    :: State IO
+    -> TrieManager IO
+    -> RunTransaction IO cf AllColumns op
+    -> SlotNo
+    -- ^ Target slot to roll back to
+    -> IO ()
+rollbackToSlot st tm rt targetSlot = do
+    mCp <- getCheckpoint (checkpoints st)
+    case mCp of
+        Nothing -> pure ()
+        Just (_currentSlot, _blockId, activeSlots) ->
+            do
+                let slotsToRevert =
+                        reverse
+                            $ filter (> targetSlot) activeSlots
+                forM_ slotsToRevert $ \slot -> do
+                    mInvs <- loadRollback rt slot
+                    forM_ mInvs $ \invs ->
+                        applyCageInverses
+                            st
+                            tm
+                            (reverse invs)
+                    deleteRollback rt slot
+                -- Update checkpoint
+                let keptSlots =
+                        filter (<= targetSlot) activeSlots
+                    emptyBlockId =
+                        BlockId mempty
+                putCheckpoint
+                    (checkpoints st)
+                    targetSlot
+                    emptyBlockId
+                    keptSlots

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
@@ -79,14 +79,16 @@ mkMockCheckpoints :: IO (Checkpoints IO)
 mkMockCheckpoints = do
     ref <-
         newIORef
-            (Nothing :: Maybe (SlotNo, BlockId))
+            ( Nothing
+                :: Maybe (SlotNo, BlockId, [SlotNo])
+            )
     pure
         Checkpoints
             { getCheckpoint = readIORef ref
-            , putCheckpoint = \s b ->
+            , putCheckpoint = \s b slots ->
                 modifyIORef'
                     ref
-                    (const (Just (s, b)))
+                    (const (Just (s, b, slots)))
             }
 
 -- | Create a complete mock 'State IO' bundling

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
@@ -66,9 +66,12 @@ data Requests m = Requests
 -- | Interface for chain sync checkpoints.
 data Checkpoints m = Checkpoints
     { getCheckpoint
-        :: m (Maybe (SlotNo, BlockId))
-    -- ^ Get the last processed checkpoint
+        :: m (Maybe (SlotNo, BlockId, [SlotNo]))
+    -- ^ Get the last processed checkpoint:
+    -- (slot, blockId, rollbackSlots). The rollback
+    -- slots list tracks which slots have stored
+    -- inverse ops, bounded by the security parameter.
     , putCheckpoint
-        :: SlotNo -> BlockId -> m ()
-    -- ^ Store a new checkpoint
+        :: SlotNo -> BlockId -> [SlotNo] -> m ()
+    -- ^ Store a new checkpoint with rollback slots
     }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
@@ -51,9 +51,22 @@ data TrieManager m = TrieManager
     -- perform arbitrary effects — only trie
     -- operations and pure computation.
     , createTrie :: TokenId -> m ()
-    -- ^ Create a new empty trie for a token
+    -- ^ Create a new empty trie for a token.
+    -- Deletes any existing data first.
     , deleteTrie :: TokenId -> m ()
-    -- ^ Delete a token's trie
+    -- ^ Delete a token's trie (permanent removal)
+    , registerTrie :: TokenId -> m ()
+    -- ^ Register an existing trie (persistent backend
+    -- only). Makes 'withTrie' work for tries that
+    -- already have data in storage. No-op for
+    -- in-memory backends.
+    , hideTrie :: TokenId -> m ()
+    -- ^ Mark a token's trie as hidden (burn forward).
+    -- Data is preserved; 'withTrie' will fail until
+    -- 'unhideTrie' is called.
+    , unhideTrie :: TokenId -> m ()
+    -- ^ Restore a hidden token's trie to visible
+    -- (burn rollback).
     }
 
 -- | Operations on a single trie.

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
@@ -349,10 +349,12 @@ checkpointsSpec = do
                             (checkpoints st)
                             s
                             b
+                            []
                         r <-
                             getCheckpoint
                                 (checkpoints st)
-                        pure (r === Just (s, b))
+                        pure
+                            (r === Just (s, b, []))
 
     prop "put overwrites previous"
         $ forAll genSlotNo
@@ -367,16 +369,19 @@ checkpointsSpec = do
                                     (checkpoints st)
                                     s1
                                     b1
+                                    []
                                 putCheckpoint
                                     (checkpoints st)
                                     s2
                                     b2
+                                    []
                                 r <-
                                     getCheckpoint
                                         (checkpoints st)
                                 pure
                                     ( r
-                                        === Just (s2, b2)
+                                        === Just
+                                            (s2, b2, [])
                                     )
 
 -- ---------------------------------------------------------
@@ -429,13 +434,14 @@ checkpointSurvivesReopen =
                     (checkpoints st)
                     fixSlot
                     fixBlockId
+                    []
             -- Phase 2: reopen and verify
             withTestStateAt dir $ \st -> do
                 r <-
                     getCheckpoint (checkpoints st)
                 r
                     `shouldBe` Just
-                        (fixSlot, fixBlockId)
+                        (fixSlot, fixBlockId, [])
 
 -- | Put then remove a token, close DB, reopen,
 -- verify removal persisted.

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/RollbackSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/RollbackSpec.hs
@@ -1,0 +1,337 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.Indexer.RollbackSpec
+-- Description : Rollback integration tests
+-- License     : Apache-2.0
+--
+-- Ports the rollback scenarios from the original TS
+-- @state.unit.test.ts@: apply events at specific
+-- slots, rollback to a target slot, verify state.
+-- Uses mock state and pure trie manager.
+module Cardano.MPFS.Indexer.RollbackSpec (spec) where
+
+import Control.Monad (forM_)
+import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as SBS
+import Data.IORef
+    ( IORef
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    )
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromJust, fromMaybe)
+import Data.Word (Word16)
+
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldReturn
+    )
+
+import Cardano.Crypto.Hash
+    ( Blake2b_224
+    , Blake2b_256
+    , hashFromStringAsHex
+    )
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.TxIn qualified as Ledger
+
+import Cardano.MPFS.Indexer.CageEvent
+    ( CageEvent (..)
+    , CageInverseOp (..)
+    )
+import Cardano.MPFS.Indexer.CageFollower
+    ( applyCageEvent
+    , applyCageInverses
+    , computeInverse
+    )
+import Cardano.MPFS.Mock.State (mkMockState)
+import Cardano.MPFS.State
+    ( Requests (..)
+    , State (..)
+    , Tokens (..)
+    )
+import Cardano.MPFS.Trie (TrieManager (..))
+import Cardano.MPFS.Trie.PureManager
+    ( mkPureTrieManager
+    )
+import Cardano.MPFS.Types
+    ( AssetName (..)
+    , Coin (..)
+    , Operation (..)
+    , Request (..)
+    , Root (..)
+    , SlotNo
+    , TokenId (..)
+    , TokenState (..)
+    , TxIn
+    )
+
+-- | Rollback environment: state, trie manager,
+-- and inverse store (slot -> [CageInverseOp]).
+data RollbackEnv = RollbackEnv
+    { envState :: !(State IO)
+    , envTM :: !(TrieManager IO)
+    , envInvs
+        :: !(IORef (Map SlotNo [CageInverseOp]))
+    }
+
+-- | Create a fresh rollback environment.
+newRollbackEnv :: IO RollbackEnv
+newRollbackEnv = do
+    st <- mkMockState
+    tm <- mkPureTrieManager
+    ref <- newIORef Map.empty
+    pure
+        RollbackEnv
+            { envState = st
+            , envTM = tm
+            , envInvs = ref
+            }
+
+-- | Apply a cage event at a given slot, storing
+-- the inverse ops for later rollback.
+applyAtSlot
+    :: RollbackEnv -> SlotNo -> CageEvent -> IO ()
+applyAtSlot RollbackEnv{..} slot evt = do
+    cageInvs <- computeInverse envState evt
+    trieInvs <- applyCageEvent envState envTM evt
+    let allInvs = cageInvs ++ trieInvs
+    modifyIORef' envInvs
+        $ Map.insertWith (++) slot allInvs
+
+-- | Roll back to a target slot by replaying inverse
+-- ops for all slots > target in reverse order.
+-- Mirrors the logic of 'rollbackToSlot'.
+rollback :: RollbackEnv -> SlotNo -> IO ()
+rollback RollbackEnv{..} targetSlot = do
+    invMap <- readIORef envInvs
+    let slotsToRevert =
+            reverse
+                $ filter (> targetSlot)
+                $ Map.keys invMap
+    forM_ slotsToRevert $ \slot -> do
+        let invs =
+                fromMaybe [] (Map.lookup slot invMap)
+        applyCageInverses
+            envState
+            envTM
+            (reverse invs)
+        modifyIORef' envInvs (Map.delete slot)
+
+spec :: Spec
+spec = describe "Rollback" $ do
+    tokenTests
+    requestTests
+    updateTests
+
+-- ---------------------------------------------------------
+-- Token rollback tests (from state.unit.test.ts)
+-- ---------------------------------------------------------
+
+tokenTests :: Spec
+tokenTests = describe "Token rollback" $ do
+    it "can rollback a token addition" $ do
+        env <- newRollbackEnv
+        let st = envState env
+            tid = tokA
+            ts = tokStateA
+        applyAtSlot env 1 (CageBoot tid ts)
+        getToken (tokens st) tid
+            `shouldReturn` Just ts
+        rollback env 0
+        getToken (tokens st) tid
+            `shouldReturn` Nothing
+
+    it "can rollback a token removal" $ do
+        env <- newRollbackEnv
+        let st = envState env
+            tid = tokA
+            ts = tokStateA
+        applyAtSlot env 1 (CageBoot tid ts)
+        applyAtSlot env 2 (CageBurn tid)
+        getToken (tokens st) tid
+            `shouldReturn` Nothing
+        rollback env 1
+        getToken (tokens st) tid
+            `shouldReturn` Just ts
+
+    it
+        "can rollback a token removal to before \
+        \the token addition"
+        $ do
+            env <- newRollbackEnv
+            let st = envState env
+                tid = tokA
+                ts = tokStateA
+            applyAtSlot env 1 (CageBoot tid ts)
+            applyAtSlot env 2 (CageBurn tid)
+            rollback env 0
+            getToken (tokens st) tid
+                `shouldReturn` Nothing
+
+-- ---------------------------------------------------------
+-- Request rollback tests (from state.unit.test.ts)
+-- ---------------------------------------------------------
+
+requestTests :: Spec
+requestTests = describe "Request rollback" $ do
+    it "can rollback a request addition" $ do
+        env <- newRollbackEnv
+        let st = envState env
+        applyAtSlot env 1 (CageRequest txInA reqA)
+        getRequest (requests st) txInA
+            `shouldReturn` Just reqA
+        rollback env 0
+        getRequest (requests st) txInA
+            `shouldReturn` Nothing
+
+    it "can rollback a request removal" $ do
+        env <- newRollbackEnv
+        let st = envState env
+        applyAtSlot env 1 (CageRequest txInA reqA)
+        applyAtSlot env 2 (CageRetract txInA)
+        getRequest (requests st) txInA
+            `shouldReturn` Nothing
+        rollback env 1
+        getRequest (requests st) txInA
+            `shouldReturn` Just reqA
+
+    it
+        "can rollback a request removal to before \
+        \the request addition"
+        $ do
+            env <- newRollbackEnv
+            let st = envState env
+            applyAtSlot
+                env
+                1
+                (CageRequest txInA reqA)
+            applyAtSlot env 2 (CageRetract txInA)
+            rollback env 0
+            getRequest (requests st) txInA
+                `shouldReturn` Nothing
+
+-- ---------------------------------------------------------
+-- Update rollback tests (from state.unit.test.ts)
+-- ---------------------------------------------------------
+
+updateTests :: Spec
+updateTests = describe "Update rollback" $ do
+    it "can rollback a token update" $ do
+        env <- newRollbackEnv
+        let st = envState env
+            tid = tokA
+            ts = tokStateA
+            newRoot = rootB
+        applyAtSlot env 1 (CageBoot tid ts)
+        applyAtSlot
+            env
+            2
+            (CageUpdate tid newRoot [])
+        mTs <- getToken (tokens st) tid
+        fmap root mTs `shouldBe` Just newRoot
+        rollback env 1
+        mTs' <- getToken (tokens st) tid
+        fmap root mTs' `shouldBe` Just (root ts)
+
+    it
+        "can rollback a token update with \
+        \consumed requests"
+        $ do
+            env <- newRollbackEnv
+            let st = envState env
+                tid = tokA
+                ts = tokStateA
+                newRoot = rootB
+            applyAtSlot env 1 (CageBoot tid ts)
+            applyAtSlot
+                env
+                1
+                (CageRequest txInA reqA)
+            applyAtSlot
+                env
+                2
+                ( CageUpdate
+                    tid
+                    newRoot
+                    [txInA]
+                )
+            -- Request should be consumed
+            getRequest (requests st) txInA
+                `shouldReturn` Nothing
+            rollback env 1
+            -- Token root restored
+            mTs <- getToken (tokens st) tid
+            fmap root mTs
+                `shouldBe` Just (root ts)
+            -- Request restored
+            getRequest (requests st) txInA
+                `shouldReturn` Just reqA
+
+-- ---------------------------------------------------------
+-- Fixed test data
+-- ---------------------------------------------------------
+
+tokA :: TokenId
+tokA = TokenId (AssetName (SBS.toShort ("token-a" :: BS.ByteString)))
+
+tokStateA :: TokenState
+tokStateA =
+    TokenState
+        { owner = testKeyHash
+        , root = rootA
+        , maxFee = Coin 1_000_000
+        , processTime = 100
+        , retractTime = 200
+        }
+
+rootA :: Root
+rootA = Root BS.empty
+
+rootB :: Root
+rootB = Root "new-root-hash-bytes"
+
+txInA :: TxIn
+txInA = genTestTxIn 0
+
+reqA :: Request
+reqA =
+    Request
+        { requestToken = tokA
+        , requestOwner = testKeyHash
+        , requestKey = "key-1"
+        , requestValue = Insert "value-1"
+        , requestFee = Coin 500_000
+        , requestSubmittedAt = 1000
+        }
+
+-- ---------------------------------------------------------
+-- Crypto helpers (minimal, deterministic)
+-- ---------------------------------------------------------
+
+testKeyHash :: KeyHash 'Payment
+testKeyHash =
+    KeyHash
+        $ fromJust
+        $ hashFromStringAsHex @Blake2b_224
+            "0000000000000000000000000000000000000000000000000000000a"
+
+genTestTxIn :: Word16 -> TxIn
+genTestTxIn ix =
+    Ledger.TxIn
+        ( Ledger.TxId
+            $ unsafeMakeSafeHash
+            $ fromJust
+            $ hashFromStringAsHex @Blake2b_256
+                "0000000000000000000000000000000000000000000000000000000000000001"
+        )
+        (TxIx ix)

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/StateSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/StateSpec.hs
@@ -168,9 +168,9 @@ checkpointsSpec newCheckpoints = do
             forAll genBlockId $ \b ->
                 monadicIO $ do
                     cp <- run newCheckpoints
-                    run $ putCheckpoint cp s b
+                    run $ putCheckpoint cp s b []
                     r <- run $ getCheckpoint cp
-                    assert (r == Just (s, b))
+                    assert (r == Just (s, b, []))
 
     prop "put overwrites previous"
         $ forAll genSlotNo
@@ -180,7 +180,18 @@ checkpointsSpec newCheckpoints = do
                     forAll genBlockId $ \b2 ->
                         monadicIO $ do
                             cp <- run newCheckpoints
-                            run $ putCheckpoint cp s1 b1
-                            run $ putCheckpoint cp s2 b2
+                            run
+                                $ putCheckpoint
+                                    cp
+                                    s1
+                                    b1
+                                    []
+                            run
+                                $ putCheckpoint
+                                    cp
+                                    s2
+                                    b2
+                                    []
                             r <- run $ getCheckpoint cp
-                            assert (r == Just (s2, b2))
+                            assert
+                                (r == Just (s2, b2, []))

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Trie/PersistentSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Trie/PersistentSpec.hs
@@ -717,9 +717,8 @@ persistsAcrossReopen =
                     db
                     nodesCF
                     kvCF
-            -- Register token (no deletion since
-            -- fresh IORef doesn't contain it)
-            createTrie mgr reopenTidA
+            -- Register token without deleting data
+            registerTrie mgr reopenTidA
             withTrie mgr reopenTidA $ \trie -> do
                 root2 <- getRoot trie
                 root2 `shouldBe` root1
@@ -811,8 +810,8 @@ multipleToksSurviveReopen =
                             db
                             nodesCF
                             kvCF
-                    createTrie mgr reopenTidA
-                    createTrie mgr reopenTidB
+                    registerTrie mgr reopenTidA
+                    registerTrie mgr reopenTidB
                     withTrie mgr reopenTidA
                         $ \trie -> do
                             rootA2 <- getRoot trie

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -194,6 +194,12 @@ dummyTrieManager =
             error "dummyTrieManager: createTrie"
         , deleteTrie = \_ ->
             error "dummyTrieManager: deleteTrie"
+        , registerTrie = \_ ->
+            error "dummyTrieManager: registerTrie"
+        , hideTrie = \_ ->
+            error "dummyTrieManager: hideTrie"
+        , unhideTrie = \_ ->
+            error "dummyTrieManager: unhideTrie"
         }
 
 -- | Build a Provider that returns different UTxOs

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -19,6 +19,7 @@ import Cardano.MPFS.Indexer.CageFollowerSpec qualified as CageFollowerSpec
 import Cardano.MPFS.Indexer.CodecsSpec qualified as CodecsSpec
 import Cardano.MPFS.Indexer.InverseSpec qualified as InverseSpec
 import Cardano.MPFS.Indexer.PersistentSpec qualified as PersistentStateSpec
+import Cardano.MPFS.Indexer.RollbackSpec qualified as RollbackSpec
 import Cardano.MPFS.OnChainSpec qualified as OnChainSpec
 import Cardano.MPFS.ProofSpec qualified as ProofSpec
 import Cardano.MPFS.StateSpec qualified as StateSpec
@@ -52,4 +53,5 @@ main =
                 PersistentStateSpec.spec
                 ProofSpec.spec
                 OnChainSpec.spec
+                RollbackSpec.spec
                 TxBuilderSpec.spec

--- a/lean/Phase4/Domain.lean
+++ b/lean/Phase4/Domain.lean
@@ -9,12 +9,20 @@
 namespace Phase4
 
 -- Abstract types (opaque in Lean, concrete in QC)
-variable (SlotNo TokenId TxIn Root : Type)
+variable (SlotNo TokenId TxIn Root K V : Type)
 
--- Cage state: tokens + requests
-structure CageState (TokenId TxIn Root : Type) where
+-- Trie visibility (models TrieStatus)
+inductive TrieVisibility where
+  | visible
+  | hidden
+  deriving Repr, DecidableEq
+
+-- Cage state: tokens + requests + trie visibility + trie entries
+structure CageState (TokenId TxIn Root K V : Type) where
   tokens : List (TokenId × Root)
   requests : List TxIn
+  trieVisibility : TokenId → TrieVisibility
+  trieEntries : TokenId → K → Option V
 
 -- A cage event from a block
 inductive CageEvent (TokenId TxIn Root : Type) where
@@ -26,10 +34,13 @@ inductive CageEvent (TokenId TxIn Root : Type) where
   | burn (tid : TokenId)
 
 -- An inverse operation (stored for rollback)
-inductive InverseOp (TokenId TxIn Root : Type) where
+inductive InverseOp (TokenId TxIn Root K V : Type) where
   | restoreToken (tid : TokenId) (root : Root)
   | removeToken (tid : TokenId)
   | restoreRequest (txIn : TxIn)
   | removeRequest (txIn : TxIn)
+  -- Trie-level inverse ops
+  | restoreTrieEntry (tid : TokenId) (k : K) (v : V)
+  | removeTrieEntry (tid : TokenId) (k : K)
 
 end Phase4

--- a/lean/Phase4/Properties.lean
+++ b/lean/Phase4/Properties.lean
@@ -14,20 +14,27 @@ set_option linter.unusedVariables false
 
 namespace Phase4
 
-variable {SlotNo TokenId TxIn Root : Type}
+variable {SlotNo TokenId TxIn Root K V : Type}
   [DecidableEq TokenId] [DecidableEq TxIn]
-  [DecidableEq Root]
+  [DecidableEq Root] [DecidableEq K]
 
--- Apply events to cage state (reference implementation)
-def applyEvent (cs : CageState TokenId TxIn Root)
+-- =========================================================
+-- Cage state operations (reference implementation)
+-- =========================================================
+
+-- Apply events to cage state.
+-- Note: applyEvent only modifies tokens/requests.
+-- Trie visibility and entries are handled separately.
+def applyEvent (cs : CageState TokenId TxIn Root K V)
     : CageEvent TokenId TxIn Root
-    → CageState TokenId TxIn Root
+    → CageState TokenId TxIn Root K V
   | .boot tid root =>
     { cs with tokens := (tid, root) :: cs.tokens }
   | .request txIn =>
     { cs with requests := txIn :: cs.requests }
   | .update tid newRoot consumed =>
-    { tokens := cs.tokens.map fun (t, r) =>
+    { cs with
+      tokens := cs.tokens.map fun (t, r) =>
         if t == tid then (t, newRoot) else (t, r)
       requests := cs.requests.filter
         fun tx => consumed.all fun c => !(tx == c) }
@@ -38,15 +45,15 @@ def applyEvent (cs : CageState TokenId TxIn Root)
     { cs with tokens :=
         cs.tokens.filter fun (t, _) => !(t == tid) }
 
-def applyEvents (cs : CageState TokenId TxIn Root)
+def applyEvents (cs : CageState TokenId TxIn Root K V)
     (events : List (CageEvent TokenId TxIn Root))
-    : CageState TokenId TxIn Root :=
+    : CageState TokenId TxIn Root K V :=
   events.foldl applyEvent cs
 
 -- Compute inverse ops for an event given current state
-def inverseOf (cs : CageState TokenId TxIn Root)
+def inverseOf (cs : CageState TokenId TxIn Root K V)
     : CageEvent TokenId TxIn Root
-    → List (InverseOp TokenId TxIn Root)
+    → List (InverseOp TokenId TxIn Root K V)
   | .boot tid _ => [.removeToken tid]
   | .request txIn => [.removeRequest txIn]
   | .update tid _ consumed =>
@@ -64,10 +71,10 @@ def inverseOf (cs : CageState TokenId TxIn Root)
     | some (_, r) => [.restoreToken tid r]
     | none => []
 
--- Apply an inverse op
-def applyInv (cs : CageState TokenId TxIn Root)
-    : InverseOp TokenId TxIn Root
-    → CageState TokenId TxIn Root
+-- Apply an inverse op to cage state
+def applyInv (cs : CageState TokenId TxIn Root K V)
+    : InverseOp TokenId TxIn Root K V
+    → CageState TokenId TxIn Root K V
   | .restoreToken tid root =>
     { cs with tokens := (tid, root) :: cs.tokens }
   | .removeToken tid =>
@@ -78,56 +85,64 @@ def applyInv (cs : CageState TokenId TxIn Root)
   | .removeRequest txIn =>
     { cs with requests :=
         cs.requests.filter fun tx => !(tx == txIn) }
+  | .restoreTrieEntry tid k v =>
+    { cs with trieEntries := fun t k' =>
+        if t == tid && k' == k then some v
+        else cs.trieEntries t k' }
+  | .removeTrieEntry tid k =>
+    { cs with trieEntries := fun t k' =>
+        if t == tid && k' == k then none
+        else cs.trieEntries t k' }
 
-def applyInvs (cs : CageState TokenId TxIn Root)
-    (invs : List (InverseOp TokenId TxIn Root))
-    : CageState TokenId TxIn Root :=
+def applyInvs (cs : CageState TokenId TxIn Root K V)
+    (invs : List (InverseOp TokenId TxIn Root K V))
+    : CageState TokenId TxIn Root K V :=
   invs.foldl applyInv cs
 
--- -------------------------------------------------------
--- PROPERTY 1: Atomic block processing
---
--- QC: process a block in a single RocksDB transaction,
--- read back all three domains, verify they match the
--- reference model.
--- -------------------------------------------------------
+-- =========================================================
+-- Trie visibility operations (reference)
+-- =========================================================
+
+/-- Hide a token's trie (burn forward operation). -/
+def hideTrie (cs : CageState TokenId TxIn Root K V)
+    (tid : TokenId)
+    : CageState TokenId TxIn Root K V :=
+  { cs with trieVisibility := fun t =>
+      if t == tid then .hidden else cs.trieVisibility t }
+
+/-- Unhide a token's trie (burn rollback operation). -/
+def unhideTrie (cs : CageState TokenId TxIn Root K V)
+    (tid : TokenId)
+    : CageState TokenId TxIn Root K V :=
+  { cs with trieVisibility := fun t =>
+      if t == tid then .visible
+      else cs.trieVisibility t }
+
+-- =========================================================
+-- PROPERTIES 1-5: Original cage state properties
+-- =========================================================
 
 /-- After processing events, the DB state matches the
     reference model applied to the pre-block state. -/
 def prop_atomicBlockProcessing
-    (pre : CageState TokenId TxIn Root)
+    (pre : CageState TokenId TxIn Root K V)
     (events : List (CageEvent TokenId TxIn Root))
-    (dbPost : CageState TokenId TxIn Root)
+    (dbPost : CageState TokenId TxIn Root K V)
     : Prop :=
   dbPost = applyEvents pre events
-
--- -------------------------------------------------------
--- PROPERTY 2: Rollback correctness
---
--- QC: process N blocks, rollback to block K, verify
--- state matches state-at-K.
--- -------------------------------------------------------
 
 /-- Processing blocks then rolling back via inverse ops
     restores the original state. -/
 def prop_rollbackCorrectness
-    (pre : CageState TokenId TxIn Root)
+    (pre : CageState TokenId TxIn Root K V)
     (event : CageEvent TokenId TxIn Root)
-    (post : CageState TokenId TxIn Root)
-    (rolled : CageState TokenId TxIn Root)
+    (post : CageState TokenId TxIn Root K V)
+    (rolled : CageState TokenId TxIn Root K V)
     : Prop :=
   let invs := inverseOf pre event
   post = applyEvent pre event
   → rolled = applyInvs post invs
   → rolled = pre
-
--- -------------------------------------------------------
--- PROPERTY 3: Trie-state consistency
---
--- QC: after processing a block with an Update event,
--- the trie root in the DB matches the root stored in
--- the token's state.
--- -------------------------------------------------------
 
 /-- After an update event, the token's stored root equals
     the trie's actual root. -/
@@ -137,34 +152,20 @@ def prop_trieStateConsistency
     : Prop :=
   tokenRoot = trieRoot
 
--- -------------------------------------------------------
--- PROPERTY 4: Inverse op round-trip
---
--- QC: for any event applied to any state, applying the
--- inverse restores the original.
--- -------------------------------------------------------
-
 /-- Applying an event then its inverse is identity on
     cage state. -/
 def prop_inverseRoundTrip
-    (pre : CageState TokenId TxIn Root)
+    (pre : CageState TokenId TxIn Root K V)
     (event : CageEvent TokenId TxIn Root)
     : Prop :=
   let post := applyEvent pre event
   let invs := inverseOf pre event
   applyInvs post invs = pre
 
--- -------------------------------------------------------
--- PROPERTY 5: Multi-block rollback
---
--- QC: process a sequence of blocks collecting inverses,
--- roll them all back in reverse, get original state.
--- -------------------------------------------------------
-
 /-- Collecting inverses for a sequence of events and
     replaying them in reverse restores the original. -/
 def prop_multiBlockRollback
-    (pre : CageState TokenId TxIn Root)
+    (pre : CageState TokenId TxIn Root K V)
     (events : List (CageEvent TokenId TxIn Root))
     : Prop :=
   let (final, allInvs) := events.foldl
@@ -177,17 +178,14 @@ def prop_multiBlockRollback
     final
   restored = pre
 
--- -------------------------------------------------------
--- PROPERTY 6: Boot/Burn symmetry
---
--- QC: boot a fresh token then burn it; the state
--- should be unchanged.
--- -------------------------------------------------------
+-- =========================================================
+-- PROPERTIES 6-10: Original structural properties
+-- =========================================================
 
 /-- Booting then burning a fresh token restores the
     original state (when the token wasn't present). -/
 def prop_bootBurnRoundTrip
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tid : TokenId) (root : Root)
     (hFresh : ∀ r, (tid, r) ∉ cs.tokens)
     : Prop :=
@@ -195,18 +193,10 @@ def prop_bootBurnRoundTrip
     (applyEvent cs (.boot tid root)) (.burn tid)
     = cs
 
--- -------------------------------------------------------
--- PROPERTY 7: Request/Retract symmetry
---
--- QC: submit a request then retract it; the state
--- should be unchanged.
--- -------------------------------------------------------
-
 /-- Requesting then retracting a fresh TxIn restores
-    the original state (when the TxIn wasn't present).
-    -/
+    the original state. -/
 def prop_requestRetractRoundTrip
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     (hFresh : txIn ∉ cs.requests)
     : Prop :=
@@ -214,17 +204,10 @@ def prop_requestRetractRoundTrip
     (applyEvent cs (.request txIn)) (.retract txIn)
     = cs
 
--- -------------------------------------------------------
--- PROPERTY 8: Update preserves non-target tokens
---
--- QC: after an update on token A, token B (B ≠ A)
--- still has its original root.
--- -------------------------------------------------------
-
 /-- An update for one token does not affect other
     tokens' state entries. -/
 def prop_updatePreservesOtherTokens
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tidA tidB : TokenId) (newRoot rootB : Root)
     (consumed : List TxIn)
     (hNeq : tidA ≠ tidB)
@@ -234,15 +217,9 @@ def prop_updatePreservesOtherTokens
     ∈ (applyEvent cs
         (.update tidA newRoot consumed)).tokens
 
--- -------------------------------------------------------
--- PROPERTY 9: Burn only removes target
---
--- QC: burning token A preserves token B (B ≠ A).
--- -------------------------------------------------------
-
 /-- Burning one token preserves all other tokens. -/
 def prop_burnPreservesOtherTokens
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tidA tidB : TokenId) (rootB : Root)
     (hNeq : tidA ≠ tidB)
     (hMem : (tidB, rootB) ∈ cs.tokens)
@@ -250,16 +227,9 @@ def prop_burnPreservesOtherTokens
   (tidB, rootB)
     ∈ (applyEvent cs (.burn tidA)).tokens
 
--- -------------------------------------------------------
--- PROPERTY 10: Inverse correctness per event type
---
--- QC: verify the specific inverse ops produced for
--- each event type are correct.
--- -------------------------------------------------------
-
 /-- Boot's inverse is exactly [removeToken tid]. -/
 def prop_inverseOfBootCorrect
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tid : TokenId) (root : Root)
     : Prop :=
   inverseOf cs (.boot tid root)
@@ -268,7 +238,7 @@ def prop_inverseOfBootCorrect
 /-- Request's inverse is exactly
     [removeRequest txIn]. -/
 def prop_inverseOfRequestCorrect
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : Prop :=
   inverseOf cs (.request txIn)
@@ -277,10 +247,118 @@ def prop_inverseOfRequestCorrect
 /-- Retract's inverse is exactly
     [restoreRequest txIn]. -/
 def prop_inverseOfRetractCorrect
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : Prop :=
   inverseOf cs (.retract txIn)
     = [.restoreRequest txIn]
+
+-- =========================================================
+-- PROPERTIES 11-15: Trie rollback properties (NEW)
+-- =========================================================
+
+-- -------------------------------------------------------
+-- PROPERTY 11: Hide/unhide round-trip
+--
+-- QC: create → insert → hide → unhide → withTrie
+-- succeeds, lookup works.
+-- -------------------------------------------------------
+
+/-- Hiding then unhiding preserves visibility. -/
+def prop_hideUnhideRoundTrip
+    (tid : TokenId)
+    (cs : CageState TokenId TxIn Root K V)
+    (hVis : cs.trieVisibility tid = .visible)
+    : Prop :=
+  (unhideTrie (hideTrie cs tid) tid).trieVisibility tid
+    = .visible
+
+-- -------------------------------------------------------
+-- PROPERTY 12: Hide preserves trie data
+--
+-- QC: create → insert → hide → unhide → lookup
+-- returns same value.
+-- -------------------------------------------------------
+
+/-- Hiding doesn't touch trie entries. -/
+def prop_hidePreservesTrieData
+    (tid : TokenId) (k : K)
+    (cs : CageState TokenId TxIn Root K V)
+    : Prop :=
+  (hideTrie cs tid).trieEntries tid k
+    = cs.trieEntries tid k
+
+-- -------------------------------------------------------
+-- PROPERTY 13: Trie inverse round-trip
+--
+-- QC: insert key → compute inverse → apply inverse →
+-- lookup = Nothing (if was absent) or old value.
+-- -------------------------------------------------------
+
+/-- Inserting then applying removeTrieEntry restores
+    absence (when key was previously absent). -/
+def prop_trieInsertRemoveRoundTrip
+    (tid : TokenId) (k : K) (v : V)
+    (cs : CageState TokenId TxIn Root K V)
+    (hAbsent : cs.trieEntries tid k = none)
+    : Prop :=
+  let inserted : CageState TokenId TxIn Root K V :=
+    { cs with trieEntries := fun t k' =>
+        if t == tid && k' == k then some v
+        else cs.trieEntries t k' }
+  let inv := InverseOp.removeTrieEntry (K := K) (V := V)
+        tid k
+  (applyInv inserted inv).trieEntries tid k
+    = cs.trieEntries tid k
+
+/-- Deleting then applying restoreTrieEntry restores
+    the original value. -/
+def prop_trieDeleteRestoreRoundTrip
+    (tid : TokenId) (k : K) (v : V)
+    (cs : CageState TokenId TxIn Root K V)
+    (hPresent : cs.trieEntries tid k = some v)
+    : Prop :=
+  let deleted : CageState TokenId TxIn Root K V :=
+    { cs with trieEntries := fun t k' =>
+        if t == tid && k' == k then none
+        else cs.trieEntries t k' }
+  let inv := InverseOp.restoreTrieEntry tid k v
+  (applyInv deleted inv).trieEntries tid k
+    = cs.trieEntries tid k
+
+-- -------------------------------------------------------
+-- PROPERTY 14: Burn rollback restores trie
+--
+-- QC: create → insert → burn(hide) →
+-- rollback(unhide) → lookup returns value.
+-- -------------------------------------------------------
+
+/-- Burning (hiding) then restoring (unhiding) preserves
+    trie data for the burned token. -/
+def prop_burnRollbackRestoresTrie
+    (tid : TokenId) (k : K)
+    (cs : CageState TokenId TxIn Root K V)
+    : Prop :=
+  let burned := hideTrie cs tid
+  let restored := unhideTrie burned tid
+  restored.trieEntries tid k = cs.trieEntries tid k
+
+-- -------------------------------------------------------
+-- PROPERTY 15: Hide preserves other tokens
+--
+-- QC: create A & B → insert into both → hide A →
+-- B lookup unchanged.
+-- -------------------------------------------------------
+
+/-- Hiding token A doesn't affect token B's entries
+    or visibility. -/
+def prop_hidePreservesOtherTokens
+    (tidA tidB : TokenId) (k : K)
+    (hNeq : tidA ≠ tidB)
+    (cs : CageState TokenId TxIn Root K V)
+    : Prop :=
+  let hidden := hideTrie cs tidA
+  hidden.trieEntries tidB k = cs.trieEntries tidB k
+  ∧ hidden.trieVisibility tidB = cs.trieVisibility tidB
 
 end Phase4

--- a/lean/Phase4/Theorems.lean
+++ b/lean/Phase4/Theorems.lean
@@ -12,9 +12,9 @@ set_option linter.unusedSectionVars false
 
 namespace Phase4
 
-variable {SlotNo TokenId TxIn Root : Type}
+variable {SlotNo TokenId TxIn Root K V : Type}
   [DecidableEq TokenId] [DecidableEq TxIn]
-  [DecidableEq Root]
+  [DecidableEq Root] [DecidableEq K]
 
 -- -------------------------------------------------------
 -- Membership after events
@@ -22,7 +22,7 @@ variable {SlotNo TokenId TxIn Root : Type}
 
 /-- After booting a token, it is in the token set. -/
 theorem boot_mem_tokens
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tid : TokenId) (root : Root)
     : (tid, root) ∈
         (applyEvent cs (.boot tid root)).tokens :=
@@ -31,7 +31,7 @@ theorem boot_mem_tokens
 /-- After submitting a request, it is in the request
     set. -/
 theorem request_mem_requests
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : txIn ∈
         (applyEvent cs (.request txIn)).requests :=
@@ -39,7 +39,7 @@ theorem request_mem_requests
 
 /-- Pre-existing tokens survive a boot event. -/
 theorem boot_preserves_mem
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tid : TokenId) (root : Root)
     (x : TokenId × Root) (h : x ∈ cs.tokens)
     : x ∈
@@ -48,7 +48,7 @@ theorem boot_preserves_mem
 
 /-- Pre-existing requests survive a request event. -/
 theorem request_preserves_mem
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn) (x : TxIn) (h : x ∈ cs.requests)
     : x ∈
         (applyEvent cs (.request txIn)).requests :=
@@ -60,7 +60,7 @@ theorem request_preserves_mem
 
 /-- Boot does not affect the request set. -/
 theorem boot_preserves_requests
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tid : TokenId) (root : Root)
     : (applyEvent cs (.boot tid root)).requests
       = cs.requests :=
@@ -68,7 +68,7 @@ theorem boot_preserves_requests
 
 /-- Request does not affect the token set. -/
 theorem request_preserves_tokens
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : (applyEvent cs (.request txIn)).tokens
       = cs.tokens :=
@@ -76,7 +76,7 @@ theorem request_preserves_tokens
 
 /-- Burn does not affect the request set. -/
 theorem burn_preserves_requests
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tid : TokenId)
     : (applyEvent cs (.burn tid)).requests
       = cs.requests :=
@@ -84,7 +84,7 @@ theorem burn_preserves_requests
 
 /-- Retract does not affect the token set. -/
 theorem retract_preserves_tokens
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : (applyEvent cs (.retract txIn)).tokens
       = cs.tokens :=
@@ -96,21 +96,21 @@ theorem retract_preserves_tokens
 
 /-- Boot produces exactly one inverse op. -/
 theorem inverse_boot_length
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tid : TokenId) (root : Root)
     : (inverseOf cs (.boot tid root)).length = 1 :=
   rfl
 
 /-- Request produces exactly one inverse op. -/
 theorem inverse_request_length
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : (inverseOf cs (.request txIn)).length = 1 :=
   rfl
 
 /-- Retract produces exactly one inverse op. -/
 theorem inverse_retract_length
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : (inverseOf cs (.retract txIn)).length = 1 :=
   rfl
@@ -121,7 +121,7 @@ theorem inverse_retract_length
 
 /-- Boot's inverse is a removeToken. -/
 theorem inverse_boot_eq
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (tid : TokenId) (root : Root)
     : inverseOf cs (.boot tid root)
       = [.removeToken tid] :=
@@ -129,7 +129,7 @@ theorem inverse_boot_eq
 
 /-- Request's inverse is a removeRequest. -/
 theorem inverse_request_eq
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : inverseOf cs (.request txIn)
       = [.removeRequest txIn] :=
@@ -137,7 +137,7 @@ theorem inverse_request_eq
 
 /-- Retract's inverse is a restoreRequest. -/
 theorem inverse_retract_eq
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (txIn : TxIn)
     : inverseOf cs (.retract txIn)
       = [.restoreRequest txIn] :=
@@ -149,15 +149,129 @@ theorem inverse_retract_eq
 
 /-- Processing an empty event list is the identity. -/
 theorem applyEvents_nil
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     : applyEvents cs [] = cs :=
   rfl
 
 /-- Processing a singleton list is applyEvent. -/
 theorem applyEvents_singleton
-    (cs : CageState TokenId TxIn Root)
+    (cs : CageState TokenId TxIn Root K V)
     (e : CageEvent TokenId TxIn Root)
     : applyEvents cs [e] = applyEvent cs e :=
   rfl
+
+-- -------------------------------------------------------
+-- Trie visibility theorems (NEW)
+-- -------------------------------------------------------
+
+set_option linter.unusedVariables false in
+/-- Hide/unhide is identity on visibility for the
+    target token. -/
+theorem hide_unhide_identity
+    (tid : TokenId)
+    (cs : CageState TokenId TxIn Root K V)
+    (hVis : cs.trieVisibility tid = .visible)
+    : (unhideTrie (hideTrie cs tid) tid).trieVisibility tid
+      = .visible := by
+  simp [hideTrie, unhideTrie]
+
+/-- Hiding preserves trie data (by construction —
+    only changes visibility). -/
+theorem hide_preserves_data
+    (tid : TokenId) (k : K)
+    (cs : CageState TokenId TxIn Root K V)
+    : (hideTrie cs tid).trieEntries tid k
+      = cs.trieEntries tid k := by
+  simp [hideTrie]
+
+/-- Hiding token A preserves token B's visibility. -/
+theorem hide_preserves_other_visibility
+    (tidA tidB : TokenId)
+    (hNeq : tidA ≠ tidB)
+    (cs : CageState TokenId TxIn Root K V)
+    : (hideTrie cs tidA).trieVisibility tidB
+      = cs.trieVisibility tidB := by
+  simp [hideTrie]
+  intro h
+  exact absurd h.symm hNeq
+
+set_option linter.unusedVariables false in
+/-- Hiding token A preserves token B's trie entries. -/
+theorem hide_preserves_other_entries
+    (tidA tidB : TokenId) (k : K)
+    (hNeq : tidA ≠ tidB)
+    (cs : CageState TokenId TxIn Root K V)
+    : (hideTrie cs tidA).trieEntries tidB k
+      = cs.trieEntries tidB k := by
+  simp [hideTrie]
+
+-- -------------------------------------------------------
+-- Trie inverse op theorems (NEW)
+-- -------------------------------------------------------
+
+/-- Inserting then removing a trie entry restores
+    the original absence. -/
+theorem trie_inverse_insert_remove
+    (tid : TokenId) (k : K) (v : V)
+    (cs : CageState TokenId TxIn Root K V)
+    (hAbsent : cs.trieEntries tid k = none)
+    : let inserted : CageState TokenId TxIn Root K V :=
+        { cs with trieEntries := fun t k' =>
+            if t == tid && k' == k then some v
+            else cs.trieEntries t k' }
+      let inv := InverseOp.removeTrieEntry
+            (K := K) (V := V) tid k
+      (applyInv inserted inv).trieEntries tid k
+        = cs.trieEntries tid k := by
+  simp [applyInv]
+  exact hAbsent.symm
+
+/-- Deleting then restoring a trie entry recovers
+    the original value. -/
+theorem trie_inverse_delete_restore
+    (tid : TokenId) (k : K) (v : V)
+    (cs : CageState TokenId TxIn Root K V)
+    (hPresent : cs.trieEntries tid k = some v)
+    : let deleted : CageState TokenId TxIn Root K V :=
+        { cs with trieEntries := fun t k' =>
+            if t == tid && k' == k then none
+            else cs.trieEntries t k' }
+      let inv := InverseOp.restoreTrieEntry tid k v
+      (applyInv deleted inv).trieEntries tid k
+        = cs.trieEntries tid k := by
+  simp [applyInv]
+  exact hPresent.symm
+
+-- -------------------------------------------------------
+-- Burn rollback theorem (NEW)
+-- -------------------------------------------------------
+
+/-- Burning (hide) then restoring (unhide) preserves
+    trie data. -/
+theorem burn_rollback_preserves_trie
+    (tid : TokenId) (k : K)
+    (cs : CageState TokenId TxIn Root K V)
+    : let burned := hideTrie cs tid
+      let restored := unhideTrie burned tid
+      restored.trieEntries tid k = cs.trieEntries tid k := by
+  simp [hideTrie, unhideTrie]
+
+-- -------------------------------------------------------
+-- Combined hide/unhide theorem for other tokens (NEW)
+-- -------------------------------------------------------
+
+/-- Hiding token A preserves both entries and visibility
+    of token B. -/
+theorem hide_preserves_other_tokens
+    (tidA tidB : TokenId) (k : K)
+    (hNeq : tidA ≠ tidB)
+    (cs : CageState TokenId TxIn Root K V)
+    : (hideTrie cs tidA).trieEntries tidB k
+        = cs.trieEntries tidB k
+      ∧ (hideTrie cs tidA).trieVisibility tidB
+        = cs.trieVisibility tidB := by
+  constructor
+  · exact hide_preserves_other_entries tidA tidB k hNeq cs
+  · exact hide_preserves_other_visibility tidA tidB hNeq cs
 
 end Phase4


### PR DESCRIPTION
Closes #34

## Summary

- Lean formalization (Phase4): `TrieVisibility`, trie inverse ops, 5 properties + 5 theorems for hide/unhide and trie mutation rollback
- `CageInverseOp` gains `InvTrieInsert`/`InvTrieDelete` for trie-level rollback
- `CageBurn` now hides tries (preserves data) instead of deleting; `TrieManager` gains `hideTrie`/`unhideTrie`/`registerTrie`
- `CageRollbacks` column family + CBOR codecs for persisting inverse ops per slot
- `CageCheckpoint` extended with `rollbackSlots` field
- New `Indexer.Rollback` module with `rollbackToSlot`
- Fix flaky "speculative read-your-writes" test: `persistentCreateTrie` always cleans stale data; reopen tests use `registerTrie`

## Test plan

- [x] 249 examples, 0 failures (3 consecutive runs, flaky test fixed)
- [x] 8 new rollback integration tests ported from TS `state.unit.test.ts`
- [x] 4 hide/unhide trie manager tests (both pure and persistent backends)
- [x] 3 new codec round-trip tests (`slotNoPrism`, `rollbackEntryPrism`, updated `checkpointPrism`)
- [x] Lean theorems compile (`lake build`)
- [x] Fourmolu formatted