### PR TITLE
feat: add mpfs-serve executable and Nix docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,15 @@ jobs:
       - name: Lint
         run: nix develop --quiet -c hlint $(find . -name '*.hs' -not -path './dist-newstyle/*' -not -path './.direnv/*')
 
+      - name: Build docker image
+        run: nix build .#docker-image --quiet
+
+      - name: Upload docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image
+          path: result
+
   e2e:
     runs-on: nixos
     steps:

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -128,6 +128,22 @@ library
     Cardano.MPFS.TxBuilder.Real.Retract
     Cardano.MPFS.TxBuilder.Real.Update
 
+executable mpfs-serve
+  import:           warnings
+  default-language: GHC2021
+  hs-source-dirs:   exe
+  main-is:          Serve.hs
+  build-depends:
+    , base
+    , bytestring
+    , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-mpfs-offchain
+    , directory
+    , warp
+
+  ghc-options:      -threaded
+
 executable mpfs-run-preprod
   import:           warnings
   default-language: GHC2021

--- a/cardano-mpfs-offchain/exe/Serve.hs
+++ b/cardano-mpfs-offchain/exe/Serve.hs
@@ -1,0 +1,233 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Main
+-- Description : MPFS HTTP service
+-- License     : Apache-2.0
+--
+-- Production service: connect to a running
+-- cardano-node via N2C, index cage events, and
+-- serve the HTTP API on a configurable port.
+--
+-- @
+-- mpfs-serve
+--   --socket \/path\/to\/node.socket
+--   --db \/path\/to\/db
+--   --port 3000
+--   --shelley-genesis \/path\/to\/shelley-genesis.json
+--   --blueprint \/path\/to\/cage.json
+-- @
+--
+-- Optional: @--byron-genesis@, @--epoch-slots@
+module Main (main) where
+
+import Data.ByteString.Short qualified as SBS
+import Network.Wai.Handler.Warp qualified as Warp
+import System.Directory
+    ( createDirectoryIfMissing
+    )
+import System.Environment (getArgs)
+import System.IO (hFlush, stdout)
+
+import Cardano.Chain.Slotting (EpochSlots (..))
+import Cardano.Ledger.BaseTypes (Network (..))
+
+import Cardano.MPFS.Application
+    ( AppConfig (..)
+    , withApplication
+    )
+import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Core.Blueprint
+    ( applyVersion
+    , extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Core.Types (Coin (..))
+import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.Trace (jsonLinesTracer)
+import Cardano.MPFS.TxBuilder.Config
+    ( CageConfig (..)
+    )
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( computeScriptHash
+    )
+
+-- -------------------------------------------------
+-- CLI
+-- -------------------------------------------------
+
+-- | Parsed command-line arguments.
+data Args = Args
+    { argSocket :: FilePath
+    , argDb :: FilePath
+    , argPort :: Int
+    , argShelleyGenesis :: FilePath
+    , argByronGenesis :: Maybe FilePath
+    , argBlueprint :: FilePath
+    , argEpochSlots :: Word
+    , argNetwork :: Network
+    , argSlotLengthMs :: Integer
+    , argSystemStartMs :: Integer
+    }
+
+-- | Default arguments.
+defaultArgs :: Args
+defaultArgs =
+    Args
+        { argSocket = ""
+        , argDb = ""
+        , argPort = 3000
+        , argShelleyGenesis = ""
+        , argByronGenesis = Nothing
+        , argBlueprint = ""
+        , argEpochSlots = 21_600
+        , argNetwork = Testnet
+        , argSlotLengthMs = 1_000
+        , argSystemStartMs = 0
+        }
+
+-- | Parse command-line arguments.
+parseArgs :: [String] -> Args
+parseArgs = go defaultArgs
+  where
+    go a [] = a
+    go a ("--socket" : v : rest) =
+        go a{argSocket = v} rest
+    go a ("--db" : v : rest) =
+        go a{argDb = v} rest
+    go a ("--port" : v : rest) =
+        go a{argPort = read v} rest
+    go a ("--shelley-genesis" : v : rest) =
+        go a{argShelleyGenesis = v} rest
+    go a ("--byron-genesis" : v : rest) =
+        go
+            a{argByronGenesis = Just v}
+            rest
+    go a ("--blueprint" : v : rest) =
+        go a{argBlueprint = v} rest
+    go a ("--epoch-slots" : v : rest) =
+        go a{argEpochSlots = read v} rest
+    go a ("--mainnet" : rest) =
+        go a{argNetwork = Mainnet} rest
+    go a ("--slot-length-ms" : v : rest) =
+        go a{argSlotLengthMs = read v} rest
+    go a ("--system-start-ms" : v : rest) =
+        go a{argSystemStartMs = read v} rest
+    go _ (unknown : _) =
+        error
+            $ "Unknown argument: " <> unknown
+
+-- -------------------------------------------------
+-- Main
+-- -------------------------------------------------
+
+main :: IO ()
+main = do
+    args <- parseArgs <$> getArgs
+    validate args
+    scriptBytes <- loadScript (argBlueprint args)
+    createDirectoryIfMissing True (argDb args)
+    let cfg = mkCageCfg args scriptBytes
+        appCfg = mkAppConfig args cfg
+    putStrLn
+        $ "mpfs-serve starting on port "
+            <> show (argPort args)
+    putStrLn
+        $ "  socket: " <> argSocket args
+    putStrLn
+        $ "  db: " <> argDb args
+    hFlush stdout
+    withApplication appCfg $ \ctx -> do
+        _ <-
+            queryProtocolParams
+                (provider ctx)
+        let url =
+                "http://localhost:"
+                    <> show (argPort args)
+        putStrLn $ "Serving on " <> url
+        putStrLn
+            $ "Swagger UI: "
+                <> url
+                <> "/swagger-ui"
+        hFlush stdout
+        Warp.run (argPort args) (mkApp ctx)
+
+-- -------------------------------------------------
+-- Validation
+-- -------------------------------------------------
+
+-- | Check required arguments are present.
+validate :: Args -> IO ()
+validate args = do
+    when (null (argSocket args))
+        $ error "--socket is required"
+    when (null (argDb args))
+        $ error "--db is required"
+    when (null (argShelleyGenesis args))
+        $ error "--shelley-genesis is required"
+    when (null (argBlueprint args))
+        $ error "--blueprint is required"
+
+-- -------------------------------------------------
+-- Config
+-- -------------------------------------------------
+
+-- | Load cage script from blueprint.
+loadScript
+    :: FilePath -> IO SBS.ShortByteString
+loadScript path = do
+    ebp <- loadBlueprint path
+    case ebp of
+        Left err ->
+            error $ "Blueprint error: " <> err
+        Right bp ->
+            case extractCompiledCode "cage." bp of
+                Nothing ->
+                    error
+                        "cage script not found \
+                        \in blueprint"
+                Just sb ->
+                    pure $ applyVersion 1 sb
+
+mkCageCfg
+    :: Args
+    -> SBS.ShortByteString
+    -> CageConfig
+mkCageCfg args scriptBytes =
+    CageConfig
+        { cageScriptBytes = scriptBytes
+        , cfgScriptHash =
+            computeScriptHash scriptBytes
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 300_000
+        , defaultMaxFee = Coin 2_000_000
+        , network = argNetwork args
+        , systemStartPosixMs =
+            argSystemStartMs args
+        , slotLengthMs = argSlotLengthMs args
+        }
+
+mkAppConfig :: Args -> CageConfig -> AppConfig
+mkAppConfig args cfg =
+    AppConfig
+        { epochSlots =
+            EpochSlots
+                (fromIntegral (argEpochSlots args))
+        , shelleyGenesisPath =
+            argShelleyGenesis args
+        , socketPath = argSocket args
+        , dbPath = argDb args
+        , channelCapacity = 16
+        , cageConfig = cfg
+        , byronGenesisPath =
+            argByronGenesis args
+        , followerEnabled = True
+        , appTracer = jsonLinesTracer
+        }
+
+-- | Re-export for validate.
+when :: Bool -> IO () -> IO ()
+when True a = a
+when False _ = pure ()

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
             devnet-genesis = cardano-node-clients.packages.${system}.devnet-genesis;
             project = import ./nix/project.nix {
               indexState = "2025-12-07T00:00:00Z";
-              inherit CHaP pkgs cardano-node-pkgs mpfs-blueprint devnet-genesis;
+              inherit CHaP pkgs cardano-node-pkgs mpfs-blueprint devnet-genesis version;
               mkdocs = mkdocs.packages.${system};
               asciinema = asciinema.packages.${system};
             };
@@ -57,7 +57,8 @@
             packages = {
               inherit (project.packages)
                 offchain-tests e2e-tests cardano-mpfs-offchain
-                mpfs-devnet-server mpfs-bootstrap-genesis haddock;
+                mpfs-serve mpfs-devnet-server mpfs-bootstrap-genesis
+                docker-image haddock;
               default = project.packages.cardano-mpfs-offchain;
             };
             inherit (project) devShells;

--- a/justfile
+++ b/justfile
@@ -104,6 +104,17 @@ hoogle port="8080":
     echo "(includes all dependencies; local packages not yet indexed — see issue #59)"
     hoogle server --local --port={{ port }}
 
+# Build docker image via Nix
+build-docker tag='latest':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    nix build .#docker-image
+    docker load < result
+    version=$(nix eval --raw .#version)
+    docker image tag \
+        "ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve:$version" \
+        "ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve:{{ tag }}"
+
 # Clean build artifacts
 clean:
     #!/usr/bin/env bash

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -1,0 +1,13 @@
+{ pkgs, project, version, ... }:
+
+pkgs.dockerTools.buildImage {
+  name = "ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve";
+  tag = version;
+  config = { EntryPoint = [ "mpfs-serve" ]; };
+  copyToRoot = pkgs.buildEnv {
+    name = "image-root";
+    paths = [
+      project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-serve
+    ];
+  };
+}

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,5 +1,5 @@
 { CHaP, indexState, pkgs, mkdocs, asciinema, cardano-node-pkgs, mpfs-blueprint
-, devnet-genesis
+, devnet-genesis, version ? "dev"
 , ... }:
 
 let
@@ -60,6 +60,11 @@ in {
   inherit project;
   packages.cardano-mpfs-offchain =
     project.hsPkgs.cardano-mpfs-offchain.components.library;
+  packages.mpfs-serve =
+    project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-serve;
+  packages.docker-image = import ./docker-image.nix {
+    inherit pkgs project version;
+  };
   packages.mpfs-devnet-server =
     project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-devnet-server;
   packages.devnet-genesis = devnet-genesis;


### PR DESCRIPTION
## Summary

- `mpfs-serve` production executable: connects to existing cardano-node, indexes cage events, serves HTTP API + Swagger UI
- Nix docker image via `pkgs.dockerTools.buildImage` (`.#docker-image`)
- `just build-docker` recipe

```
mpfs-serve \
  --socket /path/to/node.socket \
  --db /path/to/db \
  --port 3000 \
  --shelley-genesis /path/to/shelley-genesis.json \
  --blueprint /path/to/cage.json
```

Closes #136