### PR TITLE
chore: bump cardano-node-clients and cardano-utxo-csmt

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -32,20 +32,20 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-utxo-csmt
-  tag: cc8164d53a7aa7d20b9b22d2fdeb4f27da51082f
-  --sha256: 0rmzgx0gcr0sv808i0shawhrqgc2qn9b3686z08f8hq071jiwmzb
+  tag: 494f1778dcdff1da257a09d751ce9a65af8639d8
+  --sha256: 1n7qlxsqjr9g0ml5gzrxny294xwmspzm8c6173452hx1x2ggdb9f
 
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/chain-follower
-  tag: b6997a7f91139c6a904867d2c44500f7e0d59d5b
-  --sha256: 0ryfbhi0c79q7mzmm9sgysy02pb41gnj5h4nrdlgbkqfjl0c4mvl
+  tag: d592a5015f8d7edb2d6022936a67a054dfe5329f
+  --sha256: 1pm2yhsm2zg5nv01aixv6ss21f2ka8ysq6dv2q4mpf9smz0m8g78
 
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: 75f358157724208c257b7c9909bdbe89eb5ff337
-  --sha256: 1d715frc74jpqqzm9y4ly5hcbyh4k9ck4k5wq68gd780dn9hknqm
+  tag: a37b352041a1f90c00940ede0336dcc8d85140ee
+  --sha256: 0lfg6clc7nx8wnlsqz9haqmgw9a8kcm0cg098q44azs03hq3aqym
 
 source-repository-package
   type: git
@@ -68,8 +68,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-node-clients
-  tag: cce3f82d6917d55d5274783292bfb66c7d13fcf4
-  --sha256: 07jgj0xg42d6j99jffsvf1zb2aw0jr2zybqz6h1hqy7xdwvx2ayq
+  tag: f75a3c822d8993a0e792d9ecf40279bb734a9aea
+  --sha256: 0zcj6qvg53crgbnqbgkzacs25sgg3hgqfnzjwyib4b4f69gwz2h7
 
 -- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API
 constraints: contra-tracer-contrib +iohk

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -269,6 +269,7 @@ test-suite unit-tests
     , cborg
     , chain-follower
     , containers
+    , contra-tracer
     , dependent-map
     , hspec                                    >=2.11 && <2.12
     , http-types

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -147,7 +147,7 @@ import Cardano.UTxOCSMT.Ouroboros.ConnectionN2C
 import Cardano.UTxOCSMT.Ouroboros.Types
     ( Point
     )
-import ChainFollower.Backend (Init (..))
+import ChainFollower.Backend (Init (..), Restoring (..))
 import ChainFollower.Rollbacks.Store qualified as CFStore
 import ChainFollower.Rollbacks.Types (RollbackPoint (..))
 import ChainFollower.Runner (Phase (..))
@@ -258,10 +258,10 @@ allColumnFamilies =
     utxoColumnFamilies =
         [ ("kv", dbConfig)
         , ("csmt", dbConfig)
-        , ("rollbacks", dbConfig)
         , ("config", dbConfig)
         , ("journal", dbConfig)
-        , ("utxo-rollbacks", dbConfig)
+        , ("metrics", dbConfig)
+        , ("rollbacks", dbConfig)
         ]
 
 -- | Cage-only column families (7). Used by tests
@@ -368,7 +368,7 @@ withApplication cfg action = do
                     empty <-
                         CSMT.transact utxoRt
                             $ iterating
-                                RollbackPoints
+                                Rollbacks
                             $ isNothing
                                 <$> firstEntry
                     when empty
@@ -438,10 +438,12 @@ withApplication cfg action = do
                                 ]
 
                     -- Initialize Phase: always InFollowing
-                    -- resumeFollowing calls toFull which
+                    -- start → toFollowing calls toFull which
                     -- replays the journal (empty on fresh DB)
+                    restoring <-
+                        start backendInit
                     following <-
