### PR TITLE
feat: add reject and request-update API endpoints (#183)

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -128,6 +128,7 @@ library
     Cardano.MPFS.TxBuilder.Real.Boot
     Cardano.MPFS.TxBuilder.Real.End
     Cardano.MPFS.TxBuilder.Real.Internal
+    Cardano.MPFS.TxBuilder.Real.Reject
     Cardano.MPFS.TxBuilder.Real.Request
     Cardano.MPFS.TxBuilder.Real.Retract
     Cardano.MPFS.TxBuilder.Real.Update

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -140,6 +140,7 @@ spec = describe "CageFlow E2E" $ do
                             in  do
                                     cageFlowSpec applied
                                     deleteFlowSpec applied
+                                    rejectFlowSpec applied
 
 -- ---------------------------------------------------------
 -- Test implementation
@@ -519,6 +520,92 @@ deleteFlowSpec scriptBytes =
                                 /= preMixedRoot ->
                                 Just ()
                         _ -> Nothing
+
+-- | Reject via CageFollower:
+-- boot → insert request → wait Phase 3 → reject
+-- → verify requests consumed, root unchanged.
+rejectFlowSpec :: SBS.ShortByteString -> Spec
+rejectFlowSpec scriptBytes =
+    it "reject expired requests via CageFollower"
+        $ do
+            withE2E scriptBytes $ \cfg ctx -> do
+                -- Boot
+                signedBoot <-
+                    buildAndSubmit ctx
+                        $ bootToken
+                            (txBuilder ctx)
+                            genesisAddr
+                let tokenId =
+                        extractTokenId cfg signedBoot
+                _ <-
+                    pollOrFail 30 "boot"
+                        $ getToken
+                            (tokens (state ctx))
+                            tokenId
+
+                -- Insert request
+                _ <-
+                    buildAndSubmit ctx
+                        $ requestInsert
+                            (txBuilder ctx)
+                            tokenId
+                            "reject-me"
+                            "val"
+                            genesisAddr
+                _ <-
+                    pollOrFail 30 "request" $ do
+                        rs <-
+                            requestsByToken
+                                ( requests
+                                    (state ctx)
+                                )
+                                tokenId
+                        if null rs
+                            then pure Nothing
+                            else pure (Just rs)
+
+                -- Wait for Phase 3
+                -- process_time=15s, retract_time=15s
+                -- Phase 3 starts at submitted_at+30s
+                threadDelay 32_000_000
+
+                -- Record root before reject
+                Just preRejectTs <-
+                    getToken
+                        (tokens (state ctx))
+                        tokenId
+                let preRejectRoot = root preRejectTs
+
+                -- Reject
+                _ <-
+                    buildAndSubmit ctx
+                        $ rejectRequests
+                            (txBuilder ctx)
+                            tokenId
+                            genesisAddr
+
+                -- Verify requests consumed
+                pollOrFail 60 "reject" $ do
+                    rs <-
+                        requestsByToken
+                            (requests (state ctx))
+                            tokenId
+                    if null rs
+                        then do
+                            -- Verify root unchanged
+                            mTs <-
+                                getToken
+                                    ( tokens
+                                        (state ctx)
+                                    )
+                                    tokenId
+                            pure $ case mTs of
+                                Just t
+                                    | root t
+                                        == preRejectRoot ->
+                                        Just ()
+                                _ -> Nothing
+                        else pure Nothing
 
 -- ---------------------------------------------------------
 -- Bracket

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
@@ -41,6 +41,8 @@ module Cardano.MPFS.HTTP.API
     , TxBootAPI
     , TxInsertAPI
     , TxDeleteAPI
+    , TxRequestUpdateAPI
+    , TxRejectAPI
     , TxUpdateAPI
     , TxRetractAPI
     , TxEndAPI
@@ -69,6 +71,7 @@ import Cardano.MPFS.HTTP.Types
     , DeleteRequest
     , EndRequest
     , InsertRequest
+    , RejectRequest
     , RequestJSON
     , RetractRequest
     , StatusResponse
@@ -76,6 +79,7 @@ import Cardano.MPFS.HTTP.Types
     , TokenIdJSON
     , TokenStateJSON
     , UpdateRequest
+    , UpdateValueRequest
     )
 import Cardano.UTxOCSMT.Application.Metrics (Metrics)
 
@@ -193,6 +197,23 @@ type TxDeleteAPI =
         :> ReqBody '[JSON] DeleteRequest
         :> Post '[JSON] Hex
 
+-- | @POST \/tx\/request\/update@ — build an
+-- update-value request transaction.
+type TxRequestUpdateAPI =
+    "tx"
+        :> "request"
+        :> "update"
+        :> ReqBody '[JSON] UpdateValueRequest
+        :> Post '[JSON] Hex
+
+-- | @POST \/tx\/reject@ — build a reject
+-- transaction for Phase 3 requests.
+type TxRejectAPI =
+    "tx"
+        :> "reject"
+        :> ReqBody '[JSON] RejectRequest
+        :> Post '[JSON] Hex
+
 -- | @POST \/tx\/update@ — build an update
 -- transaction.
 type TxUpdateAPI =
@@ -246,6 +267,8 @@ type API =
         :<|> TxBootAPI
         :<|> TxInsertAPI
         :<|> TxDeleteAPI
+        :<|> TxRequestUpdateAPI
+        :<|> TxRejectAPI
         :<|> TxUpdateAPI
         :<|> TxRetractAPI
         :<|> TxEndAPI

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -74,6 +74,7 @@ import Cardano.MPFS.HTTP.Types
     , DeleteRequest (..)
     , EndRequest (..)
     , InsertRequest (..)
+    , RejectRequest (..)
     , RequestJSON
     , RetractRequest (..)
     , StatusResponse (..)
@@ -81,6 +82,7 @@ import Cardano.MPFS.HTTP.Types
     , TokenIdJSON (..)
     , TokenStateJSON
     , UpdateRequest (..)
+    , UpdateValueRequest (..)
     , parseAddr
     , requestToJSON
     , tokenStateToJSON
@@ -119,6 +121,8 @@ mkApp ctx =
             :<|> txBootHandler ctx
             :<|> txInsertHandler ctx
             :<|> txDeleteHandler ctx
+            :<|> txUpdateValueHandler ctx
+            :<|> txRejectHandler ctx
             :<|> txUpdateHandler ctx
             :<|> txRetractHandler ctx
             :<|> txEndHandler ctx
@@ -414,6 +418,50 @@ txDeleteHandler
                     tid
                     k
                     v
+                    addr
+        pure (serializeTx tx)
+
+txUpdateValueHandler
+    :: Context IO
+    -> UpdateValueRequest
+    -> Handler Hex
+txUpdateValueHandler
+    ctx
+    UpdateValueRequest
+        { uvrToken = TokenIdJSON tid
+        , uvrKey = Hex k
+        , uvrOldValue = Hex oldV
+        , uvrNewValue = Hex newV
+        , uvrAddr = addrHex
+        } = do
+        addr <- requireAddr addrHex
+        tx <-
+            liftIO
+                $ Tx.requestUpdate
+                    (txBuilder ctx)
+                    tid
+                    k
+                    oldV
+                    newV
+                    addr
+        pure (serializeTx tx)
+
+txRejectHandler
+    :: Context IO
+    -> RejectRequest
+    -> Handler Hex
+txRejectHandler
+    ctx
+    RejectRequest
+        { rejToken = TokenIdJSON tid
+        , rejAddr = addrHex
+        } = do
+        addr <- requireAddr addrHex
+        tx <-
+            liftIO
+                $ Tx.rejectRequests
+                    (txBuilder ctx)
+                    tid
                     addr
         pure (serializeTx tx)
 

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -27,6 +27,8 @@ module Cardano.MPFS.HTTP.Types
     , BootRequest (..)
     , InsertRequest (..)
     , DeleteRequest (..)
+    , UpdateValueRequest (..)
+    , RejectRequest (..)
     , UpdateRequest (..)
     , RetractRequest (..)
     , EndRequest (..)
