### PR TITLE
feat: integrate mts:rollbacks into cage indexer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -32,14 +32,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/paolino/cardano-utxo-csmt
-  tag: 86027606ca1e13ae40b395546c623bbe07f3dbdc
-  --sha256: 15ilfwmyqapci65sxjq33lscgjwa27s35632gs7c88p4h0l45xfy
+  tag: 98996b28c1a30b0a793aa31248b3eb756ac013f1
+  --sha256: 1jijix8929m5spxqavr7q6vjvl3w9v5izfa94fy8qasr6370kf7p
 
 source-repository-package
   type: git
   location: https://github.com/paolino/haskell-mts
-  tag: b7696e8d24a9d5c62efdd653d3031e77fd968116
-  --sha256: 117603f7fpga7pspb9cms6arn6g1alqvqqcfa6p7r93ri33hv25p
+  tag: 4cd13f802ccafcedc1d3c0944fd20f26eca21564
+  --sha256: 0qpxgjl96q63c186w1ag5cmlzc9lzg70200jph9dk4564rbq2nyz
 
 source-repository-package
   type: git

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -62,6 +62,7 @@ library
     , microlens
     , mts:mpf
     , mts:mpf-test-lib
+    , mts:rollbacks
     , ouroboros-consensus-cardano
     , ouroboros-network-api
     , plutus-core
@@ -154,6 +155,7 @@ test-suite unit-tests
     , microlens
     , mts:mpf
     , mts:mpf-test-lib
+    , mts:rollbacks
     , plutus-core
     , plutus-tx
     , QuickCheck                               >=2.14 && <2.18

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -267,7 +267,7 @@ chainsyncSpecs scriptBytes = do
                             expectationFailure
                                 "no checkpoint \
                                 \after processing"
