### PR TITLE
chore: update org references from paolino to lambdasistemi

### DIFF
--- a/cardano-mpfs-offchain/NAVIGATION.md
+++ b/cardano-mpfs-offchain/NAVIGATION.md
@@ -5,7 +5,7 @@ A human-readable map of the offchain library. Each section explains
 
 Base module: `Cardano.MPFS`
 
-[lib]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS
+[lib]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS
 
 ---
 
@@ -43,14 +43,14 @@ Ledger re-exports and MPFS-specific domain types.
 
 -> [Core/Types.hs:L69-L136][f-types]
 
-[s-TokenId]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22newtype+TokenId%22&type=code
-[s-Root]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22newtype+Root%22+path%3ACore&type=code
-[s-Request]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+Request%22+path%3ACore%2FTypes&type=code
-[s-TokenState]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+TokenState%22+path%3ACore%2FTypes&type=code
-[s-Operation]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+Operation%22+path%3ACore&type=code
-[s-Fact]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+Fact%22&type=code
-[s-BlockId]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22newtype+BlockId%22&type=code
-[f-types]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs#L69-L136
+[s-TokenId]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+TokenId%22&type=code
+[s-Root]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+Root%22+path%3ACore&type=code
+[s-Request]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Request%22+path%3ACore%2FTypes&type=code
+[s-TokenState]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+TokenState%22+path%3ACore%2FTypes&type=code
+[s-Operation]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Operation%22+path%3ACore&type=code
+[s-Fact]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Fact%22&type=code
+[s-BlockId]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+BlockId%22&type=code
+[f-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs#L69-L136
 
 ### OnChain
 
@@ -73,16 +73,16 @@ Key functions:
 - **[`deriveAssetName`][s-deriveAssetName]**: SHA2-256(txId ++ bigEndian16(idx)) — deterministic token name
   -> [Core/OnChain.hs:L728-L747][f-onchain-derive]
 
-[s-CageDatum]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+CageDatum%22&type=code
-[s-MintRedeemer]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+MintRedeemer%22&type=code
-[s-UpdateRedeemer]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+UpdateRedeemer%22&type=code
-[s-ProofStep]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+ProofStep%22+path%3AOnChain&type=code
-[s-cageScriptHash]: https://github.com/paolino/cardano-mpfs-offchain/search?q=cageScriptHash+path%3AOnChain&type=code
-[s-cageAddr]: https://github.com/paolino/cardano-mpfs-offchain/search?q=cageAddr+path%3AOnChain&type=code
-[s-deriveAssetName]: https://github.com/paolino/cardano-mpfs-offchain/search?q=deriveAssetName&type=code
-[f-onchain-hash]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L668-L710
-[f-onchain-addr]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L713-L718
-[f-onchain-derive]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L728-L747
+[s-CageDatum]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageDatum%22&type=code
+[s-MintRedeemer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+MintRedeemer%22&type=code
+[s-UpdateRedeemer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+UpdateRedeemer%22&type=code
+[s-ProofStep]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+ProofStep%22+path%3AOnChain&type=code
+[s-cageScriptHash]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=cageScriptHash+path%3AOnChain&type=code
+[s-cageAddr]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=cageAddr+path%3AOnChain&type=code
+[s-deriveAssetName]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=deriveAssetName&type=code
+[f-onchain-hash]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L668-L710
+[f-onchain-addr]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L713-L718
+[f-onchain-derive]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L728-L747
 
 ### Blueprint
 
@@ -97,14 +97,14 @@ CIP-57 Plutus blueprint loading and schema validation.
 - **[`applyVersion`][s-applyVersion]**: Apply version parameter to UPLC script
   -> [Core/Blueprint.hs:L312-L346][f-blueprint-version]
 
-[s-loadBlueprint]: https://github.com/paolino/cardano-mpfs-offchain/search?q=loadBlueprint&type=code
-[s-extractCompiledCode]: https://github.com/paolino/cardano-mpfs-offchain/search?q=extractCompiledCode&type=code
-[s-validateData]: https://github.com/paolino/cardano-mpfs-offchain/search?q=validateData+path%3ABlueprint&type=code
-[s-applyVersion]: https://github.com/paolino/cardano-mpfs-offchain/search?q=applyVersion&type=code
-[f-blueprint-load]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L198-L202
-[f-blueprint-extract]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L262-L274
-[f-blueprint-validate]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L210-L236
-[f-blueprint-version]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L312-L346
+[s-loadBlueprint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=loadBlueprint&type=code
+[s-extractCompiledCode]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=extractCompiledCode&type=code
+[s-validateData]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=validateData+path%3ABlueprint&type=code
+[s-applyVersion]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=applyVersion&type=code
+[f-blueprint-load]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L198-L202
+[f-blueprint-extract]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L262-L274
+[f-blueprint-validate]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L210-L236
+[f-blueprint-version]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L312-L346
 
 ### Proof
 
@@ -116,10 +116,10 @@ on-chain `ProofStep` lists and raw CBOR bytes.
 - **[`toProofSteps`][s-toProofSteps]**: MPF proof -> `[ProofStep]` (reverses leaf-to-root to root-to-leaf)
   -> [Core/Proof.hs:L147-L150][f-proof-steps]
 
-[s-serializeProof]: https://github.com/paolino/cardano-mpfs-offchain/search?q=serializeProof&type=code
-[s-toProofSteps]: https://github.com/paolino/cardano-mpfs-offchain/search?q=toProofSteps&type=code
-[f-proof-ser]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Proof.hs#L54-L63
-[f-proof-steps]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Proof.hs#L147-L150
+[s-serializeProof]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=serializeProof&type=code
+[s-toProofSteps]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=toProofSteps&type=code
+[f-proof-ser]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Proof.hs#L54-L63
+[f-proof-steps]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Proof.hs#L147-L150
 
 ### Balance
 
@@ -129,8 +129,8 @@ output, iterates `setMinFeeTx` until stable (max 10 rounds).
 - **[`balanceTx`][s-balanceTx]**: Pure transaction balancer
   -> [Core/Balance.hs:L64-L153][f-balance]
 
-[s-balanceTx]: https://github.com/paolino/cardano-mpfs-offchain/search?q=balanceTx+path%3ABalance&type=code
-[f-balance]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Balance.hs#L64-L153
+[s-balanceTx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=balanceTx+path%3ABalance&type=code
+[f-balance]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Balance.hs#L64-L153
 
 ### Bootstrap
 
@@ -142,10 +142,10 @@ Stream-decodes entries without loading the full map into memory.
 - **[`foldBootstrapEntries`][s-foldBootstrap]**: Stream-decode with callbacks (header, then each entry)
   -> [Core/Bootstrap.hs:L96-L135][f-bootstrap-fold]
 
-[s-encodeBootstrap]: https://github.com/paolino/cardano-mpfs-offchain/search?q=encodeBootstrapFile&type=code
-[s-foldBootstrap]: https://github.com/paolino/cardano-mpfs-offchain/search?q=foldBootstrapEntries&type=code
-[f-bootstrap-enc]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Bootstrap.hs#L69-L90
-[f-bootstrap-fold]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Bootstrap.hs#L96-L135
+[s-encodeBootstrap]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=encodeBootstrapFile&type=code
+[s-foldBootstrap]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=foldBootstrapEntries&type=code
+[f-bootstrap-enc]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Bootstrap.hs#L69-L90
+[f-bootstrap-fold]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Bootstrap.hs#L96-L135
 
 ---
 
@@ -169,9 +169,9 @@ Read-only blockchain queries.
 Real: [`mkNodeClientProvider`][s-mkNodeClientProvider] (N2C LSQ)
 Mock: [`mkMockProvider`][s-mkMockProvider] (empty results)
 
-[f-provider]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs#L24-L36
-[s-mkNodeClientProvider]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkNodeClientProvider&type=code
-[s-mkMockProvider]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockProvider&type=code
+[f-provider]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs#L24-L36
+[s-mkNodeClientProvider]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkNodeClientProvider&type=code
+[s-mkMockProvider]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockProvider&type=code
 
 ### State
 
@@ -188,12 +188,12 @@ Token and request state with three sub-records.
 Real: [`mkPersistentState`][s-mkPersistentState] (RocksDB)
 Mock: [`mkMockState`][s-mkMockState] (IORef maps)
 
-[s-Tokens]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+Tokens%22&type=code
-[s-Requests]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+Requests%22&type=code
-[s-Checkpoints]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+Checkpoints%22&type=code
-[f-state]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs#L30-L77
-[s-mkPersistentState]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPersistentState&type=code
-[s-mkMockState]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockState&type=code
+[s-Tokens]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Tokens%22&type=code
+[s-Requests]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Requests%22&type=code
+[s-Checkpoints]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Checkpoints%22&type=code
+[f-state]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs#L30-L77
+[s-mkPersistentState]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPersistentState&type=code
+[s-mkMockState]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockState&type=code
 
 ### TrieManager
 
@@ -214,10 +214,10 @@ The [`Trie m`][s-Trie] record exposes: `insert`, `delete`, `lookup`,
 Real: [`mkPersistentTrieManager`][s-mkPersistentTrieManager] (RocksDB, token-prefixed keys)
 Pure: [`mkPureTrieManager`][s-mkPureTrieManager] (IORef maps)
 
-[s-Trie]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+Trie+m%22&type=code
-[f-trie]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs#L32-L88
-[s-mkPersistentTrieManager]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPersistentTrieManager&type=code
-[s-mkPureTrieManager]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPureTrieManager&type=code
+[s-Trie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Trie+m%22&type=code
+[f-trie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs#L32-L88
+[s-mkPersistentTrieManager]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPersistentTrieManager&type=code
+[s-mkPureTrieManager]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPureTrieManager&type=code
 
 ### Submitter
 
@@ -229,9 +229,9 @@ or `Rejected reason`.
 Real: [`mkN2CSubmitter`][s-mkN2CSubmitter] (N2C LocalTxSubmission)
 Mock: [`mkMockSubmitter`][s-mkMockSubmitter] (rejects all)
 
-[f-submitter]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs#L20-L35
-[s-mkN2CSubmitter]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkN2CSubmitter&type=code
-[s-mkMockSubmitter]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockSubmitter&type=code
+[f-submitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs#L20-L35
+[s-mkN2CSubmitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkN2CSubmitter&type=code
+[s-mkMockSubmitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockSubmitter&type=code
 
 ### TxBuilder
 
@@ -250,9 +250,9 @@ Constructs transactions for all cage protocol operations.
 Real: [`mkRealTxBuilder`][s-mkRealTxBuilder]
 Mock: [`mkMockTxBuilder`][s-mkMockTxBuilder] (throws on all ops)
 
-[f-txbuilder]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs#L24-L56
-[s-mkRealTxBuilder]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkRealTxBuilder&type=code
-[s-mkMockTxBuilder]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockTxBuilder&type=code
+[f-txbuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs#L24-L56
+[s-mkRealTxBuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkRealTxBuilder&type=code
+[s-mkMockTxBuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockTxBuilder&type=code
 
 ### Indexer
 
@@ -269,11 +269,11 @@ Chain sync follower with lifecycle control.
 Real: [`Indexer.Follower`][s-Follower] (block processing)
 Mock: [`mkSkeletonIndexer`][s-mkSkeletonIndexer] (no-op) / [`mkMockIndexer`][s-mkMockIndexer]
 
-[s-ChainTip]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+ChainTip%22&type=code
-[f-indexer]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer.hs#L16-L36
-[s-Follower]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
-[s-mkSkeletonIndexer]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkSkeletonIndexer&type=code
-[s-mkMockIndexer]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockIndexer&type=code
+[s-ChainTip]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+ChainTip%22&type=code
+[f-indexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer.hs#L16-L36
+[s-Follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
+[s-mkSkeletonIndexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkSkeletonIndexer&type=code
+[s-mkMockIndexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockIndexer&type=code
 
 ### Context
 
@@ -281,7 +281,7 @@ Facade record bundling all singletons into one environment.
 
 -> [Context.hs:L19-L32][f-context]
 
-[f-context]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs#L19-L32
+[f-context]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs#L19-L32
 
 ---
 
@@ -297,11 +297,11 @@ Two mini-protocols share one connection.
 - **[`newLSQChannel`][s-newLSQChannel]** / **[`newLTxSChannel`][s-newLTxSChannel]**: Create `TBQueue`-backed channels
   -> [NodeClient/Connection.hs:L234-L244][f-nc-chan]
 
-[s-runNodeClient]: https://github.com/paolino/cardano-mpfs-offchain/search?q=runNodeClient+path%3AConnection&type=code
-[s-newLSQChannel]: https://github.com/paolino/cardano-mpfs-offchain/search?q=newLSQChannel&type=code
-[s-newLTxSChannel]: https://github.com/paolino/cardano-mpfs-offchain/search?q=newLTxSChannel&type=code
-[f-nc-conn]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Connection.hs#L122-L143
-[f-nc-chan]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Connection.hs#L234-L244
+[s-runNodeClient]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=runNodeClient+path%3AConnection&type=code
+[s-newLSQChannel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=newLSQChannel&type=code
+[s-newLTxSChannel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=newLTxSChannel&type=code
+[f-nc-conn]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Connection.hs#L122-L143
+[f-nc-chan]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Connection.hs#L234-L244
 
 ### Channel Types
 
@@ -313,10 +313,10 @@ Two mini-protocols share one connection.
 
 -> [NodeClient/Types.hs:L36-L75][f-nc-types]
 
-[s-LSQChannel]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22newtype+LSQChannel%22&type=code
-[s-LTxSChannel]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22newtype+LTxSChannel%22&type=code
-[s-SomeLSQQuery]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+SomeLSQQuery%22&type=code
-[f-nc-types]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Types.hs#L36-L75
+[s-LSQChannel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+LSQChannel%22&type=code
+[s-LTxSChannel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+LTxSChannel%22&type=code
+[s-SomeLSQQuery]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+SomeLSQQuery%22&type=code
+[f-nc-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Types.hs#L36-L75
 
 ### LocalStateQuery
 
@@ -326,16 +326,16 @@ query (no long-lived acquired state).
 - **[`queryLSQ`][s-queryLSQ]**: Submit query through channel, block on `TMVar` result
   -> [NodeClient/LocalStateQuery.hs:L124-L133][f-lsq]
 
-[s-queryLSQ]: https://github.com/paolino/cardano-mpfs-offchain/search?q=queryLSQ&type=code
-[f-lsq]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/LocalStateQuery.hs#L124-L133
+[s-queryLSQ]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=queryLSQ&type=code
+[f-lsq]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/LocalStateQuery.hs#L124-L133
 
 ### LocalTxSubmission
 
 - **[`submitTxN2C`][s-submitTxN2C]**: Submit `GenTx` through channel, block on result
   -> [NodeClient/LocalTxSubmission.hs:L77-L89][f-ltxs]
 
-[s-submitTxN2C]: https://github.com/paolino/cardano-mpfs-offchain/search?q=submitTxN2C&type=code
-[f-ltxs]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/LocalTxSubmission.hs#L77-L89
+[s-submitTxN2C]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=submitTxN2C&type=code
+[f-ltxs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/LocalTxSubmission.hs#L77-L89
 
 ---
 
@@ -352,15 +352,15 @@ network, slot parameters.
 
 -> [TxBuilder/Config.hs:L24-L41][f-txb-cfg]
 
-[s-CageConfig]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+CageConfig%22&type=code
-[f-txb-cfg]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs#L24-L41
+[s-CageConfig]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageConfig%22&type=code
+[f-txb-cfg]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs#L24-L41
 
 ### Entry Point
 
 - **[`mkRealTxBuilder`][s-mkRealTxBuilder]**: Wire Config + Provider + State + TrieManager into `TxBuilder IO`
   -> [TxBuilder/Real.hs:L56-L74][f-txb-real]
 
-[f-txb-real]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs#L56-L74
+[f-txb-real]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs#L56-L74
 
 ### Per-Operation Builders
 
@@ -372,11 +372,11 @@ network, slot parameters.
 | [`Real.Retract`][f-txb-ret] | Cancel request | Spend request UTxO with `Retract` redeemer, reference state UTxO, Phase 2 validity window |
 | [`Real.End`][f-txb-end] | Burn token | Consume state with `End` spending, mint -1 with `Burning` minting |
 
-[f-txb-boot]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs#L80-L200
-[f-txb-req]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs#L56-L161
-[f-txb-upd]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs#L95-L284
-[f-txb-ret]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs#L83-L224
-[f-txb-end]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs#L75-L178
+[f-txb-boot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs#L80-L200
+[f-txb-req]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs#L56-L161
+[f-txb-upd]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs#L95-L284
+[f-txb-ret]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs#L83-L224
+[f-txb-end]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs#L75-L178
 
 ### Internal Helpers
 
@@ -394,15 +394,15 @@ Shared helpers used by all builders.
 
 -> [TxBuilder/Real/Internal.hs][f-txb-int]
 
-[s-posixMsToSlot]: https://github.com/paolino/cardano-mpfs-offchain/search?q=posixMsToSlot&type=code
-[s-posixMsCeilSlot]: https://github.com/paolino/cardano-mpfs-offchain/search?q=posixMsCeilSlot&type=code
-[s-findStateUtxo]: https://github.com/paolino/cardano-mpfs-offchain/search?q=findStateUtxo&type=code
-[s-findRequestUtxos]: https://github.com/paolino/cardano-mpfs-offchain/search?q=findRequestUtxos&type=code
-[s-extractCageDatum]: https://github.com/paolino/cardano-mpfs-offchain/search?q=extractCageDatum&type=code
-[s-mkRequestDatum]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkRequestDatum&type=code
-[s-spendingIndex]: https://github.com/paolino/cardano-mpfs-offchain/search?q=spendingIndex+path%3AInternal&type=code
-[s-computeScriptIntegrity]: https://github.com/paolino/cardano-mpfs-offchain/search?q=computeScriptIntegrity&type=code
-[f-txb-int]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
+[s-posixMsToSlot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=posixMsToSlot&type=code
+[s-posixMsCeilSlot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=posixMsCeilSlot&type=code
+[s-findStateUtxo]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=findStateUtxo&type=code
+[s-findRequestUtxos]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=findRequestUtxos&type=code
+[s-extractCageDatum]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=extractCageDatum&type=code
+[s-mkRequestDatum]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkRequestDatum&type=code
+[s-spendingIndex]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=spendingIndex+path%3AInternal&type=code
+[s-computeScriptIntegrity]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=computeScriptIntegrity&type=code
+[f-txb-int]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
 
 ---
 
@@ -428,12 +428,12 @@ All state changes in one block commit in a single RocksDB WriteBatch.
 - **[`inversesOf`][s-inversesOf]**: Compute [`CageInverseOp`][s-CageInverseOp] for rollback
   -> [Indexer/Event.hs:L346-L380][f-idx-inverse]
 
-[s-CageEvent]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+CageEvent%22&type=code
-[s-detectCageEvents]: https://github.com/paolino/cardano-mpfs-offchain/search?q=detectCageEvents&type=code
-[s-inversesOf]: https://github.com/paolino/cardano-mpfs-offchain/search?q=inversesOf&type=code
-[s-CageInverseOp]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+CageInverseOp%22&type=code
-[f-idx-detect]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs#L146-L154
-[f-idx-inverse]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs#L346-L380
+[s-CageEvent]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageEvent%22&type=code
+[s-detectCageEvents]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=detectCageEvents&type=code
+[s-inversesOf]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=inversesOf&type=code
+[s-CageInverseOp]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageInverseOp%22&type=code
+[f-idx-detect]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs#L146-L154
+[f-idx-inverse]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs#L346-L380
 
 ### Block Processor (Follower)
 
@@ -447,12 +447,12 @@ to state and trie, record inverse ops for rollback.
 - **[`applyCageInverses`][s-applyCageInverses]**: Replay inverse ops for rollback
   -> [Indexer/Follower.hs:L310-L342][f-follower-inv]
 
-[s-processCageBlock]: https://github.com/paolino/cardano-mpfs-offchain/search?q=processCageBlock&type=code
-[s-applyCageEvent]: https://github.com/paolino/cardano-mpfs-offchain/search?q=applyCageEvent&type=code
-[s-applyCageInverses]: https://github.com/paolino/cardano-mpfs-offchain/search?q=applyCageInverses&type=code
-[f-follower-block]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L86-L107
-[f-follower-apply]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L200-L253
-[f-follower-inv]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L310-L342
+[s-processCageBlock]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=processCageBlock&type=code
+[s-applyCageEvent]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=applyCageEvent&type=code
+[s-applyCageInverses]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=applyCageInverses&type=code
+[f-follower-block]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L86-L107
+[f-follower-apply]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L200-L253
+[f-follower-inv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L310-L342
 
 ### Column Families
 
@@ -470,9 +470,9 @@ the shared RocksDB instance.
 
 -> [Indexer/Columns.hs:L49-L95][f-columns]
 
-[s-AllColumns]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+AllColumns%22&type=code
-[s-CageCheckpoint]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+CageCheckpoint%22&type=code
-[f-columns]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs#L49-L95
+[s-AllColumns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+AllColumns%22&type=code
+[s-CageCheckpoint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageCheckpoint%22&type=code
+[f-columns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs#L49-L95
 
 ### Codecs
 
@@ -482,8 +482,8 @@ CBOR serialization for all column key-value types. Uses
 - **[`allCodecs`][s-allCodecs]**: `DMap` of codecs keyed by `AllColumns`
   -> [Indexer/Codecs.hs:L93-L126][f-codecs]
 
-[s-allCodecs]: https://github.com/paolino/cardano-mpfs-offchain/search?q=allCodecs+path%3ACodecs&type=code
-[f-codecs]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs#L93-L126
+[s-allCodecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=allCodecs+path%3ACodecs&type=code
+[f-codecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs#L93-L126
 
 ### Rollback
 
@@ -494,10 +494,10 @@ Slot-based rollback by replaying stored inverse operations.
 - **[`rollbackToSlot`][s-rollbackToSlot]**: Replay inverses from current tip back to target slot
   -> [Indexer/Rollback.hs:L80-L113][f-rollback-to]
 
-[s-storeRollback]: https://github.com/paolino/cardano-mpfs-offchain/search?q=storeRollback&type=code
-[s-rollbackToSlot]: https://github.com/paolino/cardano-mpfs-offchain/search?q=rollbackToSlot&type=code
-[f-rollback-store]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs#L46-L56
-[f-rollback-to]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs#L80-L113
+[s-storeRollback]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=storeRollback&type=code
+[s-rollbackToSlot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=rollbackToSlot&type=code
+[f-rollback-store]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs#L46-L56
+[f-rollback-to]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs#L80-L113
 
 ### Persistent State
 
@@ -506,7 +506,7 @@ RocksDB-backed `State IO` implementation.
 - **[`mkPersistentState`][s-mkPersistentState]**: Build State from RocksDB column families
   -> [Indexer/Persistent.hs:L48-L56][f-persistent]
 
-[f-persistent]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs#L48-L56
+[f-persistent]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs#L48-L56
 
 ---
 
@@ -523,9 +523,9 @@ Three `TrieManager` implementations sharing the same interface.
 - **[`mkPureTrieManager`][s-mkPureTrieManager]**: Manager backed by `Map TokenId (IORef MPFInMemoryDB)`
   -> [Trie/PureManager.hs:L39-L57][f-trie-pm]
 
-[s-mkPureTrie]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPureTrie&type=code
-[f-trie-pure]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs#L51-L54
-[f-trie-pm]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/PureManager.hs#L39-L57
+[s-mkPureTrie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPureTrie&type=code
+[f-trie-pure]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs#L51-L54
+[f-trie-pm]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/PureManager.hs#L39-L57
 
 ### Persistent (RocksDB)
 
@@ -539,11 +539,11 @@ sessions via transactional snapshots.
 - **[`tokenPrefix`][s-tokenPrefix]**: Serialize `TokenId` to prefix bytes
   -> [Trie/Persistent.hs:L206-L210][f-trie-prefix]
 
-[s-mkPrefixedTrieDB]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPrefixedTrieDB&type=code
-[s-tokenPrefix]: https://github.com/paolino/cardano-mpfs-offchain/search?q=tokenPrefix+path%3APersistent&type=code
-[f-trie-pers]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L117-L162
-[f-trie-prefixed]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L365-L409
-[f-trie-prefix]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L206-L210
+[s-mkPrefixedTrieDB]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPrefixedTrieDB&type=code
+[s-tokenPrefix]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=tokenPrefix+path%3APersistent&type=code
+[f-trie-pers]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L117-L162
+[f-trie-prefixed]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L365-L409
+[f-trie-prefix]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L206-L210
 
 ---
 
@@ -562,14 +562,14 @@ connection required.
 | [`Mock.Indexer`][f-mock-idx] | [`mkMockIndexer`][s-mkMockIndexer] | No-op lifecycle |
 | [`Mock.Skeleton`][f-mock-skel] | [`mkSkeletonIndexer`][s-mkSkeletonIndexer] | IORef/MVar tracking, no chain sync |
 
-[s-mkMockContext]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockContext&type=code
-[f-mock-ctx]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
-[f-mock-st]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
-[f-mock-prv]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Provider.hs
-[f-mock-sub]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Submitter.hs
-[f-mock-txb]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
-[f-mock-idx]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Indexer.hs
-[f-mock-skel]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Skeleton.hs
+[s-mkMockContext]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockContext&type=code
+[f-mock-ctx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
+[f-mock-st]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
+[f-mock-prv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Provider.hs
+[f-mock-sub]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Submitter.hs
+[f-mock-txb]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
+[f-mock-idx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Indexer.hs
+[f-mock-skel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Skeleton.hs
 
 ---
 
@@ -597,7 +597,7 @@ connection required.
 
 -> [Application.hs:L76-L89][f-app-cfg]
 
-[s-withApplication]: https://github.com/paolino/cardano-mpfs-offchain/search?q=withApplication&type=code
-[f-app]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L123-L190
-[f-app-cfg]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L76-L89
-[f-app-cfs]: https://github.com/paolino/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L107-L115
+[s-withApplication]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=withApplication&type=code
+[f-app]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L123-L190
+[f-app-cfg]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L76-L89
+[f-app-cfs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L107-L115

--- a/docs/PHASE4-DESIGN.md
+++ b/docs/PHASE4-DESIGN.md
@@ -284,22 +284,22 @@ Add `cardano-utxo-csmt` as a `source-repository-package` in
 ```cabal
 source-repository-package
   type: git
-  location: https://github.com/paolino/cardano-utxo-csmt
+  location: https://github.com/lambdasistemi/cardano-utxo-csmt
   tag: <commit-hash>
 
 source-repository-package
   type: git
-  location: https://github.com/paolino/haskell-csmt
+  location: https://github.com/lambdasistemi/haskell-mts
   tag: <commit-hash>
 
 source-repository-package
   type: git
-  location: https://github.com/paolino/cardano-read-ledger
+  location: https://github.com/lambdasistemi/cardano-read-ledger
   tag: <commit-hash>
 
 source-repository-package
   type: git
-  location: https://github.com/paolino/contra-tracer-contrib
+  location: https://github.com/lambdasistemi/contra-tracer-contrib
   tag: <commit-hash>
 ```
 

--- a/docs/architecture/block-processing.md
+++ b/docs/architecture/block-processing.md
@@ -267,9 +267,9 @@ transactional layer).
 | [`Indexer.Persistent`][s-persistent] | `mkTransactionalState`, `mkPersistentState` |
 | [`Trie.Persistent`][s-trie-pers] | `mkUnifiedTrieManager`, `mkPersistentTrieManager` |
 
-[s-cage-follower]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code
-[s-follower]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
-[s-columns]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Columns%22&type=code
-[s-rollback]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Rollback%22&type=code
-[s-persistent]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code
-[s-trie-pers]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.Persistent%22&type=code
+[s-cage-follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code
+[s-follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
+[s-columns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Columns%22&type=code
+[s-rollback]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Rollback%22&type=code
+[s-persistent]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code
+[s-trie-pers]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.Persistent%22&type=code

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -118,7 +118,7 @@ graph TD
 The `cardano-mpfs-offchain` library is organized in layers.
 All modules live under `Cardano.MPFS`.
 
-[search all modules]: https://github.com/paolino/cardano-mpfs-offchain/search?q=path%3Acardano-mpfs-offchain%2Flib+extension%3Ahs&type=code
+[search all modules]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=path%3Acardano-mpfs-offchain%2Flib+extension%3Ahs&type=code
 
 ### Core — domain types and pure logic
 
@@ -131,12 +131,12 @@ All modules live under `Cardano.MPFS`.
 | [`Core.Balance`][s-balance] | `balanceTx` — fee estimation fixpoint loop |
 | [`Core.Bootstrap`][s-bootstrap] | CBOR bootstrap file for UTxO seeding |
 
-[s-types]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Types%22&type=code
-[s-onchain]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.OnChain%22&type=code
-[s-blueprint]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Blueprint%22&type=code
-[s-proof]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Proof%22&type=code
-[s-balance]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Balance%22&type=code
-[s-bootstrap]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Bootstrap%22&type=code
+[s-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Types%22&type=code
+[s-onchain]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.OnChain%22&type=code
+[s-blueprint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Blueprint%22&type=code
+[s-proof]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Proof%22&type=code
+[s-balance]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Balance%22&type=code
+[s-bootstrap]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Bootstrap%22&type=code
 
 ### Interfaces — record-of-functions singletons
 
@@ -151,14 +151,14 @@ All modules live under `Cardano.MPFS`.
 | [`Submitter`][s-submitter] | `submitTx :: Tx ConwayEra -> m SubmitResult` |
 | [`Application`][s-application] | `withApplication` — wiring and lifecycle |
 
-[s-context]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Context%22&type=code
-[s-provider]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Provider%22+path%3Alib%2FCardano%2FMPFS%2FProvider.hs&type=code
-[s-state]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.State%22&type=code
-[s-trie]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie%22+path%3Alib%2FCardano%2FMPFS%2FTrie.hs&type=code
-[s-txbuilder]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder%22+path%3Alib%2FCardano%2FMPFS%2FTxBuilder.hs&type=code
-[s-indexer]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer%22+path%3Alib%2FCardano%2FMPFS%2FIndexer.hs&type=code
-[s-submitter]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Submitter%22+path%3Alib%2FCardano%2FMPFS%2FSubmitter.hs&type=code
-[s-application]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Application%22&type=code
+[s-context]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Context%22&type=code
+[s-provider]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Provider%22+path%3Alib%2FCardano%2FMPFS%2FProvider.hs&type=code
+[s-state]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.State%22&type=code
+[s-trie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie%22+path%3Alib%2FCardano%2FMPFS%2FTrie.hs&type=code
+[s-txbuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder%22+path%3Alib%2FCardano%2FMPFS%2FTxBuilder.hs&type=code
+[s-indexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer%22+path%3Alib%2FCardano%2FMPFS%2FIndexer.hs&type=code
+[s-submitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Submitter%22+path%3Alib%2FCardano%2FMPFS%2FSubmitter.hs&type=code
+[s-application]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Application%22&type=code
 
 ### Indexer — chain sync and persistence
 
@@ -172,17 +172,17 @@ All modules live under `Cardano.MPFS`.
 | [`Indexer.Codecs`][s-idx-codecs] | CBOR serialization for column key-value types |
 | [`Indexer.Rollback`][s-idx-rollback] | `storeRollbackT`, `rollbackToSlotT` — transactional rollback |
 
-[s-idx-cage]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code
-[s-idx-event]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Event%22&type=code
-[s-detect]: https://github.com/paolino/cardano-mpfs-offchain/search?q=detectCageEvents&type=code
-[s-idx-follower]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
-[s-idx-persist]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code
-[s-idx-columns]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Columns%22&type=code
-[s-allcolumns]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+AllColumns%22&type=code
-[s-unifiedcols]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+UnifiedColumns%22&type=code
-[s-idx-codecs]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Codecs%22&type=code
-[s-idx-rollback]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Rollback%22&type=code
-[s-inverseop]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22data+CageInverseOp%22&type=code
+[s-idx-cage]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code
+[s-idx-event]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Event%22&type=code
+[s-detect]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=detectCageEvents&type=code
+[s-idx-follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
+[s-idx-persist]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code
+[s-idx-columns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Columns%22&type=code
+[s-allcolumns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+AllColumns%22&type=code
+[s-unifiedcols]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+UnifiedColumns%22&type=code
+[s-idx-codecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Codecs%22&type=code
+[s-idx-rollback]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Rollback%22&type=code
+[s-inverseop]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageInverseOp%22&type=code
 
 ### NodeClient — N2C protocol clients
 
@@ -194,12 +194,12 @@ All modules live under `Cardano.MPFS`.
 | [`NodeClient.Codecs`][s-nc-codecs] | N2C codec bundle |
 | [`NodeClient.Types`][s-nc-types] | `LSQChannel`, `LTxSChannel` |
 
-[s-nc-conn]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Connection%22&type=code
-[s-runnc]: https://github.com/paolino/cardano-mpfs-offchain/search?q=runNodeClient+path%3ANodeClient&type=code
-[s-nc-lsq]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.LocalStateQuery%22&type=code
-[s-nc-ltxs]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.LocalTxSubmission%22&type=code
-[s-nc-codecs]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Codecs%22&type=code
-[s-nc-types]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Types%22&type=code
+[s-nc-conn]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Connection%22&type=code
+[s-runnc]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=runNodeClient+path%3ANodeClient&type=code
+[s-nc-lsq]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.LocalStateQuery%22&type=code
+[s-nc-ltxs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.LocalTxSubmission%22&type=code
+[s-nc-codecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Codecs%22&type=code
+[s-nc-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Types%22&type=code
 
 ### TxBuilder — cage protocol transactions
 
@@ -214,15 +214,15 @@ All modules live under `Cardano.MPFS`.
 | [`TxBuilder.Real.End`][s-txb-end] | Burn cage token |
 | [`TxBuilder.Real.Internal`][s-txb-int] | Shared helpers, POSIX-to-slot conversion |
 
-[s-txb-cfg]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Config%22&type=code
-[s-txb-real]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real%22+path%3AReal.hs&type=code
-[s-mkrealtxb]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkRealTxBuilder&type=code
-[s-txb-boot]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Boot%22&type=code
-[s-txb-req]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Request%22&type=code
-[s-txb-upd]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Update%22&type=code
-[s-txb-ret]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Retract%22&type=code
-[s-txb-end]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.End%22&type=code
-[s-txb-int]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Internal%22&type=code
+[s-txb-cfg]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Config%22&type=code
+[s-txb-real]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real%22+path%3AReal.hs&type=code
+[s-mkrealtxb]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkRealTxBuilder&type=code
+[s-txb-boot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Boot%22&type=code
+[s-txb-req]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Request%22&type=code
+[s-txb-upd]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Update%22&type=code
+[s-txb-ret]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Retract%22&type=code
+[s-txb-end]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.End%22&type=code
+[s-txb-int]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Internal%22&type=code
 
 ### Trie — MPF backends
 
@@ -231,9 +231,9 @@ All modules live under `Cardano.MPFS`.
 | [`Trie.Persistent`][s-trie-pers] | `mkUnifiedTrieManager` (transactional) + `mkPersistentTrieManager` (IO with caches) |
 | [`Trie.PureManager`][s-trie-pm] | [`mkPureTrieManager`][s-mkpuretm] — in-memory `TrieManager` for tests |
 
-[s-trie-pm]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.PureManager%22&type=code
-[s-mkpuretm]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPureTrieManager&type=code
-[s-trie-pers]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.Persistent%22&type=code
+[s-trie-pm]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.PureManager%22&type=code
+[s-mkpuretm]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPureTrieManager&type=code
+[s-trie-pers]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.Persistent%22&type=code
 
 ### Mock — test doubles
 
@@ -247,17 +247,17 @@ All modules live under `Cardano.MPFS`.
 | [`Mock.Indexer`][s-mock-idx] | No-op indexer |
 | [`Mock.Skeleton`][s-mock-skel] | [`mkSkeletonIndexer`][s-mkskel] — lifecycle-only skeleton |
 
-[s-mock-ctx]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Context%22&type=code
-[s-withmock]: https://github.com/paolino/cardano-mpfs-offchain/search?q=withMockContext&type=code
-[s-mock-prv]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Provider%22&type=code
-[s-mock-st]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.State%22&type=code
-[s-mkmockst]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockState&type=code
-[s-mock-sub]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Submitter%22&type=code
-[s-mock-txb]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.TxBuilder%22&type=code
-[s-mkmocktxb]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockTxBuilder&type=code
-[s-mock-idx]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Indexer%22&type=code
-[s-mock-skel]: https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Skeleton%22&type=code
-[s-mkskel]: https://github.com/paolino/cardano-mpfs-offchain/search?q=mkSkeletonIndexer&type=code
+[s-mock-ctx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Context%22&type=code
+[s-withmock]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=withMockContext&type=code
+[s-mock-prv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Provider%22&type=code
+[s-mock-st]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.State%22&type=code
+[s-mkmockst]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockState&type=code
+[s-mock-sub]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Submitter%22&type=code
+[s-mock-txb]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.TxBuilder%22&type=code
+[s-mkmocktxb]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockTxBuilder&type=code
+[s-mock-idx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Indexer%22&type=code
+[s-mock-skel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Skeleton%22&type=code
+[s-mkskel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkSkeletonIndexer&type=code
 
 ## Design Principles
 

--- a/docs/architecture/singletons.md
+++ b/docs/architecture/singletons.md
@@ -10,7 +10,7 @@ a mock.
 Blockchain queries (read-only). Queries a Cardano node via N2C
 LocalStateQuery.
 
-**Implementation:** [`mkNodeClientProvider`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkNodeClientProvider&type=code) (real N2C, in [`Provider.NodeClient`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Provider.NodeClient%22&type=code))
+**Implementation:** [`mkNodeClientProvider`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkNodeClientProvider&type=code) (real N2C, in [`Provider.NodeClient`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Provider.NodeClient%22&type=code))
 
 ```haskell
 data Provider m = Provider
@@ -45,9 +45,9 @@ Manages a map of token identifiers to MPF tries. Each token has
 its own isolated trie, sharing the same RocksDB column families
 with per-token `HexKey` prefix scoping.
 
-**Transactional:** [`mkUnifiedTrieManager`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkUnifiedTrieManager&type=code) — composes into the caller's `Transaction` (used by `CageFollower` for atomic block processing)
-**IO:** [`mkPersistentTrieManager`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPersistentTrieManager&type=code) — auto-commits + IORef caches (used by `TxBuilder` and speculative sessions)
-**Test:** [`mkPureTrieManager`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPureTrieManager&type=code) — in-memory (in [`Trie.PureManager`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.PureManager%22&type=code))
+**Transactional:** [`mkUnifiedTrieManager`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkUnifiedTrieManager&type=code) — composes into the caller's `Transaction` (used by `CageFollower` for atomic block processing)
+**IO:** [`mkPersistentTrieManager`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPersistentTrieManager&type=code) — auto-commits + IORef caches (used by `TxBuilder` and speculative sessions)
+**Test:** [`mkPureTrieManager`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPureTrieManager&type=code) — in-memory (in [`Trie.PureManager`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.PureManager%22&type=code))
 
 ```haskell
 data TrieManager m = TrieManager
@@ -80,9 +80,9 @@ data Trie m = Trie
 Token and request state tracking. Three sub-records for tokens,
 requests, and chain sync checkpoints.
 
-**Transactional:** [`mkTransactionalState`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkTransactionalState&type=code) — composes into the caller's `Transaction` (used by `CageFollower`)
-**IO:** [`mkPersistentState`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkPersistentState&type=code) — auto-commits via `hoistState` (in [`Indexer.Persistent`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code))
-**Test:** [`mkMockState`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockState&type=code) — in-memory (in [`Mock.State`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.State%22&type=code))
+**Transactional:** [`mkTransactionalState`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkTransactionalState&type=code) — composes into the caller's `Transaction` (used by `CageFollower`)
+**IO:** [`mkPersistentState`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPersistentState&type=code) — auto-commits via `hoistState` (in [`Indexer.Persistent`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code))
+**Test:** [`mkMockState`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockState&type=code) — in-memory (in [`Mock.State`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.State%22&type=code))
 
 ```haskell
 data State m = State
@@ -117,8 +117,8 @@ data Checkpoints m = Checkpoints
 
 Chain sync follower with lifecycle control.
 
-**Real:** [`CageFollower`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code) — processes each block in a [single atomic transaction](block-processing.md) covering UTxO, cage state, tries, and rollback
-**Mock:** [`mkSkeletonIndexer`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkSkeletonIndexer&type=code) (lifecycle-only skeleton, in [`Mock.Skeleton`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Skeleton%22&type=code))
+**Real:** [`CageFollower`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code) — processes each block in a [single atomic transaction](block-processing.md) covering UTxO, cage state, tries, and rollback
+**Mock:** [`mkSkeletonIndexer`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkSkeletonIndexer&type=code) (lifecycle-only skeleton, in [`Mock.Skeleton`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Skeleton%22&type=code))
 
 ```haskell
 data ChainTip = ChainTip
@@ -142,7 +142,7 @@ data Indexer m = Indexer
 Transaction submission via N2C LocalTxSubmission. Takes a full
 ledger `Tx ConwayEra` and returns a `SubmitResult`.
 
-**Implementation:** [`mkN2CSubmitter`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkN2CSubmitter&type=code) (real N2C, in [`Submitter.N2C`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Submitter.N2C%22&type=code))
+**Implementation:** [`mkN2CSubmitter`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkN2CSubmitter&type=code) (real N2C, in [`Submitter.N2C`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Submitter.N2C%22&type=code))
 
 ```haskell
 data SubmitResult
@@ -161,8 +161,8 @@ newtype Submitter m = Submitter
 Constructs transactions for all MPFS protocol operations. Returns
 full ledger `Tx` values ready for signing.
 
-**Mock:** [`mkMockTxBuilder`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkMockTxBuilder&type=code) (in [`Mock.TxBuilder`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.TxBuilder%22&type=code))
-**Real:** [`mkRealTxBuilder`](https://github.com/paolino/cardano-mpfs-offchain/search?q=mkRealTxBuilder&type=code) (in [`TxBuilder.Real`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real%22+path%3AReal.hs&type=code))
+**Mock:** [`mkMockTxBuilder`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockTxBuilder&type=code) (in [`Mock.TxBuilder`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.TxBuilder%22&type=code))
+**Real:** [`mkRealTxBuilder`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkRealTxBuilder&type=code) (in [`TxBuilder.Real`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real%22+path%3AReal.hs&type=code))
 
 ```haskell
 data TxBuilder m = TxBuilder
@@ -194,9 +194,9 @@ data TxBuilder m = TxBuilder
 ## Balance
 
 Pure transaction balancing function (not a singleton record), in
-[`Core.Balance`](https://github.com/paolino/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Balance%22&type=code).
+[`Core.Balance`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Balance%22&type=code).
 Adds a fee-paying UTxO and change output, finding the fee via
-a fixpoint loop over [`estimateMinFeeTx`](https://github.com/paolino/cardano-mpfs-offchain/search?q=estimateMinFeeTx&type=code).
+a fixpoint loop over [`estimateMinFeeTx`](https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=estimateMinFeeTx&type=code).
 
 ```haskell
 balanceTx

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Cardano MPFS Offchain
 site_url: https://paolino.github.io/cardano-mpfs-offchain/
-repo_url: https://github.com/paolino/cardano-mpfs-offchain
+repo_url: https://github.com/lambdasistemi/cardano-mpfs-offchain
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

- Replace `paolino/cardano-mpfs-offchain` → `lambdasistemi/cardano-mpfs-offchain` across mkdocs, architecture docs, and NAVIGATION.md
- Update `paolino/haskell-csmt` → `lambdasistemi/haskell-mts` (renamed + transferred)
- Update `paolino/cardano-utxo-csmt`, `cardano-read-ledger`, `contra-tracer-contrib` → `lambdasistemi/`
- `paolino/dev-assets` and `paolino/cardano-mpfs-onchain` left unchanged (not transferred)
- `cabal.project` already had correct `lambdasistemi/` references

Closes #102