### PR TITLE
feat: implement endToken (burn) tx builder

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -111,6 +111,7 @@ library
     Cardano.MPFS.TxBuilder.Config
     Cardano.MPFS.TxBuilder.Real
     Cardano.MPFS.TxBuilder.Real.Boot
+    Cardano.MPFS.TxBuilder.Real.End
     Cardano.MPFS.TxBuilder.Real.Internal
     Cardano.MPFS.TxBuilder.Real.Request
     Cardano.MPFS.TxBuilder.Real.Retract

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
@@ -31,6 +31,9 @@ import Cardano.MPFS.TxBuilder.Config
 import Cardano.MPFS.TxBuilder.Real.Boot
     ( bootTokenImpl
     )
+import Cardano.MPFS.TxBuilder.Real.End
+    ( endTokenImpl
+    )
 import Cardano.MPFS.TxBuilder.Real.Internal
     ( computeScriptHash
     , extractCageDatum
@@ -67,8 +70,5 @@ mkRealTxBuilder cfg prov st tm =
             updateTokenImpl cfg prov st tm
         , retractRequest =
             retractRequestImpl cfg prov st
-        , endToken = \_ _ ->
-            error
-                "mkRealTxBuilder: endToken \
-                \not yet implemented"
+        , endToken = endTokenImpl cfg prov
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
@@ -1,0 +1,178 @@
+-- |
+-- Module      : Cardano.MPFS.TxBuilder.Real.End
+-- Description : End token (burn) transaction
+-- License     : Apache-2.0
+module Cardano.MPFS.TxBuilder.Real.End
+    ( endTokenImpl
+    ) where
+
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Lens.Micro ((&), (.~), (^.))
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
+import Cardano.Ledger.Alonzo.TxBody
+    ( reqSignerHashesTxBodyL
+    , scriptIntegrityHashTxBodyL
+    )
+import Cardano.Ledger.Api.Tx
+    ( Tx
+    , mkBasicTx
+    , witsTxL
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( collateralInputsTxBodyL
+    , inputsTxBodyL
+    , mintTxBodyL
+    , mkBasicTxBody
+    )
+import Cardano.Ledger.Api.Tx.Wits
+    ( Redeemers (..)
+    , rdmrsTxWitsL
+    , scriptTxWitsL
+    )
+import Cardano.Ledger.Conway.Scripts
+    ( ConwayPlutusPurpose (..)
+    )
+import Cardano.Ledger.Core (hashScript)
+import Cardano.Ledger.Mary.Value
+    ( MultiAsset (..)
+    )
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    )
+
+import Cardano.MPFS.Balance (balanceTx)
+import Cardano.MPFS.OnChain
+    ( CageDatum (..)
+    , MintRedeemer (..)
+    , OnChainTokenState (..)
+    , UpdateRedeemer (..)
+    )
+import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.TxBuilder.Config
+    ( CageConfig (..)
+    )
+import Cardano.MPFS.TxBuilder.Real.Internal
+import Cardano.MPFS.Types
+    ( ConwayEra
+    , TokenId (..)
+    )
+
+import Data.List (sortOn)
+import Data.Ord (Down (..))
+
+import Cardano.Ledger.Api.Tx.Out (coinTxOutL)
+
+-- | Build an end-token (burn) transaction.
+--
+-- Consumes the state UTxO with an @End@ spending
+-- redeemer, mints -1 of the cage token with a
+-- @Burning@ minting redeemer, and returns remaining
+-- ADA to the owner. The token is permanently
+-- destroyed.
+endTokenImpl
+    :: CageConfig
+    -> Provider IO
+    -> TokenId
+    -> Addr
+    -> IO (Tx ConwayEra)
+endTokenImpl cfg prov tid addr = do
+    -- 1. Query cage UTxOs
+    let scriptAddr =
+            cageAddrFromCfg cfg (network cfg)
+    cageUtxos <- queryUTxOs prov scriptAddr
+    -- 2. Find state UTxO
+    let policyId = cagePolicyIdFromCfg cfg
+    stateUtxo <-
+        case findStateUtxo policyId tid cageUtxos of
+            Nothing ->
+                error
+                    "endToken: state UTxO not found"
+            Just x -> pure x
+    let (stateIn, stateOut) = stateUtxo
+    -- 3. Extract owner from state datum
+    let OnChainTokenState
+            { stateOwner =
+                BuiltinByteString ownerBs
+            } = case extractCageDatum stateOut of
+                Just (StateDatum s) -> s
+                _ ->
+                    error
+                        "endToken: invalid state datum"
+        ownerKh = addrWitnessKeyHash ownerBs
+    -- 4. Get wallet UTxO for fees
+    pp <- queryProtocolParams prov
+    walletUtxos <- queryUTxOs prov addr
+    feeUtxo <- case sortOn
+        (Down . (^. coinTxOutL) . snd)
+        walletUtxos of
+        [] -> error "endToken: no UTxOs"
+        (u : _) -> pure u
+    -- 5. Build mint value (-1 token)
+    let assetName = unTokenId tid
+        burnMA =
+            MultiAsset
+                $ Map.singleton policyId
+                $ Map.singleton assetName (-1)
+    -- 6. Build redeemers
+    let script = mkCageScript cfg
+        scriptHash = hashScript script
+        allInputs =
+            Set.fromList [stateIn, fst feeUtxo]
+        stateIx =
+            spendingIndex stateIn allInputs
+        spendRedeemer = End
+        mintRedeemer = Burning
+        redeemers =
+            Redeemers
+                $ Map.fromList
+                    [
+                        ( ConwaySpending
+                            (AsIx stateIx)
+                        ,
+                            ( toLedgerData spendRedeemer
+                            , defaultSpendExUnits
+                            )
+                        )
+                    ,
+                        ( ConwayMinting (AsIx 0)
+                        ,
+                            ( toLedgerData mintRedeemer
+                            , defaultMintExUnits
+                            )
+                        )
+                    ]
+        integrity =
+            computeScriptIntegrity pp redeemers
+    -- 7. Build tx body
+    let body =
+            mkBasicTxBody
+                & inputsTxBodyL
+                    .~ Set.singleton stateIn
+                & mintTxBodyL .~ burnMA
+                & collateralInputsTxBodyL
+                    .~ Set.singleton
+                        (fst feeUtxo)
+                & reqSignerHashesTxBodyL
+                    .~ Set.singleton ownerKh
+                & scriptIntegrityHashTxBodyL
+                    .~ integrity
+        tx =
+            mkBasicTx body
+                & witsTxL . scriptTxWitsL
+                    .~ Map.singleton
+                        scriptHash
+                        script
+                & witsTxL . rdmrsTxWitsL
+                    .~ redeemers
+    case balanceTx
+        pp
+        [feeUtxo, stateUtxo]
+        addr
+        tx of
+        Left err ->
+            error
+                $ "endToken: " <> show err
+        Right balanced -> pure balanced


### PR DESCRIPTION
## Summary

- New module `TxBuilder.Real.End` — builds burn transaction that spends the state UTxO with `End` redeemer and mints -1 of the cage token with `Burning` redeemer
- 5 unit tests: balanced tx, burns exactly one token, script witness, spending+minting redeemers, consumes state UTxO
- E2E test: boot → burn → verify `CageBurn` event detected and token removed from state (replaces `pending` placeholder)

Closes #35