### PR TITLE
Wire evaluateTx and replace hardcoded ExUnits

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Provider.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Provider.hs
@@ -5,7 +5,7 @@
 --
 -- Stub implementation of the 'Provider' interface
 -- for unit tests and wiring checks. Returns empty
--- UTxO sets and zero execution units.
+-- UTxO sets and empty evaluation results.
 -- 'queryProtocolParams' throws — tests that need
 -- real params should use a custom fixture instead.
 -- See "Cardano.MPFS.Provider.NodeClient" for the
@@ -15,12 +15,13 @@ module Cardano.MPFS.Mock.Provider
       mkMockProvider
     ) where
 
-import Cardano.MPFS.Core.Types (ExUnits (..))
+import Data.Map.Strict qualified as Map
+
 import Cardano.MPFS.Provider (Provider (..))
 
 -- | Create a mock 'Provider IO'. Returns empty UTxO
--- sets, default protocol params, and zero execution
--- units.
+-- sets, default protocol params, and empty evaluation
+-- results.
 mkMockProvider :: Provider IO
 mkMockProvider =
     Provider
@@ -30,5 +31,5 @@ mkMockProvider =
                 "mkMockProvider: queryProtocolParams \
                 \not implemented"
         , evaluateTx = \_ ->
-            pure (ExUnits 0 0)
+            pure Map.empty
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
@@ -11,19 +11,39 @@
 module Cardano.MPFS.Provider
     ( -- * Provider interface
       Provider (..)
+
+      -- * Result types
+    , EvaluateTxResult
     ) where
 
-import Data.ByteString (ByteString)
+import Data.Map.Strict (Map)
 
+import Cardano.Ledger.Alonzo.Plutus.Evaluate
+    ( TransactionScriptFailure
+    )
+import Cardano.Ledger.Alonzo.Scripts
+    ( AsIx
+    , PlutusPurpose
+    )
+import Cardano.Ledger.Api.Tx (Tx)
 import Cardano.Ledger.Api.Tx.Out (TxOut)
+import Cardano.Ledger.Plutus (ExUnits)
 
 import Cardano.MPFS.Core.Types
     ( Addr
     , ConwayEra
-    , ExUnits
     , PParams
     , TxIn
     )
+
+-- | Per-script evaluation result.
+type EvaluateTxResult era =
+    Map
+        (PlutusPurpose AsIx era)
+        ( Either
+            (TransactionScriptFailure era)
+            ExUnits
+        )
 
 -- | Interface for querying the blockchain.
 -- All era-specific types are fixed to 'ConwayEra'.
@@ -36,7 +56,7 @@ data Provider m = Provider
         :: m (PParams ConwayEra)
     -- ^ Fetch current protocol parameters
     , evaluateTx
-        :: ByteString -> m ExUnits
-    -- ^ Evaluate execution units for a serialised
-    -- CBOR transaction
+        :: Tx ConwayEra
+        -> m (EvaluateTxResult ConwayEra)
+    -- ^ Evaluate script execution units
     }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider/NodeClient.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider/NodeClient.hs
@@ -5,8 +5,7 @@
 --
 -- Production implementation of the 'Provider'
 -- interface. Delegates to the @cardano-node-clients@
--- library for N2C LocalStateQuery queries, adding
--- the MPFS-specific 'evaluateTx' stub.
+-- library for N2C LocalStateQuery queries.
 module Cardano.MPFS.Provider.NodeClient
     ( -- * Construction
       mkNodeClientProvider
@@ -31,8 +30,6 @@ mkNodeClientProvider ch =
                 Lib.queryProtocolParams libProv
             , queryUTxOs =
                 Lib.queryUTxOs libProv
-            , evaluateTx = \_ ->
-                error
-                    "evaluateTx: requires local \
-                    \Plutus evaluator"
+            , evaluateTx =
+                Lib.evaluateTx libProv
             }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
@@ -76,7 +76,6 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Node.Client.Balance (balanceTx)
 
 -- | Build a boot-token minting transaction.
 --
@@ -165,7 +164,7 @@ bootTokenImpl cfg prov addr = do
                         $ Map.singleton
                             mintPurpose
                             ( toLedgerData redeemer
-                            , defaultMintExUnits
+                            , placeholderExUnits
                             )
             -- 6. Build tx body
             let integrity =
@@ -196,14 +195,10 @@ bootTokenImpl cfg prov addr = do
                                 script
                         & witsTxL . rdmrsTxWitsL
                             .~ redeemers
-            -- 7. Balance
-            case balanceTx
+            -- 7. Evaluate and balance
+            evaluateAndBalance
+                prov
                 pp
                 allInputUtxos
                 addr
-                tx of
-                Left err ->
-                    error
-                        $ "bootToken: "
-                            <> show err
-                Right balanced -> pure balanced
+                tx

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
@@ -63,7 +63,6 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Node.Client.Balance (balanceTx)
 
 import Data.List (sortOn)
 import Data.Ord (Down (..))