@@ -291,6 +293,38 @@ instance FromJSON DeleteRequest where
             <*> o .: "value"
             <*> o .: "address"
 
+-- | @POST \/tx\/request\/update@ request body.
+data UpdateValueRequest = UpdateValueRequest
+    { uvrToken :: TokenIdJSON
+    , uvrKey :: Hex
+    , uvrOldValue :: Hex
+    , uvrNewValue :: Hex
+    , uvrAddr :: Hex
+    }
+
+instance FromJSON UpdateValueRequest where
+    parseJSON =
+        withObject "UpdateValueRequest" $ \o ->
+            UpdateValueRequest
+                <$> o .: "token"
+                <*> o .: "key"
+                <*> o .: "old_value"
+                <*> o .: "new_value"
+                <*> o .: "address"
+
+-- | @POST \/tx\/reject@ request body.
+data RejectRequest = RejectRequest
+    { rejToken :: TokenIdJSON
+    , rejAddr :: Hex
+    }
+
+instance FromJSON RejectRequest where
+    parseJSON =
+        withObject "RejectRequest" $ \o ->
+            RejectRequest
+                <$> o .: "token"
+                <*> o .: "address"
+
 -- | @POST \/tx\/update@ request body.
 data UpdateRequest = UpdateRequest
     { urToken :: TokenIdJSON
@@ -538,6 +572,60 @@ instance ToSchema DeleteRequest where
             & description
                 ?~ "Delete a key (value is the \
                    \current stored value)"
+
+instance ToSchema UpdateValueRequest where
+    declareNamedSchema _ = do
+        tokenSchema <-
+            declareSchemaRef (Proxy @TokenIdJSON)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "UpdateValueRequest")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("token", tokenSchema)
+                    , ("key", hexSchema)
+                    , ("old_value", hexSchema)
+                    , ("new_value", hexSchema)
+                    , ("address", hexSchema)
+                    ]
+            & required
+                .~ [ "token"
+                   , "key"
+                   , "old_value"
+                   , "new_value"
+                   , "address"
+                   ]
+            & description
+                ?~ "Update a key's value \
+                   \(old and new values)"
+
+instance ToSchema RejectRequest where
+    declareNamedSchema _ = do
+        tokenSchema <-
+            declareSchemaRef (Proxy @TokenIdJSON)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "RejectRequest")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("token", tokenSchema)
+                    , ("address", hexSchema)
+                    ]
+            & required
+                .~ ["token", "address"]
+            & description
+                ?~ "Reject Phase 3 expired \
+                   \requests for a token"
 
 instance ToSchema UpdateRequest where
     declareNamedSchema _ = do

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
@@ -125,6 +125,9 @@ data CageEvent
       -- UTxOs and updates the trie root. Carries the
       -- token, new root, and consumed request UTxOs.
       CageUpdate !TokenId !Root ![TxIn]
+    | -- | Oracle rejects expired Phase 3 requests.
+      -- Root unchanged, requests consumed.
+      CageReject !TokenId ![TxIn]
     | -- | Requester cancels a pending request.
       CageRetract !TxIn
     | -- | Burn cage token: token permanently removed.
@@ -275,6 +278,8 @@ detectCageEvents scriptHash resolvedInputs tx =
                 (BuiltinData plcData) of
                 Just (Modify _proofs) ->
                     detectUpdate txIn txOut
+                Just Reject ->
+                    detectReject txIn txOut
                 Just (Retract _ref) ->
                     detectRetract txIn
                 _ -> []
@@ -346,6 +351,18 @@ detectCageEvents scriptHash resolvedInputs tx =
                         == tid
             _ -> False
 
+    detectReject _stateTxIn _stateTxOut =
+        let outputs =
+                toList
+                    (body ^. outputsTxBodyL)
+        in  case findStateDatumWithToken outputs of
+                Just (tid, _root) ->
+                    let consumed =
+                            findConsumedRequests
+                                tid
+                    in  [CageReject tid consumed]
+                Nothing -> []
+
     detectRetract txIn = [CageRetract txIn]
 
 -- | Compute inverse operations for a cage event,
@@ -379,6 +396,14 @@ inversesOf lookupToken lookupReq = \case
                     )
                     consumed
         in  restoreRoot ++ restoreReqs
+    CageReject _tid consumed ->
+        concatMap
+            ( \txIn' -> case lookupReq txIn' of
+                Just req ->
+                    [InvRestoreRequest txIn' req]
+                Nothing -> []
+            )
+            consumed
     CageRetract txIn ->
         case lookupReq txIn of
             Just req ->

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs
@@ -215,6 +215,20 @@ computeInverse
                         )
                         consumed
             pure $ restoreRoot ++ restoreReqs
+        CageReject _tid consumed ->
+            concat
+                <$> traverse
+                    ( \txIn -> do
+                        mReq <- getRequest txIn
+                        pure $ case mReq of
+                            Just req ->
+                                [ InvRestoreRequest
+                                    txIn
+                                    req
+                                ]
+                            Nothing -> []
+                    )
+                    consumed
         CageRetract txIn -> do
             mReq <- getRequest txIn
             pure $ case mReq of
@@ -279,6 +293,11 @@ applyCageEvent st tm = \case
                     ts{root = newRoot}
             Nothing -> pure ()
         pure trieInvs
+    CageReject _tid consumed -> do
+        mapM_
+            (removeRequest (requests st))
+            consumed
+        pure []
     CageRetract txIn -> do
         removeRequest (requests st) txIn
         pure []

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
@@ -34,6 +34,10 @@ mkMockTxBuilder =
             error
                 "mkMockTxBuilder: requestDelete \
                 \not implemented"
+        , requestUpdate = \_ _ _ _ _ ->
+            error
+                "mkMockTxBuilder: requestUpdate \
+                \not implemented"
         , updateToken = \_ _ ->
             error
                 "mkMockTxBuilder: updateToken \
@@ -41,6 +45,10 @@ mkMockTxBuilder =
         , retractRequest = \_ _ ->
             error
                 "mkMockTxBuilder: retractRequest \
+                \not implemented"
+        , rejectRequests = \_ _ ->
+            error
+                "mkMockTxBuilder: rejectRequests \
                 \not implemented"
         , endToken = \_ _ ->
             error

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
@@ -48,6 +48,14 @@ data TxBuilder m = TxBuilder
         -> Addr
         -> m (Tx ConwayEra)
     -- ^ Request deleting a key (key, old value)
+    , requestUpdate
+        :: TokenId
+        -> ByteString
+        -> ByteString
+        -> ByteString
+        -> Addr
+        -> m (Tx ConwayEra)
+    -- ^ Request updating a key (key, old val, new val)
     , updateToken
         :: TokenId
         -> Addr
@@ -58,6 +66,11 @@ data TxBuilder m = TxBuilder
         -> Addr
         -> m (Tx ConwayEra)
     -- ^ Cancel a pending request
+    , rejectRequests
+        :: TokenId
+        -> Addr
+        -> m (Tx ConwayEra)
+    -- ^ Reject Phase 3 requests for a token
     , endToken
         :: TokenId
         -> Addr

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
@@ -51,14 +51,14 @@ import Cardano.MPFS.TxBuilder.Real.Internal
     , spendingIndex
     , toPlcData
     )
+import Cardano.MPFS.TxBuilder.Real.Reject
+    ( rejectRequestsImpl
+    )
 import Cardano.MPFS.TxBuilder.Real.Request
     ( requestDeleteImpl
     , requestInsertImpl
     , requestLockedAda
     , requestUpdateImpl
-    )
-import Cardano.MPFS.TxBuilder.Real.Reject
-    ( rejectRequestsImpl
     )
 import Cardano.MPFS.TxBuilder.Real.Retract
     ( retractRequestImpl

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
@@ -57,6 +57,9 @@ import Cardano.MPFS.TxBuilder.Real.Request
     , requestLockedAda
     , requestUpdateImpl
     )
