### PR TITLE
fix: add wget to Docker image for health checks

### DIFF
--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -14,6 +14,7 @@ in pkgs.dockerTools.buildImage {
     paths = [
       project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-serve
       blueprint-dir
+      pkgs.wget
     ];
   };
 }


### PR DESCRIPTION
## Summary
- Add `pkgs.wget` to the Docker image so the docker-compose health check works
- Fixes the restart loop caused by `autoheal=true` when `wget` is missing

Closes #140