-                        resumeFollowing backendInit
+                        toFollowing restoring
                     let initialPhase =
                             InFollowing
                                 initialCount

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Backend.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Backend.hs
@@ -159,8 +159,8 @@ resolveUtxoT txIn = do
 -- UTxO CSMT and cage state.
 --
 -- Takes the KVOnly 'Ops' (same as @createBackend@
--- in cardano-utxo-csmt). 'startRestoring' uses
--- KVOnly ops; 'toFollowing' calls 'toFull' for
+-- in cardano-utxo-csmt). 'start' returns a Restoring
+-- with KVOnly ops; 'toFollowing' calls 'toFull' for
 -- journal replay and switches to Full ops.
 composedInit
     :: ScriptHash
@@ -186,18 +186,7 @@ composedInit
         BlockId
 composedInit scriptHash ops =
     Init
-        { startRestoring =
-            pure $ mkRestoring kvOps
-        , resumeFollowing = do
-            mFull <- liftIO (toFull ops)
-            case mFull of
-                Just fullOps ->
-                    pure
-                        $ mkFollowing
-                            (fullOpsToCSMTOps fullOps)
-                Nothing ->
-                    fail
-                        "composedInit: toFull failed"
+        { start = pure $ mkRestoring kvOps
         }
   where
     kvOps = kvCommonToCSMTOps (kvCommon ops)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
@@ -43,6 +43,7 @@ import ChainFollower.Runner
     , processBlock
     , rollbackTo
     )
+import Control.Tracer (nullTracer)
 
 import Database.KV.Transaction
     ( Transaction
@@ -200,17 +201,23 @@ mkCageFollower
                 , rollBackward = rollBwd phase
                 }
 
-        rollFwd phase fetched _tipSlot = do
+        rollFwd phase fetched tipSlot = do
             let slot =
                     pointToSlot (fetchedPoint fetched)
+                withinWindow =
+                    unSlotNo slot
+                        + fromIntegral securityParam
+                        >= unSlotNo tipSlot
             phase' <-
-                run
-                    $ processBlock
-                        InRollbacks
-                        securityParam
-                        slot
-                        fetched
-                        phase
+                processBlock
+                    nullTracer
+                    withinWindow
+                    run
+                    InRollbacks
+                    securityParam
+                    slot
+                    fetched
+                    phase
             onCommit
             pure $ go phase'
 
@@ -241,8 +248,7 @@ mkCageFollower
                             | otherwise -> do
                                 armageddon
                                 restoring <-
-                                    startRestoring
-                                        backendInit
+                                    start backendInit
                                 pure
                                     $ Reset
                                     $ mkCageIntersector
@@ -252,13 +258,12 @@ mkCageFollower
                                         armageddon
                                         onCommit
                                         ( InRestoration
-                                            0
                                             restoring
                                         )
-                InRestoration _ _ -> do
+                InRestoration _ -> do
                     armageddon
                     restoring <-
-                        startRestoring backendInit
+                        start backendInit
                     pure
                         $ Reset
                         $ mkCageIntersector
@@ -267,4 +272,4 @@ mkCageFollower
                             backendInit
                             armageddon
                             onCommit
-                            (InRestoration 0 restoring)
+                            (InRestoration restoring)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trace.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trace.hs
@@ -87,7 +87,7 @@ instance ToJSON AppTrace where
                    )
             , "slot" .= show slot
             ]
-    toJSON (TraceReplay (ReplayStart cs bs tb opb)) =
+    toJSON (TraceReplay (ReplayStart cs bs tb opb remaining)) =
         object
             [ "event"
                 .= ("replay_start" :: String)
@@ -95,6 +95,7 @@ instance ToJSON AppTrace where
             , "buckets" .= bs
             , "total_buckets" .= tb
             , "ops_per_bucket" .= opb
+            , "remaining" .= remaining
             ]
     toJSON (TraceReplay ReplayStop) =
         object

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ArmageddonSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ArmageddonSpec.hs
@@ -22,6 +22,7 @@
 module Cardano.MPFS.Indexer.ArmageddonSpec (spec) where
 
 import Control.Monad (forM_)
+import Control.Tracer (nullTracer)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short qualified as SBS
@@ -294,83 +295,95 @@ spec :: Spec
 spec = describe "Cage Runner E2E" $ do
     it "processes blocks in restoration" $ do
         withCageRunnerDB $ \transact -> do
