### PR TITLE
fix: scale ExUnits for batch update redeemers

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
@@ -39,6 +39,8 @@ module Cardano.MPFS.TxBuilder.Real.Internal
       -- * Execution units
     , defaultMintExUnits
     , defaultSpendExUnits
+    , modifyExUnits
+    , contributeExUnits
 
       -- * Script integrity
     , computeScriptIntegrity
@@ -189,6 +191,23 @@ defaultMintExUnits =
 defaultSpendExUnits :: ExUnits
 defaultSpendExUnits =
     ExUnits 14_000_000 500_000_000
+
+-- | Execution units for the @Modify@ redeemer,
+-- scaled by the number of proofs. Each proof
+-- adds roughly 500M CPU steps for the on-chain
+-- MPF fold.
+modifyExUnits :: Int -> ExUnits
+modifyExUnits nProofs =
+    ExUnits
+        14_000_000
+        (fromIntegral nProofs * 500_000_000)
+
+-- | Execution units for the @Contribute@ redeemer.
+-- Contribute just checks the request token matches
+-- the state token — much cheaper than @Modify@.
+contributeExUnits :: ExUnits
+contributeExUnits =
+    ExUnits 200_000 100_000_000
 
 -- | Build the cage 'Script' from config bytes.
 mkCageScript :: CageConfig -> Script ConwayEra

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -208,7 +208,7 @@ updateTokenImpl cfg prov _st tm tid addr = do
                     in  ( ConwaySpending (AsIx ix)
                         ,
                             ( toLedgerData rdm
-                            , defaultSpendExUnits
+                            , contributeExUnits
                             )
                         )
                 )
@@ -220,7 +220,8 @@ updateTokenImpl cfg prov _st tm tid addr = do
                         (AsIx stateIx)
                   ,
                       ( toLedgerData modifyRedeemer
-                      , defaultSpendExUnits
+                      , modifyExUnits
+                            (length proofs)
                       )
                   )
                     : contributeEntries


### PR DESCRIPTION
## Summary

- Scale `Modify` redeemer ExUnits by number of proofs (500M steps per proof) — the flat 500M budget was too low for 2+ proofs causing `PlutusFailure`
- Use lighter `Contribute` ExUnits (200K mem, 100M steps) matching the working TS implementation
- Add `modifyExUnits` and `contributeExUnits` to `Internal.hs`

## Analysis

The on-chain MPF fold in `validRootUpdate` runs one `mpf.insert`/`delete`/`update` per request. With 2 proofs the computation exceeds the flat 500M step budget, causing the Plutus evaluator to terminate the script. The TS version uses 1B steps for Modify — this fix scales linearly instead.

Follow-up: #51 (implement `evaluateTx` for precise budgets)

Closes #36

## Test plan

- [x] Unit tests pass (249/249)
- [ ] E2E "batch update (2 requests)" test passes with Cardano node
- [ ] Single-request updates still work