### PR TITLE
refactor: replace polling with push-based await in txAwaitHandler

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -32,8 +32,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-utxo-csmt
-  tag: b60b6d299cb680be3258982f43a4114ff17b9edc
-  --sha256: 1n46a55gmzqf1006bx781z7v3ajv3246nkvdnjqm8lxgbd9n9p00
+  tag: cc8164d53a7aa7d20b9b22d2fdeb4f27da51082f
+  --sha256: 0rmzgx0gcr0sv808i0shawhrqgc2qn9b3686z08f8hq071jiwmzb
 
 source-repository-package
   type: git

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -80,6 +80,7 @@ library
     , servant-server                           >=0.20 && <0.21
     , servant-swagger
     , servant-swagger-ui
+    , stm
     , swagger2
     , text                                     >=2.0  && <2.2
     , time

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -50,10 +50,16 @@ module Cardano.MPFS.Application
     ) where
 
 import Cardano.Chain.Slotting (EpochSlots)
+import Cardano.UTxOCSMT.Application.Run.Query (queryAwaitValue)
 import Control.Concurrent.Async
     ( async
     , cancel
     , link
+    )
+import Control.Concurrent.STM
+    ( atomically
+    , modifyTVar'
+    , newTVarIO
     )
 import Control.Exception (finally, throwIO)
 import Control.Monad (when)
@@ -440,6 +446,9 @@ withApplication cfg action = do
                             InFollowing
                                 initialCount
                                 following
+                    -- Commit notification TVar for awaitUtxo
+                    commitNotify' <-
+                        newTVarIO (0 :: Int)
                     -- Connection 1: ChainSync
                     -- (optional, controlled by
                     -- followerEnabled)
@@ -456,12 +465,18 @@ withApplication cfg action = do
                                             )
                                             utxoRt
                                             armageddonParams
+                                let onCommit =
+                                        atomically
+                                            $ modifyTVar'
+                                                commitNotify'
+                                                (+ 1)
                                     cageIntersector =
                                         mkCageIntersector
                                             (fromIntegral stabilityWindow)
                                             run
                                             backendInit
                                             csmtArmageddon
+                                            onCommit
                                             initialPhase
                                     chainSyncApp =
                                         mkN2CChainSyncApplication
@@ -574,6 +589,10 @@ withApplication cfg action = do
                                 , indexer = idx
                                 , utxoExists = exists
                                 , resolveUtxo = resolve
+                                , awaitUtxo =
+                                    queryAwaitValue
+                                        commitNotify'
+                                        resolve
                                 , utxoRoot = root
                                 , utxoProof = proof
                                 , readMetrics =

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
@@ -46,6 +46,9 @@ data Context m = Context
     , resolveUtxo
         :: TxIn -> m (Maybe ByteString)
     -- ^ Resolve a TxIn to its CBOR-encoded TxOut
+    , awaitUtxo
+        :: TxIn -> Maybe Int -> m (Maybe ByteString)
+    -- ^ Block until a UTxO appears or timeout expires
     , utxoRoot :: m (Maybe ByteString)
     -- ^ Current CSMT Merkle root hash (raw bytes)
     , utxoProof

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -15,9 +15,8 @@ module Cardano.MPFS.HTTP.Server
       mkApp
     ) where
 
-import Control.Concurrent (threadDelay)
+import Control.Applicative ((<|>))
 import Control.Monad.IO.Class (liftIO)
-import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import Data.Word (Word64)
@@ -297,15 +296,12 @@ requireTxIn txIdHex txIx = do
 -- ---------------------------------------------------------
 
 -- | Default timeout for tx confirmation (seconds).
-defaultTimeout :: Word64
+defaultTimeout :: Int
 defaultTimeout = 30
-
--- | Poll interval (microseconds).
-pollInterval :: Int
-pollInterval = 500_000
 
 -- | @GET \/tx\/:txId?timeout=N@ — block until
 -- TxIn(txId, 0) appears in the indexed UTxO set.
+-- Uses STM-based push notification instead of polling.
 txAwaitHandler
     :: Context IO
     -> Hex
@@ -315,15 +311,12 @@ txAwaitHandler ctx (Hex txIdBytes) mTimeout = do
     txId <- parseTxIdRaw txIdBytes
     let txIn = mkTxInPartial txId 0
         timeoutSec =