@@ -142,14 +141,14 @@ endTokenImpl cfg prov tid addr = do
                             (AsIx stateIx)
                         ,
                             ( toLedgerData spendRedeemer
-                            , defaultSpendExUnits
+                            , placeholderExUnits
                             )
                         )
                     ,
                         ( ConwayMinting (AsIx 0)
                         ,
                             ( toLedgerData mintRedeemer
-                            , defaultMintExUnits
+                            , placeholderExUnits
                             )
                         )
                     ]
@@ -176,12 +175,9 @@ endTokenImpl cfg prov tid addr = do
                         script
                 & witsTxL . rdmrsTxWitsL
                     .~ redeemers
-    case balanceTx
+    evaluateAndBalance
+        prov
         pp
         [feeUtxo, stateUtxo]
         addr
-        tx of
-        Left err ->
-            error
-                $ "endToken: " <> show err
-        Right balanced -> pure balanced
+        tx

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
@@ -77,7 +77,6 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Node.Client.Balance (balanceTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -194,7 +193,7 @@ retractRequestImpl cfg prov st reqTxIn addr = do
                 $ Map.singleton
                     spendPurpose
                     ( toLedgerData redeemer
-                    , defaultSpendExUnits
+                    , placeholderExUnits
                     )
         integrity =
             computeScriptIntegrity pp redeemers
@@ -224,13 +223,9 @@ retractRequestImpl cfg prov st reqTxIn addr = do
                         script
                 & witsTxL . rdmrsTxWitsL
                     .~ redeemers
-    case balanceTx
+    evaluateAndBalance
+        prov
         pp
         [feeUtxo, reqUtxoPair]
         addr
-        tx of
-        Left err ->
-            error
-                $ "retractRequest: "
-                    <> show err
-        Right balanced -> pure balanced
+        tx

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -92,7 +92,6 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Node.Client.Balance (balanceTx)
 
 -- | Build an update-token transaction.
 --
@@ -221,7 +220,7 @@ updateTokenImpl cfg prov _st tm tid addr = do
                     in  ( ConwaySpending (AsIx ix)
                         ,
                             ( toLedgerData rdm
-                            , contributeExUnits
+                            , placeholderExUnits
                             )
                         )
                 )
@@ -233,8 +232,7 @@ updateTokenImpl cfg prov _st tm tid addr = do
                         (AsIx stateIx)
                   ,
                       ( toLedgerData modifyRedeemer
-                      , modifyExUnits
-                            (length proofs)
+                      , placeholderExUnits
                       )
                   )
                     : contributeEntries
@@ -286,15 +284,12 @@ updateTokenImpl cfg prov _st tm tid addr = do
                         script
                 & witsTxL . rdmrsTxWitsL
                     .~ redeemers
-    case balanceTx
+    evaluateAndBalance
+        prov
         pp
         (feeUtxo : stateUtxo : reqUtxos)
         addr
-        tx of
-        Left err ->
-            error
-                $ "updateToken: " <> show err
-        Right balanced -> pure balanced
+        tx
   where
     when False _ = pure ()
     when True act = act

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -72,9 +72,6 @@ import Cardano.Ledger.Mary.Value
     , MultiAsset (..)
     , PolicyID (..)
     )
-import Cardano.Ledger.Plutus.ExUnits
-    ( ExUnits (..)
-    )
 import Cardano.Ledger.TxIn (TxIn)
 
 import Cardano.MPFS.Core.Blueprint
@@ -177,8 +174,7 @@ mkTestProvider utxos =
     Provider
         { queryUTxOs = \_ -> pure utxos
         , queryProtocolParams = pure zeroPP
-        , evaluateTx = \_ ->
-            pure (ExUnits 0 0)
+        , evaluateTx = \_ -> pure Map.empty
         }
 
 -- | Dummy TrieManager that errors on use.
@@ -219,8 +215,7 @@ mkRoutingProvider routes =
                         routes
                     )
         , queryProtocolParams = pure zeroPP
-        , evaluateTx = \_ ->
-            pure (ExUnits 0 0)
+        , evaluateTx = \_ -> pure Map.empty
         }
 
 -- | Build a state TxOut with the cage token.


### PR DESCRIPTION
## Summary

- Change `Provider.evaluateTx` type from `ByteString -> m ExUnits` to `Tx ConwayEra -> m (EvaluateTxResult ConwayEra)` and delegate to the cardano-node-clients library
- Add `evaluateAndBalance` helper that evaluates script execution units, patches redeemers, recomputes `scriptIntegrityHash`, and balances in one step
- Replace all hardcoded ExUnits (`defaultMintExUnits`, `defaultSpendExUnits`, `modifyExUnits`, `contributeExUnits`) with placeholder `ExUnits 0 0` that get replaced by real evaluation results

Closes #70
Closes #51

## Test plan

- [x] 257 unit tests pass (mock provider returns `Map.empty`, placeholders kept)
- [x] 19 E2E tests pass (real evaluation via cardano-node-clients)
- [x] CI passes (build, format-check, hlint)