-            let phase0 = InRestoration 0 mkCageRestoring
+            let phase0 = InRestoration mkCageRestoring
             phase1 <-
-                transact
-                    $ processBlock
-                        TestRollbacks
-                        maxBound
-                        1
-                        [CageBoot tokA tokStateA]
-                        phase0
+                processBlock
+                    nullTracer
+                    False
+                    transact
+                    TestRollbacks
+                    maxBound
+                    1
+                    [CageBoot tokA tokStateA]
+                    phase0
             case phase1 of
-                InRestoration _ _ -> pure ()
+                InRestoration _ -> pure ()
                 InFollowing _ _ ->
                     fail "expected Restoration"
 
-    it "restoration stores no rollback points" $ do
+    it "restoration stores a checkpoint (no inverses)" $ do
         withCageRunnerDB $ \transact -> do
-            let phase0 = InRestoration 0 mkCageRestoring
+            let phase0 = InRestoration mkCageRestoring
             _ <-
-                transact
-                    $ processBlock
-                        TestRollbacks
-                        maxBound
-                        1
-                        [CageBoot tokA tokStateA]
-                        phase0
+                processBlock
+                    nullTracer
+                    False
+                    transact
+                    TestRollbacks
+                    maxBound
+                    1
+                    [CageBoot tokA tokStateA]
+                    phase0
+            -- Runner stores one sentinel checkpoint per
+            -- restoration block (empty inverses, no meta)
             count <-
                 transact
                     $ Store.countPoints TestRollbacks
-            count `shouldBe` 0
+            count `shouldBe` 1
 
     it "restoration then transition to following" $ do
         withCageRunnerDB $ \transact -> do
-            let phase0 = InRestoration 0 mkCageRestoring
+            let phase0 = InRestoration mkCageRestoring
             phase1 <-
-                transact
-                    $ processBlock
-                        TestRollbacks
-                        maxBound
-                        1
-                        [CageBoot tokA tokStateA]
-                        phase0
+                processBlock
+                    nullTracer
+                    False
+                    transact
+                    TestRollbacks
+                    maxBound
+                    1
+                    [CageBoot tokA tokStateA]
+                    phase0
             case phase1 of
-                InRestoration _ restoring -> do
+                InRestoration restoring -> do
                     following <-
                         Backend.toFollowing restoring
                     let phase2 = InFollowing 0 following
                     phase3 <-
-                        transact
-                            $ processBlock
-                                TestRollbacks
-                                maxBound
-                                2
-                                [CageRequest txInA reqA]
-                                phase2
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            TestRollbacks
+                            maxBound
+                            2
+                            [CageRequest txInA reqA]
+                            phase2
                     case phase3 of
                         InFollowing n _ ->
                             n `shouldBe` 1
-                        InRestoration _ _ ->
+                        InRestoration _ ->
                             fail "expected Following"
                 InFollowing _ _ ->
                     fail "expected Restoration"
 
     it "full lifecycle: restore, follow, rollback" $ do
         withCageRunnerDB $ \transact -> do
-            let phase0 = InRestoration 0 mkCageRestoring
+            let phase0 = InRestoration mkCageRestoring
             phase1 <-
-                transact
-                    $ processBlock
-                        TestRollbacks
-                        maxBound
-                        1
-                        [ CageBoot tokA tokStateA
-                        , CageRequest txInA reqA
-                        ]
-                        phase0
+                processBlock
+                    nullTracer
+                    False
+                    transact
+                    TestRollbacks
+                    maxBound
+                    1
+                    [ CageBoot tokA tokStateA
+                    , CageRequest txInA reqA
+                    ]
+                    phase0
             case phase1 of
-                InRestoration _ restoring -> do
+                InRestoration restoring -> do
                     following <-
                         Backend.toFollowing restoring
                     transact
@@ -380,25 +393,29 @@ spec = describe "Cage Runner E2E" $ do
                             (Just (BlockId mempty))
                     let phase2 = InFollowing 1 following
                     phase3 <-
