### PR TITLE
refactor: unify cage and UTxO transaction runners via mapColumns

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,14 +27,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/paolino/rocksdb-kv-transactions
-  tag: 0888387a5de81711273ea9b1e9d160decc33c231
-  --sha256: 0ywi4p744sk688p50f6n69llvxa1fws27wqciyhj4b57cqcpam4m
+  tag: 44c3c2a4b7bab8ca0ca444c99977a358fc6af0ae
+  --sha256: 0rxc1g7imzlapdgab1v6cyy5nrgg8ilwbr9r015dxbdazl5rm9b9
 
 source-repository-package
   type: git
   location: https://github.com/paolino/cardano-utxo-csmt
-  tag: e9c6de3c6d4163db0b736581cb90db38b40b99a9
-  --sha256: 1nyp8ha1p9b1az0d1fry99vybyq48bwzkngxfwng1ql57qvjys70
+  tag: 0cfcf85659ec7541d8bd2a87fd37d002020ae38a
+  --sha256: 0jvz19sz20jc6mpddx38gzjp35szpnhd6rrr20l82fyark1xpgmx
 
 source-repository-package
   type: git

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -55,6 +55,7 @@ library
     , containers                               >=0.6  && <0.8
     , contra-tracer
     , crypton
+    , dependent-map
     , lens
     , memory
     , merkle-patricia-forestry


### PR DESCRIPTION
## Summary

- Replace two separate RocksDB transaction runners (cage + UTxO) with a single unified runner over all 10 column families
- Add `UnifiedColumns` GADT (`InUtxo`/`InCage`) to select column subsets
- Use `mapColumns` from rocksdb-kv-transactions to project into each domain
- Bump `rocksdb-kv-transactions` to `44c3c2a` (includes `mapColumns`)
- Bump `cardano-utxo-csmt` to `0cfcf85` (exports `createUpdateState`, `CSMTContext`)

Closes #71