### PR TITLE
feat: use Ops GADT from MTS via mkCSMTKVOnlyOps

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -32,14 +32,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-utxo-csmt
-  tag: 3180863a280f18675f4241742f7930240f40b0bd
-  --sha256: 19as0g1jrsgfxqnln6zblc7482rayfikf1kxz6wyh30pbvz284rx
+  tag: 57dd91063632b8f6490a64a4c9e6a56fa291a076
 
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: 253ca2e7f0736c1740303162480d0fc9a77a9f68
-  --sha256: 0p12wlza8kflipxv81im0l9kmv5a7lasmv0cm3iclm7ydan7s04n
+  tag: d49077c29ad724e4728241edcb35da53f171eb2c
+  --sha256: 0z8qvl88s4z3xjvphryp9bzw5vpm586h6qkjhsg5qh8x361xjnlk
 
 source-repository-package
   type: git
@@ -56,8 +55,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/contra-tracer-contrib
-  tag: 4f0c611e61b866905455a5d5469dea62afc55c3a
-  --sha256: 1k5c9kr1pw4c6qswssbjvma0ki7d31n3w275v6w9kkp23wwdh2g2
+  tag: 6b63539fb67c2247d18ef2c4ec86f2f82f3a0d2e
+  --sha256: 16qa1ldd6m3whbs124vj8wbdr3zz4yi4dxsc4x4ny7lk47671n5v
 
 source-repository-package
   type: git

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -95,6 +95,7 @@ import CSMT.Hashes
     ( generateInclusionProof
     , renderHash
     )
+import CSMT.MTS (journalEmptyT)
 import Cardano.Ledger.Shelley.Genesis
     ( ShelleyGenesis
     , sgNetworkMagic
@@ -114,11 +115,9 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , CSMTOps (..)
-    , journalEmpty
-    , kvOnlyCSMTOps
+    , mkCSMTKVOnlyOps
     , mkCSMTOps
     , queryMerkleRoot
-    , replayJournal
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction qualified as CSMT
     ( RunTransaction (..)
@@ -146,6 +145,7 @@ import Cardano.UTxOCSMT.Ouroboros.ConnectionN2C
 import Cardano.UTxOCSMT.Ouroboros.Types
     ( Point
     )
+import Control.Lens (iso)
 import MTS.Rollbacks.Store qualified as Store
 
 import Ouroboros.Consensus.Cardano.Node ()
@@ -326,9 +326,6 @@ withApplication cfg action = do
                             mkCSMTOps
                                 (fromKV context)
                                 (hashing context)
-                        kvOps =
-                            kvOnlyCSMTOps
-                                BSL.toStrict
 
                     -- Seed genesis UTxOs on fresh DB
                     seedGenesis
@@ -358,12 +355,22 @@ withApplication cfg action = do
                             utxoRt
                             armageddonParams
 
+                    -- Build KVOnly Ops GADT (wires
+                    -- journal replay into toFull)
+                    let kvOnlyOps =
+                            mkCSMTKVOnlyOps
+                                4
+                                1000
+                                (iso BSL.toStrict BSL.fromStrict)
+                                (fromKV context)
+                                (hashing context)
+                                (CSMT.transact utxoRt)
+
                     -- Detect starting phase for
                     -- split mode
                     jEmpty <-
-                        CSMT.transact
-                            utxoRt
-                            journalEmpty
+                        CSMT.transact utxoRt
+                            $ journalEmptyT JournalCol
                     let startPhase =
                             if not empty && jEmpty
                                 then Full
@@ -372,19 +379,10 @@ withApplication cfg action = do
                             tipSlot - curSlot
                                 < SlotNo
                                     stabilityWindow
-                        replay =
-                            replayJournal
-                                1000
-                                BSL.fromStrict
-                                (fromKV context)
-                                (hashing context)
-                                utxoRt
                     splitMode <-
                         mkSplitMode
-                            kvOps
-                            fullOps
+                            kvOnlyOps
                             isAtTip
-                            replay
                             startPhase
 
                     -- Sample rollback points for

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,8 @@
   };
 
   outputs = inputs@{ self, nixpkgs, flake-parts, haskellNix, mkdocs, asciinema
-    , iohkNix, CHaP, cardano-node, cardano-mpfs-onchain, cardano-node-clients, ... }:
+    , iohkNix, CHaP, cardano-node, cardano-mpfs-onchain, cardano-node-clients
+    , ... }:
     let
       version = self.dirtyShortRev or self.shortRev;
       parts = flake-parts.lib.mkFlake { inherit inputs; } {
@@ -46,19 +47,20 @@
             };
             cardano-node-pkgs = cardano-node.packages.${system};
             mpfs-blueprint = cardano-mpfs-onchain.packages.${system}.default;