-                        transact
-                            $ processBlock
-                                TestRollbacks
-                                maxBound
-                                2
-                                [ CageUpdate
-                                    tokA
-                                    (Root "new-root")
-                                    [txInA]
-                                ]
-                                phase2
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            TestRollbacks
+                            maxBound
+                            2
+                            [ CageUpdate
+                                tokA
+                                (Root "new-root")
+                                [txInA]
+                            ]
+                            phase2
                     phase4 <-
-                        transact
-                            $ processBlock
-                                TestRollbacks
-                                maxBound
-                                3
-                                [CageRequest txInB reqB]
-                                phase3
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            TestRollbacks
+                            maxBound
+                            3
+                            [CageRequest txInB reqB]
+                            phase3
                     case phase4 of
                         InFollowing n f -> do
                             (result, _) <-
@@ -413,7 +430,7 @@ spec = describe "Cage Runner E2E" $ do
                                     d `shouldBe` 1
                                 Store.RollbackImpossible ->
                                     fail "unexpected"
-                        InRestoration _ _ ->
+                        InRestoration _ ->
                             fail "expected Following"
                 InFollowing _ _ ->
                     fail "expected Restoration"
@@ -422,18 +439,20 @@ spec = describe "Cage Runner E2E" $ do
         withCageRunnerDB $ \transact -> do
             let doCycle n = do
                     let phase0 =
-                            InRestoration 0 mkCageRestoring
+                            InRestoration mkCageRestoring
                         s = n * 10
                     phase1 <-
-                        transact
-                            $ processBlock
-                                TestRollbacks
-                                maxBound
-                                (s + 1)
-                                [CageBoot tokA tokStateA]
-                                phase0
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            TestRollbacks
+                            maxBound
+                            (s + 1)
+                            [CageBoot tokA tokStateA]
+                            phase0
                     case phase1 of
-                        InRestoration _ restoring -> do
+                        InRestoration restoring -> do
                             following <-
                                 Backend.toFollowing
                                     restoring
@@ -447,28 +466,32 @@ spec = describe "Cage Runner E2E" $ do
                                         1
                                         following
                             phase3 <-
-                                transact
-                                    $ processBlock
-                                        TestRollbacks
-                                        maxBound
-                                        (s + 2)
-                                        [ CageRequest
-                                            txInA
-                                            reqA
-                                        ]
-                                        phase2
+                                processBlock
+                                    nullTracer
+                                    False
+                                    transact
+                                    TestRollbacks
+                                    maxBound
+                                    (s + 2)
+                                    [ CageRequest
+                                        txInA
+                                        reqA
+                                    ]
+                                    phase2
                             phase4 <-
-                                transact
-                                    $ processBlock
-                                        TestRollbacks
-                                        maxBound
-                                        (s + 3)
-                                        [ CageUpdate
-                                            tokA
-                                            (Root "r")
-                                            [txInA]
-                                        ]
-                                        phase3
+                                processBlock
+                                    nullTracer
+                                    False
+                                    transact
+                                    TestRollbacks
+                                    maxBound
+                                    (s + 3)
+                                    [ CageUpdate
+                                        tokA
+                                        (Root "r")
+                                        [txInA]
+                                    ]
+                                    phase3
                             case phase4 of
                                 InFollowing nn f -> do
                                     _ <-
@@ -479,7 +502,7 @@ spec = describe "Cage Runner E2E" $ do
                                                 nn
                                                 (s + 2)
                                     pure ()
-                                InRestoration _ _ ->
+                                InRestoration _ ->
                                     fail "expected Following"
                         InFollowing _ _ ->
                             fail "expected Restoration"
@@ -487,19 +510,21 @@ spec = describe "Cage Runner E2E" $ do
 
     it "two tokens with interleaved trie ops" $ do
         withCageRunnerDB $ \transact -> do
-            let phase0 = InRestoration 0 mkCageRestoring
+            let phase0 = InRestoration mkCageRestoring
             phase1 <-
