### PR TITLE
fix: run unit tests inside nix develop for MPFS_BLUEPRINT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build and run offchain tests
         run: |
           nix build .#offchain-tests --quiet
-          ./result/bin/unit-tests
+          nix develop --quiet -c ./result/bin/unit-tests
 
       - name: Build offchain interfaces
         run: nix build .#cardano-mpfs-offchain --quiet


### PR DESCRIPTION
Closes #46

CI ran `./result/bin/unit-tests` directly, outside `nix develop`, so the shellHook never fired and `MPFS_BLUEPRINT` was unset. Blueprint-gated tests silently skipped.

Now runs `nix develop --quiet -c ./result/bin/unit-tests`, matching the E2E job pattern.