### PR TITLE
feat: replace nullTracer with structured logging

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -103,6 +103,7 @@ library
     Cardano.MPFS.State
     Cardano.MPFS.Submitter
     Cardano.MPFS.Submitter.N2C
+    Cardano.MPFS.Trace
     Cardano.MPFS.Trie
     Cardano.MPFS.Trie.Persistent
     Cardano.MPFS.Trie.Pure
@@ -204,6 +205,7 @@ test-suite e2e-tests
     , cardano-node-clients
     , cardano-node-clients:devnet
     , containers
+    , contra-tracer
     , directory
     , filepath
     , hspec                        >=2.11 && <2.12

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -51,6 +51,8 @@ import Cardano.Ledger.Mary.Value
 import Cardano.Ledger.TxIn (TxIn (..))
 
 import Cardano.Chain.Slotting (EpochSlots (..))
+import Control.Tracer (nullTracer)
+
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -312,6 +314,8 @@ withE2E scriptBytes action = do
                                 Just bsFile
                             , followerEnabled =
                                 True
+                            , appTracer =
+                                nullTracer
                             }
                 withApplication appCfg $ \ctx -> do
                     _ <-

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -59,6 +59,8 @@ import Cardano.Ledger.Mary.Value
 import Cardano.Ledger.TxIn (TxIn (..))
 
 import Cardano.Chain.Slotting (EpochSlots (..))
+import Control.Tracer (nullTracer)
+
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -417,6 +419,8 @@ withE2E scriptBytes action = do
                         Just bsFile
                     , followerEnabled =
                         False
+                    , appTracer =
+                        nullTracer
                     }
         withApplication appCfg $ \ctx -> do
             _ <-

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -40,6 +40,8 @@ import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.Mary.Value (MultiAsset (..))
 
 import Cardano.Chain.Slotting (EpochSlots (..))
+import Control.Tracer (nullTracer)
+
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -319,6 +321,8 @@ withE2E scriptBytes action = do
                                 Just bsFile
                             , followerEnabled =
                                 True
+                            , appTracer =
+                                nullTracer
                             }
                 withApplication appCfg $ \ctx -> do
                     _ <-

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -38,6 +38,8 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.TxIn (TxIn (..))
 
 import Cardano.Chain.Slotting (EpochSlots (..))
+import Control.Tracer (nullTracer)
+
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -946,6 +948,8 @@ withE2E scriptBytes action = do
                                 Just bsFile
                             , followerEnabled =
                                 False
+                            , appTracer =
+                                nullTracer
                             }
                 withApplication appCfg $ \ctx -> do
                     _ <-

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -56,7 +56,7 @@ import Control.Concurrent.Async
     )
 import Control.Exception (throwIO)
 import Control.Monad (when)
-import Control.Tracer (nullTracer)
+import Control.Tracer (Tracer, contramap)
 import Data.IORef (newIORef)
 import Data.Maybe (isNothing)
 
@@ -83,6 +83,9 @@ import Database.RocksDB
 import Ouroboros.Network.Magic (NetworkMagic)
 import Ouroboros.Network.Point (WithOrigin (..))
 
+import Cardano.UTxOCSMT.Application.BlockFetch
+    ( HeaderSkipProgress (..)
+    )
 import Cardano.UTxOCSMT.Application.ChainSyncN2C
     ( mkN2CChainSyncApplication
     )
@@ -117,6 +120,7 @@ import Cardano.UTxOCSMT.Ouroboros.Types
     )
 import MTS.Rollbacks.Store qualified as Store
 
+import Ouroboros.Consensus.Cardano.Node ()
 import Ouroboros.Network.Block qualified as Network
 
 import Cardano.MPFS.Context (Context (..))
@@ -144,6 +148,10 @@ import Cardano.MPFS.Provider.NodeClient
     )
 import Cardano.MPFS.State qualified as CageSt
 import Cardano.MPFS.Submitter.N2C (mkN2CSubmitter)
+import Cardano.MPFS.Trace
+    ( AppTrace (..)
+    , adaptUpdate
+    )
 import Cardano.MPFS.Trie.Persistent
     ( mkPersistentTrieManager
     )
@@ -177,6 +185,8 @@ data AppConfig = AppConfig
     -- ^ CBOR bootstrap file for fresh DB seeding
     , followerEnabled :: !Bool
     -- ^ Start CageFollower ChainSync processing
+    , appTracer :: Tracer IO AppTrace
+    -- ^ Application event tracer
     }
 
 -- | Default RocksDB configuration.
@@ -296,7 +306,10 @@ withApplication cfg action =
                                 <$> firstEntry
                     when empty
                         $ setup
-                            nullTracer
+                            ( contramap
+                                TraceArmageddon
+                                (appTracer cfg)
+                            )
                             utxoRt
                             armageddonParams
 
@@ -338,16 +351,34 @@ withApplication cfg action =
                                                 $ cageConfig
                                                     cfg
                                             )
-                                            nullTracer
+                                            ( contramap
+                                                adaptUpdate
+                                                (appTracer cfg)
+                                            )
                                             ops
                                             slotHash
                                             countRef
                                             run
                                     chainSyncApp =
                                         mkN2CChainSyncApplication