-                transact
-                    $ processBlock
-                        TestRollbacks
-                        maxBound
-                        1
-                        [ CageBoot tokA tokStateA
-                        , CageBoot tokB tokStateB
-                        ]
-                        phase0
+                processBlock
+                    nullTracer
+                    False
+                    transact
+                    TestRollbacks
+                    maxBound
+                    1
+                    [ CageBoot tokA tokStateA
+                    , CageBoot tokB tokStateB
+                    ]
+                    phase0
             case phase1 of
-                InRestoration _ restoring -> do
+                InRestoration restoring -> do
                     following <-
                         Backend.toFollowing restoring
                     transact
@@ -509,31 +534,35 @@ spec = describe "Cage Runner E2E" $ do
                             Nothing
                     let phase2 = InFollowing 1 following
                     phase3 <-
-                        transact
-                            $ processBlock
-                                TestRollbacks
-                                maxBound
-                                2
-                                [ CageRequest txInA reqA
-                                , CageRequest txInB reqB
-                                ]
-                                phase2
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            TestRollbacks
+                            maxBound
+                            2
+                            [ CageRequest txInA reqA
+                            , CageRequest txInB reqB
+                            ]
+                            phase2
                     _ <-
-                        transact
-                            $ processBlock
-                                TestRollbacks
-                                maxBound
-                                3
-                                [ CageUpdate
-                                    tokA
-                                    (Root "rA")
-                                    [txInA]
-                                , CageUpdate
-                                    tokB
-                                    (Root "rB")
-                                    [txInB]
-                                ]
-                                phase3
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            TestRollbacks
+                            maxBound
+                            3
+                            [ CageUpdate
+                                tokA
+                                (Root "rA")
+                                [txInA]
+                            , CageUpdate
+                                tokB
+                                (Root "rB")
+                                [txInB]
+                            ]
+                            phase3
                     ts <-
                         transact
                             $ mapColumns InCage

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
@@ -21,6 +21,7 @@ import Control.Concurrent.Async
     , replicateConcurrently_
     )
 import Control.Monad (forM_, replicateM_)
+import Control.Tracer (nullTracer)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.ByteString.Short qualified as SBS
@@ -595,20 +596,22 @@ spec = describe "Unified 14-CF" $ do
                     restoring =
                         mkComposedRestoring csmtOps
                     phase0 =
-                        InRestoration 0 restoring
+                        InRestoration restoring
                 -- Restore a block
                 phase1 <-
-                    transact
-                        $ processBlock
-                            InRollbacks
-                            maxBound
-                            (1 :: SlotNo)
-                            ( [CageBoot tokA tokStateA]
-                            , [UTxO.Insert "k1-pad-32bytes-xxxxxxxxxxxx" "v1"]
-                            )
-                            phase0
+                    processBlock
+                        nullTracer
+                        False
+                        transact
+                        InRollbacks
+                        maxBound
+                        (1 :: SlotNo)
+                        ( [CageBoot tokA tokStateA]
+                        , [UTxO.Insert "k1-pad-32bytes-xxxxxxxxxxxx" "v1"]
+                        )
+                        phase0
                 case phase1 of
-                    InRestoration _ _ -> pure ()
+                    InRestoration _ -> pure ()
                     InFollowing _ _ ->
                         fail "expected Restoration"
                 -- Verify cage state persisted
@@ -626,25 +629,26 @@ spec = describe "Unified 14-CF" $ do
                         mkCSMTOps testFromKV testHashing
                     phase0 =
                         InRestoration
-                            0
                             (mkComposedRestoring csmtOps)
                 -- Restore: boot + request + UTxO insert
                 phase1 <-
-                    transact
-                        $ processBlock
-                            InRollbacks
-                            maxBound
-                            (1 :: SlotNo)
-                            (
-                                [ CageBoot tokA tokStateA
-                                , CageRequest txInA reqA
-                                ]
-                            , [UTxO.Insert "utxo1-pad-32bytes-xxxxxxxxxx" "out1"]
-                            )
-                            phase0
+                    processBlock
+                        nullTracer
+                        False
+                        transact
+                        InRollbacks
+                        maxBound
+                        (1 :: SlotNo)
+                        (
+                            [ CageBoot tokA tokStateA
+                            , CageRequest txInA reqA
+                            ]
+                        , [UTxO.Insert "utxo1-pad-32bytes-xxxxxxxxxx" "out1"]
+                        )
+                        phase0
                 -- Transition to Following
                 case phase1 of
