### PR TITLE
chore: bump cardano-utxo-csmt and align shared deps

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -33,14 +33,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/paolino/cardano-utxo-csmt
-  tag: 0cfcf85659ec7541d8bd2a87fd37d002020ae38a
-  --sha256: 0jvz19sz20jc6mpddx38gzjp35szpnhd6rrr20l82fyark1xpgmx
+  tag: 24d2e2de470e0ea466abc8e293e51b6e6567eb93
+  --sha256: 18br8zm3ba8ww709jq0aivzma51w32hqhxs8dwc400p042p8gmxa
 
 source-repository-package
   type: git
-  location: https://github.com/paolino/haskell-csmt
-  tag: e46ef731076cf0884d5ed0f047d0dd74e622aea8
-  --sha256: 00rmqxffkdpr4jbbz3s9pw5bqmb97jgkxzg5m235n9l364m748c0
+  location: https://github.com/paolino/haskell-mts
+  tag: e876bea60e7a4d00a4966252fac0132ad0645656
+  --sha256: 0c2ffvr3dvv6dxy0gyhwvv5424xa600cgcd5gcvms4z2xw5d249m
 
 source-repository-package
   type: git
@@ -57,7 +57,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/paolino/cardano-node-clients
-  tag: 6586effe864e0a6f28d0df36210958b62c4e3f39
+  tag: a965c5eee0af2057141a798edc223693170707b6
   --sha256: 09bsmrp8pgnqzxx2hxw9b3pdv0p0zzqiji43wxw7ha8b6d0igivv
 
 -- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -43,6 +43,7 @@ library
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-binary
+    , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
@@ -189,6 +190,7 @@ test-suite e2e-tests
     , cardano-ledger-allegra
     , cardano-ledger-api
     , cardano-ledger-binary
+    , cardano-ledger-byron
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-ledger-shelley

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -50,6 +50,7 @@ import Cardano.Ledger.Mary.Value
     )
 import Cardano.Ledger.TxIn (TxIn (..))
 
+import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -299,7 +300,9 @@ withE2E scriptBytes action = do
                         cageCfg scriptBytes startMs
                     appCfg =
                         AppConfig
