### PR TITLE
test: unit tests for detectCageEvents edge cases and field roundtrips

### DIFF
--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/FollowerSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/FollowerSpec.hs
@@ -86,14 +86,17 @@ import Cardano.MPFS.Indexer.Follower
     , computeInverse
     )
 import Cardano.MPFS.Indexer.TxFixtures
-    ( mkBootTx
+    ( mkBootRequestTx
+    , mkBootTx
     , mkBurnTx
+    , mkPlainTx
     , mkRequestTx
     , mkRetractTx
     , mkUpdateTx
     , testCageAddr
     , testPolicyId
     , testScriptHash
+    , wrongScriptHash
     )
 import Cardano.MPFS.Mock.State (mkMockState)
 import Cardano.MPFS.State
@@ -738,6 +741,125 @@ detectionTests =
                         events
                             `shouldSatisfy` any
                                 (isUpdate tid)
+
+            -- Edge cases and field extraction
+
+            it
+                "returns [] for a tx with no\
+                \ cage content"
+                $ property
+                $ forAll genTxIn
+                $ \dummyIn -> do
+                    let tx = mkPlainTx dummyIn
+                        events =
+                            detectCageEvents
+                                testScriptHash
+                                []
+                                tx
+                    events `shouldBe` []
+
+            it
+                "returns [] when ScriptHash\
+                \ does not match"
+                $ property
+                $ forAll
+                    ( (,,)
+                        <$> genTokenId
+                        <*> genTokenState
+                        <*> genTxIn
+                    )
+                $ \(tid, ts, seedIn) -> do
+                    let tx =
+                            mkBootTx tid ts seedIn
+                        events =
+                            detectCageEvents
+                                wrongScriptHash
+                                []
+                                tx
+                    events `shouldBe` []
+
+            it
+                "boot roundtrips TokenId and\
+                \ TokenState fields"
+                $ property
+                $ forAll
+                    ( (,,)
+                        <$> genTokenId
+                        <*> genTokenState
+                        <*> genTxIn
+                    )
+                $ \(tid, ts, seedIn) -> do
+                    let tx =
+                            mkBootTx tid ts seedIn
+                        events =
+                            detectCageEvents
+                                testScriptHash
+                                []
+                                tx
+                    events
+                        `shouldBe` [CageBoot tid ts]
+
+            it
+                "request roundtrips all Request\
+                \ fields"
+                $ property
+                $ forAll
+                    ( do
+                        tid <- genTokenId
+                        txIn <- genTxIn
+                        req <- genRequest tid
+                        pure (txIn, req)
+                    )
+                $ \(txIn, req) -> do
+                    let tx = mkRequestTx req txIn
+                        events =
+                            detectCageEvents
+                                testScriptHash
+                                []
+                                tx
+                    length events
+                        `shouldBe` 1
+                    case events of
+                        [CageRequest _ req'] ->
+                            req' `shouldBe` req
+                        other ->
+                            fail
+                                $ "expected [CageRequest\
+                                  \ ...], got "
+                                    ++ show other
+
+            it
+                "detects multiple events in\
+                \ one tx (boot + request)"
+                $ property
+                $ forAll
+                    ( do
+                        tid <- genTokenId
+                        ts <- genTokenState
+                        req <- genRequest tid
+                        seedIn <- genTxIn
+                        pure (tid, ts, req, seedIn)
+                    )
+                $ \(tid, ts, req, seedIn) -> do
+                    let tx =
+                            mkBootRequestTx
+                                tid
+                                ts
+                                req
+                                seedIn
+                        events =
+                            detectCageEvents
+                                testScriptHash
+                                []
+                                tx
+                    events
+                        `shouldSatisfy` any
+                            (isBoot tid)
+                    events
+                        `shouldSatisfy` any
+                            isRequestEvt
+                    length events
+                        `shouldSatisfy` (>= 2)
 
 -- ---------------------------------------------------------
 -- Event classifiers

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
@@ -18,20 +18,24 @@ module Cardano.MPFS.Indexer.TxFixtures
     , mkRequestTx
     , mkUpdateTx
     , mkRetractTx
+    , mkPlainTx
+    , mkBootRequestTx
 
       -- * Test script hash
     , testScriptHash
+    , wrongScriptHash
     , testPolicyId
     , testCageAddr
     ) where
 
 import Data.ByteString.Short qualified as SBS
+import Data.Foldable (toList)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
 import Data.Word (Word32)
-import Lens.Micro ((&), (.~))
+import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Crypto.Hash
     ( Blake2b_224
@@ -42,6 +46,7 @@ import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Api.Tx
     ( Tx
+    , bodyTxL
     , mkBasicTx
     , witsTxL
     )
@@ -121,6 +126,16 @@ testScriptHash =
 -- | Test policy ID from 'testScriptHash'.
 testPolicyId :: PolicyID
 testPolicyId = PolicyID testScriptHash
+
+-- | A different script hash (28 bytes of 0xBB) for
+-- testing that the ScriptHash filter works.
+wrongScriptHash :: ScriptHash
+wrongScriptHash =
+    ScriptHash
+        $ fromJust
+        $ hashFromStringAsHex @Blake2b_224
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbb\
+            \bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 -- | Test cage address (Testnet).
 testCageAddr :: Addr
@@ -302,6 +317,63 @@ mkRetractTx reqInput extraInput =
                 & inputsTxBodyL .~ allInputs
     in  mkBasicTx body
             & witsTxL . rdmrsTxWitsL .~ redeemers
+
+-- | Build a plain transaction with no cage-related
+-- content: no mints, no cage-address outputs, no
+-- spending redeemers.
+mkPlainTx :: TxIn -> Tx ConwayEra
+mkPlainTx dummyInput =
+    let body =
+            mkBasicTxBody
+                & inputsTxBodyL
+                    .~ Set.singleton dummyInput
+    in  mkBasicTx body
+
+-- | Build a transaction containing both a boot
+-- (mint +1 with StateDatum) and a request
+-- (RequestDatum output) for the same token.
+-- | Combine a boot and a request into one tx.
+-- Reuses 'mkBootTx' structure for the state output
+-- and 'mkRequestTx' logic for the request output.
+mkBootRequestTx
+    :: TokenId
+    -> TokenState
+    -> Request
+    -> TxIn
+    -- ^ Seed input
+    -> Tx ConwayEra
+mkBootRequestTx tid ts req seedInput =
+    let
+        -- Extract the request-only tx body to get
+        -- the request output
+        reqTx = mkRequestTx req seedInput
+        reqOuts =
+            toList
+                (reqTx ^. bodyTxL . outputsTxBodyL)
+        -- Build boot parts
+        assetName = unTokenId tid
+        mintMA =
+            MultiAsset
+                $ Map.singleton testPolicyId
+                $ Map.singleton assetName 1
+        stateDatum = mkStateDatum ts (root ts)
+        outValue =
+            MaryValue (Coin 2_000_000) mintMA
+        stateOut =
+            mkBasicTxOut testCageAddr outValue
+                & datumTxOutL
+                    .~ mkInlineDatum
+                        (toPlcData stateDatum)
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL
+                    .~ Set.singleton seedInput
+                & outputsTxBodyL
+                    .~ StrictSeq.fromList
+                        (stateOut : reqOuts)
+                & mintTxBodyL .~ mintMA
+    in
+        mkBasicTx body
 
 -- ---------------------------------------------------------
 -- Internal helpers


### PR DESCRIPTION
## Summary

- Add 5 new property tests for `detectCageEvents` covering edge cases and field extraction:
  - No-cage tx returns `[]`
  - Wrong `ScriptHash` returns `[]`
  - Boot roundtrips `TokenId` + `TokenState` exactly
  - Request roundtrips all `Request` fields exactly
  - Multiple events (boot + request) detected in a single tx
- Add `mkPlainTx`, `mkBootRequestTx`, `wrongScriptHash` to `TxFixtures`

Closes #43

## Test plan

- [x] All 317 unit tests pass (5 new)