### PR TITLE
docs: deepen haddock across all 45 library modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist-newstyle/
 .llm/
 result
 .direnv/
+.hoogle/

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -3,9 +3,20 @@
 -- Description : Application wiring and lifecycle
 -- License     : Apache-2.0
 --
--- Wires all service interfaces into a 'Context IO'
--- backed by a real N2C node connection, persistent
--- RocksDB state, and persistent trie management.
+-- Top-level wiring module that assembles all
+-- service interfaces into a fully operational
+-- 'Context IO'. The bracket 'withApplication' opens
+-- a shared RocksDB database, connects to a local
+-- Cardano node via N2C, and builds the production
+-- 'Provider', 'Submitter', persistent 'State',
+-- persistent 'TrieManager', real 'TxBuilder', and a
+-- skeleton 'Indexer'. On exit it cancels the node
+-- connection thread and closes the database.
+--
+-- Optionally seeds a fresh database from a CBOR
+-- bootstrap file (see "Cardano.MPFS.Core.Bootstrap")
+-- so chain sync can resume from the bootstrap point
+-- rather than genesis.
 module Cardano.MPFS.Application
     ( -- * Configuration
       AppConfig (..)
@@ -121,7 +132,11 @@ cageColumnFamilies =
 -- wires real Provider, Submitter, persistent State
 -- and TrieManager, and tears down on exit.
 withApplication
-    :: AppConfig -> (Context IO -> IO a) -> IO a
+    :: AppConfig
+    -- ^ Application configuration
+    -> (Context IO -> IO a)
+    -- ^ Action receiving the fully wired context
+    -> IO a
 withApplication cfg action =
     withDBCF
         (dbPath cfg)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
@@ -2,6 +2,14 @@
 -- Module      : Cardano.MPFS.Context
 -- Description : Facade bundling all singleton interfaces
 -- License     : Apache-2.0
+--
+-- Top-level product type that bundles every service
+-- interface into a single value. Constructed once at
+-- application startup (see "Cardano.MPFS.Application")
+-- and threaded to all callers. Parametric in the
+-- effect @m@ so both real ('IO') and mock
+-- ('Control.Monad.State.Strict.StateT') code share
+-- the same record shape.
 module Cardano.MPFS.Context
     ( -- * Context
       Context (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Balance.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Balance.hs
@@ -5,9 +5,16 @@
 -- Description : Simple transaction balancing
 -- License     : Apache-2.0
 --
--- Balance a transaction by adding a fee-paying UTxO
--- and a change output. The fee is estimated via
--- 'setMinFeeTx' from @cardano-ledger-api@.
+-- Balance an unsigned Conway-era transaction by adding
+-- fee-paying inputs and a change output. The fee is
+-- estimated iteratively via 'estimateMinFeeTx' from
+-- @cardano-ledger-api@ until the value converges
+-- (at most 10 rounds).
+--
+-- This is a simplified balancer that only handles
+-- ADA-only fee inputs. Multi-asset coin selection is
+-- out of scope — callers construct the script inputs
+-- and this module adds the fee delta.
 module Cardano.MPFS.Core.Balance
     ( -- * Balancing
       balanceTx

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Bootstrap.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Bootstrap.hs
@@ -3,11 +3,21 @@
 -- Description : CBOR bootstrap file for UTxO seeding
 -- License     : Apache-2.0
 --
--- Encode and decode CBOR bootstrap files for seeding
--- a fresh database with UTxO entries. The file format
--- is a 3-element CBOR array: slot number, optional
--- block hash, and an indefinite-length map of
--- serialized key-value byte pairs.
+-- Encode and decode CBOR bootstrap files for seeding a
+-- fresh database with UTxO entries. A bootstrap file
+-- captures a UTxO snapshot at a known chain point so
+-- the indexer can start from that slot instead of
+-- replaying the entire chain.
+--
+-- The file format is a 3-element CBOR array:
+--
+-- @
+-- [slot :: Word64, blockHash :: bytes|null, {_ k: v, … }]
+-- @
+--
+-- Decoding is streaming ('foldBootstrapEntries') so
+-- arbitrarily large snapshots can be loaded without
+-- holding the full map in memory.
 module Cardano.MPFS.Core.Bootstrap
     ( -- * Header
       BootstrapHeader (..)
@@ -51,7 +61,10 @@ import Data.Word (Word64)
 -- the actual block hash at the given slot.
 data BootstrapHeader = BootstrapHeader
     { bootstrapSlot :: !Word64
+    -- ^ Slot number at which the snapshot was taken
     , bootstrapBlockHash :: !(Maybe ByteString)
+    -- ^ Block header hash, or 'Nothing' if discovery
+    -- ChainSync is needed to resolve it
     }
     deriving stock (Eq, Show)
 
@@ -68,8 +81,11 @@ data BootstrapHeader = BootstrapHeader
 -- the appropriate ledger CBOR version).
 encodeBootstrapFile
     :: FilePath
+    -- ^ Output file path
     -> BootstrapHeader
+    -- ^ Slot and optional block hash
     -> [(ByteString, ByteString)]
+    -- ^ Key-value pairs (pre-serialized CBOR)
     -> IO ()
 encodeBootstrapFile fp hdr pairs =
     BSL.writeFile fp
@@ -95,8 +111,11 @@ encodeBootstrapFile fp hdr pairs =
 -- Never loads the full map into memory.
 foldBootstrapEntries
     :: FilePath
+    -- ^ Path to the bootstrap CBOR file
     -> (BootstrapHeader -> IO ())
+    -- ^ Callback invoked once with the header
     -> (ByteString -> ByteString -> IO ())
+    -- ^ Callback invoked for each key-value entry
     -> IO ()
 foldBootstrapEntries fp onHeader onEntry = do
     lbs <- BSL.readFile fp

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs
@@ -5,8 +5,15 @@
 -- Description : Core domain types for the MPFS offchain service
 -- License     : Apache-2.0
 --
--- Re-exports ledger types and defines MPFS-specific domain
--- types aligned with the on-chain Aiken validators.
+-- Central type vocabulary for the MPFS offchain service.
+-- Re-exports ledger types (Conway era) and defines domain
+-- types that bridge the gap between cardano-ledger
+-- representations and the Aiken on-chain validator layout.
+--
+-- Every module in the @Cardano.MPFS@ hierarchy imports
+-- from here rather than reaching into @cardano-ledger-*@
+-- directly, ensuring a single point of control for era
+-- transitions and type aliases.
 module Cardano.MPFS.Core.Types
     ( -- * Ledger re-exports
       ConwayEra
@@ -81,11 +88,19 @@ newtype Root = Root
 -- | An operation to perform on a key in the trie.
 data Operation
     = -- | Insert a new key-value pair
-      Insert !ByteString
+      Insert
+        !ByteString
+        -- ^ Value to insert
     | -- | Delete a key
-      Delete !ByteString
+      Delete
+        !ByteString
+        -- ^ Old value being deleted (needed for proof)
     | -- | Update an existing key with a new value
-      Update !ByteString !ByteString
+      Update
+        !ByteString
+        -- ^ Old value being replaced
+        !ByteString
+        -- ^ New value to store
     deriving (Eq, Show)
 
 -- | A request to modify a token's trie.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer.hs
@@ -2,6 +2,16 @@
 -- Module      : Cardano.MPFS.Indexer
 -- Description : Chain sync follower interface
 -- License     : Apache-2.0
+--
+-- Record-of-functions interface for the chain sync
+-- indexer. The indexer follows the blockchain via
+-- ChainSync, detects cage-protocol events (boot,
+-- request, update, retract, end), and updates
+-- 'State' and 'TrieManager' accordingly.
+--
+-- See "Cardano.MPFS.Indexer.Follower" for the real
+-- implementation and "Cardano.MPFS.Mock.Indexer"
+-- for the test stub.
 module Cardano.MPFS.Indexer
     ( -- * Indexer interface
       Indexer (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs
@@ -9,14 +9,15 @@
 -- Description : CBOR serialization codecs for indexer columns
 -- License     : Apache-2.0
 --
--- Provides 'Prism''-based codecs for encoding and
--- decoding indexer column keys and values to/from
--- 'ByteString'. Uses CBOR via @cborg@ for
--- structured types. Ledger types ('TxIn', 'Coin',
--- 'KeyHash') are serialized to bytes via
--- @cardano-ledger-binary@ and embedded as CBOR
--- byte strings. Trie columns use identity codecs
--- (raw 'ByteString' passthrough).
+-- 'Prism''-based codecs for encoding and decoding
+-- indexer column keys and values to\/from
+-- 'ByteString'. Uses CBOR via @cborg@ for structured
+-- types. Ledger types ('TxIn', 'Coin', 'KeyHash')
+-- are serialized via @cardano-ledger-binary@ (version
+-- 2) and embedded as CBOR byte strings within the
+-- outer encoding. Trie columns use identity codecs
+-- (raw 'ByteString' passthrough) since the MPF
+-- library handles its own serialization.
 module Cardano.MPFS.Indexer.Codecs
     ( -- * Column codecs
       allCodecs

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs
@@ -8,11 +8,18 @@
 -- License     : Apache-2.0
 --
 -- Type-safe column family definitions for the
--- indexer's RocksDB-backed persistent state. Each
--- constructor selects a column with its key-value
--- types enforced at the type level. Covers cage
--- state (tokens, requests, checkpoint), rollback
--- storage, and trie storage (nodes, key-value pairs).
+-- indexer's RocksDB-backed persistent state using
+-- @rocksdb-kv-transactions@. Each 'AllColumns'
+-- constructor selects a RocksDB column family with
+-- its key-value types enforced at the type level via
+-- the 'KV' kind. Six column families cover:
+--
+--   * Cage state: 'CageTokens', 'CageRequests', 'CageCfg'
+--   * Rollback storage: 'CageRollbacks'
+--   * Trie storage: 'TrieNodes', 'TrieKV'
+--
+-- Serialization codecs for these columns live in
+-- "Cardano.MPFS.Indexer.Codecs".
 module Cardano.MPFS.Indexer.Columns
     ( -- * Column selector
       AllColumns (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs
@@ -7,11 +7,11 @@
 -- License     : Apache-2.0
 --
 -- Implements the 'State' interface on top of
--- RocksDB via @rocksdb-kv-transactions@.
--- Each operation runs in its own serialized
--- transaction. For atomic block processing (where
--- multiple operations must commit together), use
--- the 'Transaction' monad directly.
+-- RocksDB via @rocksdb-kv-transactions@. Each
+-- individual operation (get, put, remove, list) runs
+-- in its own serialized transaction. Column families
+-- are defined in "Cardano.MPFS.Indexer.Columns" and
+-- serialization codecs in "Cardano.MPFS.Indexer.Codecs".
 module Cardano.MPFS.Indexer.Persistent
     ( -- * Construction
       mkPersistentState
@@ -47,6 +47,7 @@ import Cardano.MPFS.State
 -- transaction via 'RunTransaction'.
 mkPersistentState
     :: RunTransaction IO cf AllColumns op
+    -- ^ Transaction runner from @rocksdb-kv-transactions@
     -> State IO
 mkPersistentState rt =
     State

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
@@ -3,9 +3,15 @@
 -- Description : Complete mock Context for testing
 -- License     : Apache-2.0
 --
--- Wires all mock implementations into a complete
--- 'Context IO'. Useful for integration tests and
--- development workflows.
+-- Convenience function that wires all mock
+-- implementations into a complete 'Context IO':
+-- 'mkMockProvider', 'mkMockSubmitter',
+-- 'mkMockTxBuilder', 'mkMockState', 'mkMockIndexer',
+-- and 'mkPureTrieManager'. Useful for integration
+-- tests and development workflows that need a fully
+-- typed 'Context' without any real infrastructure.
+-- See "Cardano.MPFS.Application" for the production
+-- wiring.
 module Cardano.MPFS.Mock.Context
     ( -- * Construction
       mkMockContext

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Indexer.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Indexer.hs
@@ -3,8 +3,13 @@
 -- Description : No-op mock Indexer implementation
 -- License     : Apache-2.0
 --
--- Provides a mock 'Indexer IO' where start\/stop are
--- no-ops and 'getTip' returns a genesis-like tip.
+-- Stub implementation of the 'Indexer' interface
+-- where all lifecycle operations (start, stop,
+-- pause, resume) are no-ops and 'getTip' returns
+-- slot 0 with a null block id. Useful for tests
+-- that don't need chain-sync indexing. See
+-- "Cardano.MPFS.Mock.Skeleton" for a slightly
+-- richer skeleton with lifecycle tracking.
 module Cardano.MPFS.Mock.Indexer
     ( -- * Construction
       mkMockIndexer

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Provider.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Provider.hs
@@ -3,9 +3,13 @@
 -- Description : No-op mock Provider implementation
 -- License     : Apache-2.0
 --
--- Provides a mock 'Provider IO' that returns empty
--- results. Useful for testing components that don't
--- require real chain queries.
+-- Stub implementation of the 'Provider' interface
+-- for unit tests and wiring checks. Returns empty
+-- UTxO sets and zero execution units.
+-- 'queryProtocolParams' throws — tests that need
+-- real params should use a custom fixture instead.
+-- See "Cardano.MPFS.Provider.NodeClient" for the
+-- production implementation.
 module Cardano.MPFS.Mock.Provider
     ( -- * Construction
       mkMockProvider

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Skeleton.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Skeleton.hs
@@ -3,10 +3,15 @@
 -- Description : Skeleton Indexer with no-op chain sync
 -- License     : Apache-2.0
 --
--- Provides a skeleton 'Indexer IO' with lifecycle
--- management (start\/stop\/pause\/resume) backed by
--- 'IORef' and 'MVar'. Returns a genesis tip.
--- Placeholder until csmt chain sync is wired.
+-- Skeleton implementation of the 'Indexer' interface
+-- that tracks lifecycle state via 'IORef' (running
+-- flag) and 'MVar' (pause/resume gate) but does not
+-- perform any actual chain synchronization.
+-- 'getTip' always returns genesis (slot 0).
+--
+-- Used by 'withApplication' as a temporary
+-- placeholder until the real chain-sync indexer
+-- (see "Cardano.MPFS.Indexer.Follower") is wired.
 module Cardano.MPFS.Mock.Skeleton
     ( -- * Construction
       mkSkeletonIndexer

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
@@ -5,9 +5,13 @@
 -- Description : In-memory mock State implementation
 -- License     : Apache-2.0
 --
--- Provides mock 'Tokens', 'Requests', and
--- 'Checkpoints' implementations backed by 'IORef'
--- maps. Useful for testing and development.
+-- In-memory implementations of the 'Tokens',
+-- 'Requests', and 'Checkpoints' interfaces, each
+-- backed by an 'IORef' holding a 'Map'. Useful for
+-- unit tests and development where persistent
+-- RocksDB state is not desired. See
+-- "Cardano.MPFS.Indexer.Persistent" for the
+-- production implementation.
 module Cardano.MPFS.Mock.State
     ( -- * Construction
       mkMockTokens

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Submitter.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Submitter.hs
@@ -5,9 +5,13 @@
 -- Description : No-op mock Submitter implementation
 -- License     : Apache-2.0
 --
--- Provides a mock 'Submitter IO' that always reports
--- rejection. Useful for testing components that
--- build but don't submit transactions.
+-- Stub implementation of the 'Submitter' interface.
+-- Every call to 'submitTx' returns 'Rejected' with
+-- a descriptive message. Useful for unit tests that
+-- exercise transaction construction without
+-- submitting to a real node. See
+-- "Cardano.MPFS.Submitter.N2C" for the production
+-- implementation.
 module Cardano.MPFS.Mock.Submitter
     ( -- * Construction
       mkMockSubmitter

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
@@ -3,10 +3,13 @@
 -- Description : No-op mock TxBuilder implementation
 -- License     : Apache-2.0
 --
--- Provides a mock 'TxBuilder IO' that throws on all
--- operations. Transaction building requires real
--- protocol params and UTxOs; the mock is a
--- placeholder for type-checking and wiring tests.
+-- Stub implementation of the 'TxBuilder' interface.
+-- All operations throw with a descriptive error.
+-- Transaction building requires real protocol
+-- parameters and UTxOs, so this mock exists purely
+-- as a placeholder for type-checking and wiring
+-- tests. See "Cardano.MPFS.TxBuilder.Real" for the
+-- production implementation.
 module Cardano.MPFS.Mock.TxBuilder
     ( -- * Construction
       mkMockTxBuilder

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Codecs.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Codecs.hs
@@ -8,6 +8,9 @@
 --
 -- Codec configuration shared between the
 -- LocalStateQuery and LocalTxSubmission protocols.
+-- Uses @CardanoNodeToClientVersion16@ and a
+-- hard-coded 'EpochSlots' value matching the
+-- @cardano-utxo-csmt@ configuration.
 module Cardano.MPFS.NodeClient.Codecs
     ( -- * Codec config
       ccfg

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/LocalTxSubmission.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/LocalTxSubmission.hs
@@ -3,9 +3,10 @@
 -- Description : LocalTxSubmission protocol client
 -- License     : Apache-2.0
 --
--- A channel-driven LocalTxSubmission client that
--- reads transactions from a 'TBQueue', submits them
--- to the node, and delivers results via 'TMVar'.
+-- Channel-driven LocalTxSubmission client. Reads
+-- 'TxSubmitRequest' values from the 'LTxSChannel'
+-- queue, submits each to the node, and delivers
+-- the accept\/reject result via the request's 'TMVar'.
 module Cardano.MPFS.NodeClient.LocalTxSubmission
     ( -- * Client construction
       mkLocalTxSubmissionClient
@@ -76,7 +77,9 @@ clientIdle ch = do
 -- block until the result is available.
 submitTxN2C
     :: LTxSChannel
+    -- ^ Channel to the LocalTxSubmission client
     -> GenTx Block
+    -- ^ Generalized transaction to submit
     -> IO (Either (ApplyTxErr Block) ())
 submitTxN2C ch tx = do
     resultVar <- newEmptyTMVarIO

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Types.hs
@@ -5,9 +5,14 @@
 -- Description : Type aliases for N2C node client
 -- License     : Apache-2.0
 --
--- Type aliases and channel types for communicating
--- with the node-to-client Ouroboros protocols:
--- LocalStateQuery and LocalTxSubmission.
+-- Type aliases, channel types, and request wrappers for
+-- communicating with the Cardano node via the
+-- node-to-client Ouroboros mini-protocols:
+-- LocalStateQuery (UTxO and protocol-parameter queries)
+-- and LocalTxSubmission (signed transaction submission).
+--
+-- Communication is channel-based: callers enqueue requests
+-- into a 'TBQueue' and block on a 'TMVar' for the result.
 module Cardano.MPFS.NodeClient.Types
     ( -- * Block types
       Block

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
@@ -2,6 +2,12 @@
 -- Module      : Cardano.MPFS.Provider
 -- Description : Blockchain query interface
 -- License     : Apache-2.0
+--
+-- Record-of-functions interface for querying the Cardano
+-- blockchain. Implementations live in
+-- "Cardano.MPFS.Provider.NodeClient" (node-to-client
+-- LocalStateQuery) and "Cardano.MPFS.Mock.Provider"
+-- (in-memory stub for tests).
 module Cardano.MPFS.Provider
     ( -- * Provider interface
       Provider (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider/NodeClient.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider/NodeClient.hs
@@ -6,9 +6,14 @@
 -- Description : N2C-backed Provider via LocalStateQuery
 -- License     : Apache-2.0
 --
--- Provider implementation that queries a Cardano
--- node via the LocalStateQuery mini-protocol for
--- protocol parameters and UTxOs.
+-- Production implementation of the 'Provider'
+-- interface. Queries a local Cardano node via the
+-- N2C LocalStateQuery mini-protocol using an
+-- 'LSQChannel' (see "Cardano.MPFS.NodeClient.Connection").
+--
+-- Protocol parameters and UTxOs are retrieved with
+-- Conway-era queries. An era mismatch (node not yet
+-- in Conway) results in a runtime error.
 module Cardano.MPFS.Provider.NodeClient
     ( -- * Construction
       mkNodeClientProvider
@@ -38,7 +43,10 @@ import Cardano.MPFS.Provider (Provider (..))
 
 -- | Create a 'Provider IO' backed by the N2C
 -- LocalStateQuery protocol.
-mkNodeClientProvider :: LSQChannel -> Provider IO
+mkNodeClientProvider
+    :: LSQChannel
+    -- ^ LocalStateQuery channel to the Cardano node
+    -> Provider IO
 mkNodeClientProvider ch =
     Provider
         { queryProtocolParams = do

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
@@ -2,6 +2,12 @@
 -- Module      : Cardano.MPFS.State
 -- Description : Token and request state tracking interface
 -- License     : Apache-2.0
+--
+-- Record-of-functions interface for tracking the
+-- off-chain projection of token state, pending requests,
+-- and chain sync checkpoints. Implementations:
+-- "Cardano.MPFS.Indexer.Persistent" (RocksDB-backed)
+-- and "Cardano.MPFS.Mock.State" (in-memory for tests).
 module Cardano.MPFS.State
     ( -- * Combined state
       State (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs
@@ -2,6 +2,11 @@
 -- Module      : Cardano.MPFS.Submitter
 -- Description : Transaction submission interface
 -- License     : Apache-2.0
+--
+-- Record-of-functions interface for submitting signed
+-- transactions. The real implementation uses node-to-client
+-- LocalTxSubmission ("Cardano.MPFS.Submitter.N2C"); the
+-- mock records submitted transactions in memory.
 module Cardano.MPFS.Submitter
     ( -- * Submitter interface
       Submitter (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter/N2C.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter/N2C.hs
@@ -6,9 +6,16 @@
 -- Description : N2C-backed transaction submitter
 -- License     : Apache-2.0
 --
--- Submitter implementation that sends transactions
--- to a Cardano node via the LocalTxSubmission
--- mini-protocol.
+-- Production implementation of the 'Submitter'
+-- interface. Sends signed transactions to a local
+-- Cardano node via the N2C LocalTxSubmission
+-- mini-protocol using an 'LTxSChannel' (see
+-- "Cardano.MPFS.NodeClient.Connection").
+--
+-- The ledger 'Tx ConwayEra' is wrapped into a
+-- consensus 'GenTx Block' before submission.
+-- Rejection reasons are serialized to 'ByteString'
+-- and returned as 'Rejected'.
 module Cardano.MPFS.Submitter.N2C
     ( -- * Construction
       mkN2CSubmitter
@@ -45,7 +52,10 @@ import Ouroboros.Consensus.Ledger.SupportsMempool
 
 -- | Create a 'Submitter IO' backed by the N2C
 -- LocalTxSubmission protocol.
-mkN2CSubmitter :: LTxSChannel -> Submitter IO
+mkN2CSubmitter
+    :: LTxSChannel
+    -- ^ LocalTxSubmission channel to the Cardano node
+    -> Submitter IO
 mkN2CSubmitter ch =
     Submitter
         { submitTx = \tx -> do

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
@@ -4,6 +4,16 @@
 -- Module      : Cardano.MPFS.Trie
 -- Description : Per-token MPF trie management interface
 -- License     : Apache-2.0
+--
+-- Record-of-functions interface for managing
+-- per-token Merkle Patricia Forestry tries. The
+-- 'TrieManager' mediates access to individual 'Trie'
+-- handles and provides speculative (read-your-writes,
+-- then-discard) sessions for transaction building.
+--
+-- Implementations: "Cardano.MPFS.Trie.PureManager"
+-- (in-memory 'IORef'-based) and
+-- "Cardano.MPFS.Trie.Persistent" (RocksDB-backed).
 module Cardano.MPFS.Trie
     ( -- * Trie manager
       TrieManager (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs
@@ -3,9 +3,19 @@
 -- Description : Pure in-memory Trie backed by merkle-patricia-forestry
 -- License     : Apache-2.0
 --
--- Provides a 'Trie IO' implementation backed by an
--- 'IORef' holding an 'MPFInMemoryDB'. Useful for
--- testing and development without a real database.
+-- In-memory implementation of the 'Trie' interface
+-- backed by an 'IORef' holding an 'MPFInMemoryDB'
+-- from the @merkle-patricia-forestry@ library.
+--
+-- All keys and values are hashed through MPF
+-- conventions ('mkMPFHash') so proof paths match
+-- what the Aiken on-chain validator expects.
+--
+-- Use 'mkPureTrie' for standalone testing, or
+-- 'mkPureTrieFromRef' when sharing the underlying
+-- database with a 'PureManager' (see
+-- "Cardano.MPFS.Trie.PureManager").
+-- For production use "Cardano.MPFS.Trie.Persistent".
 module Cardano.MPFS.Trie.Pure
     ( -- * Construction
       mkPureTrie

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/PureManager.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/PureManager.hs
@@ -5,9 +5,16 @@
 -- Description : Pure in-memory TrieManager
 -- License     : Apache-2.0
 --
--- Provides a 'TrieManager IO' backed by a 'Map' of
--- per-token 'IORef' databases. Useful for testing
--- and development.
+-- In-memory implementation of the 'TrieManager'
+-- interface backed by a 'Map TokenId (IORef
+-- MPFInMemoryDB)'. Each token gets its own isolated
+-- in-memory MPF database; speculative sessions copy
+-- the 'IORef' contents so the original is never
+-- mutated.
+--
+-- Useful for unit tests and development where
+-- RocksDB is not available or not desired. For
+-- production use "Cardano.MPFS.Trie.Persistent".
 module Cardano.MPFS.Trie.PureManager
     ( -- * Construction
       mkPureTrieManager

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
@@ -2,6 +2,15 @@
 -- Module      : Cardano.MPFS.TxBuilder
 -- Description : Transaction construction interface
 -- License     : Apache-2.0
+--
+-- Record-of-functions interface for building MPFS
+-- protocol transactions. Each method corresponds to a
+-- cage-protocol action (boot, request insert\/delete,
+-- update, retract, end). The real implementation lives
+-- in "Cardano.MPFS.TxBuilder.Real"; the mock in
+-- "Cardano.MPFS.Mock.TxBuilder". Returned transactions
+-- are unsigned — callers add key witnesses before
+-- submission.
 module Cardano.MPFS.TxBuilder
     ( -- * Transaction builder interface
       TxBuilder (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs
@@ -2,6 +2,12 @@
 -- Module      : Cardano.MPFS.TxBuilder.Config
 -- Description : Configuration for real transaction builders
 -- License     : Apache-2.0
+--
+-- Configuration record for the real cage transaction
+-- builders. Holds the applied PlutusV3 script bytes,
+-- computed script hash, default token parameters, and
+-- time-conversion constants needed for validity
+-- interval calculations.
 module Cardano.MPFS.TxBuilder.Config
     ( -- * Configuration
       CageConfig (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
@@ -3,11 +3,15 @@
 -- Description : Real transaction builders for the MPFS cage
 -- License     : Apache-2.0
 --
--- Builds unsigned Cardano transactions for the MPFS
--- cage protocol: minting tokens, submitting requests,
--- retracting requests, and processing updates.
+-- Assembles the real 'TxBuilder' by wiring
+-- per-operation implementations from the @Real.*@
+-- submodules to a 'Provider', 'State', and
+-- 'TrieManager'. Returned transactions are unsigned
+-- Conway-era ledger values ready for key-witness
+-- addition and submission.
 --
--- Re-exports from per-operation submodules.
+-- Also re-exports 'computeScriptHash' and datum
+-- helpers used in tests.
 module Cardano.MPFS.TxBuilder.Real
     ( -- * Construction
       mkRealTxBuilder
@@ -55,9 +59,13 @@ import Cardano.MPFS.TxBuilder.Real.Update
 -- 'Provider', 'State', and 'TrieManager'.
 mkRealTxBuilder
     :: CageConfig
+    -- ^ Cage script config (bytes, hash, params)
     -> Provider IO
+    -- ^ Blockchain query interface
     -> State IO
+    -- ^ Token and request state
     -> TrieManager IO
+    -- ^ Per-token trie manager
     -> TxBuilder IO
 mkRealTxBuilder cfg prov st tm =
     TxBuilder

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
@@ -4,6 +4,12 @@
 -- Module      : Cardano.MPFS.TxBuilder.Real.Boot
 -- Description : Boot token minting transaction
 -- License     : Apache-2.0
+--
+-- Builds the minting transaction for a new MPFS cage
+-- token. Picks a wallet UTxO as seed for asset-name
+-- derivation, mints +1 token at the cage policy, and
+-- creates a State UTxO with empty root and configured
+-- default parameters.
 module Cardano.MPFS.TxBuilder.Real.Boot
     ( bootTokenImpl
     ) where
@@ -79,8 +85,11 @@ import Cardano.MPFS.TxBuilder.Real.Internal
 -- a State UTxO with empty root and maxFee.
 bootTokenImpl
     :: CageConfig
+    -- ^ Cage script config
     -> Provider IO
+    -- ^ Blockchain query interface
     -> Addr
+    -- ^ Owner address (receives change, owns the token)
     -> IO (Tx ConwayEra)
 bootTokenImpl cfg prov addr = do
     pp <- queryProtocolParams prov

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
@@ -2,6 +2,11 @@
 -- Module      : Cardano.MPFS.TxBuilder.Real.End
 -- Description : End token (burn) transaction
 -- License     : Apache-2.0
+--
+-- Builds the burn transaction that retires an MPFS
+-- cage token. Consumes the State UTxO with an @End@
+-- spending redeemer, mints -1 with @Burning@, and
+-- returns remaining ADA to the owner.
 module Cardano.MPFS.TxBuilder.Real.End
     ( endTokenImpl
     ) where
@@ -74,9 +79,13 @@ import Cardano.Ledger.Api.Tx.Out (coinTxOutL)
 -- destroyed.
 endTokenImpl
     :: CageConfig
+    -- ^ Cage script config
     -> Provider IO
+    -- ^ Blockchain query interface
     -> TokenId
+    -- ^ Token to retire
     -> Addr
+    -- ^ Fee-paying address (receives remaining ADA)
     -> IO (Tx ConwayEra)
 endTokenImpl cfg prov tid addr = do
     -- 1. Query cage UTxOs

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -4,6 +4,12 @@
 -- Module      : Cardano.MPFS.TxBuilder.Real.Request
 -- Description : Request insert/delete transactions
 -- License     : Apache-2.0
+--
+-- Builds request transactions for inserting or
+-- deleting a key in a token's trie. No script
+-- execution occurs — the transaction simply pays to
+-- the cage address with an inline 'RequestDatum'.
+-- The locked ADA includes the token's @maxFee@.
 module Cardano.MPFS.TxBuilder.Real.Request
     ( requestInsertImpl
     , requestDeleteImpl
@@ -55,12 +61,19 @@ import Cardano.MPFS.TxBuilder.Real.Internal
 -- address with an inline 'RequestDatum'.
 requestInsertImpl
     :: CageConfig
+    -- ^ Cage script config
     -> Provider IO
+    -- ^ Blockchain query interface
     -> State IO
+    -- ^ Token state (to look up maxFee)
     -> TokenId
+    -- ^ Token whose trie to modify
     -> ByteString
+    -- ^ Key to insert
     -> ByteString
+    -- ^ Value to insert
     -> Addr
+    -- ^ Requester's address (pays fee, owns request)
     -> IO (Tx ConwayEra)
 requestInsertImpl cfg prov st tid key value addr =
     do
@@ -112,11 +125,17 @@ requestInsertImpl cfg prov st tid key value addr =
 -- Same structure as requestInsert with 'OpDelete'.
 requestDeleteImpl
     :: CageConfig
+    -- ^ Cage script config
     -> Provider IO
+    -- ^ Blockchain query interface
     -> State IO
+    -- ^ Token state (to look up maxFee)
     -> TokenId
+    -- ^ Token whose trie to modify
     -> ByteString
+    -- ^ Key to delete
     -> Addr
+    -- ^ Requester's address
     -> IO (Tx ConwayEra)
 requestDeleteImpl cfg prov st tid key addr = do
     mTs <- getToken (tokens st) tid

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
@@ -2,6 +2,13 @@
 -- Module      : Cardano.MPFS.TxBuilder.Real.Retract
 -- Description : Retract request transaction
 -- License     : Apache-2.0
+--
+-- Builds the retract transaction that cancels a
+-- pending request. The requester spends their request
+-- UTxO (recovering locked ADA) while referencing the
+-- State UTxO. Validity interval is Phase 2:
+-- @entirely_after(submitted_at + process_time)@ and
+-- @entirely_before(submitted_at + process_time + retract_time)@.
 module Cardano.MPFS.TxBuilder.Real.Retract
     ( retractRequestImpl
     ) where
@@ -82,10 +89,15 @@ import PlutusTx.Builtins.Internal
 -- state UTxO. Requires Phase 2 validity.
 retractRequestImpl
     :: CageConfig
+    -- ^ Cage script config
     -> Provider IO
+    -- ^ Blockchain query interface
     -> State IO
+    -- ^ Request state (to look up the request)
     -> TxIn
+    -- ^ UTxO reference of the request to retract
     -> Addr
+    -- ^ Requester's address (receives refund)
     -> IO (Tx ConwayEra)
 retractRequestImpl cfg prov st reqTxIn addr = do
     -- 1. Look up the request to find its token

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -2,6 +2,13 @@
 -- Module      : Cardano.MPFS.TxBuilder.Real.Update
 -- Description : Update token transaction
 -- License     : Apache-2.0
+--
+-- Builds the oracle update transaction that processes
+-- all pending requests for a token. Consumes the State
+-- UTxO and all request UTxOs, applies each operation
+-- speculatively through the trie to generate proofs,
+-- then outputs a new State UTxO with the updated root
+-- and per-request refund outputs.
 module Cardano.MPFS.TxBuilder.Real.Update
     ( updateTokenImpl
     ) where
@@ -94,11 +101,17 @@ import Cardano.MPFS.TxBuilder.Real.Internal
 -- and outputs a new state UTxO with updated root.
 updateTokenImpl
     :: CageConfig
+    -- ^ Cage script config
     -> Provider IO
+    -- ^ Blockchain query interface
     -> State IO
+    -- ^ Token and request state
     -> TrieManager IO
+    -- ^ Trie manager (for speculative proof generation)
     -> TokenId
+    -- ^ Token to process requests for
     -> Addr
+    -- ^ Oracle's address (pays fee, receives fee income)
     -> IO (Tx ConwayEra)
 updateTokenImpl cfg prov _st tm tid addr = do
     -- 1. Query cage UTxOs

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,8 @@
           in {
             packages = {
               inherit (project.packages)
-                unit-tests offchain-tests e2e-tests cardano-mpfs-offchain;
+                unit-tests offchain-tests e2e-tests cardano-mpfs-offchain
+                haddock;
               default = project.packages.merkle-patricia-forestry;
             };
             inherit (project) devShells;

--- a/justfile
+++ b/justfile
@@ -100,6 +100,14 @@ e2e match="":
 docs:
     mkdocs serve
 
+# Serve hoogle (all dependencies, from nix shell)
+hoogle port="8080":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Serving hoogle on http://localhost:{{ port }}"
+    echo "(includes all dependencies; local packages not yet indexed — see issue #59)"
+    hoogle server --local --port={{ port }}
+
 # Clean build artifacts
 clean:
     #!/usr/bin/env bash

--- a/nix/haddock.nix
+++ b/nix/haddock.nix
@@ -1,0 +1,72 @@
+# Combined haddock documentation for gh-pages deployment.
+#
+# Copies per-package haddock outputs into a single directory,
+# rewrites nix-store file:// links to relative URLs, and
+# generates a unified index with haddock --gen-contents.
+#
+# Usage:
+#   nix build .#haddock
+#   ls result/          # cardano-mpfs-offchain/ merkle-patricia-forestry/ index.html
+{ pkgs, project }:
+
+let
+  haddock =
+    pkgs.buildPackages.haskell-nix.compiler.ghc984.passthru.haddock
+      or pkgs.haskellPackages.haddock;
+
+  mpfDoc =
+    project.hsPkgs.merkle-patricia-forestry.components.library.doc;
+
+  offchainDoc =
+    project.hsPkgs.cardano-mpfs-offchain.components.library.doc;
+
+  mpfName = "merkle-patricia-forestry";
+  offchainName = "cardano-mpfs-offchain";
+
+  mpfHtml = "${mpfDoc}/share/doc/${mpfName}/html";
+  offchainHtml = "${offchainDoc}/share/doc/${offchainName}/html";
+
+in pkgs.runCommand "combined-haddock" {
+  nativeBuildInputs = [ pkgs.haskell-nix.compiler.ghc984 ];
+} ''
+  mkdir -p $out
+
+  # Copy both package docs
+  cp -R ${mpfHtml} $out/${mpfName}
+  cp -R ${offchainHtml} $out/${offchainName}
+  chmod -R +w $out
+
+  # Rewrite file:// store-path references to relative URLs
+  # so cross-package links work in a browser.
+  for f in $(find $out -name "*.html" -o -name "*.json"); do
+    dir=$(dirname "$f")
+    rel_mpf=$(realpath --relative-to="$dir" "$out/${mpfName}")
+    rel_offchain=$(realpath --relative-to="$dir" "$out/${offchainName}")
+
+    sed -i \
+      -e "s|file://${mpfHtml}|$rel_mpf|g" \
+      -e "s|file://${offchainHtml}|$rel_offchain|g" \
+      "$f"
+    # Rewrite GHC boot-library file:// refs to Hackage URLs
+    ${pkgs.perl}/bin/perl -pi -e \
+      's{file:///nix/store/[^/]+-ghc-[\d.]+-doc/share/doc/ghc-[\d.]+/html/libraries/([^/]+)-inplace/}{https://hackage.haskell.org/package/$1/docs/}g' \
+      "$f"
+  done
+
+  # Generate combined index and contents page
+  haddock \
+    --gen-contents \
+    --gen-index \
+    --odir=$out \
+    --read-interface=${mpfName},${mpfHtml}/${mpfName}.haddock \
+    --read-interface=${offchainName},${offchainHtml}/${offchainName}.haddock \
+    || true
+
+  # Copy shared static assets from the offchain docs
+  for asset in linuwial.css quick-jump.css quick-jump.min.js \
+               haddock-bundle.min.js; do
+    if [ -f ${offchainHtml}/$asset ] && [ ! -f $out/$asset ]; then
+      cp ${offchainHtml}/$asset $out/
+    fi
+  done
+''

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,85 +1,70 @@
-{
-  CHaP,
-  indexState,
-  pkgs,
-  mkdocs,
-  asciinema,
-  cardano-node-pkgs,
-  mpfs-blueprint,
-  ...
-}:
+{ CHaP, indexState, pkgs, mkdocs, asciinema, cardano-node-pkgs, mpfs-blueprint
+, ... }:
 
 let
-  indexTool = {
-    index-state = indexState;
+  indexTool = { index-state = indexState; };
+  fix-libs = { lib, pkgs, ... }: {
+    packages.cardano-crypto-praos.components.library.pkgconfig =
+      lib.mkForce [ [ pkgs.libsodium-vrf ] ];
+    packages.cardano-crypto-class.components.library.pkgconfig =
+      lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ]];
   };
-  fix-libs =
-    { lib, pkgs, ... }:
-    {
-      packages.cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf ] ];
-      packages.cardano-crypto-class.components.library.pkgconfig = lib.mkForce [
-        [
-          pkgs.libsodium-vrf
-          pkgs.secp256k1
-          pkgs.libblst
-        ]
-      ];
+  shell = { pkgs, ... }: {
+    tools = {
+      cabal = indexTool;
+      cabal-fmt = indexTool;
+      haskell-language-server = indexTool;
+      hoogle = indexTool;
+      fourmolu = indexTool;
+      hlint = indexTool;
     };
-  shell =
-    { pkgs, ... }:
-    {
-      tools = {
-        cabal = indexTool;
-        cabal-fmt = indexTool;
-        haskell-language-server = indexTool;
-        hoogle = indexTool;
-        fourmolu = indexTool;
-        hlint = indexTool;
-      };
-      withHoogle = true;
-      buildInputs = [
-        pkgs.just
-        pkgs.nixfmt-classic
-        pkgs.shellcheck
-        pkgs.mkdocs
-        mkdocs.from-nixpkgs
-        mkdocs.asciinema-plugin
-        mkdocs.markdown-callouts
-        asciinema.compress
-        asciinema.resize
-        pkgs.asciinema
-        cardano-node-pkgs.cardano-node
-        cardano-node-pkgs.cardano-cli
-        pkgs.aiken
-      ];
-      shellHook = ''
-        echo "Entering merkle-patricia-forestry dev shell"
-        export MPFS_BLUEPRINT="${mpfs-blueprint}"
-      '';
-    };
+    withHoogle = true;
+    buildInputs = [
+      pkgs.just
+      pkgs.nixfmt-classic
+      pkgs.shellcheck
+      pkgs.mkdocs
+      mkdocs.from-nixpkgs
+      mkdocs.asciinema-plugin
+      mkdocs.markdown-callouts
+      asciinema.compress
+      asciinema.resize
+      pkgs.asciinema
+      cardano-node-pkgs.cardano-node
+      cardano-node-pkgs.cardano-cli
+      pkgs.aiken
+    ];
+    shellHook = ''
+      echo "Entering merkle-patricia-forestry dev shell"
+      export MPFS_BLUEPRINT="${mpfs-blueprint}"
+    '';
+  };
 
-  mkProject =
-    ctx@{ lib, pkgs, ... }:
-    {
-      name = "merkle-patricia-forestry";
-      src = ./..;
-      compiler-nix-name = "ghc984";
-      shell = shell { inherit pkgs; };
-      modules = [ fix-libs ];
-      inputMap = {
-        "https://chap.intersectmbo.org/" = CHaP;
-      };
-    };
+  mkProject = ctx@{ lib, pkgs, ... }: {
+    name = "merkle-patricia-forestry";
+    src = ./..;
+    compiler-nix-name = "ghc984";
+    shell = shell { inherit pkgs; };
+    modules = [ fix-libs ];
+    inputMap = { "https://chap.intersectmbo.org/" = CHaP; };
+  };
 
   project = pkgs.haskell-nix.cabalProject' mkProject;
 
-in
-{
+  haddock = import ./haddock.nix { inherit pkgs project; };
+
+in {
   devShells.default = project.shell;
   inherit project;
-  packages.merkle-patricia-forestry = project.hsPkgs.merkle-patricia-forestry.components.library;
-  packages.unit-tests = project.hsPkgs.merkle-patricia-forestry.components.tests.unit-tests;
-  packages.cardano-mpfs-offchain = project.hsPkgs.cardano-mpfs-offchain.components.library;
-  packages.offchain-tests = project.hsPkgs.cardano-mpfs-offchain.components.tests.unit-tests;
-  packages.e2e-tests = project.hsPkgs.cardano-mpfs-offchain.components.tests.e2e-tests;
+  packages.merkle-patricia-forestry =
+    project.hsPkgs.merkle-patricia-forestry.components.library;
+  packages.unit-tests =
+    project.hsPkgs.merkle-patricia-forestry.components.tests.unit-tests;
+  packages.cardano-mpfs-offchain =
+    project.hsPkgs.cardano-mpfs-offchain.components.library;
+  packages.offchain-tests =
+    project.hsPkgs.cardano-mpfs-offchain.components.tests.unit-tests;
+  packages.e2e-tests =
+    project.hsPkgs.cardano-mpfs-offchain.components.tests.e2e-tests;
+  packages.haddock = haddock;
 }


### PR DESCRIPTION
## Summary

- Enriched module headers across all 45 `cardano-mpfs-offchain` library modules with architectural descriptions, design rationale, and cross-references
- Added `-- ^` annotations to record fields and function parameters that were missing them
- Added `-- |` docs to undocumented internal helpers
- Added `nix/haddock.nix` combined derivation (`nix build .#haddock`) that merges `cardano-mpfs-offchain` + `merkle-patricia-forestry` docs with cross-package relative links and GHC boot-library types rewritten to Hackage URLs
- Added `just hoogle` recipe for local documentation server (all dependencies indexed)

## Known limitations (tracked in #59)

- Cardano dependency types (`Network`, `ExUnits`, `Data`, etc.) render as plain text in the static haddock output — the haskell.nix haddock build doesn't receive dependency interface files
- Hoogle indexes all dependencies but not the project's own packages

## Test plan

- [x] `cabal build all -O0` — all 45 modules compile
- [x] `cabal test unit-tests -O0` — 80 examples pass
- [x] `fourmolu -m check` — clean
- [x] `nix build .#haddock` — combined derivation builds successfully
- [x] Zero remaining `file:///nix/store` references in output