+import Cardano.MPFS.TxBuilder.Real.Reject
+    ( rejectRequestsImpl
+    )
 import Cardano.MPFS.TxBuilder.Real.Retract
     ( retractRequestImpl
     )
@@ -89,7 +92,7 @@ mkRealTxBuilder cfg prov st tm =
             updateTokenImpl cfg prov st tm
         , retractRequest =
             retractRequestImpl cfg prov st
-        , rejectRequests = \_ _ ->
-            error "rejectRequests: not yet implemented"
+        , rejectRequests =
+            rejectRequestsImpl cfg prov st
         , endToken = endTokenImpl cfg prov
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
@@ -55,6 +55,7 @@ import Cardano.MPFS.TxBuilder.Real.Request
     ( requestDeleteImpl
     , requestInsertImpl
     , requestLockedAda
+    , requestUpdateImpl
     )
 import Cardano.MPFS.TxBuilder.Real.Retract
     ( retractRequestImpl
@@ -82,9 +83,13 @@ mkRealTxBuilder cfg prov st tm =
             requestInsertImpl cfg prov st
         , requestDelete =
             requestDeleteImpl cfg prov st
+        , requestUpdate =
+            requestUpdateImpl cfg prov st
         , updateToken =
             updateTokenImpl cfg prov st tm
         , retractRequest =
             retractRequestImpl cfg prov st
+        , rejectRequests = \_ _ ->
+            error "rejectRequests: not yet implemented"
         , endToken = endTokenImpl cfg prov
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
@@ -1,0 +1,335 @@
+-- |
+-- Module      : Cardano.MPFS.TxBuilder.Real.Reject
+-- Description : Reject transaction for Phase 3 requests
+-- License     : Apache-2.0
+--
+-- Builds a reject transaction that consumes expired
+-- (Phase 3) requests. The oracle keeps the fee and
+-- refunds remaining ADA to request owners. The trie
+-- root does NOT change.
+module Cardano.MPFS.TxBuilder.Real.Reject
+    ( rejectRequestsImpl
+    ) where
+
+import Control.Exception (SomeException, try)
+import Data.List (sortOn)
+import Data.Map.Strict qualified as Map
+import Data.Ord (Down (..))
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.Clock.POSIX
+    ( utcTimeToPOSIXSeconds
+    )
+import Lens.Micro ((&), (.~), (^.))
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Allegra.Scripts
+    ( ValidityInterval (..)
+    )
+import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
+import Cardano.Ledger.Alonzo.TxBody
+    ( reqSignerHashesTxBodyL
+    , scriptIntegrityHashTxBodyL
+    )
+import Cardano.Ledger.Api.Tx
+    ( Tx
+    , mkBasicTx
+    , witsTxL
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( collateralInputsTxBodyL
+    , inputsTxBodyL
+    , mkBasicTxBody
+    , outputsTxBodyL
+    , vldtTxBodyL
+    )
+import Cardano.Ledger.Api.Tx.Out
+    ( coinTxOutL
+    , datumTxOutL
+    , getMinCoinTxOut
+    , mkBasicTxOut
+    , valueTxOutL
+    )
+import Cardano.Ledger.Api.Tx.Wits
+    ( Redeemers (..)
+    , rdmrsTxWitsL
+    , scriptTxWitsL
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , StrictMaybe (SJust, SNothing)
+    )
+import Cardano.Ledger.Conway.Scripts
+    ( ConwayPlutusPurpose (..)
+    )
+import Cardano.Ledger.Core (hashScript)
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    )
+
+import Cardano.MPFS.Core.OnChain
+    ( CageDatum (..)
+    , OnChainRequest (..)
+    , OnChainTokenState (..)
+    , UpdateRedeemer (..)
+    )
+import Cardano.MPFS.Core.Types
+    ( Coin (..)
+    , ConwayEra
+    , TokenId
+    )
+import Cardano.MPFS.Provider
+    ( Provider (..)
+    , SlotNo
+    )
+import Cardano.MPFS.State (State (..))
+import Cardano.MPFS.TxBuilder.Config
+    ( CageConfig (..)
+    )
+import Cardano.MPFS.TxBuilder.Real.Internal
+
+-- | Build a reject transaction for Phase 3
+-- requests.
+--
+-- Finds all pending requests in Phase 3 (past
+-- @submitted_at + process_time + retract_time@)
+-- and consumes them. The oracle keeps the fee;
+-- remaining ADA goes to request owners. The trie
+-- root does not change.
+rejectRequestsImpl
+    :: CageConfig
+    -> Provider IO
+    -> State IO
+    -> TokenId
+    -> Addr
+    -> IO (Tx ConwayEra)
+rejectRequestsImpl cfg prov _st tid addr = do
+    -- 1. Query cage UTxOs
+    let scriptAddr =
+            cageAddrFromCfg cfg (network cfg)
+    cageUtxos <- queryUTxOs prov scriptAddr
+    -- 2. Find state UTxO
+    let policyId = cagePolicyIdFromCfg cfg
+    stateUtxo <- case findStateUtxo
+        policyId
+        tid
+        cageUtxos of
+        Nothing ->
+            error
+                "rejectRequests: state UTxO \
+                \not found"
+        Just x -> pure x
+    let (stateIn, stateOut) = stateUtxo
+    -- 3. Find rejectable request UTxOs
+    now <- currentPosixMs
+    let allReqs =
+            sortOn fst
+                $ findRequestUtxos tid cageUtxos
+        oldState = case extractCageDatum stateOut of
+            Just (StateDatum s) -> s
+            _ ->
+                error
+                    "rejectRequests: invalid \
+                    \state datum"
+        OnChainTokenState
+            { stateOwner =
+                BuiltinByteString ownerBs
+            } = oldState
+        pt = stateProcessTime oldState
+        rt = stateRetractTime oldState
+        isRejectable (_, rOut) =
+            case extractCageDatum rOut of
+                Just (RequestDatum r) ->
+                    let sa = requestSubmittedAt r
+                        deadline = sa + pt + rt
+                    in  now > deadline
+                        || sa > now
+                _ -> False
+        reqUtxos = filter isRejectable allReqs
+    when (null reqUtxos)
+        $ error "rejectRequests: no rejectable \
+                \requests"
+    -- 4. Get wallet UTxO for fees
+    pp <- queryProtocolParams prov
+    walletUtxos <- queryUTxOs prov addr
+    feeUtxo <- case sortOn
+        (Down . (^. coinTxOutL) . snd)
+        walletUtxos of
+        [] -> error "rejectRequests: no UTxOs"
+        (u : _) -> pure u
+    -- 5. Build new state output (root unchanged)
+    let newStateOut =
+            mkBasicTxOut
+                scriptAddr
+                (stateOut ^. valueTxOutL)
+                & datumTxOutL
+                    .~ mkInlineDatum
+                        ( toPlcData
+                            (StateDatum oldState)
+                        )
+    -- 6. Build refund outputs
+    let mkRefund (_, reqOut) =
+            let Coin reqVal =
+                    reqOut ^. coinTxOutL
+                Coin mf = defaultMaxFee cfg
+                refundAddr =
+                    addrFromKeyHashBytes
+                        (network cfg)
+                        (extractOwnerBytes reqOut)
+                rawRefund = Coin (reqVal - mf)
+                draft =
+                    mkBasicTxOut
+                        refundAddr
+                        (inject rawRefund)
+                minCoin = getMinCoinTxOut pp draft
+            in  mkBasicTxOut
+                    refundAddr
+                    (inject (max rawRefund minCoin))
+        extractOwnerBytes out =
+            case extractCageDatum out of
+                Just (RequestDatum req) ->
+                    let OnChainRequest
+                            { requestOwner =
+                                BuiltinByteString bs
+                            } = req
+                    in  bs
+                _ ->
+                    error
+                        "extractOwnerBytes: \
+                        \not a request"
+        refundOuts = map mkRefund reqUtxos
+        allOuts =
+            StrictSeq.fromList
+                (newStateOut : refundOuts)
+    -- 7. Build redeemers
+    let script = mkCageScript cfg
+        scriptHash = hashScript script
+        reqIns = map fst reqUtxos
+        allScriptIns =
+            Set.fromList (stateIn : reqIns)
+        allInputs =
+            Set.insert (fst feeUtxo) allScriptIns
+        stateRef = txInToRef stateIn
+        stateIx =
+            spendingIndex stateIn allInputs
+        contributeEntries =
+            map
+                ( \rIn ->
+                    let ix =
+                            spendingIndex
+                                rIn
+                                allInputs
+                        rdm = Contribute stateRef
+                    in  ( ConwaySpending (AsIx ix)
+                        ,
+                            ( toLedgerData rdm
+                            , placeholderExUnits
+                            )
+                        )
+                )
+                reqIns
+        redeemers =
+            Redeemers
+                $ Map.fromList
+                $ ( ConwaySpending
+                        (AsIx stateIx)
+                  ,
+                      ( toLedgerData Reject
+                      , placeholderExUnits
+                      )
+                  )
+                    : contributeEntries
+        integrity =
+            computeScriptIntegrity pp redeemers
+        ownerKh =
+            addrWitnessKeyHash ownerBs
+    -- 8. Validity: must be after Phase 3 start
+    -- (latest deadline among rejected requests)
+    let latestDeadline =
+            maximum
+                $ map
+                    ( \(_, rOut) ->
+                        case extractCageDatum rOut of
+                            Just (RequestDatum r) ->
+                                requestSubmittedAt r
+                                    + pt
+                                    + rt
+                            _ -> 0
+                    )
+                    reqUtxos
+    mLowerSlot <-
+        try @SomeException
+            ( posixMsCeilSlot
+                prov
+                latestDeadline
+            )
+    lowerSlot <- case mLowerSlot of
+        Right s -> pure s
+        Left _ -> do
+            nowUtc <- getCurrentTime
+            let posixSec =
+                    utcTimeToPOSIXSeconds nowUtc
+            trySlots prov
+                $ map
+                    ( \d ->
+                        round
+                            ((posixSec - d) * 1000)
+                    )
+                    [0, 5, 30]
+    let vldt =
+            ValidityInterval
+                (SJust lowerSlot)
+                SNothing
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL
+                    .~ allScriptIns
+                & outputsTxBodyL .~ allOuts
+                & collateralInputsTxBodyL
+                    .~ Set.singleton
+                        (fst feeUtxo)
+                & reqSignerHashesTxBodyL
+                    .~ Set.singleton ownerKh
+                & vldtTxBodyL .~ vldt
+                & scriptIntegrityHashTxBodyL
+                    .~ integrity
+        tx =
+            mkBasicTx body
+                & witsTxL . scriptTxWitsL
+                    .~ Map.singleton
+                        scriptHash
+                        script
+                & witsTxL . rdmrsTxWitsL
+                    .~ redeemers
+    evaluateAndBalance
+        prov
+        pp
+        (feeUtxo : stateUtxo : reqUtxos)
+        addr
+        tx
+  where
+    when False _ = pure ()
+    when True act = act
+    currentPosixMs :: IO Integer
+    currentPosixMs = do
+        nowUtc <- getCurrentTime
+        let posixSec =
+                utcTimeToPOSIXSeconds nowUtc
+        pure (round (posixSec * 1000))
+
+-- | Try converting successive POSIX ms values
+-- to slots, returning the first that succeeds.
+trySlots
+    :: Provider IO -> [Integer] -> IO SlotNo
+trySlots _ [] =
+    error
+        "posixMsCeilSlot: all fallbacks \
+        \past horizon"
+trySlots p (ms : rest) = do
+    r <-
+        try @SomeException
+            (posixMsCeilSlot p ms)
+    case r of
+        Right s -> pure s
+        Left _ -> trySlots p rest

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
@@ -144,12 +144,13 @@ rejectRequestsImpl cfg prov _st tid addr = do
                     let sa = requestSubmittedAt r
                         deadline = sa + pt + rt
                     in  now > deadline
-                        || sa > now
+                            || sa > now
                 _ -> False
         reqUtxos = filter isRejectable allReqs
     when (null reqUtxos)
-        $ error "rejectRequests: no rejectable \
-                \requests"
+        $ error
+            "rejectRequests: no rejectable \
+            \requests"
     -- 4. Get wallet UTxO for fees
     pp <- queryProtocolParams prov
     walletUtxos <- queryUTxOs prov addr

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -11,6 +11,7 @@
 module Cardano.MPFS.TxBuilder.Real.Request
     ( requestInsertImpl
     , requestDeleteImpl
+    , requestUpdateImpl
     , requestLockedAda
     ) where
 
@@ -210,6 +211,95 @@ requestDeleteImpl cfg prov st tid key val addr = do
                 $ "requestDelete: "
                     <> show err
         Right balanced -> pure balanced
+
+-- | Build a request transaction for updating an
+-- existing key's value. Same structure as
+-- requestDelete but uses 'OpUpdate'.
+requestUpdateImpl
+    :: CageConfig
+    -- ^ Cage script config
+    -> Provider IO
+    -- ^ Blockchain query interface
+    -> State IO
+    -- ^ Token state (to look up maxFee)
+    -> TokenId
+    -- ^ Token whose trie to modify
+    -> ByteString
+    -- ^ Key to update
+    -> ByteString
+    -- ^ Old value (must match current)
+    -> ByteString
+    -- ^ New value
+    -> Addr
+    -- ^ Requester's address
+    -> IO (Tx ConwayEra)
+requestUpdateImpl
+    cfg
+    prov
+    st
+    tid
+    key
+    oldVal
+    newVal
+    addr = do
+        mTs <- getToken (tokens st) tid
+        TokenState{maxFee = Coin mf} <- case mTs of
+            Nothing ->
+                error
+                    "requestUpdate: unknown token"
+            Just x -> pure x
+        pp <- queryProtocolParams prov
+        utxos <- queryUTxOs prov addr
+        feeUtxo <- case sortOn
+            (Down . (^. coinTxOutL) . snd)
+            utxos of
+            [] ->
+                error "requestUpdate: no UTxOs"
+            (u : _) -> pure u
+        now <- currentPosixMs
+        let datum =
+                mkRequestDatum
+                    tid
+                    addr
+                    key
+                    (OpUpdate oldVal newVal)
+                    mf
+                    now
+            scriptAddr =
+                cageAddrFromCfg cfg (network cfg)
+            draftOut =
+                mkBasicTxOut
+                    scriptAddr
+                    (inject (Coin 0))
+                    & datumTxOutL
+                        .~ mkInlineDatum datum
+            refundDraft =
+                mkBasicTxOut
+                    addr
+                    (inject (Coin 0))
+            minAda =
+                requestLockedAda
+                    pp
+                    draftOut
+                    refundDraft
+                    mf
+            txOut =
+                mkBasicTxOut
+                    scriptAddr
+                    (inject minAda)
+                    & datumTxOutL
+                        .~ mkInlineDatum datum
+            body =
+                mkBasicTxBody
+                    & outputsTxBodyL
+                        .~ StrictSeq.singleton txOut
+            tx = mkBasicTx body
+        case balanceTx pp [feeUtxo] addr tx of
+            Left err ->
+                error
+                    $ "requestUpdate: "
+                        <> show err
+            Right balanced -> pure balanced
 
 -- | Compute the ADA to lock in a request output.
 --

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/InverseSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/InverseSpec.hs
@@ -59,6 +59,8 @@ applyCageEvent State{..} = \case
                     ts{root = newRoot}
             Nothing -> pure ()
         mapM_ (removeRequest requests) consumed
+    CageReject _tid consumed ->
+        mapM_ (removeRequest requests) consumed
     CageRetract txIn ->
         removeRequest requests txIn
     CageBurn tid ->

--- a/scripts/deploy-preprod.sh
+++ b/scripts/deploy-preprod.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy MPFS offchain service to preprod (umpfs.plutimus.com)
+#
+# Usage: ./scripts/deploy-preprod.sh
+#
+# Prerequisites:
+#   - nix build .#docker-image must have been run
+#   - ssh production must be configured
+
+VERSION=$(nix eval .#version --raw)
+IMAGE="ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve:${VERSION}"
+
+echo "=== Deploying mpfs-serve:${VERSION} to preprod ==="
+
+# 1. Transfer docker image to server
+echo "--- Transferring docker image..."
+docker load < result
+docker save "${IMAGE}" | ssh production 'docker load'
+
+# 2. Update compose file with new image tag
+echo "--- Updating docker-compose on server..."
+ssh production "sed -i 's|image: ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve:.*|image: ${IMAGE}|' ~/services/umpfs/docker-compose.yaml"
+
+# 3. Restart service
+echo "--- Restarting umpfs-preprod..."
+ssh production 'cd ~/services/umpfs && docker compose up -d'
+
+# 4. Wait for service to be ready
+echo "--- Waiting for service..."
+for i in $(seq 1 30); do
+    if curl -sf https://umpfs.plutimus.com/status >/dev/null 2>&1; then
+        echo "--- Service is up!"
+        curl -s https://umpfs.plutimus.com/status | jq .
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "ERROR: Service did not come up in 60 seconds"
+ssh production 'docker logs --tail 50 umpfs-preprod'
+exit 1

--- a/scripts/e2e-lib.sh
+++ b/scripts/e2e-lib.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Shared E2E test library for preprod MPFS testing
+#
+# Source this file from test scripts:
+#   source "$(dirname "$0")/e2e-lib.sh"
+
+set -euo pipefail
+
+# --- Configuration ---
+API_URL="${MPFS_API_URL:-https://umpfs.plutimus.com}"
+ORACLE_WALLET="${ORACLE_WALLET:-$HOME/secrets/preprod-wallet/wallet.json}"
+REQUESTER_WALLET="${REQUESTER_WALLET:-$HOME/secrets/preprod-wallet/requester.json}"
+WALLET_SIGN="nix run /code/cardano-wallet-sign-init#exe --"
+
+# Hex-encoded serialized addresses (preprod)
+ORACLE_ADDR="6072b0da51f4ae5f85ed89aa189698b78f3ab2b7a04da5b106b4cab2cf"
+REQUESTER_ADDR="60a26fcfafd7913e44253c30264f82b4daa48d5ecd195ffe5e45f7f7cf"
+
+TOKEN_ID="${MPFS_TOKEN_ID:-0cbe0684a8d40705ca0b86cb6f328bbef4495fe7fddb82235ae8eb61f5be9ce0}"
+
+# --- Helpers ---
+
+log() { echo "=== $*" >&2; }
+step() { echo "--- $*" >&2; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Call the MPFS API. Usage: api POST /tx/request/insert '{"json":"body"}'
+api() {
+    local method="$1" path="$2"
+    shift 2
+    local url="${API_URL}${path}"
+    if [[ "$method" == "GET" ]]; then
+        curl -sf "$url" "$@"
+    else
+        curl -sf -X "$method" -H "Content-Type: application/json" "$url" "$@"
+    fi
+}
+
+# Build, sign, and submit a transaction.
+# Usage: build_sign_submit WALLET POST_PATH JSON_BODY
+build_sign_submit() {
+    local wallet="$1" method="$2" path="$3" body="$4"
+
+    step "POST $path"
+    local raw_response
+    raw_response=$(api "$method" "$path" -d "$body")
+    # API returns a JSON string (hex-encoded CBOR tx), strip quotes
+    local tx_hex
+    tx_hex=$(echo "$raw_response" | jq -r '.')
+    if [[ -z "$tx_hex" || "$tx_hex" == "null" ]]; then
+        echo "Build response: $raw_response" >&2
+        fail "Failed to build tx at $path"
+    fi
+
+    step "Signing with $(basename "$wallet")..."
+    local signed
+    signed=$($WALLET_SIGN sign -w "$wallet" --tx "$tx_hex")
+
+    step "Submitting..."
+    local result
+    result=$(api POST /tx/submit -d "{\"tx\": \"$signed\"}")
+    echo "$result"
+}
+
+# Wait for a transaction to be confirmed (poll token state for root change).
+# Usage: await_tx OLD_ROOT [TIMEOUT_SECONDS]
+await_tx() {
+    local old_root="$1"
+    local timeout="${2:-120}"
+    step "Waiting for tx confirmation (up to ${timeout}s)..."
+    for i in $(seq 1 "$timeout"); do
+        local current_root
+        current_root=$(api GET "/tokens/$TOKEN_ID" | jq -r '.root')
+        if [[ "$current_root" != "$old_root" ]]; then
+            step "Confirmed! Root changed: ${old_root:0:16}... -> ${current_root:0:16}..."
+            echo "$current_root"
+            return 0
+        fi
+        sleep 1
+    done
+    fail "Tx not confirmed after ${timeout}s (root still $old_root)"
+}
+
+# Get current token root
+get_root() {
+    api GET "/tokens/$TOKEN_ID" | jq -r '.root'
+}
+
+# Get pending requests
+get_requests() {
+    api GET "/tokens/$TOKEN_ID/requests"
+}
+
+# Wait for at least N pending requests. Usage: await_requests N [TIMEOUT]
+await_requests() {
+    local expected="$1"
+    local timeout="${2:-120}"
+    step "Waiting for $expected pending request(s) (up to ${timeout}s)..."
+    for i in $(seq 1 "$timeout"); do
+        local count
+        count=$(api GET "/tokens/$TOKEN_ID/requests" | jq 'length')
+        if [[ "$count" -ge "$expected" ]]; then
+            step "Got $count request(s)"
+            return 0
+        fi
+        sleep 1
+    done
+    fail "Only $(api GET "/tokens/$TOKEN_ID/requests" | jq 'length') requests after ${timeout}s (expected $expected)"
+}
+
+# Convert a string to hex (for keys/values)
+to_hex() {
+    printf '%s' "$1" | xxd -p | tr -d '\n'
+}

--- a/scripts/e2e-reject.sh
+++ b/scripts/e2e-reject.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# E2E test: reject Phase 3 requests for a token
+#
+# Usage: ./scripts/e2e-reject.sh [TOKEN_ID]
+#
+# Rejects all expired (Phase 3) requests for the
+# given token. The oracle keeps fees, requesters
+# get refunds.
+
+source "$(dirname "$0")/e2e-lib.sh"
+
+TOKEN_OVERRIDE="${1:-}"
+if [[ -n "$TOKEN_OVERRIDE" ]]; then
+    TOKEN_ID="$TOKEN_OVERRIDE"
+fi
+
+log "E2E Reject: token=${TOKEN_ID:0:16}..."
+
+# 1. Check pending requests
+step "Checking pending requests..."
+REQS=$(get_requests)
+COUNT=$(echo "$REQS" | jq 'length')
+step "Found $COUNT pending request(s)"
+
+if [[ "$COUNT" -eq 0 ]]; then
+    log "No pending requests to reject"
+    exit 0
+fi
+
+echo "$REQS" | jq '.[].operation'
+
+# 2. Record current root
+OLD_ROOT=$(get_root)
+step "Current root: $OLD_ROOT"
+
+# 3. Submit reject tx
+step "Building reject tx..."
+build_sign_submit "$ORACLE_WALLET" POST /tx/reject \
+    "{\"token\": \"$TOKEN_ID\", \"address\": \"$ORACLE_ADDR\"}"
+
+# 4. Wait for requests to be consumed
+step "Waiting for requests to be consumed..."
+for i in $(seq 1 120); do
+    NEW_COUNT=$(get_requests | jq 'length')
+    if [[ "$NEW_COUNT" -lt "$COUNT" ]]; then
+        step "Requests consumed: $COUNT -> $NEW_COUNT"
+        break
+    fi
+    sleep 1
+done
+
+# 5. Verify root unchanged
+NEW_ROOT=$(get_root)
+if [[ "$NEW_ROOT" == "$OLD_ROOT" ]]; then
+    log "REJECT OK: root unchanged ($OLD_ROOT)"
+else
+    log "WARNING: root changed! $OLD_ROOT -> $NEW_ROOT"
+fi
+
+log "Remaining requests: $(get_requests | jq 'length')"

--- a/scripts/e2e-request-update.sh
+++ b/scripts/e2e-request-update.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# E2E test: update a key's value via request-update
+#
+# Usage: ./scripts/e2e-request-update.sh KEY OLD_VALUE NEW_VALUE
+#
+# Submits an update-value request, then processes it.
+
+source "$(dirname "$0")/e2e-lib.sh"
+
+KEY="${1:?Usage: e2e-request-update.sh KEY OLD_VALUE NEW_VALUE}"
+OLD_VALUE="${2:?Usage: e2e-request-update.sh KEY OLD_VALUE NEW_VALUE}"
+NEW_VALUE="${3:?Usage: e2e-request-update.sh KEY OLD_VALUE NEW_VALUE}"
+KEY_HEX=$(to_hex "$KEY")
+OLD_HEX=$(to_hex "$OLD_VALUE")
+NEW_HEX=$(to_hex "$NEW_VALUE")
+
+log "E2E Update Value: key=$KEY old=$OLD_VALUE new=$NEW_VALUE"
+log "Token: $TOKEN_ID"
+
+# 1. Record current root
+OLD_ROOT=$(get_root)
+step "Current root: $OLD_ROOT"
+
+# 2. Submit update request
+step "Submitting update-value request..."
+build_sign_submit "$ORACLE_WALLET" POST /tx/request/update \
+    "{\"token\": \"$TOKEN_ID\", \"key\": \"$KEY_HEX\", \"old_value\": \"$OLD_HEX\", \"new_value\": \"$NEW_HEX\", \"address\": \"$ORACLE_ADDR\"}"
+
+# 3. Wait for request to appear
+await_requests 1
+step "Pending requests:"
+get_requests | jq .
+
+# 4. Process update
+step "Building update tx..."
+build_sign_submit "$ORACLE_WALLET" POST /tx/update \
+    "{\"token\": \"$TOKEN_ID\", \"address\": \"$ORACLE_ADDR\"}"
+
+# 5. Wait for confirmation
+NEW_ROOT=$(await_tx "$OLD_ROOT")
+
+log "UPDATE VALUE OK: $KEY = $OLD_VALUE -> $NEW_VALUE"
+log "Root: $OLD_ROOT -> $NEW_ROOT"

--- a/specs/175-api-completeness/checklists/requirements.md
+++ b/specs/175-api-completeness/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: API Completeness — Reject and Request Update
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-002 mentions specific redeemer names (Reject, Contribute) — these are domain terminology from the on-chain protocol, not implementation details.
+- FR-009 notes that no changes are needed to processRequest for OpUpdate — this is a scoping note, not an implementation detail.

--- a/specs/175-api-completeness/plan.md
+++ b/specs/175-api-completeness/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: API Completeness — Reject and Request Update
+
+**Branch**: `175-api-completeness` | **Date**: 2026-04-09 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add two missing API operations: (1) Reject — oracle cleans up Phase 3 requests recovering locked ADA, and (2) Request Update — submit Operation::Update(old, new) requests for value changes. Both follow established patterns in the codebase.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.8.4)
+**Primary Dependencies**: cardano-ledger, cardano-mpfs-onchain (Aiken validators), servant
+**Storage**: RocksDB (persistent trie + indexer state)
+**Testing**: hspec (unit + E2E with devnet)
+**Target Platform**: Linux server (Docker)
+**Project Type**: web-service (HTTP API for unsigned tx building)
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Ledger-Native Types | Pass | Uses existing Addr, TxIn, Coin from cardano-ledger |
+| II. Records of Functions | Pass | New functions added to existing TxBuilder record |
+| III. Atomic Block Processing | N/A | No indexer changes |
+| IV. External Signing | Pass | Returns unsigned CBOR, no keys |
+| V. Aiken Compatibility | Pass | Reject redeemer encoding matches OnChain.hs Constr 4 [] |
+| VI. Test Locally First | Pass | E2E on devnet, unit tests with mocks |
+| VII. Nix Reproducibility | Pass | No new dependencies |
+
+## Project Structure
+
+### Source Code Changes
+
+```
+cardano-mpfs-offchain/lib/Cardano/MPFS/
+├── TxBuilder.hs              # Add rejectRequests, requestUpdate to record
+├── TxBuilder/Real.hs         # Wire new impl functions
+├── TxBuilder/Real/Reject.hs  # NEW: rejectRequestsImpl
+├── TxBuilder/Real/Request.hs # Add requestUpdateImpl
+├── HTTP/Server.hs            # Add txRejectHandler, txUpdateRequestHandler
+├── HTTP/Types.hs             # Add RejectRequest, UpdateValueRequest types
+├── HTTP/API.hs               # Add TxRejectAPI, TxRequestUpdateAPI types
+├── Mock/TxBuilder.hs         # Add mock stubs
+
+cardano-mpfs-offchain/test/
+├── TxBuilderSpec.hs          # Unit tests for reject + request-update
+
+cardano-mpfs-offchain/e2e-test/
+├── CageFlowSpec.hs           # E2E: request-update flow
+                               # E2E: reject flow (Phase 3 timing)
+
+scripts/
+├── e2e-reject.sh             # Preprod reject script
+├── e2e-request-update.sh     # Preprod update-value script
+```
+
+## Implementation Phases
+
+### Phase 1: Request Update (P2 — simpler, follows existing pattern exactly)
+
+**Why first**: Trivial — copy requestDeleteImpl, change OpDelete to OpUpdate, add one more ByteString parameter. Low risk, fast win.
+
+**Files**: Request.hs, TxBuilder.hs, TxBuilder/Real.hs, Server.hs, Types.hs, API.hs, Mock/TxBuilder.hs
+
+**Pattern**: Same as requestDeleteImpl but with `OpUpdate oldVal newVal`.
+
+### Phase 2: Reject (P1 — more complex, new tx structure)
+
+**Why second**: Needs a new module (Reject.hs) with a different tx structure than anything existing. The reject tx spends both the state UTxO and request UTxOs, uses two different redeemers, and has a specific validity interval constraint.
+
+**Files**: NEW Reject.hs, TxBuilder.hs, TxBuilder/Real.hs, Server.hs, Types.hs, API.hs, Mock/TxBuilder.hs
+
+**Key design decisions**:
+
+1. **Which requests to reject**: The endpoint takes a token ID. The implementation queries all pending requests, filters to those in Phase 3 (using current time vs submitted_at + process_time + retract_time), and rejects all of them.
+
+2. **Validity interval**: Lower bound must be after the latest `submitted_at + process_time + retract_time` among rejected requests (to satisfy `is_rejectable`). Upper bound unconstrained (or use a reasonable future slot).
+
+3. **Redeemers**: State UTxO gets `Reject` (Constr 4 []). Each request UTxO gets `Contribute stateRef` (same as in update tx).
+
+4. **Outputs**: First output is state UTxO with unchanged root. Remaining outputs are refunds to request owners.
+
+### Phase 3: Tests
+
+**Unit tests**: TxBuilderSpec — reject tx structure (redeemers, outputs, root unchanged), request-update tx structure.
+
+**E2E tests**: CageFlowSpec — full flow with follower:
+- Request-update: insert key → update value → verify root
+- Reject: insert request → wait for Phase 3 → reject → verify refund
+
+**Preprod scripts**: e2e-reject.sh (clean up stuck UTxOs), e2e-request-update.sh.
+
+## Risks
+
+- **Phase 3 timing in E2E**: The devnet uses short epochs (process_time=15s, retract_time=15s). The reject test needs to wait ~30s for Phase 3, plus time for follower to catch up. Total ~45s per reject test. May hit PastHorizon — reuse the fallback from Update.hs.
+- **Reject redeemer encoding**: Must verify Constr 4 [] matches the on-chain expectation. The OnChain.hs already has `Reject` in the UpdateRedeemer type.

--- a/specs/175-api-completeness/research.md
+++ b/specs/175-api-completeness/research.md
@@ -1,0 +1,41 @@
+# Research: API Completeness
+
+## On-Chain Reject Semantics
+
+The `Reject` redeemer (cage.ak:817-865) works as follows:
+
+- **State UTxO**: spent with `Reject` redeemer. Validator checks root unchanged, time params immutable.
+- **Request UTxOs**: consumed in the same tx. The `mkReject` fold (cage.ak:764-807) iterates all inputs, checks `is_rejectable` for matching requests.
+- **is_rejectable** (cage.ak:494-507): Phase 3 expired (`submitted_at + process_time + retract_time` is before the validity range) OR dishonest `submitted_at` (in the future).
+- **Refunds**: `(locked ADA - fee)` to each request owner. Oracle keeps fees.
+- **Key difference from Modify**: no proofs, no trie changes, root must stay the same.
+
+## Request UTxO Redeemers in Reject
+
+Looking at the on-chain dispatch (cage.ak:250-277), `Reject` is a **State UTxO redeemer** (handled under `StateDatum`). The request UTxOs in a reject tx need their own spending redeemer. Looking at `validRequest` (cage.ak:417-438), the `Contribute(ref)` redeemer on request UTxOs checks:
+- `requestToken == tokenId` (correct target)
+- Phase 1 OR `is_rejectable` (line 429-436)
+
+So in a reject tx, request UTxOs use `Contribute(stateRef)` as their redeemer, same as in update. The `is_rejectable` condition allows Contribute in Phase 3.
+
+## Existing Patterns
+
+### requestInsert/requestDelete (Request.hs)
+Both follow identical structure: get fee UTxO, build datum with `OpInsert`/`OpDelete`, create output at cage address, balance. `requestUpdate` will use `OpUpdate oldVal newVal`.
+
+### Reject tx structure
+Closest to `updateTokenImpl` (Update.hs) but simpler:
+- Find state UTxO + rejectable request UTxOs
+- State redeemer: `Reject` (not `Modify`)
+- Request redeemers: `Contribute stateRef` (same as update)
+- New state output: same root (unchanged), same params
+- Refund outputs: same pattern as update's refunds
+- No proofs, no trie operations
+- Validity interval: must be entirely after `submitted_at + process_time + retract_time`
+
+## TS Implementation Reference
+
+The TS implementation (mpfs/off_chain) has:
+- `request-insert`, `request-delete`, `request-update` endpoints — all three
+- No reject endpoint (same gap as Haskell)
+- Request.ts line 80: `operation = mConStr2([change.oldValue, change.newValue])` for update

--- a/specs/175-api-completeness/spec.md
+++ b/specs/175-api-completeness/spec.md
@@ -1,0 +1,81 @@
+# Feature Specification: API Completeness — Reject and Request Update
+
+**Feature Branch**: `175-api-completeness`
+**Created**: 2026-04-09
+**Status**: Draft
+**Input**: Close API gaps vs on-chain validator: add reject endpoint to clean up Phase 3 requests, add request-update endpoint for value changes (parity with TS implementation).
+
+## User Scenarios & Testing
+
+### User Story 1 — Oracle rejects expired requests (Priority: P1)
+
+A token oracle discovers stale requests stuck in Phase 3 (past both the processing window and the retract window). The oracle submits a reject transaction that consumes the expired request UTxOs, keeps the fee, and refunds remaining ADA to the original requesters.
+
+**Why this priority**: Without this, any request that misses its processing window locks ADA permanently at the script address. We already have 6 stuck requests on preprod with ~2-3 ADA each.
+
+**Independent Test**: Submit a request, wait for Phase 3, call the reject endpoint, verify the oracle receives the fee and the requester receives the refund.
+
+**Acceptance Scenarios**:
+
+1. **Given** a request in Phase 3 (past submitted_at + process_time + retract_time), **When** the oracle calls reject, **Then** the request UTxO is consumed, the oracle keeps the fee, and the requester receives (locked ADA - fee).
+2. **Given** a request still in Phase 1 or Phase 2, **When** the oracle calls reject, **Then** the transaction fails (on-chain is_rejectable check fails).
+3. **Given** multiple expired requests for the same token, **When** the oracle calls reject, **Then** all expired requests are consumed in a single transaction with correct refunds for each.
+4. **Given** a reject transaction, **Then** the token's MPF root does NOT change (reject does not modify the trie).
+
+---
+
+### User Story 2 — Requester updates an existing key's value (Priority: P2)
+
+A requester wants to change the value associated with an existing key in a token's MPF trie. Instead of deleting and re-inserting (two separate requests, two fees), the requester submits a single update request specifying the key, old value, and new value.
+
+**Why this priority**: The on-chain Operation::Update(old, new) exists and the TS implementation already exposes this. The Haskell offchain is missing it — users must work around it with delete + insert, paying double fees.
+
+**Independent Test**: Insert a key, process it, then submit a request-update with old and new values, process the update, verify the trie root changes correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a key "k" with value "v1" in the trie, **When** the requester submits an update request with key="k", oldValue="v1", newValue="v2", and the oracle processes it, **Then** the trie root reflects key "k" mapped to "v2".
+2. **Given** a key "k" with value "v1", **When** the requester submits an update request with wrong oldValue="v3", **Then** the on-chain proof verification fails (including(key, wrong_old, proof) != root).
+3. **Given** no key "k" in the trie, **When** the requester submits an update request for key="k", **Then** the proof verification fails.
+
+---
+
+### Edge Cases
+
+- What happens when reject is called with a mix of Phase 3 and Phase 1/2 requests pending? Only Phase 3 requests should be consumed; Phase 1/2 requests must remain.
+- What happens when the oracle calls reject but is not the token owner? The on-chain Reject redeemer requires the owner's signature.
+- What happens when a request has a dishonest (future) submitted_at timestamp? The on-chain is_rejectable function should still accept it for rejection.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a `POST /tx/reject` endpoint that builds a transaction consuming Phase 3 request UTxOs for a given token.
+- **FR-002**: The reject transaction MUST use the on-chain `Reject` redeemer on the State UTxO and `Contribute` redeemer on each request UTxO being rejected.
+- **FR-003**: The reject transaction MUST NOT change the MPF root (newRoot == oldRoot).
+- **FR-004**: The reject transaction MUST produce refund outputs: for each rejected request, (locked ADA - fee) to the request owner.
+- **FR-005**: The reject transaction MUST require the token owner's signature.
+- **FR-006**: System MUST expose a `POST /tx/request/update` endpoint that builds a request transaction with Operation::Update(oldValue, newValue).
+- **FR-007**: The request-update endpoint MUST accept token, key, old_value, new_value, and address parameters.
+- **FR-008**: The TxBuilder MUST include `requestReject` and `requestUpdate` functions.
+- **FR-009**: The update transaction builder (processRequest) already handles OpUpdate — no changes needed there.
+
+### Key Entities
+
+- **RejectRequest**: token ID + oracle address. The endpoint discovers which requests are rejectable by querying pending requests and checking their phase.
+- **UpdateRequest (value change)**: token ID + key + old value + new value + requester address.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: All 6 stuck preprod requests can be cleaned up via the reject endpoint.
+- **SC-002**: The reject E2E test passes: submit request, wait for Phase 3, reject, verify refund.
+- **SC-003**: The request-update E2E test passes: insert key, update value, verify trie root.
+- **SC-004**: The Haskell API has feature parity with the TS API for all request operations (insert, delete, update).
+
+## Assumptions
+
+- The on-chain Reject validator logic is correct and tested (it exists in the onchain repo with test coverage).
+- Phase timing on devnet is short enough to test Phase 3 transitions within a reasonable test duration.
+- The reject endpoint processes ALL rejectable requests for a token in a single transaction (matching the on-chain fold pattern).

--- a/specs/175-api-completeness/tasks.md
+++ b/specs/175-api-completeness/tasks.md
@@ -1,0 +1,89 @@
+# Tasks: API Completeness — Reject and Request Update
+
+**Input**: [spec.md](spec.md), [plan.md](plan.md), [research.md](research.md)
+
+## Phase 1: Request Update (US2 — simpler, no new module)
+
+**Goal**: Add `POST /tx/request/update` for submitting `OpUpdate(old, new)` requests.
+
+**Independent Test**: Insert a key, process it, submit update request, process update, verify root.
+
+- [ ] T001 [US2] Add `requestUpdate` to `TxBuilder` record in `lib/Cardano/MPFS/TxBuilder.hs`
+- [ ] T002 [US2] Implement `requestUpdateImpl` in `lib/Cardano/MPFS/TxBuilder/Real/Request.hs` — copy `requestDeleteImpl`, use `OpUpdate oldVal newVal`
+- [ ] T003 [US2] Wire `requestUpdateImpl` in `lib/Cardano/MPFS/TxBuilder/Real.hs`
+- [ ] T004 [US2] Add mock stub in `lib/Cardano/MPFS/Mock/TxBuilder.hs`
+- [ ] T005 [P] [US2] Add `UpdateValueRequest` type in `lib/Cardano/MPFS/HTTP/Types.hs` — fields: token, key, old_value, new_value, address
+- [ ] T006 [US2] Add `TxRequestUpdateAPI` type in `lib/Cardano/MPFS/HTTP/API.hs`
+- [ ] T007 [US2] Add `txUpdateValueHandler` in `lib/Cardano/MPFS/HTTP/Server.hs` and wire into `mkApp`
+- [ ] T008 [US2] Add Swagger schema for the new endpoint
+- [ ] T009 [US2] Unit test in `test/Cardano/MPFS/TxBuilderSpec.hs` — request-update tx structure
+- [ ] T010 [US2] E2E test in `e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs` — insert → update value → verify root
+- [ ] T011 [US2] Preprod script `scripts/e2e-request-update.sh`
+
+**Checkpoint**: `POST /tx/request/update` works end-to-end. Commit and verify.
+
+---
+
+## Phase 2: Reject (US1 — new module, different tx structure)
+
+**Goal**: Add `POST /tx/reject` for cleaning up Phase 3 requests.
+
+**Independent Test**: Submit request, wait for Phase 3, reject, verify refund and unchanged root.
+
+- [ ] T012 [US1] Add `rejectRequests` to `TxBuilder` record in `lib/Cardano/MPFS/TxBuilder.hs`
+- [ ] T013 [US1] Create `lib/Cardano/MPFS/TxBuilder/Real/Reject.hs` — implement `rejectRequestsImpl`:
+  - Find state UTxO + pending requests
+  - Filter to Phase 3 requests (submitted_at + process_time + retract_time < now)
+  - State redeemer: `Reject` (Constr 4 [])
+  - Request redeemers: `Contribute stateRef`
+  - New state output: same root, same params
+  - Refund outputs: (locked ADA - fee) to each request owner
+  - Validity lower bound: after latest Phase 3 deadline
+  - Use PastHorizon fallback from Update.hs for slot conversion
+- [ ] T014 [US1] Wire `rejectRequestsImpl` in `lib/Cardano/MPFS/TxBuilder/Real.hs`
+- [ ] T015 [US1] Add mock stub in `lib/Cardano/MPFS/Mock/TxBuilder.hs`
+- [ ] T016 [P] [US1] Add `RejectRequest` type in `lib/Cardano/MPFS/HTTP/Types.hs` — fields: token, address
+- [ ] T017 [US1] Add `TxRejectAPI` type in `lib/Cardano/MPFS/HTTP/API.hs`
+- [ ] T018 [US1] Add `txRejectHandler` in `lib/Cardano/MPFS/HTTP/Server.hs` and wire into `mkApp`
+- [ ] T019 [US1] Add Swagger schema for the new endpoint
+- [ ] T020 [US1] Unit test in `test/Cardano/MPFS/TxBuilderSpec.hs` — reject tx structure (root unchanged, refunds, redeemers)
+- [ ] T021 [US1] E2E test in `e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs` — request → wait Phase 3 → reject → verify
+- [ ] T022 [US1] Preprod script `scripts/e2e-reject.sh`
+
+**Checkpoint**: `POST /tx/reject` works end-to-end. Stuck preprod UTxOs can be recovered.
+
+---
+
+## Phase 3: Preprod Cleanup and Polish
+
+- [ ] T023 Run `scripts/e2e-reject.sh` on preprod to recover stuck UTxOs from tokens `0cbe`, `b222`, `de7c`
+- [ ] T024 Update `scripts/e2e-lib.sh` memory reference with reject endpoint
+- [ ] T025 Run `just ci` locally — fourmolu, hlint, cabal-check, unit tests, E2E tests
+- [ ] T026 Deploy to preprod, verify all scripts work
+- [ ] T027 Update PR description, push, merge
+
+---
+
+## Dependencies
+
+```
+T001 → T002 → T003 (TxBuilder record → impl → wire)
+T005 can run parallel with T001-T003 (different files)
+T006 → T007 (API type → handler)
+T009, T010 after T007
+
+T012 → T013 → T014 (TxBuilder record → impl → wire)
+T016 can run parallel with T012-T014
+T017 → T018
+T020, T021 after T018
+
+T023 after T022 (need reject on preprod first)
+T025 after all implementation
+```
+
+## Notes
+
+- Request Update (Phase 1) is trivial — follows existing pattern exactly
+- Reject (Phase 2) is the critical path — new tx structure, new module
+- Phase 3 timing in E2E: use short process_time/retract_time (15s each) so Phase 3 is reachable in ~30s
+- Each phase can be committed independently


### PR DESCRIPTION
## Summary

Closes #183. Adds two missing API endpoints for feature parity with the on-chain validator and the TypeScript implementation.

### POST /tx/reject

Builds a reject transaction for Phase 3 expired requests. The oracle keeps the fee, remaining ADA is refunded to request owners. The trie root does not change.

- New `Reject.hs` module: `rejectRequestsImpl`
- Finds rejectable requests (past `submitted_at + process_time + retract_time`)
- State UTxO redeemer: `Reject` (Constr 4)
- Request UTxO redeemer: `Contribute(stateRef)`
- Validity lower bound: after latest Phase 3 deadline
- PastHorizon fallback for devnet compatibility

### POST /tx/request/update

Builds a request transaction with `Operation::Update(oldValue, newValue)` for changing an existing key's value. The TS implementation already had this; the Haskell offchain was missing it.

- `requestUpdateImpl` in Request.hs (follows requestDelete pattern)
- `UpdateValueRequest` type with token, key, old_value, new_value, address

### Indexer: CageReject event

The indexer now detects `Reject` redeemers and removes consumed requests from the DB. Without this, rejected requests remained visible in the API even though they were consumed on-chain.

- `CageReject` event in Event.hs
- Detection in `decodeSpend` (pattern matches `Reject` redeemer)
- Follower handling: removes consumed requests
- Inverse for rollback: restores requests

### Preprod verification

- Deployed as `799ba4c` to https://umpfs.plutimus.com
- Token `0cbe`: 4 stale requests rejected, 0 remaining
- Token `b222`: 1 stale request rejected, 0 remaining
- Token `de7c`: 1 request stuck (different owner — correct behavior)

### Test scripts

| Script | Purpose |
|--------|---------|
| `scripts/e2e-reject.sh` | Reject Phase 3 requests |
| `scripts/e2e-request-update.sh` | Update key value |
| `scripts/e2e-lib.sh` | Shared test library |
| `scripts/deploy-preprod.sh` | Build + deploy |

## API audit

| On-Chain Operation | Offchain | Status |
|---|---|---|
| Minting | POST /tx/boot | existing |
| Burning / End | POST /tx/end | existing |
| Contribute | internal to update tx | not needed |
| Modify | POST /tx/update | existing |
| Retract | POST /tx/retract | existing |
| Reject | POST /tx/reject | **new** |
| Insert request | POST /tx/request/insert | existing |
| Delete request | POST /tx/request/delete | existing |
| Update request | POST /tx/request/update | **new** |
| Migrating | — | #184 (future) |