### PR TITLE
feat: expose CSMT UTxO proofs and TxIn resolution in HTTP API

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -61,6 +61,7 @@ library
     , lens
     , memory
     , microlens
+    , mts:csmt
     , mts:mpf
     , mts:mpf-test-lib
     , mts:rollbacks

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -91,6 +91,10 @@ import Ouroboros.Network.Point
     , WithOrigin (..)
     )
 
+import CSMT.Hashes
+    ( generateInclusionProof
+    , renderHash
+    )
 import Cardano.Ledger.Shelley.Genesis
     ( ShelleyGenesis
     , sgNetworkMagic
@@ -113,6 +117,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , journalEmpty
     , kvOnlyCSMTOps
     , mkCSMTOps
+    , queryMerkleRoot
     , replayJournal
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction qualified as CSMT
@@ -520,6 +525,33 @@ withApplication cfg action = do
                                 $ fmap isJust
                                 $ query KVCol
                                 $ cborEncode txIn
+                        resolve txIn =
+                            CSMT.transact utxoRt
+                                $ fmap
+                                    (fmap BSL.toStrict)
+                                $ query KVCol
+                                $ cborEncode txIn
+                        root =
+                            CSMT.transact utxoRt
+                                $ fmap renderHash
+                                    <$> queryMerkleRoot
+                                        ( hashing
+                                            context
+                                        )
+                        proof txIn =
+                            CSMT.transact utxoRt $ do
+                                let fkv =
+                                        fromKV context
+                                result <-
+                                    generateInclusionProof
+                                        fkv
+                                        KVCol
+                                        CSMTCol
+                                        ( cborEncode
+                                            txIn
+                                        )
+                                pure
+                                    $ fmap snd result
                         ctx =
                             Context
                                 { provider = prov
@@ -538,6 +570,9 @@ withApplication cfg action = do
                                         tm
                                 , indexer = idx
                                 , utxoExists = exists
+                                , resolveUtxo = resolve
+                                , utxoRoot = root
+                                , utxoProof = proof
                                 }
                     result <- action ctx
                     mapM_ cancel mChainThread

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
@@ -15,6 +15,8 @@ module Cardano.MPFS.Context
       Context (..)
     ) where
 
+import Data.ByteString (ByteString)
+
 import Cardano.MPFS.Core.Types (TxIn)
 import Cardano.MPFS.Indexer (Indexer)
 import Cardano.MPFS.Provider (Provider)
@@ -40,4 +42,12 @@ data Context m = Context
     -- ^ Transaction construction
     , utxoExists :: TxIn -> m Bool
     -- ^ Check if a UTxO exists in the indexed state
+    , resolveUtxo
+        :: TxIn -> m (Maybe ByteString)
+    -- ^ Resolve a TxIn to its CBOR-encoded TxOut
+    , utxoRoot :: m (Maybe ByteString)
+    -- ^ Current CSMT Merkle root hash (raw bytes)
+    , utxoProof
+        :: TxIn -> m (Maybe ByteString)
+    -- ^ CSMT inclusion proof for a TxIn (raw bytes)
     }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
@@ -25,6 +25,11 @@ module Cardano.MPFS.HTTP.API
     , TokenProofAPI
     , TokenRequestsAPI
 
+      -- * UTxO CSMT endpoints
+    , UtxoResolveAPI
+    , UtxoProofAPI
+    , UtxoRootAPI
+
       -- * Confirmation
     , TxAwaitAPI
 
@@ -112,6 +117,29 @@ type TokenRequestsAPI =
         :> "requests"
         :> Get '[JSON] [RequestJSON]
 
+-- | @GET \/utxo\/:txId\/:txIx@ — resolve a TxIn to
+-- its CBOR-encoded TxOut (hex).
+type UtxoResolveAPI =
+    "utxo"
+        :> Capture "txId" Hex
+        :> Capture "txIx" Word64
+        :> Get '[JSON] Hex
+
+-- | @GET \/utxo\/:txId\/:txIx\/proof@ — CSMT
+-- inclusion proof for a UTxO (hex bytes).
+type UtxoProofAPI =
+    "utxo"
+        :> Capture "txId" Hex
+        :> Capture "txIx" Word64
+        :> "proof"
+        :> Get '[JSON] Hex
+
+-- | @GET \/utxo\/root@ — current CSMT Merkle root.
+type UtxoRootAPI =
+    "utxo"
+        :> "root"
+        :> Get '[JSON] Hex
+
 -- | @GET \/tx\/:txId?timeout=30@ — block until the
 -- transaction's first output (TxIn(txId, 0)) appears
 -- in the indexed UTxO set. Returns 204 on success,
@@ -191,6 +219,9 @@ type API =
         :<|> TokenFactAPI
         :<|> TokenProofAPI
         :<|> TokenRequestsAPI
+        :<|> UtxoResolveAPI
+        :<|> UtxoProofAPI
+        :<|> UtxoRootAPI
         :<|> TxAwaitAPI
         :<|> TxBootAPI
         :<|> TxInsertAPI

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -51,6 +51,7 @@ import Cardano.Ledger.Hashes
     )
 import Cardano.Ledger.TxIn
     ( TxId (..)
+    , TxIn
     , mkTxInPartial
     )
 
@@ -105,6 +106,9 @@ mkApp ctx =
             :<|> tokenFactHandler ctx
             :<|> tokenProofHandler ctx
             :<|> tokenRequestsHandler ctx
