### PR TITLE
fix: parse retract tx_id as raw hash, not CBOR (#181)

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -492,7 +492,7 @@ txRetractHandler
         , rrAddr = addrHex
         } = do
         addr <- requireAddr addrHex
-        txId <- parseTxId tidBytes
+        txId <- parseTxIdRaw tidBytes
         let txIn = mkTxInPartial txId (fromIntegral ix)
         tx <-
             liftIO
@@ -552,15 +552,3 @@ decodeTx
     :: ByteString
     -> Either DecoderError (Tx ConwayEra)
 decodeTx = decodeFull' (natVersion @11)
-
--- | Parse a 32-byte TxId from raw bytes.
-parseTxId :: ByteString -> Handler TxId
-parseTxId bs =
-    case decodeFull' (natVersion @11) bs of
-        Right tid -> pure tid
-        Left _err ->
-            throwError
-                err400
-                    { errBody =
-                        "Invalid transaction ID"
-                    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -17,8 +17,11 @@ module Cardano.MPFS.HTTP.Server
 
 import Control.Applicative ((<|>))
 import Control.Monad.IO.Class (liftIO)
+import Data.ByteString.Base16 qualified as B16
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Data.Word (Word64)
 import Servant
     ( Application
@@ -33,6 +36,7 @@ import Servant
     , throwError
     , (:<|>) (..)
     )
+import Text.Read (readMaybe)
 
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy.Char8 qualified as BL
@@ -487,13 +491,11 @@ txRetractHandler
 txRetractHandler
     ctx
     RetractRequest
-        { rrTxId = Hex tidBytes
-        , rrTxIx = ix
+        { rrUtxo = utxoRef
         , rrAddr = addrHex
         } = do
         addr <- requireAddr addrHex
-        txId <- parseTxIdRaw tidBytes
-        let txIn = mkTxInPartial txId (fromIntegral ix)
+        txIn <- parseUtxoRef utxoRef
         tx <-
             liftIO
                 $ Tx.retractRequest
@@ -546,6 +548,45 @@ txSubmitHandler ctx (SubmitRequest (Hex txCbor)) = do
 -- ---------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------
+
+-- | Parse a UTxO reference in @txhash#ix@ format.
+parseUtxoRef :: Text -> Handler TxIn
+parseUtxoRef t =
+    case T.splitOn "#" t of
+        [hashHex, ixText] -> do
+            let hashBs =
+                    B16.decode
+                        (TE.encodeUtf8 hashHex)
+            case hashBs of
+                Right bs -> do
+                    txId <- parseTxIdRaw bs
+                    case readMaybe (T.unpack ixText) of
+                        Just ix ->
+                            pure
+                                $ mkTxInPartial
+                                    txId
+                                    ix
+                        Nothing ->
+                            throwError
+                                err400
+                                    { errBody =
+                                        "Invalid \
+                                        \output index"
+                                    }
+                Left _ ->
+                    throwError
+                        err400
+                            { errBody =
+                                "Invalid tx hash \
+                                \hex"
+                            }
+        _ ->
+            throwError
+                err400
+                    { errBody =
+                        "Invalid UTxO ref: \
+                        \expected txhash#ix"
+                    }
 
 -- | Decode CBOR bytes to a 'Tx ConwayEra'.
 decodeTx

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -339,10 +339,8 @@ instance FromJSON UpdateRequest where
 
 -- | @POST \/tx\/retract@ request body.
 data RetractRequest = RetractRequest
-    { rrTxId :: Hex
-    -- ^ Transaction ID (32 bytes, hex)
-    , rrTxIx :: Word64
-    -- ^ Output index
+    { rrUtxo :: Text
+    -- ^ UTxO reference: @txhash#ix@
     , rrAddr :: Hex
     -- ^ Address
     }
@@ -350,8 +348,7 @@ data RetractRequest = RetractRequest
 instance FromJSON RetractRequest where
     parseJSON = withObject "RetractRequest" $ \o ->
         RetractRequest
-            <$> o .: "tx_id"
-            <*> o .: "tx_ix"
+            <$> o .: "utxo"
             <*> o .: "address"
 
 -- | @POST \/tx\/end@ request body.
@@ -651,10 +648,10 @@ instance ToSchema UpdateRequest where
 
 instance ToSchema RetractRequest where
     declareNamedSchema _ = do
+        stringSchema <-
+            declareSchemaRef (Proxy @String)
         hexSchema <-
             declareSchemaRef (Proxy @Hex)
-        word64Schema <-
-            declareSchemaRef (Proxy @Word64)
         pure
             $ Swagger.NamedSchema
                 (Just "RetractRequest")
@@ -663,14 +660,14 @@ instance ToSchema RetractRequest where
                 ?~ Swagger.SwaggerObject
             & properties
                 .~ fromList
-                    [ ("tx_id", hexSchema)
-                    , ("tx_ix", word64Schema)
+                    [ ("utxo", stringSchema)
                     , ("address", hexSchema)
                     ]
             & required
-                .~ ["tx_id", "tx_ix", "address"]
+                .~ ["utxo", "address"]
             & description
-                ?~ "Retract a pending request"
+                ?~ "Retract a pending request. \
+                   \UTxO format: txhash#ix"
 
 instance ToSchema EndRequest where
     declareNamedSchema _ = do


### PR DESCRIPTION
## Summary

Closes #181.

The retract endpoint used separate `tx_id` + `tx_ix` fields, where `tx_id` required CBOR-encoded bytes (`5820` prefix). But the submit endpoint returns raw 32-byte hex hashes. Users couldn't use the tx hash from submit directly in retract.

## Change

Replace the two fields with a single `utxo` field in standard Cardano `txhash#ix` format:

**Before:**
```json
{"tx_id": "5820abcd...", "tx_ix": 0, "address": "..."}
```

**After:**
```json
{"utxo": "abcd1234...#0", "address": "..."}
```

This is the standard format used by cardano-cli and block explorers.

- `RetractRequest` type: `rrTxId + rrTxIx` → `rrUtxo :: Text`
- New `parseUtxoRef` helper: splits on `#`, hex-decodes the hash, parses the index
- Swagger schema updated
- Removed unused `parseTxId` (CBOR decoder)

**Breaking change** for anyone calling the retract endpoint with the old field names.