-                    InRestoration _ r -> do
+                    InRestoration r -> do
                         following <-
                             Backend.toFollowing r
                         transact
@@ -655,35 +659,39 @@ spec = describe "Unified 14-CF" $ do
                         let phase2 = InFollowing 1 following
                         -- Follow: update + UTxO insert
                         phase3 <-
-                            transact
-                                $ processBlock
-                                    InRollbacks
-                                    maxBound
-                                    (2 :: SlotNo)
-                                    (
-                                        [ CageUpdate
-                                            tokA
-                                            (Root "root2")
-                                            [txInA]
-                                        ]
-                                    ,
-                                        [ UTxO.Insert
-                                            "utxo2-pad-32bytes-xxxxxxxxxx"
-                                            "out2"
-                                        ]
-                                    )
-                                    phase2
+                            processBlock
+                                nullTracer
+                                False
+                                transact
+                                InRollbacks
+                                maxBound
+                                (2 :: SlotNo)
+                                (
+                                    [ CageUpdate
+                                        tokA
+                                        (Root "root2")
+                                        [txInA]
+                                    ]
+                                ,
+                                    [ UTxO.Insert
+                                        "utxo2-pad-32bytes-xxxxxxxxxx"
+                                        "out2"
+                                    ]
+                                )
+                                phase2
                         -- Follow: another block
                         phase4 <-
-                            transact
-                                $ processBlock
-                                    InRollbacks
-                                    maxBound
-                                    (3 :: SlotNo)
-                                    ( [CageRequest txInB reqB]
-                                    , []
-                                    )
-                                    phase3
+                            processBlock
+                                nullTracer
+                                False
+                                transact
+                                InRollbacks
+                                maxBound
+                                (3 :: SlotNo)
+                                ( [CageRequest txInB reqB]
+                                , []
+                                )
+                                phase3
                         -- Rollback to slot 2
                         case phase4 of
                             InFollowing n f -> do
@@ -699,7 +707,7 @@ spec = describe "Unified 14-CF" $ do
                                         d `shouldBe` 1
                                     Store.RollbackImpossible ->
                                         fail "unexpected"
-                            InRestoration _ _ ->
+                            InRestoration _ ->
                                 fail "expected Following"
                     InFollowing _ _ ->
                         fail "expected Restoration"
@@ -712,23 +720,24 @@ spec = describe "Unified 14-CF" $ do
                     let s = n * 10
                         phase0 =
                             InRestoration
-                                0
                                 ( mkComposedRestoring
                                     csmtOps
                                 )
                     -- Restore
                     phase1 <-
-                        transact
-                            $ processBlock
-                                InRollbacks
-                                maxBound
-                                (s + 1)
-                                ( [CageBoot tokA tokStateA]
-                                , []
-                                )
-                                phase0
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            InRollbacks
+                            maxBound
+                            (s + 1)
+                            ( [CageBoot tokA tokStateA]
+                            , []
+                            )
+                            phase0
                     case phase1 of
-                        InRestoration _ r -> do
+                        InRestoration r -> do
                             following <-
                                 Backend.toFollowing r
                             transact
@@ -742,34 +751,38 @@ spec = describe "Unified 14-CF" $ do
                                         following
                             -- Follow 2 blocks
                             phase3 <-
-                                transact
-                                    $ processBlock
-                                        InRollbacks
-                                        maxBound
-                                        (s + 2)
-                                        (
-                                            [ CageRequest
-                                                txInA
-                                                reqA
-                                            ]
-                                        , []
-                                        )
-                                        phase2
+                                processBlock
+                                    nullTracer
+                                    False
+                                    transact
+                                    InRollbacks
+                                    maxBound
+                                    (s + 2)
+                                    (
+                                        [ CageRequest
+                                            txInA
+                                            reqA
+                                        ]
+                                    , []
+                                    )
+                                    phase2
                             phase4 <-