-            fromMaybe defaultTimeout mTimeout
-        maxIters =
-            fromIntegral timeoutSec
-                * 1_000_000
-                `div` pollInterval
-    found <- liftIO $ poll maxIters txIn
-    if found
-        then pure NoContent
-        else
+            fmap fromIntegral mTimeout
+                <|> Just defaultTimeout
+    mval <- liftIO $ awaitUtxo ctx txIn timeoutSec
+    case mval of
+        Just _ -> pure NoContent
+        Nothing ->
             throwError
                 ServerError
                     { errHTTPCode = 408
@@ -332,15 +325,6 @@ txAwaitHandler ctx (Hex txIdBytes) mTimeout = do
                         "Transaction not confirmed"
                     , errHeaders = []
                     }
-  where
-    poll 0 _ = pure False
-    poll n txIn = do
-        exists <- utxoExists ctx txIn
-        if exists
-            then pure True
-            else do
-                threadDelay pollInterval
-                poll (n - 1) txIn
 
 -- | Extract raw 32-byte hash from a 'TxId'.
 txIdToBytes :: TxId -> ByteString

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
@@ -113,6 +113,8 @@ mkCageIntersector
     -- ^ Backend initializer
     -> IO ()
     -- ^ Armageddon action (wipe + reset)
+    -> IO ()
+    -- ^ Post-commit callback (e.g. TVar notification)
     -> AppPhase hash cf op
     -- ^ Current phase
     -> Intersector Point SlotNo Fetched
@@ -121,6 +123,7 @@ mkCageIntersector
     run
     backendInit
     armageddon
+    onCommit
     phase =
         Intersector
             { intersectFound = \_point ->
@@ -130,6 +133,7 @@ mkCageIntersector
                         run
                         backendInit
                         armageddon
+                        onCommit
                         phase
             , intersectNotFound =
                 pure
@@ -138,6 +142,7 @@ mkCageIntersector
                         run
                         backendInit
                         armageddon
+                        onCommit
                         phase
                     , [Network.Point Origin]
                     )
@@ -176,6 +181,8 @@ mkCageFollower
     -- ^ Backend initializer
     -> IO ()
     -- ^ Armageddon action (wipe + reset)
+    -> IO ()
+    -- ^ Post-commit callback (e.g. TVar notification)
     -> AppPhase hash cf op
     -- ^ Current phase
     -> Follower Point SlotNo Fetched
@@ -183,7 +190,8 @@ mkCageFollower
     securityParam
     run
     backendInit
-    armageddon =
+    armageddon
+    onCommit =
         go
       where
         go phase =
@@ -203,6 +211,7 @@ mkCageFollower
                         slot
                         fetched
                         phase
+            onCommit
             pure $ go phase'
 
         rollBwd phase point = do
@@ -241,6 +250,7 @@ mkCageFollower
                                         run
                                         backendInit
                                         armageddon
+                                        onCommit
                                         ( InRestoration
                                             0
                                             restoring
@@ -256,4 +266,5 @@ mkCageFollower
                             run
                             backendInit
                             armageddon
+                            onCommit
                             (InRestoration 0 restoring)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
@@ -47,6 +47,7 @@ mkMockContext = do
             , txBuilder = mkMockTxBuilder
             , utxoExists = \_ -> pure False
             , resolveUtxo = \_ -> pure Nothing
+            , awaitUtxo = \_ _ -> pure Nothing
             , utxoRoot = pure Nothing
             , utxoProof = \_ -> pure Nothing
             , readMetrics = pure Nothing

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
@@ -65,6 +65,7 @@ mkTestContext = do
             , txBuilder = mkMockTxBuilder
             , utxoExists = \_ -> pure False
             , resolveUtxo = \_ -> pure Nothing
+            , awaitUtxo = \_ _ -> pure Nothing
             , utxoRoot = pure Nothing
             , utxoProof = \_ -> pure Nothing
             , readMetrics = pure Nothing


### PR DESCRIPTION
## Summary
- Replace `threadDelay` polling loop (500ms interval) with STM-based `queryAwaitValue`
- Add `awaitUtxo` to `Context` interface
- Add post-commit callback to `CageFollower` (TVar notification)
- Bump cardano-utxo-csmt to cc8164d (`queryAwaitValue`, `WithSentinel`, build gate, etc.)
- Near-instant wake-up, zero CPU while waiting

Closes #163