+            :<|> utxoResolveHandler ctx
+            :<|> utxoProofHandler ctx
+            :<|> utxoRootHandler ctx
             :<|> txAwaitHandler ctx
             :<|> txBootHandler ctx
             :<|> txInsertHandler ctx
@@ -210,6 +214,52 @@ tokenRequestsHandler ctx (TokenIdJSON tid) = do
                 (St.requests (state ctx))
                 tid
     pure (map requestToJSON reqs)
+
+-- ---------------------------------------------------------
+-- UTxO CSMT handlers
+-- ---------------------------------------------------------
+
+-- | @GET \/utxo\/:txId\/:txIx@ — resolve a TxIn.
+utxoResolveHandler
+    :: Context IO
+    -> Hex
+    -> Word64
+    -> Handler Hex
+utxoResolveHandler ctx txIdHex txIx = do
+    txIn <- requireTxIn txIdHex txIx
+    mbs <- liftIO $ resolveUtxo ctx txIn
+    case mbs of
+        Nothing -> throwError err404
+        Just bs -> pure (Hex bs)
+
+-- | @GET \/utxo\/:txId\/:txIx\/proof@ — CSMT proof.
+utxoProofHandler
+    :: Context IO
+    -> Hex
+    -> Word64
+    -> Handler Hex
+utxoProofHandler ctx txIdHex txIx = do
+    txIn <- requireTxIn txIdHex txIx
+    mbs <- liftIO $ utxoProof ctx txIn
+    case mbs of
+        Nothing -> throwError err404
+        Just bs -> pure (Hex bs)
+
+-- | @GET \/utxo\/root@ — current CSMT root.
+utxoRootHandler
+    :: Context IO -> Handler Hex
+utxoRootHandler ctx = do
+    mbs <- liftIO $ utxoRoot ctx
+    case mbs of
+        Nothing -> throwError err404
+        Just bs -> pure (Hex bs)
+
+-- | Build a 'TxIn' from hex txId + index.
+requireTxIn
+    :: Hex -> Word64 -> Handler TxIn
+requireTxIn txIdHex txIx = do
+    tid <- parseTxIdRaw (unHex txIdHex)
+    pure $ mkTxInPartial tid (fromIntegral txIx)
 
 -- ---------------------------------------------------------
 -- Confirmation handler

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
@@ -46,4 +46,7 @@ mkMockContext = do
             , submitter = mkMockSubmitter
             , txBuilder = mkMockTxBuilder
             , utxoExists = \_ -> pure False
+            , resolveUtxo = \_ -> pure Nothing
+            , utxoRoot = pure Nothing
+            , utxoProof = \_ -> pure Nothing
             }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
@@ -64,6 +64,9 @@ mkTestContext = do
             , submitter = mkMockSubmitter
             , txBuilder = mkMockTxBuilder
             , utxoExists = \_ -> pure False
+            , resolveUtxo = \_ -> pure Nothing
+            , utxoRoot = pure Nothing
+            , utxoProof = \_ -> pure Nothing
             }
 
 getStatus :: Context IO -> IO SResponse

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -1,5 +1,4 @@
 Entering cardano-mpfs-offchain dev shell
-Resolving dependencies...
 {
     "definitions": {
         "BootRequest": {
@@ -659,6 +658,91 @@ Resolving dependencies...
                     },
                     "400": {
                         "description": "Invalid `timeout` or `txId`"
+                    }
+                }
+            }
+        },
+        "/utxo/root": {
+            "get": {
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Hex"
+                        }
+                    }
+                }
+            }
+        },
+        "/utxo/{txId}/{txIx}": {
+            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "txId",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "format": "int64",
+                        "in": "path",
+                        "maximum": 1.8446744073709551615e19,
+                        "minimum": 0,
+                        "name": "txIx",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Hex"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid `txIx` or `txId`"
+                    }
+                }
+            }
+        },
+        "/utxo/{txId}/{txIx}/proof": {
+            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "txId",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "format": "int64",
+                        "in": "path",
+                        "maximum": 1.8446744073709551615e19,
+                        "minimum": 0,
+                        "name": "txIx",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Hex"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid `txIx` or `txId`"
                     }
                 }
             }

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -1,5 +1,11 @@
-{ pkgs, project, version, ... }:
+{ pkgs, project, version, mpfs-blueprint, ... }:
 
+let
+  blueprint-dir = pkgs.runCommand "mpfs-blueprint" {} ''
+    mkdir -p $out/etc/mpfs
+    cp ${mpfs-blueprint} $out/etc/mpfs/blueprint.json
+  '';
+in
 pkgs.dockerTools.buildImage {
   name = "ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve";
   tag = version;
@@ -8,6 +14,7 @@ pkgs.dockerTools.buildImage {
     name = "image-root";
     paths = [
       project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-serve
+      blueprint-dir
     ];
   };
 }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -63,7 +63,7 @@ in {
   packages.mpfs-serve =
     project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-serve;
   packages.docker-image = import ./docker-image.nix {
-    inherit pkgs project version;
+    inherit pkgs project version mpfs-blueprint;
   };
   packages.mpfs-devnet-server =
     project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-devnet-server;


### PR DESCRIPTION
## Summary

Three new endpoints for off-chain UTxO verification:

- `GET /utxo/:txId/:txIx` — resolve TxIn to CBOR-encoded TxOut
- `GET /utxo/:txId/:txIx/proof` — CSMT Merkle inclusion proof
- `GET /utxo/root` — current CSMT Merkle root hash

Enables the full verification chain:
```
Institutional root (trusted) ← CSMT proof ← cage UTxO ← MPF proof ← fact
```

Closes #117