-                        Just (SlotNo s, _, _) ->
+                        Just (SlotNo s, _) ->
                             s
                                 `shouldSatisfy` (> 0)
 

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -101,8 +101,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction qualifie
     ( RunTransaction (..)
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
-    ( countRollbackPoints
-    , sampleRollbackPoints
+    ( sampleRollbackPoints
     )
 import Cardano.UTxOCSMT.Application.Run.Config
     ( armageddonParams
@@ -116,6 +115,7 @@ import Cardano.UTxOCSMT.Ouroboros.ConnectionN2C
 import Cardano.UTxOCSMT.Ouroboros.Types
     ( Point
     )
+import MTS.Rollbacks.Store qualified as Store
 
 import Ouroboros.Network.Block qualified as Network
 
@@ -312,9 +312,8 @@ withApplication cfg action =
                     initialCount <-
                         run
                             $ mapColumns InUtxo
-                            $ iterating
+                            $ Store.countPoints
                                 RollbackPoints
-                                countRollbackPoints
                     countRef <-
                         newIORef initialCount
 
@@ -461,7 +460,6 @@ seedBootstrap (Just fp) st runner ops =
                     (CageSt.checkpoints st)
                     (SlotNo bootstrapSlot)
                     (BlockId h)
-                    []
     onEntry k v =
         CSMT.transact runner
             $ csmtInsert

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 
 -- |
@@ -43,6 +45,7 @@ module Cardano.MPFS.Indexer.CageFollower
     , mkCageIntersector
     ) where
 
+import Control.Monad (forM_)
 import Control.Tracer (Tracer)
 import Data.ByteString.Lazy (LazyByteString)
 import Data.IORef
@@ -71,14 +74,15 @@ import Cardano.UTxOCSMT.Application.BlockFetch
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     ( Columns (..)
     )
+import Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
+    ( pattern UTxORollbackPoint
+    )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
-    ( CSMTOps
+    ( CSMTOps (..)
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
-    ( RollbackResult (..)
-    , UpdateTrace
+    ( UpdateTrace
     , forwardTip
-    , rollbackTip
     , sampleRollbackPoints
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
@@ -94,6 +98,7 @@ import Cardano.UTxOCSMT.Ouroboros.Types
     , Point
     , ProgressOrRewind (..)
     )
+import MTS.Rollbacks.Store qualified as Store
 
 import Database.KV.Transaction
     ( Transaction
@@ -124,11 +129,7 @@ import Cardano.MPFS.Indexer.Persistent
 import Cardano.MPFS.Indexer.Rollback
     ( putCheckpointT
     , rollbackToSlotT
-    , storeRollbackT
-    )
-import Cardano.MPFS.State
-    ( Checkpoints (..)
-    , State (..)
+    , storeRollbackPointT
     )
 import Cardano.MPFS.Trie.Persistent
     ( mkUnifiedTrieManager
@@ -381,25 +382,14 @@ mkCageFollower
                             fetchedPoint
                             utxoOps
 
-                -- 4. Read current checkpoint for
-                -- active slots list
-                mCp <-
-                    mapColumns InCage
-                        $ getCheckpoint
-                            (checkpoints txState)
-                let activeSlots = case mCp of
-                        Nothing -> [slot]
-                        Just (_, _, slots) ->
-                            slot : slots
-
-                -- 5. Store rollback inverses and
+                -- 4. Store rollback inverses and
                 -- update checkpoint
                 mapColumns InCage $ do
-                    storeRollbackT slot invs
-                    putCheckpointT
+                    storeRollbackPointT
                         slot
-                        blockId
-                        activeSlots
+                        invs
+                        (Just blockId)
+                    putCheckpointT slot blockId
 
                 pure tipStored
 
@@ -417,36 +407,64 @@ mkCageFollower
         rollBwd point = do
             let targetSlot = pointToSlot point
 
-            (result, deleted) <- run $ do
-                -- 1. Rollback UTxO CSMT
-                r@(rbResult, _) <-
+            result <- run $ do
+                -- Guard: if the rollback target is
+                -- ahead of the UTxO tip, the rollback
+                -- is a no-op (e.g. initial RollBackward
+                -- to genesis when tip is Origin).
+                utxoTip <-
                     mapColumns InUtxo
-                        $ rollbackTip
-                            ops
-                            point
-                -- 2. Rollback cage state only if
-                -- UTxO rollback succeeded — both
-                -- subsystems must stay in sync.
-                case rbResult of
-                    RollbackSucceeded ->
-                        mapColumns InCage
-                            $ rollbackToSlotT
-                                txState
-                                txTm
-                                targetSlot
-                    RollbackImpossible ->
-                        pure ()
-                pure r
+                        $ Store.queryTip
+                            RollbackPoints
+                case utxoTip of
+                    Just tip
+                        | At point > tip ->
+                            pure
+                                $ Store.RollbackSucceeded
+                                    0
+                    _ -> do
+                        -- 1. Rollback UTxO CSMT
+                        utxoResult <-
+                            mapColumns InUtxo
+                                $ Store.rollbackTo
+                                    RollbackPoints
+                                    ( \(UTxORollbackPoint _ ios _) ->
+                                        forM_ ios
+                                            $ \case
+                                                Insert k v ->
+                                                    csmtInsert
+                                                        ops
+                                                        k
+                                                        v
+                                                Delete k ->
+                                                    csmtDelete
+                                                        ops
+                                                        k
+                                    )
+                                    (At point)
+                        -- 2. Rollback cage state only
+                        -- if UTxO rollback succeeded —
+                        -- both subsystems must stay in
+                        -- sync.
+                        case utxoResult of
+                            Store.RollbackSucceeded _ ->
+                                mapColumns InCage
+                                    $ rollbackToSlotT
+                                        txState
+                                        txTm
+                                        targetSlot
+                            Store.RollbackImpossible ->
+                                pure ()
+                        pure utxoResult
 
             -- Post-commit: adjust rollback counter
-            modifyIORef'
-                countRef
-                (subtract deleted)
-
             case result of
-                RollbackSucceeded ->
+                Store.RollbackSucceeded deleted -> do
+                    modifyIORef'
+                        countRef
+                        (subtract deleted)
                     pure $ Progress follower
-                RollbackImpossible -> do
+                Store.RollbackImpossible -> do
                     -- Sample remaining rollback
                     -- points to find new
                     -- intersection

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs
@@ -37,7 +37,7 @@ module Cardano.MPFS.Indexer.Codecs
     , unitPrism
     , checkpointPrism
     , slotNoPrism
-    , rollbackEntryPrism
+    , rollbackPointPrism
     , trieStatusPrism
     ) where
 
@@ -102,10 +102,11 @@ import Cardano.MPFS.Core.Types
     , TokenState (..)
     , TxIn
     )
+import MTS.Rollbacks.Types (RollbackPoint (..))
+
 import Cardano.MPFS.Indexer.Columns
     ( AllColumns (..)
     , CageCheckpoint (..)
-    , CageRollbackEntry (..)
     , TrieStatus (..)
     , UnifiedColumns (..)
     )
@@ -135,7 +136,7 @@ allCodecs =
         , CageRollbacks
             :=> Codecs
                 { keyCodec = slotNoPrism
-                , valueCodec = rollbackEntryPrism
+                , valueCodec = rollbackPointPrism
                 }
         , TrieNodes
             :=> mpfCodecs isoMPFHash
@@ -258,46 +259,66 @@ unitPrism :: Prism' ByteString ()
 unitPrism =
     prism' (const mempty) (const (Just ()))
 
--- | Encode/decode 'CageCheckpoint' as a 3-element
--- CBOR list: @[slot, blockId, rollbackSlots]@.
+-- | Encode/decode 'CageCheckpoint' as a 2-element
+-- CBOR list: @[slot, blockId]@.
 checkpointPrism :: Prism' ByteString CageCheckpoint
 checkpointPrism = prism' enc dec
   where
     enc CageCheckpoint{..} =
         toStrictByteString
-            $ encodeListLen 3
+            $ encodeListLen 2
                 <> encodeBytes
                     (ledgerEnc checkpointSlot)
                 <> encodeBytes
                     (unBlockId checkpointBlockId)
-                <> encodeSlotList rollbackSlots
     dec = decodeCBOR $ do
-        decodeListLenOf 3
+        decodeListLenOf 2
         s <- ledgerDec =<< decodeBytes
         b <- BlockId <$> decodeBytes
-        slots <- decodeSlotList
         pure
             CageCheckpoint
                 { checkpointSlot = s
                 , checkpointBlockId = b
-                , rollbackSlots = slots
                 }
 
 -- | Encode/decode 'SlotNo' via ledger CBOR.
 slotNoPrism :: Prism' ByteString SlotNo
 slotNoPrism = prism' ledgerEnc ledgerDecMaybe
 
--- | Encode/decode 'CageRollbackEntry' as a CBOR
--- list of tagged inverse ops.
-rollbackEntryPrism
-    :: Prism' ByteString CageRollbackEntry
-rollbackEntryPrism = prism' enc dec
+-- | Encode/decode 'RollbackPoint CageInverseOp
+-- BlockId' as a 2-element CBOR list:
+-- @[inverses, meta]@.
+rollbackPointPrism
+    :: Prism'
+        ByteString
+        (RollbackPoint CageInverseOp BlockId)
+rollbackPointPrism = prism' enc dec
   where
-    enc (CageRollbackEntry ops) =
-        toStrictByteString $ encodeInvOps ops
-    dec =
-        decodeCBOR
-            $ CageRollbackEntry <$> decodeInvOps
+    enc RollbackPoint{..} =
+        toStrictByteString
+            $ encodeListLen 2
+                <> encodeInvOps rpInverses
+                <> encodeMaybeMeta rpMeta
+    dec = decodeCBOR $ do
+        decodeListLenOf 2
+        invs <- decodeInvOps
+        meta <- decodeMaybeMeta
+        pure
+            RollbackPoint
+                { rpInverses = invs
+                , rpMeta = meta
+                }
+    encodeMaybeMeta Nothing = encodeListLen 0
+    encodeMaybeMeta (Just (BlockId bs)) =
+        encodeListLen 1 <> encodeBytes bs
+    decodeMaybeMeta = do
+        n <- decodeListLen
+        case n of
+            0 -> pure Nothing
+            1 ->
+                Just . BlockId <$> decodeBytes
+            _ ->
+                fail "decodeMaybeMeta: bad len"
 
 -- | Prism for 'MPFHash' values in trie columns.
 -- Reuses the codec from @haskell-mts@ test lib.
@@ -393,20 +414,6 @@ decodeOperation = do
                 <$> decodeBytes
                 <*> decodeBytes
         _ -> fail "Unknown Operation tag"
-
--- --------------------------------------------------------
--- Slot list encoding
--- --------------------------------------------------------
-
-encodeSlotList :: [SlotNo] -> Encoding
-encodeSlotList ss =
-    encodeListLen (fromIntegral (length ss))
-        <> foldMap (encodeBytes . ledgerEnc) ss
-
-decodeSlotList :: Decoder s [SlotNo]
-decodeSlotList = do
-    n <- decodeListLen
-    mapM (const $ ledgerDec =<< decodeBytes) [1 .. n]
 
 -- --------------------------------------------------------
 -- CageInverseOp CBOR encoding

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs
@@ -40,9 +40,6 @@ module Cardano.MPFS.Indexer.Columns
       -- * Checkpoint type
     , CageCheckpoint (..)
 
-      -- * Rollback entry type
-    , CageRollbackEntry (..)
-
       -- * Trie registry status
     , TrieStatus (..)
     ) where
@@ -61,6 +58,8 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
 
 import MPF.Hashes (MPFHash)
 import MPF.Interface (HexIndirect, HexKey)
+
+import MTS.Rollbacks.Types (RollbackPoint)
 
 import Cardano.MPFS.Core.Types
     ( BlockId
@@ -90,16 +89,6 @@ data CageCheckpoint = CageCheckpoint
     -- ^ Slot of the last processed block
     , checkpointBlockId :: !BlockId
     -- ^ Header hash of the last processed block
-    , rollbackSlots :: ![SlotNo]
-    -- ^ Slots with stored inverse ops, bounded by
-    -- the security parameter (k ≈ 2160).
-    }
-    deriving stock (Eq, Show)
-
--- | Inverse ops stored for a single block's slot,
--- used for rollback.
-newtype CageRollbackEntry = CageRollbackEntry
-    { unRollbackEntry :: [CageInverseOp]
     }
     deriving stock (Eq, Show)
 
@@ -120,9 +109,16 @@ data AllColumns x where
     CageCfg
         :: AllColumns (KV () CageCheckpoint)
     -- | Rollback storage: maps slot numbers to
-    -- inverse ops for rollback.
+    -- inverse 'RollbackPoint's for rollback.
     CageRollbacks
-        :: AllColumns (KV SlotNo CageRollbackEntry)
+        :: AllColumns
+            ( KV
+                SlotNo
+                ( RollbackPoint
+                    CageInverseOp
+                    BlockId
+                )
+            )
     -- | Trie nodes: MPF trie structure. Keys are
     -- 'HexKey' paths, values are 'HexIndirect'
     -- nodes containing hash pointers.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs
@@ -162,9 +162,8 @@ mkTransactionalCheckpoints =
                     Just
                         ( checkpointSlot
                         , checkpointBlockId
-                        , rollbackSlots
                         )
-        , putCheckpoint = \s b slots ->
+        , putCheckpoint = \s b ->
             insert CageCfg ()
-                $ CageCheckpoint s b slots
+                $ CageCheckpoint s b
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs
@@ -3,26 +3,27 @@
 -- Description : Rollback to a previous slot
 -- License     : Apache-2.0
 --
--- Slot-based rollback for the cage indexer. All
--- operations are transactional: they compose into a
--- single DB write batch, ensuring atomicity from
--- protocol to protocol (one rollback = one commit).
+-- Slot-based rollback for the cage indexer using the
+-- @mts:rollbacks@ library. All operations are
+-- transactional: they compose into a single DB write
+-- batch, ensuring atomicity (one rollback = one
+-- commit).
 module Cardano.MPFS.Indexer.Rollback
     ( -- * Transactional operations
-      storeRollbackT
-    , loadRollbackT
-    , deleteRollbackT
+      storeRollbackPointT
     , putCheckpointT
     , rollbackToSlotT
+    , queryTipT
+    , pruneRollbacksT
     ) where
 
-import Control.Monad (forM_)
+import MTS.Rollbacks.Store qualified as Store
+import MTS.Rollbacks.Types (RollbackPoint (..))
 
 import Cardano.MPFS.Core.Types (BlockId (..), SlotNo)
 import Cardano.MPFS.Indexer.Columns
     ( AllColumns (..)
     , CageCheckpoint (..)
-    , CageRollbackEntry (..)
     )
 import Cardano.MPFS.Indexer.Event
     ( CageInverseOp
@@ -31,65 +32,60 @@ import Cardano.MPFS.Indexer.Follower
     ( applyCageInverses
     )
 import Cardano.MPFS.State
-    ( Checkpoints (..)
-    , State (..)
+    ( State (..)
     )
 import Cardano.MPFS.Trie (TrieManager)
 import Database.KV.Transaction
     ( Transaction
-    , delete
     , insert
-    , query
     )
 
--- | Store inverse ops for a block within a
--- transaction. No auto-commit.
-storeRollbackT
+-- | Store a rollback point at the given slot.
+storeRollbackPointT
     :: SlotNo
     -> [CageInverseOp]
+    -> Maybe BlockId
     -> Transaction m cf AllColumns ops ()
-storeRollbackT slot invs =
-    insert
+storeRollbackPointT slot invs meta =
+    Store.storeRollbackPoint
         CageRollbacks
         slot
-        (CageRollbackEntry invs)
-
--- | Load inverse ops for a slot within a
--- transaction.
-loadRollbackT
-    :: (Monad m)
-    => SlotNo
-    -> Transaction
-        m
-        cf
-        AllColumns
-        ops
-        (Maybe [CageInverseOp])
-loadRollbackT slot = do
-    mEntry <- query CageRollbacks slot
-    pure $ fmap unRollbackEntry mEntry
-
--- | Delete stored inverse ops within a transaction.
-deleteRollbackT
-    :: SlotNo
-    -> Transaction m cf AllColumns ops ()
-deleteRollbackT = delete CageRollbacks
+        RollbackPoint
+            { rpInverses = invs
+            , rpMeta = meta
+            }
 
 -- | Store a checkpoint within a transaction.
 putCheckpointT
     :: SlotNo
     -> BlockId
-    -> [SlotNo]
     -> Transaction m cf AllColumns ops ()
-putCheckpointT s b slots =
-    insert CageCfg () (CageCheckpoint s b slots)
+putCheckpointT s b =
+    insert CageCfg () (CageCheckpoint s b)
 
--- | Roll back cage state to a target slot within a
--- transaction. Replays inverse ops for all slots
--- after the target, in reverse order. The entire
--- rollback (load inverses, apply them, delete
--- entries, update checkpoint) executes in one
--- atomic write batch.
+-- | Query the current rollback tip slot.
+queryTipT
+    :: (Monad m)
+    => Transaction
+        m
+        cf
+        AllColumns
+        ops
+        (Maybe SlotNo)
+queryTipT = Store.queryTip CageRollbacks
+
+-- | Prune rollback points below a slot.
+pruneRollbacksT
+    :: (Monad m)
+    => SlotNo
+    -> Transaction m cf AllColumns ops Int
+pruneRollbacksT =
+    Store.pruneBelow CageRollbacks
+
+-- | Roll back cage state to a target slot within
+-- a transaction. Uses the library's cursor-based
+-- backward walk to iterate from tip, applying
+-- inverses for each point strictly after target.
 rollbackToSlotT
     :: (Monad m)
     => State
@@ -99,30 +95,20 @@ rollbackToSlotT
     -> SlotNo
     -> Transaction m cf AllColumns ops ()
 rollbackToSlotT st tm targetSlot = do
-    mCp <- getCheckpoint (checkpoints st)
-    case mCp of
-        Nothing -> pure ()
-        Just (_currentSlot, _blockId, activeSlots) ->
-            do
-                let slotsToRevert =
-                        reverse
-                            $ filter
-                                (> targetSlot)
-                                activeSlots
-                forM_ slotsToRevert $ \slot -> do
-                    mInvs <- loadRollbackT slot
-                    forM_ mInvs $ \invs ->
-                        applyCageInverses
-                            st
-                            tm
-                            (reverse invs)
-                    deleteRollbackT slot
-                -- Update checkpoint
-                let keptSlots =
-                        filter
-                            (<= targetSlot)
-                            activeSlots
-                putCheckpointT
-                    targetSlot
-                    (BlockId mempty)
-                    keptSlots
+    result <-
+        Store.rollbackTo
+            CageRollbacks
+            ( \RollbackPoint{rpInverses} ->
+                applyCageInverses
+                    st
+                    tm
+                    (reverse rpInverses)
+            )
+            targetSlot
+    case result of
+        Store.RollbackSucceeded _ ->
+            putCheckpointT
+                targetSlot
+                (BlockId mempty)
+        Store.RollbackImpossible ->
+            pure ()

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
@@ -84,15 +84,15 @@ mkMockCheckpoints = do
     ref <-
         newIORef
             ( Nothing
-                :: Maybe (SlotNo, BlockId, [SlotNo])
+                :: Maybe (SlotNo, BlockId)
             )
     pure
         Checkpoints
             { getCheckpoint = readIORef ref
-            , putCheckpoint = \s b slots ->
+            , putCheckpoint = \s b ->
                 modifyIORef'
                     ref
-                    (const (Just (s, b, slots)))
+                    (const (Just (s, b)))
             }
 
 -- | Create a complete mock 'State IO' bundling

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
@@ -80,14 +80,12 @@ data Requests m = Requests
 -- | Interface for chain sync checkpoints.
 data Checkpoints m = Checkpoints
     { getCheckpoint
-        :: m (Maybe (SlotNo, BlockId, [SlotNo]))
+        :: m (Maybe (SlotNo, BlockId))
     -- ^ Get the last processed checkpoint:
-    -- (slot, blockId, rollbackSlots). The rollback
-    -- slots list tracks which slots have stored
-    -- inverse ops, bounded by the security parameter.
+    -- (slot, blockId).
     , putCheckpoint
-        :: SlotNo -> BlockId -> [SlotNo] -> m ()
-    -- ^ Store a new checkpoint with rollback slots
+        :: SlotNo -> BlockId -> m ()
+    -- ^ Store a new checkpoint
     }
 
 -- | Lift a 'State' across a natural transformation.
@@ -136,6 +134,6 @@ hoistCheckpoints
 hoistCheckpoints f Checkpoints{..} =
     Checkpoints
         { getCheckpoint = f getCheckpoint
-        , putCheckpoint = \s b slots ->
-            f (putCheckpoint s b slots)
+        , putCheckpoint = \s b ->
+            f (putCheckpoint s b)
         }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/CodecsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/CodecsSpec.hs
@@ -13,7 +13,8 @@ import Data.ByteString qualified as BS
 import Test.Hspec (Spec, describe)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck
-    ( choose
+    ( Gen
+    , choose
     , forAll
     , vectorOf
     , (=/=)
@@ -21,6 +22,9 @@ import Test.QuickCheck
     , (==>)
     )
 
+import MTS.Rollbacks.Types (RollbackPoint (..))
+
+import Cardano.MPFS.Core.Types (BlockId)
 import Cardano.MPFS.Generators
     ( genBlockId
     , genCageInverseOp
@@ -33,7 +37,7 @@ import Cardano.MPFS.Generators
 import Cardano.MPFS.Indexer.Codecs
     ( checkpointPrism
     , requestPrism
-    , rollbackEntryPrism
+    , rollbackPointPrism
     , slotNoPrism
     , tokenIdPrism
     , tokenStatePrism
@@ -42,7 +46,9 @@ import Cardano.MPFS.Indexer.Codecs
     )
 import Cardano.MPFS.Indexer.Columns
     ( CageCheckpoint (..)
-    , CageRollbackEntry (..)
+    )
+import Cardano.MPFS.Indexer.Event
+    ( CageInverseOp
     )
 
 spec :: Spec
@@ -92,16 +98,14 @@ spec = describe "Codecs" $ do
             $ forAll genSlotNo
             $ \s ->
                 forAll genBlockId $ \b ->
-                    forAll genSlotList $ \slots ->
-                        let cp =
-                                CageCheckpoint s b slots
-                        in  preview
+                    let cp = CageCheckpoint s b
+                    in  preview
+                            checkpointPrism
+                            ( review
                                 checkpointPrism
-                                ( review
-                                    checkpointPrism
-                                    cp
-                                )
-                                === Just cp
+                                cp
+                            )
+                            === Just cp
 
         prop "slotNoPrism"
             $ forAll genSlotNo
@@ -111,16 +115,16 @@ spec = describe "Codecs" $ do
                     (review slotNoPrism s)
                     === Just s
 
-        prop "rollbackEntryPrism"
-            $ forAll genRollbackEntry
-            $ \entry ->
+        prop "rollbackPointPrism"
+            $ forAll genRollbackPoint
+            $ \rp ->
                 preview
-                    rollbackEntryPrism
+                    rollbackPointPrism
                     ( review
-                        rollbackEntryPrism
-                        entry
+                        rollbackPointPrism
+                        rp
                     )
-                    === Just entry
+                    === Just rp
 
     -- -------------------------------------------
     -- Injectivity (Lean: roundTrip_implies_injective)
@@ -171,23 +175,22 @@ spec = describe "Codecs" $ do
             $ forAll genSlotNo
             $ \s ->
                 forAll genBlockId $ \b ->
-                    forAll genSlotList $ \slots ->
-                        not
-                            ( BS.null
-                                ( review
-                                    checkpointPrism
-                                    ( CageCheckpoint
-                                        s
-                                        b
-                                        slots
-                                    )
-                                )
+                    not
+                        ( BS.null
+                            ( review
+                                checkpointPrism
+                                (CageCheckpoint s b)
                             )
+                        )
   where
-    genSlotList = do
+    genRollbackPoint
+        :: Gen
+            (RollbackPoint CageInverseOp BlockId)
+    genRollbackPoint = do
         n <- choose (0 :: Int, 5)
-        vectorOf n genSlotNo
-    genRollbackEntry = do
-        n <- choose (0 :: Int, 5)
-        CageRollbackEntry
-            <$> vectorOf n genCageInverseOp
+        invs <- vectorOf n genCageInverseOp
+        pure
+            RollbackPoint
+                { rpInverses = invs
+                , rpMeta = Nothing
+                }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
@@ -349,12 +349,11 @@ checkpointsSpec = do
                             (checkpoints st)
                             s
                             b
-                            []
                         r <-
                             getCheckpoint
                                 (checkpoints st)
                         pure
-                            (r === Just (s, b, []))
+                            (r === Just (s, b))
 
     prop "put overwrites previous"
         $ forAll genSlotNo
@@ -369,19 +368,17 @@ checkpointsSpec = do
                                     (checkpoints st)
                                     s1
                                     b1
-                                    []
                                 putCheckpoint
                                     (checkpoints st)
                                     s2
                                     b2
-                                    []
                                 r <-
                                     getCheckpoint
                                         (checkpoints st)
                                 pure
                                     ( r
                                         === Just
-                                            (s2, b2, [])
+                                            (s2, b2)
                                     )
 
 -- ---------------------------------------------------------
@@ -434,14 +431,13 @@ checkpointSurvivesReopen =
                     (checkpoints st)
                     fixSlot
                     fixBlockId
-                    []
             -- Phase 2: reopen and verify
             withTestStateAt dir $ \st -> do
                 r <-
                     getCheckpoint (checkpoints st)
                 r
                     `shouldBe` Just
-                        (fixSlot, fixBlockId, [])
+                        (fixSlot, fixBlockId)
 
 -- | Put then remove a token, close DB, reopen,
 -- verify removal persisted.

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/StateSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/StateSpec.hs
@@ -168,9 +168,9 @@ checkpointsSpec newCheckpoints = do
             forAll genBlockId $ \b ->
                 monadicIO $ do
                     cp <- run newCheckpoints
-                    run $ putCheckpoint cp s b []
+                    run $ putCheckpoint cp s b
                     r <- run $ getCheckpoint cp
-                    assert (r == Just (s, b, []))
+                    assert (r == Just (s, b))
 
     prop "put overwrites previous"
         $ forAll genSlotNo
@@ -185,13 +185,11 @@ checkpointsSpec newCheckpoints = do
                                     cp
                                     s1
                                     b1
-                                    []
                             run
                                 $ putCheckpoint
                                     cp
                                     s2
                                     b2
-                                    []
                             r <- run $ getCheckpoint cp
                             assert
-                                (r == Just (s2, b2, []))
+                                (r == Just (s2, b2))


### PR DESCRIPTION
## Summary

- Replace hand-rolled rollback storage with `mts:rollbacks` library
- Remove `CageRollbackEntry` newtype, use `RollbackPoint` directly
- Simplify `CageCheckpoint` to 2 fields (drop `rollbackSlots`)
- Simplify `Checkpoints` interface (drop slot list)
- Fix infinite rollback loop: add tip-ahead guard in `CageFollower.rollBwd`
- Bump cardano-utxo-csmt pin to `98996b2`

Breaking change: DB wipe required (codec changes).

Closes #99

## Test plan

- [x] 317 unit tests pass
- [x] 19 E2E tests pass (including CageFlow and ChainSync)