### PR TITLE
Add just docs recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,6 +96,10 @@ e2e match="":
             --test-option="{{ match }}"
     fi
 
+# Serve documentation locally
+docs:
+    mkdocs serve
+
 # Clean build artifacts
 clean:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- Add `just docs` recipe to serve MkDocs documentation locally

## Test plan
- [ ] Run `just docs` and verify docs serve at http://127.0.0.1:8000/cardano-mpfs-offchain/