-                                            nullTracer
-                                            nullTracer
-                                            nullTracer
+                                            ( contramap
+                                                ( TraceBlockReceived
+                                                    . Network.blockSlot
+                                                )
+                                                (appTracer cfg)
+                                            )
+                                            ( contramap
+                                                TraceChainTip
+                                                (appTracer cfg)
+                                            )
+                                            ( contramap
+                                                ( \p ->
+                                                    TraceSkipProgress
+                                                        (skipCurrentSlot p)
+                                                        (skipTargetSlot p)
+                                                )
+                                                (appTracer cfg)
+                                            )
                                             (\_ -> pure ())
                                             (pure ())
                                             Nothing

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trace.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trace.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.Trace
+-- Description : Structured application tracing
+-- License     : Apache-2.0
+--
+-- Unified trace type for the MPFS offchain service.
+-- All runtime events — block processing, chain tip
+-- updates, Mithril skip progress, and armageddon
+-- setup — are funnelled through 'AppTrace' so a
+-- single 'Tracer IO AppTrace' can drive structured
+-- logging.
+module Cardano.MPFS.Trace
+    ( -- * Trace types
+      AppTrace (..)
+
+      -- * Formatters
+    , jsonLinesTracer
+
+      -- * Sub-tracer adapters
+    , adaptUpdate
+    ) where
+
+import Control.Tracer (Tracer (..))
+import Data.Aeson
+    ( ToJSON (..)
+    , object
+    , (.=)
+    )
+import Data.ByteString.Lazy.Char8 qualified as BSL
+import Data.Time (getCurrentTime)
+import Ouroboros.Network.Block
+    ( SlotNo
+    , pointSlot
+    )
+import Ouroboros.Network.Point (WithOrigin (..))
+import System.IO (hFlush, stderr)
+
+import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
+    ( ArmageddonTrace (..)
+    )
+import Cardano.UTxOCSMT.Application.Database.Implementation.Update
+    ( UpdateTrace (..)
+    )
+import Cardano.UTxOCSMT.Ouroboros.Types
+    ( Point
+    )
+
+import Data.Aeson qualified as Aeson
+
+-- | Unified application trace type.
+data AppTrace
+    = -- | Armageddon setup events (once at startup)
+      TraceArmageddon ArmageddonTrace
+    | -- | Per-block UTxO update (slot, inserts, deletes)
+      TraceBlock SlotNo Int Int
+    | -- | Chain tip slot update
+      TraceChainTip SlotNo
+    | -- | Mithril skip progress (current, target)
+      TraceSkipProgress SlotNo SlotNo
+    | -- | Raw block received from ChainSync
+      TraceBlockReceived SlotNo
+    deriving (Show)
+
+instance ToJSON AppTrace where
+    toJSON (TraceArmageddon t) =
+        object
+            [ "event" .= ("armageddon" :: String)
+            , "phase" .= show t
+            ]
+    toJSON (TraceBlock slot ins del) =
+        object
+            [ "event" .= ("block" :: String)
+            , "slot" .= show slot
+            , "inserts" .= ins
+            , "deletes" .= del
+            ]
+    toJSON (TraceChainTip slot) =
+        object
+            [ "event" .= ("chain_tip" :: String)
+            , "slot" .= show slot
+            ]
+    toJSON (TraceSkipProgress cur tgt) =
+        object
+            [ "event"
+                .= ("skip_progress" :: String)
+            , "current" .= show cur
+            , "target" .= show tgt
+            ]
+    toJSON (TraceBlockReceived slot) =
+        object
+            [ "event"
+                .= ( "block_received"
+                        :: String
+                   )
+            , "slot" .= show slot
+            ]
+
+-- | JSON-lines tracer writing to stderr with
+-- timestamps.
+jsonLinesTracer :: Tracer IO AppTrace
+jsonLinesTracer = Tracer $ \ev -> do
+    now <- getCurrentTime
+    let entry =
+            object
+                [ "ts" .= show now
+                , "trace" .= ev
+                ]
+    BSL.hPut stderr
+        $ Aeson.encode entry <> "\n"
+    hFlush stderr
+
+-- | Adapt 'UpdateTrace' to 'AppTrace'.
+-- Extracts the interesting fields from the
+-- polymorphic 'UpdateTrace' sum.
+adaptUpdate
+    :: UpdateTrace Point hash -> AppTrace
+adaptUpdate (UpdateArmageddon t) =
+    TraceArmageddon t
+adaptUpdate (UpdateForwardTip pt ins del _) =
+    TraceBlock (ptSlot pt) ins del
+adaptUpdate (UpdateNewState pts) =
+    case pts of
+        (p : _) -> TraceChainTip (ptSlot p)
+        [] -> TraceChainTip 0
+
+-- | Extract 'SlotNo' from a 'Point', defaulting
+-- to 0 for 'Origin'.
+ptSlot :: Point -> SlotNo
+ptSlot p = case pointSlot p of
+    Origin -> 0
+    At s -> s


### PR DESCRIPTION
Closes #68

## Summary

- Add `Cardano.MPFS.Trace` module with `AppTrace` sum type (5 constructors), `ToJSON` instance, and `jsonLinesTracer` for JSON-lines stderr output
- Add `appTracer :: Tracer IO AppTrace` field to `AppConfig`
- Replace all 5 `nullTracer` sites in `Application.hs` with `contramap`-derived sub-tracers covering: armageddon setup, block processing, chain tip updates, skip progress, and block received events
- E2E tests pass `nullTracer` for the new field

## Test plan

- [x] `cabal build all -O0` — library, executable, and test suites compile
- [x] `cabal test unit-tests` — all 317 tests pass
- [ ] E2E tests (require devnet node)