-                                transact
-                                    $ processBlock
-                                        InRollbacks
-                                        maxBound
-                                        (s + 3)
-                                        (
-                                            [ CageUpdate
-                                                tokA
-                                                (Root "r")
-                                                [txInA]
-                                            ]
-                                        , []
-                                        )
-                                        phase3
+                                processBlock
+                                    nullTracer
+                                    False
+                                    transact
+                                    InRollbacks
+                                    maxBound
+                                    (s + 3)
+                                    (
+                                        [ CageUpdate
+                                            tokA
+                                            (Root "r")
+                                            [txInA]
+                                        ]
+                                    , []
+                                    )
+                                    phase3
                             -- Rollback
                             case phase4 of
                                 InFollowing nn f -> do
@@ -781,7 +794,7 @@ spec = describe "Unified 14-CF" $ do
                                                 nn
                                                 (s + 2)
                                     pure ()
-                                InRestoration _ _ ->
+                                InRestoration _ ->
                                     fail "expected Following"
                         InFollowing _ _ ->
                             fail "expected Restoration"
@@ -791,22 +804,23 @@ spec = describe "Unified 14-CF" $ do
             withUnifiedDBFull $ \csmtOps transact _tm -> do
                 let phase0 =
                         InRestoration
-                            0
                             (mkComposedRestoring csmtOps)
                 -- Restore: boot + UTxO insert
                 phase1 <-
-                    transact
-                        $ processBlock
-                            InRollbacks
-                            maxBound
-                            (1 :: SlotNo)
-                            ( [CageBoot tokA tokStateA, CageRequest txInA reqA]
-                            , [UTxO.Insert "utxo-key-padded-to-32-bytesXX" "val1"]
-                            )
-                            phase0
+                    processBlock
+                        nullTracer
+                        False
+                        transact
+                        InRollbacks
+                        maxBound
+                        (1 :: SlotNo)
+                        ( [CageBoot tokA tokStateA, CageRequest txInA reqA]
+                        , [UTxO.Insert "utxo-key-padded-to-32-bytesXX" "val1"]
+                        )
+                        phase0
                 -- Transition
                 case phase1 of
-                    InRestoration _ r -> do
+                    InRestoration r -> do
                         following <- Backend.toFollowing r
                         transact
                             $ Store.armageddonSetup
@@ -816,23 +830,27 @@ spec = describe "Unified 14-CF" $ do
                         let phase2 = InFollowing 1 following
                         -- Follow: update + UTxO
                         phase3 <-
-                            transact
-                                $ processBlock
-                                    InRollbacks
-                                    maxBound
-                                    (2 :: SlotNo)
-                                    ( [CageUpdate tokA (Root "r2") [txInA]]
-                                    , [UTxO.Insert "utxo-key2-padded-to-32-byteX" "val2"]
-                                    )
-                                    phase2
+                            processBlock
+                                nullTracer
+                                False
+                                transact
+                                InRollbacks
+                                maxBound
+                                (2 :: SlotNo)
+                                ( [CageUpdate tokA (Root "r2") [txInA]]
+                                , [UTxO.Insert "utxo-key2-padded-to-32-byteX" "val2"]
+                                )
+                                phase2
                         phase4 <-
-                            transact
-                                $ processBlock
-                                    InRollbacks
-                                    maxBound
-                                    (3 :: SlotNo)
-                                    ([CageRequest txInB reqB], [])
-                                    phase3
+                            processBlock
+                                nullTracer
+                                False
+                                transact
+                                InRollbacks
+                                maxBound
+                                (3 :: SlotNo)
+                                ([CageRequest txInB reqB], [])
+                                phase3
                         -- Rollback
                         case phase4 of
                             InFollowing n f -> do
@@ -848,7 +866,7 @@ spec = describe "Unified 14-CF" $ do
                                         d `shouldBe` 1
                                     Store.RollbackImpossible ->
                                         fail "unexpected"
-                            InRestoration _ _ ->
+                            InRestoration _ ->
                                 fail "expected Following"
                     InFollowing _ _ ->
                         fail "expected Restoration"
