### PR TITLE
perf: start in InRestoration on fresh DB

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -437,17 +437,23 @@ withApplication cfg action = do
                                 | (s, rp) <- history
                                 ]
 
-                    -- Initialize Phase: always InFollowing
-                    -- start → toFollowing calls toFull which
-                    -- replays the journal (empty on fresh DB)
+                    -- Initialize Phase:
+                    -- Existing DB: toFollowing replays journal
+                    -- Fresh DB: InRestoration (fast KVOnly)
                     restoring <-
                         start backendInit
-                    following <-
-                        toFollowing restoring
-                    let initialPhase =
-                            InFollowing
-                                initialCount
-                                following
+                    initialPhase <-
+                        if initialCount > 0
+                            then do
+                                following <-
+                                    toFollowing restoring
+                                pure
+                                    $ InFollowing
+                                        initialCount
+                                        following
+                            else
+                                pure
+                                    $ InRestoration restoring
                     -- Commit notification TVar for awaitUtxo
                     commitNotify' <-
                         newTVarIO (0 :: Int)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
@@ -260,16 +260,8 @@ mkCageFollower
                                         ( InRestoration
                                             restoring
                                         )
-                InRestoration _ -> do
-                    armageddon
-                    restoring <-
-                        start backendInit
-                    pure
-                        $ Reset
-                        $ mkCageIntersector
-                            securityParam
-                            run
-                            backendInit
-                            armageddon
-                            onCommit
-                            (InRestoration restoring)
+                InRestoration _ ->
+                    -- During restoration rollbacks are
+                    -- harmless — we're replaying from
+                    -- origin anyway. Just continue.
+                    pure $ Progress $ go phase


### PR DESCRIPTION
## Summary

Fresh databases now start in `InRestoration` (fast KVOnly path) instead of `InFollowing` (full tree + inverses on every block). The Runner transitions to Following automatically when near tip.

**Root cause of the original segfault (March):** Rollbacks during `InRestoration` triggered an infinite armageddon loop — every rollback called `setup` (sentinel write) then re-intersected from Origin, causing another rollback. Fix: ignore rollbacks during restoration since we're replaying from origin anyway.

**Changes:**
- `Application.hs`: conditional phase — `InRestoration` on fresh DB, `InFollowing` on existing DB
- `CageFollower.hs`: ignore rollbacks during InRestoration instead of triggering armageddon

**Expected sync time improvement:** ~6 days → minutes for preprod.

Closes #171