### PR TITLE
feat: add mpfs-devnet-server executable

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -144,6 +144,25 @@ executable mpfs-run-preprod
 
   ghc-options:      -threaded
 
+executable mpfs-devnet-server
+  import:           warnings
+  default-language: GHC2021
+  hs-source-dirs:   exe
+  main-is:          DevnetServer.hs
+  build-depends:
+    , base
+    , bytestring
+    , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-mpfs-offchain
+    , cardano-node-clients:devnet
+    , contra-tracer
+    , filepath
+    , temporary
+    , warp
+
+  ghc-options:      -threaded
+
 executable cardano-mpfs-swagger
   import:           warnings
   default-language: GHC2021

--- a/cardano-mpfs-offchain/exe/DevnetServer.hs
+++ b/cardano-mpfs-offchain/exe/DevnetServer.hs
@@ -1,0 +1,174 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Main
+-- Description : Devnet server for E2E testing
+-- License     : Apache-2.0
+--
+-- Starts a single-node devnet and serves the MPFS
+-- HTTP API against it. Intended for E2E testing of
+-- external clients (e.g. cardano-mpfs-browser).
+--
+-- Usage:
+--
+-- @
+-- mpfs-devnet-server --port 8080
+-- @
+--
+-- Requires @cardano-node@ in PATH and
+-- @MPFS_BLUEPRINT@ set to the cage blueprint path.
+-- Set @E2E_GENESIS_DIR@ to the devnet genesis
+-- directory (defaults to @e2e-test\/genesis@).
+module Main (main) where
+
+import Control.Concurrent (threadDelay)
+import Data.ByteString.Short qualified as SBS
+import Network.Wai.Handler.Warp qualified as Warp
+import System.Environment
+    ( getArgs
+    , lookupEnv
+    )
+import System.FilePath ((</>))
+import System.IO (hFlush, stdout)
+import System.IO.Temp
+    ( withSystemTempDirectory
+    )
+
+import Cardano.Chain.Slotting (EpochSlots (..))
+import Cardano.Ledger.BaseTypes (Network (..))
+import Control.Tracer (nullTracer)
+
+import Cardano.MPFS.Application
+    ( AppConfig (..)
+    , withApplication
+    )
+import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Core.Blueprint
+    ( applyVersion
+    , extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Core.Types (Coin (..))
+import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.TxBuilder.Config
+    ( CageConfig (..)
+    )
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( computeScriptHash
+    )
+import Cardano.Node.Client.E2E.Devnet
+    ( withCardanoNode
+    )
+import Cardano.Node.Client.E2E.Setup
+    ( genesisDir
+    )
+
+main :: IO ()
+main = do
+    port <- parsePort
+    scriptBytes <- loadScript
+    gDir <- genesisDir
+    putStrLn
+        $ "Starting devnet server on port "
+            <> show port
+    hFlush stdout
+    withCardanoNode gDir $ \sock startMs ->
+        withSystemTempDirectory
+            "mpfs-devnet-server"
+            $ \tmpDir -> do
+                let cfg = mkCageCfg scriptBytes startMs
+                    appCfg =
+                        AppConfig
+                            { epochSlots =
+                                EpochSlots 4320
+                            , shelleyGenesisPath =
+                                gDir
+                                    </> "shelley-genesis.json"
+                            , socketPath = sock
+                            , dbPath =
+                                tmpDir </> "db"
+                            , channelCapacity = 16
+                            , cageConfig = cfg
+                            , byronGenesisPath =
+                                Nothing
+                            , followerEnabled = True
+                            , appTracer = nullTracer
+                            }
+                withApplication appCfg $ \ctx -> do
+                    _ <-
+                        queryProtocolParams
+                            (provider ctx)
+                    threadDelay 5_000_000
+                    let url =
+                            "http://localhost:"
+                                <> show port
+                    putStrLn $ "Serving on " <> url
+                    putStrLn
+                        $ "Swagger UI: "
+                            <> url
+                            <> "/swagger-ui"
+                    hFlush stdout
+                    Warp.run port (mkApp ctx)
+
+-- -------------------------------------------------
+-- CLI
+-- -------------------------------------------------
+
+-- | Parse @--port N@ from args, default 8080.
+parsePort :: IO Int
+parsePort = go <$> getArgs
+  where
+    go ("--port" : n : _) = read n
+    go (_ : rest) = go rest
+    go [] = 8080
+
+-- | Load cage script from @MPFS_BLUEPRINT@ env.
+loadScript :: IO SBS.ShortByteString
+loadScript = do
+    mPath <- lookupEnv "MPFS_BLUEPRINT"
+    case mPath of
+        Nothing ->
+            error
+                "MPFS_BLUEPRINT not set. \
+                \Point it to the cage \
+                \blueprint JSON."
+        Just path -> do
+            ebp <- loadBlueprint path
+            case ebp of
+                Left err ->
+                    error
+                        $ "Blueprint error: " <> err
+                Right bp ->
+                    case extractCompiledCode
+                        "cage."
+                        bp of
+                        Nothing ->
+                            error
+                                "cage script not \
+                                \found in blueprint"
+                        Just sb ->
+                            pure
+                                $ applyVersion 1 sb
+
+-- -------------------------------------------------
+-- Config
+-- -------------------------------------------------
+
+mkCageCfg
+    :: SBS.ShortByteString
+    -> Integer
+    -> CageConfig
+mkCageCfg scriptBytes startMs =
+    CageConfig
+        { cageScriptBytes = scriptBytes
+        , cfgScriptHash =
+            computeScriptHash scriptBytes
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 300_000
+        , defaultMaxFee = Coin 2_000_000
+        , network = Testnet
+        , systemStartPosixMs = startMs
+        , slotLengthMs = 100
+        }

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
             packages = {
               inherit (project.packages)
                 offchain-tests e2e-tests cardano-mpfs-offchain
-                mpfs-bootstrap-genesis haddock;
+                mpfs-devnet-server mpfs-bootstrap-genesis haddock;
               default = project.packages.cardano-mpfs-offchain;
             };
             inherit (project) devShells;

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -58,6 +58,8 @@ in {
   inherit project;
   packages.cardano-mpfs-offchain =
     project.hsPkgs.cardano-mpfs-offchain.components.library;
+  packages.mpfs-devnet-server =
+    project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-devnet-server;
   packages.offchain-tests =
     project.hsPkgs.cardano-mpfs-offchain.components.tests.unit-tests;
   packages.e2e-tests =


### PR DESCRIPTION
## Summary

- Standalone devnet server: cardano-node + MPFS backend + HTTP API
- `mpfs-devnet-server --port 8080` (requires `MPFS_BLUEPRINT` env)
- Exposed as nix flake output: `nix run .#mpfs-devnet-server`
- For E2E testing of external clients (cardano-mpfs-browser)

Closes #122