-            devnet-genesis = cardano-node-clients.packages.${system}.devnet-genesis;
+            devnet-genesis =
+              cardano-node-clients.packages.${system}.devnet-genesis;
             project = import ./nix/project.nix {
               indexState = "2025-12-07T00:00:00Z";
-              inherit CHaP pkgs cardano-node-pkgs mpfs-blueprint devnet-genesis version;
+              inherit CHaP pkgs cardano-node-pkgs mpfs-blueprint devnet-genesis
+                version;
               mkdocs = mkdocs.packages.${system};
               asciinema = asciinema.packages.${system};
             };
           in {
             packages = {
               inherit (project.packages)
-                offchain-tests e2e-tests cardano-mpfs-offchain
-                mpfs-serve mpfs-devnet-server mpfs-bootstrap-genesis
-                docker-image haddock;
+                offchain-tests e2e-tests cardano-mpfs-offchain mpfs-serve
+                mpfs-devnet-server mpfs-bootstrap-genesis docker-image haddock;
               default = project.packages.cardano-mpfs-offchain;
             };
             inherit (project) devShells;

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -1,12 +1,11 @@
 { pkgs, project, version, mpfs-blueprint, ... }:
 
 let
-  blueprint-dir = pkgs.runCommand "mpfs-blueprint" {} ''
+  blueprint-dir = pkgs.runCommand "mpfs-blueprint" { } ''
     mkdir -p $out/etc/mpfs
     cp ${mpfs-blueprint} $out/etc/mpfs/blueprint.json
   '';
-in
-pkgs.dockerTools.buildImage {
+in pkgs.dockerTools.buildImage {
   name = "ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve";
   tag = version;
   config = { EntryPoint = [ "mpfs-serve" ]; };

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,6 +1,5 @@
 { CHaP, indexState, pkgs, mkdocs, asciinema, cardano-node-pkgs, mpfs-blueprint
-, devnet-genesis, version ? "dev"
-, ... }:
+, devnet-genesis, version ? "dev", ... }:
 
 let
   indexTool = { index-state = indexState; };
@@ -62,9 +61,8 @@ in {
     project.hsPkgs.cardano-mpfs-offchain.components.library;
   packages.mpfs-serve =
     project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-serve;
-  packages.docker-image = import ./docker-image.nix {
-    inherit pkgs project version mpfs-blueprint;
-  };
+  packages.docker-image =
+    import ./docker-image.nix { inherit pkgs project version mpfs-blueprint; };
   packages.mpfs-devnet-server =
     project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-devnet-server;
   packages.devnet-genesis = devnet-genesis;


### PR DESCRIPTION
## Summary
- Bump cardano-utxo-csmt + haskell-mts + contra-tracer-contrib
- Replace `kvOnlyCSMTOps`/`replayJournal`/`journalEmpty` with `mkCSMTKVOnlyOps` + `journalEmptyT`
- `SplitMode` now backed by MTS Ops GADT — `toFull` handles journal replay

## Test plan
- [x] `cabal build cardano-mpfs-offchain -O0` succeeds
- [x] fourmolu + hlint clean
- [ ] CI