@@ -859,18 +877,19 @@ spec = describe "Unified 14-CF" $ do
                     let s = n * 10
                         phase0 =
                             InRestoration
-                                0
                                 (mkComposedRestoring csmtOps)
                     phase1 <-
-                        transact
-                            $ processBlock
-                                InRollbacks
-                                maxBound
-                                (s + 1)
-                                ([CageBoot tokA tokStateA], [])
-                                phase0
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            InRollbacks
+                            maxBound
+                            (s + 1)
+                            ([CageBoot tokA tokStateA], [])
+                            phase0
                     case phase1 of
-                        InRestoration _ r -> do
+                        InRestoration r -> do
                             following <- Backend.toFollowing r
                             transact
                                 $ Store.armageddonSetup
@@ -879,23 +898,27 @@ spec = describe "Unified 14-CF" $ do
                                     Nothing
                             let phase2 = InFollowing 1 following
                             phase3 <-
-                                transact
-                                    $ processBlock
-                                        InRollbacks
-                                        maxBound
-                                        (s + 2)
-                                        ([CageRequest txInA reqA], [])
-                                        phase2
+                                processBlock
+                                    nullTracer
+                                    False
+                                    transact
+                                    InRollbacks
+                                    maxBound
+                                    (s + 2)
+                                    ([CageRequest txInA reqA], [])
+                                    phase2
                             phase4 <-
-                                transact
-                                    $ processBlock
-                                        InRollbacks
-                                        maxBound
-                                        (s + 3)
-                                        ( [CageUpdate tokA (Root "r") [txInA]]
-                                        , []
-                                        )
-                                        phase3
+                                processBlock
+                                    nullTracer
+                                    False
+                                    transact
+                                    InRollbacks
+                                    maxBound
+                                    (s + 3)
+                                    ( [CageUpdate tokA (Root "r") [txInA]]
+                                    , []
+                                    )
+                                    phase3
                             case phase4 of
                                 InFollowing nn f -> do
                                     _ <-
@@ -906,7 +929,7 @@ spec = describe "Unified 14-CF" $ do
                                                 nn
                                                 (s + 2)
                                     pure ()
-                                InRestoration _ _ ->
+                                InRestoration _ ->
                                     fail "expected Following"
                         InFollowing _ _ ->
                             fail "expected Restoration"
@@ -982,7 +1005,6 @@ spec = describe "Unified 14-CF" $ do
             withUnifiedDBFull $ \csmtOps transact _tm -> do
                 let mkPhase =
                         InRestoration
-                            0
                             (mkComposedRestoring csmtOps)
                 -- Run 10 concurrent restore cycles
                 -- (each in its own phase, serialized
@@ -990,15 +1012,17 @@ spec = describe "Unified 14-CF" $ do
                 replicateConcurrently_ 10 $ do
                     let phase0 = mkPhase
                     _ <-
-                        transact
-                            $ processBlock
-                                InRollbacks
-                                maxBound
-                                (1 :: SlotNo)
-                                ( [CageBoot tokA tokStateA]
-                                , []
-                                )
-                                phase0
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            InRollbacks
+                            maxBound
+                            (1 :: SlotNo)
+                            ( [CageBoot tokA tokStateA]
+                            , []
+                            )
+                            phase0
                     pure ()
 
 -- ---------------------------------------------------------

--- a/dist-newstyle
+++ b/dist-newstyle
@@ -1,1 +1,0 @@
-/code/cardano-mpfs-offchain/dist-newstyle


### PR DESCRIPTION
## Summary

Bump to latest main for all deps and adapt to breaking API changes:

- **cardano-node-clients** → f75a3c8 (generic `killDuring` crash recovery harness)
- **cardano-utxo-csmt** → 006a1cd (`killDuring` integration, MetricsCol, exclusion proofs)
- **chain-follower** → d592a50 (`processBlock` takes Tracer + withinStabilityWindow, `Init` newtype with single `start` field, `InRestoration` 1-arg)
- **haskell-mts** → a37b352 (`ReplayStart` 5th field: remaining entries)

Closes #166