### PR TITLE
test: add property-based tests across all spec modules

### DIFF
--- a/merkle-patricia-forestry.cabal
+++ b/merkle-patricia-forestry.cabal
@@ -94,8 +94,9 @@ library mpf-test-lib
     , bytestring
     , lens
     , merkle-patricia-forestry
+    , QuickCheck                               >=2.14 && <2.18
     , rocksdb-kv-transactions:kv-transactions
-    , text                                     >=2.0 && <2.2
+    , text                                     >=2.0  && <2.2
 
   hs-source-dirs:   test-lib
   default-language: Haskell2010

--- a/test/MPF/HashesSpec.hs
+++ b/test/MPF/HashesSpec.hs
@@ -3,15 +3,29 @@
 module MPF.HashesSpec (spec) where
 
 import Data.ByteString qualified as B
+import Data.Maybe (fromMaybe)
 import MPF.Hashes
-    ( computeLeafHash
+    ( MPFHash
+    , computeLeafHash
     , computeMerkleRoot
+    , merkleProof
     , mkMPFHash
     , nullHash
+    , parseMPFHash
     , renderMPFHash
     )
 import MPF.Interface (HexDigit (..))
+import MPF.Test.Lib (genMPFHash)
 import Test.Hspec
+import Test.QuickCheck
+    ( Gen
+    , choose
+    , forAll
+    , property
+    , vectorOf
+    , (===)
+    , (==>)
+    )
 
 spec :: Spec
 spec = describe "MPF.Hashes" $ do
@@ -53,3 +67,77 @@ spec = describe "MPF.Hashes" $ do
                 children = Just h : replicate 15 Nothing
                 result = computeMerkleRoot children
             B.length (renderMPFHash result) `shouldBe` 32
+
+    describe "properties" $ do
+        it "mkMPFHash always produces 32 bytes"
+            $ forAll genArbitraryBS
+            $ \bs ->
+                B.length (renderMPFHash (mkMPFHash bs)) === 32
+
+        it "parseMPFHash . renderMPFHash = Just"
+            $ forAll genMPFHash
+            $ \h ->
+                parseMPFHash (renderMPFHash h) === Just h
+
+        it "parseMPFHash rejects non-32-byte inputs"
+            $ forAll genNon32ByteBS
+            $ \bs ->
+                parseMPFHash bs === Nothing
+
+        it "computeLeafHash output is always 32 bytes" $ property $ \suffix ->
+            forAll genMPFHash $ \val ->
+                B.length (renderMPFHash (computeLeafHash suffix val)) === 32
+
+        it "computeMerkleRoot position sensitivity"
+            $ forAll ((,) <$> genMPFHash <*> genMPFHash)
+            $ \(h1, h2) ->
+                h1
+                    /= h2
+                    ==> let children1 = Just h1 : Just h2 : replicate 14 Nothing
+                            children2 = Just h2 : Just h1 : replicate 14 Nothing
+                        in  computeMerkleRoot children1 /= computeMerkleRoot children2
+
+        it "merkleProof reconstruction matches computeMerkleRoot"
+            $ forAll genSparseChildren
+            $ \(children, idx) ->
+                let root = computeMerkleRoot children
+                    proof = merkleProof children idx
+                    padded = take 16 $ children ++ repeat Nothing
+                    element = fromMaybe nullHash (padded !! idx)
+                    reconstructed = reconstructFromProof element proof idx
+                in  reconstructed === root
+
+genArbitraryBS :: Gen B.ByteString
+genArbitraryBS = B.pack <$> vectorOf 10 (choose (0, 255))
+
+genNon32ByteBS :: Gen B.ByteString
+genNon32ByteBS = do
+    len <- choose (0, 64)
+    if len == 32
+        then B.pack <$> vectorOf 31 (choose (0, 255))
+        else B.pack <$> vectorOf len (choose (0, 255))
+
+-- | Generate a sparse 16-element child array with some slots filled
+genSparseChildren :: Gen ([Maybe MPFHash], Int)
+genSparseChildren = do
+    idx <- choose (0, 15)
+    nFilled <- choose (1, 16)
+    filledPositions <- vectorOf nFilled (choose (0, 15))
+    hashes <- vectorOf 16 genMPFHash
+    let children =
+            [ if i `elem` filledPositions
+                then Just (hashes !! i)
+                else Nothing
+            | i <- [0 .. 15]
+            ]
+    pure (children, idx)
+
+-- | Reconstruct merkle root from element, proof hashes, and position
+reconstructFromProof :: MPFHash -> [MPFHash] -> Int -> MPFHash
+reconstructFromProof element proofList me =
+    foldl step element (zip (reverse proofList) [1, 2, 4, 8 :: Int])
+  where
+    step acc (sibling, pivot) =
+        if even (me `div` pivot)
+            then mkMPFHash (renderMPFHash acc <> renderMPFHash sibling)
+            else mkMPFHash (renderMPFHash sibling <> renderMPFHash acc)


### PR DESCRIPTION
## Summary

Closes #63

- Add shared QuickCheck generators to `mpf-test-lib` (`Arbitrary` instances for `HexDigit`, `MPFHash`, plus generators for keys, values, hex indirects)
- Add ~35 property tests across 7 spec modules covering serialization roundtrips, hash invariants, merkle proof reconstruction, insertion/deletion properties, proof soundness, and backend transaction composition
- Refactor `PropertySpec` to use shared generators from test-lib
- Test count: 77 → 257

## Test plan

- [x] `just ci` passes locally (format, hlint, build, 257 tests)