### PR TITLE
feat: persist trie registry in RocksDB

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
@@ -65,11 +65,6 @@ data TrieManager m = TrieManager
     -- Deletes any existing data first.
     , deleteTrie :: TokenId -> m ()
     -- ^ Delete a token's trie (permanent removal)
-    , registerTrie :: TokenId -> m ()
-    -- ^ Register an existing trie (persistent backend
-    -- only). Makes 'withTrie' work for tries that
-    -- already have data in storage. No-op for
-    -- in-memory backends.
     , hideTrie :: TokenId -> m ()
     -- ^ Mark a token's trie as hidden (burn forward).
     -- Data is preserved; 'withTrie' will fail until

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/PureManager.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/PureManager.hs
@@ -58,7 +58,6 @@ mkPureTrieManager = do
                 pureWithSpeculativeTrie ref hiddenRef
             , createTrie = pureCreateTrie ref
             , deleteTrie = pureDeleteTrie ref
-            , registerTrie = \_ -> pure ()
             , hideTrie = pureHideTrie hiddenRef
             , unhideTrie = pureUnhideTrie hiddenRef
             }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -229,8 +229,6 @@ dummyTrieManager =
             error "dummyTrieManager: createTrie"
         , deleteTrie = \_ ->
             error "dummyTrieManager: deleteTrie"
-        , registerTrie = \_ ->
-            error "dummyTrieManager: registerTrie"
         , hideTrie = \_ ->
             error "dummyTrieManager: hideTrie"
         , unhideTrie = \_ ->

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -32,7 +32,7 @@ import Cardano.MPFS.TxBuilderSpec qualified as TxBuilderSpec
 main :: IO ()
 main =
     PersistentSpec.withTestDB
-        $ \db nodesCF kvCF -> do
+        $ \db nodesCF kvCF metaCF -> do
             counterRef <- newIORef (0 :: Int)
             hspec $ do
                 BootstrapSpec.spec
@@ -47,6 +47,7 @@ main =
                     db
                     nodesCF
                     kvCF
+                    metaCF
                     counterRef
                 StateSpec.spec
                     mkMockTokens


### PR DESCRIPTION
Closes #55

## Summary

- Add `trie-meta` RocksDB column family storing `TokenId -> TrieStatus` (Visible/Hidden)
- On startup, `scanTrieMeta` rebuilds the IORef caches so trie state survives restarts
- `createTrie`/`deleteTrie`/`hideTrie`/`unhideTrie` now persist status atomically alongside data operations
- Remove `registerTrie` from the `TrieManager` interface (no longer needed)
- Existing reopen tests now pass without any `registerTrie` calls

## Changes

- **Columns.hs**: Add `TrieStatus` type, `TrieMeta` constructor, update GEq/GCompare
- **Codecs.hs**: Add `trieStatusPrism` (0x01=Visible, 0x02=Hidden), `TrieMeta` codec entry
- **Trie.hs**: Remove `registerTrie` field
- **PureManager.hs**: Remove `registerTrie` field assignment
- **Persistent.hs**: Add `metaCF` parameter, startup scan, persist registry ops atomically
- **Application.hs**: Add `trie-meta` CF (7 cage CFs, 11 total), pass `metaCF`
- **Tests**: Thread `metaCF`, remove `registerTrie` calls, add test isolation for shared DB