-                            { networkMagic =
+                            { epochSlots =
+                                EpochSlots 4320
+                            , networkMagic =
                                 devnetMagic
                             , socketPath = sock
                             , dbPath = dbDir

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -58,6 +58,7 @@ import Cardano.Ledger.Mary.Value
     )
 import Cardano.Ledger.TxIn (TxIn (..))
 
+import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -404,7 +405,9 @@ withE2E scriptBytes action = do
         let cfg = cageCfg scriptBytes startMs
             appCfg =
                 AppConfig
-                    { networkMagic =
+                    { epochSlots =
+                        EpochSlots 4320
+                    , networkMagic =
                         devnetMagic
                     , socketPath = sock
                     , dbPath = dbDir

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -39,6 +39,7 @@ import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
 import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.Mary.Value (MultiAsset (..))
 
+import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -306,7 +307,9 @@ withE2E scriptBytes action = do
                         cageCfg scriptBytes startMs
                     appCfg =
                         AppConfig
-                            { networkMagic =
+                            { epochSlots =
+                                EpochSlots 4320
+                            , networkMagic =
                                 devnetMagic
                             , socketPath = sock
                             , dbPath = dbDir

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -37,6 +37,7 @@ import Cardano.Ledger.BaseTypes
     )
 import Cardano.Ledger.TxIn (TxIn (..))
 
+import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -933,7 +934,9 @@ withE2E scriptBytes action = do
                         cageCfg scriptBytes startMs
                     appCfg =
                         AppConfig
-                            { networkMagic =
+                            { epochSlots =
+                                EpochSlots 4320
+                            , networkMagic =
                                 devnetMagic
                             , socketPath = sock
                             , dbPath = dbDir

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -49,6 +49,7 @@ import Control.Exception (throwIO)
 import Control.Monad (when)
 import Control.Tracer (nullTracer)
 
+import Cardano.Chain.Slotting (EpochSlots)
 import Cardano.Ledger.Binary
     ( DecCBOR
     , DecoderError
@@ -68,6 +69,7 @@ import Database.KV.Transaction
     )
 import Database.KV.Transaction qualified as L
     ( RunTransaction (..)
+    , Transaction
     )
 import Database.RocksDB
     ( Config (..)
@@ -85,7 +87,8 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
-    , insertCSMT
+    , CSMTOps (..)
+    , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction qualified as CSMT
     ( RunTransaction (..)
@@ -156,7 +159,9 @@ import Cardano.Node.Client.N2C.Connection
 
 -- | Application configuration.
 data AppConfig = AppConfig
-    { networkMagic :: !NetworkMagic
+    { epochSlots :: !EpochSlots
+    -- ^ Byron epoch slots (21600 mainnet/preprod, 4320 preview)
+    , networkMagic :: !NetworkMagic
     -- ^ Network magic (e.g. mainnet, preview)
     , socketPath :: !FilePath
     -- ^ Path to the cardano-node Unix socket
@@ -263,11 +268,14 @@ withApplication cfg action =
                             metaCF
 
                     -- UTxO state machine
+                    let ops =
+                            mkCSMTOps
+                                (fromKV context)
+                                (hashing context)
                     (utxoUpdate, availPts) <-
                         createUpdateState
                             nullTracer
-                            (fromKV context)
-                            (hashing context)
+                            ops
                             slotHash
                             (\_ _ -> pure ())
                             armageddonParams
@@ -278,7 +286,7 @@ withApplication cfg action =
                         (bootstrapFile cfg)
                         st
                         utxoRt
-                        context
+                        ops
 
                     let startPts :: [Point]
                         startPts =
@@ -323,6 +331,7 @@ withApplication cfg action =
                                     async $ do
                                         er <-
                                             runLocalNodeApplication
+                                                (epochSlots cfg)
                                                 (networkMagic cfg)
                                                 (socketPath cfg)
                                                 chainSyncApp
@@ -390,10 +399,19 @@ seedBootstrap
     :: Maybe FilePath
     -> CageSt.State IO
     -> CSMT.RunTransaction cf op slot hash BSL.ByteString BSL.ByteString IO
-    -> CSMTContext hash BSL.ByteString BSL.ByteString
+    -> CSMTOps
+        ( L.Transaction
+            IO
+            cf
+            (Columns slot hash BSL.ByteString BSL.ByteString)
+            op
+        )
+        BSL.ByteString
+        BSL.ByteString
+        hash
     -> IO ()
 seedBootstrap Nothing _ _ _ = pure ()
-seedBootstrap (Just fp) st runner CSMTContext{..} =
+seedBootstrap (Just fp) st runner ops =
     do
         existing <-
             CageSt.getCheckpoint
@@ -421,9 +439,8 @@ seedBootstrap (Just fp) st runner CSMTContext{..} =
                     []
     onEntry k v =
         CSMT.transact runner
-            $ insertCSMT
-                fromKV
-                hashing
+            $ csmtInsert
+                ops
                 (BSL.fromStrict k)
                 (BSL.fromStrict v)
 


### PR DESCRIPTION
## Summary
- cardano-utxo-csmt → 24d2e2d (mts migration, isValid fix, empty block skip, db-query tool, EpochSlots param)
- haskell-csmt → haskell-mts at e876bea
- cardano-node-clients → a965c5e (public devnet sublibrary)
- Adapt to CSMTOps API replacing insertCSMT/FromKV+Hashing
- Add EpochSlots to AppConfig for parameterized Byron codec

Note: rocksdb-kv-transactions stays at 44c3c2a (needs mapColumns, which csmt's pin 0888387 lacks). Opened cardano-utxo-csmt#123 to align.

Closes #85