### PR TITLE
feat: adopt fair fee model and upstream helpers (#188)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -68,8 +68,15 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-node-clients
-  tag: dcad2ebf4c15d4c07d0885d0d4ddcfb5712758b7
-  --sha256: 1sv91a6g9817fklpkn8fm5gwcql1p98w9xvg2c0xs4fy1z11cz7x
+  tag: a37cbd62170740efc86dae1a1cf242a8608e4b78
+  --sha256: 0n8803527vl8cnfwwl80mjzdlgn43rjzr3m3f8qf5gf4408zrq75
+
+source-repository-package
+  type: git
+  location: https://github.com/cardano-foundation/cardano-mpfs-onchain
+  tag: 8b73389d933180c02a6d8097dce5066aff781bf9
+  --sha256: 0dgln3xzrhqfmkcaanrcficapvyb29asbz4xvcpwzqajqcrk5x07
+  subdir: cardano-mpfs-onchain
 
 -- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API
 constraints: contra-tracer-contrib +iohk

--- a/cabal.project
+++ b/cabal.project
@@ -68,8 +68,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-node-clients
-  tag: a37cbd62170740efc86dae1a1cf242a8608e4b78
-  --sha256: 0n8803527vl8cnfwwl80mjzdlgn43rjzr3m3f8qf5gf4408zrq75
+  tag: 177989d29a0c0c9a1c40475afae82076fdb2dca9
+  --sha256: 0c5hx65dcraig0xml2rq45i2pyaq6bpw1lq2932szx2gkrcx6ib6
 
 source-repository-package
   type: git
@@ -80,6 +80,11 @@ source-repository-package
 
 -- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API
 constraints: contra-tracer-contrib +iohk
+
+-- Disable pkgconfig for lzma (bundled C sources)
+package lzma
+  flags: -pkgconfig
+
 
 -- chain-follower has data-default <0.8 but cardano-ledger-shelley pulls 0.8
 allow-newer: chain-follower:data-default

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -757,6 +757,6 @@ cageCfg scriptBytes =
             computeScriptHash scriptBytes
         , defaultProcessTime = 15_000
         , defaultRetractTime = 15_000
-        , defaultMaxFee = Coin 1_000_000
+        , defaultTip = Coin 100_000
         , network = Testnet
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -200,7 +200,7 @@ cageFlowSpec bpPath scriptBytes =
                                     32
                                     0
                                 )
-                        , maxFee =
+                        , tip =
                             Coin 1_000_000
                         , processTime =
                             30_000
@@ -599,6 +599,6 @@ cageCfg scriptBytes =
             computeScriptHash scriptBytes
         , defaultProcessTime = 30_000
         , defaultRetractTime = 30_000
-        , defaultMaxFee = Coin 1_000_000
+        , defaultTip = Coin 1_000_000
         , network = Testnet
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -403,6 +403,6 @@ cageCfg scriptBytes =
             computeScriptHash scriptBytes
         , defaultProcessTime = 15_000
         , defaultRetractTime = 15_000
-        , defaultMaxFee = Coin 1_000_000
+        , defaultTip = Coin 1_000_000
         , network = Testnet
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
@@ -354,6 +354,6 @@ cageCfg scriptBytes =
             computeScriptHash scriptBytes
         , defaultProcessTime = 15_000
         , defaultRetractTime = 15_000
-        , defaultMaxFee = Coin 1_000_000
+        , defaultTip = Coin 1_000_000
         , network = Testnet
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -420,6 +420,6 @@ cageCfg scriptBytes =
             computeScriptHash scriptBytes
         , defaultProcessTime = 5_000
         , defaultRetractTime = 5_000
-        , defaultMaxFee = Coin 1_000_000
+        , defaultTip = Coin 1_000_000
         , network = Testnet
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -1050,6 +1050,6 @@ cageCfg scriptBytes =
             computeScriptHash scriptBytes
         , defaultProcessTime = 15_000
         , defaultRetractTime = 15_000
-        , defaultMaxFee = Coin 1_000_000
+        , defaultTip = Coin 1_000_000
         , network = Testnet
         }

--- a/cardano-mpfs-offchain/exe/DevnetServer.hs
+++ b/cardano-mpfs-offchain/exe/DevnetServer.hs
@@ -166,6 +166,6 @@ mkCageCfg scriptBytes =
             computeScriptHash scriptBytes
         , defaultProcessTime = 300_000
         , defaultRetractTime = 300_000
-        , defaultMaxFee = Coin 2_000_000
+        , defaultTip = Coin 2_000_000
         , network = Testnet
         }

--- a/cardano-mpfs-offchain/exe/RunPreprod.hs
+++ b/cardano-mpfs-offchain/exe/RunPreprod.hs
@@ -63,7 +63,7 @@ dummyCageConfig =
                     (hashFromBytes (BS.replicate 28 0))
         , defaultProcessTime = 300_000
         , defaultRetractTime = 300_000
-        , defaultMaxFee = Coin 2_000_000
+        , defaultTip = Coin 2_000_000
         , network = Testnet
         }
 

--- a/cardano-mpfs-offchain/exe/Serve.hs
+++ b/cardano-mpfs-offchain/exe/Serve.hs
@@ -194,7 +194,7 @@ mkCageCfg args scriptBytes =
             computeScriptHash scriptBytes
         , defaultProcessTime = 300_000
         , defaultRetractTime = 300_000
-        , defaultMaxFee = Coin 2_000_000
+        , defaultTip = Coin 2_000_000
         , network = argNetwork args
         }
 

--- a/cardano-mpfs-offchain/exe/TxVectors.hs
+++ b/cardano-mpfs-offchain/exe/TxVectors.hs
@@ -136,7 +136,7 @@ testTokenState =
     TokenState
         { owner = testKeyHash
         , root = Root (BS.replicate 32 0xbb)
-        , maxFee = Coin 2_000_000
+        , tip = Coin 2_000_000
         , processTime = 300_000
         , retractTime = 600_000
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs
@@ -157,7 +157,7 @@ data OnChainTokenState = OnChainTokenState
     -- ^ Payment key hash of the token owner (28 bytes)
     , stateRoot :: !OnChainRoot
     -- ^ Current Merkle root of the token's trie
-    , stateMaxFee :: !Integer
+    , stateTip :: !Integer
     -- ^ Maximum fee (lovelace) charged per request
     , stateProcessTime :: !Integer
     -- ^ Oracle processing window duration (ms)
@@ -441,7 +441,7 @@ instance ToData OnChainTokenState where
                 0
                 [ bbsToD stateOwner
                 , unD (toBuiltinData stateRoot)
-                , I stateMaxFee
+                , I stateTip
                 , I stateProcessTime
                 , I stateRetractTime
                 ]
@@ -451,7 +451,7 @@ instance FromData OnChainTokenState where
         Constr 0 [own, r, I mf, I pt, I rt] -> do
             stateOwner <- bbsFromD own
             stateRoot <- fromBuiltinData (mkD r)
-            let stateMaxFee = mf
+            let stateTip = mf
                 stateProcessTime = pt
                 stateRetractTime = rt
             Just OnChainTokenState{..}
@@ -465,7 +465,7 @@ instance UnsafeFromData OnChainTokenState where
                     BuiltinByteString own
                 , stateRoot =
                     unsafeFromBuiltinData (mkD r)
-                , stateMaxFee = mf
+                , stateTip = mf
                 , stateProcessTime = pt
                 , stateRetractTime = rt
                 }
@@ -719,34 +719,34 @@ instance UnsafeFromData UpdateRedeemer where
 cageScriptHash :: ByteString
 cageScriptHash =
     BS.pack
-        [ 0x7f
-        , 0xbe
-        , 0xb9
-        , 0xca
-        , 0x9c
-        , 0xbd
-        , 0x42
-        , 0xaf
-        , 0x3d
-        , 0xf0
-        , 0x70
-        , 0xf0
-        , 0xff
-        , 0xb8
-        , 0xc5
-        , 0x16
-        , 0xe2
-        , 0x83
+        [ 0xe4
+        , 0x62
+        , 0xb3
+        , 0x8f
+        , 0xe5
+        , 0xcd
+        , 0xb6
+        , 0xee
+        , 0x3e
+        , 0xe5
+        , 0x1f
+        , 0x9d
+        , 0xc2
         , 0xda
-        , 0x31
-        , 0xfe
-        , 0x04
-        , 0x9e
-        , 0x03
-        , 0xfe
-        , 0xce
-        , 0x89
-        , 0xb8
+        , 0xa7
+        , 0x3c
+        , 0x77
+        , 0x1b
+        , 0x26
+        , 0x99
+        , 0x57
+        , 0xa9
+        , 0x9a
+        , 0x06
+        , 0x99
+        , 0x99
+        , 0x23
+        , 0x93
         ]
 
 -- | The cage validator 'ScriptHash' (ledger type).

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs
@@ -126,7 +126,7 @@ data TokenState = TokenState
     -- ^ Owner's payment key hash
     , root :: !Root
     -- ^ Current root hash of the token's trie
-    , maxFee :: !Coin
+    , tip :: !Coin
     -- ^ Maximum fee charged per request
     , processTime :: !Integer
     -- ^ Duration (ms) of the oracle processing window

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -148,7 +148,7 @@ data TokenStateJSON = TokenStateJSON
     -- ^ Owner payment key hash (hex)
     , root :: Hex
     -- ^ Current trie root hash
-    , maxFee :: Integer
+    , tip :: Integer
     -- ^ Maximum fee in lovelace
     , processTime :: Integer
     -- ^ Processing window (ms)
@@ -162,7 +162,7 @@ instance ToJSON TokenStateJSON where
         object
             [ "owner" .= owner
             , "root" .= root
-            , "max_fee" .= maxFee
+            , "tip" .= tip
             , "process_time" .= processTime
             , "retract_time" .= retractTime
             ]
@@ -173,14 +173,14 @@ tokenStateToJSON
     TokenState
         { owner = tsOwner
         , root = tsRoot
-        , maxFee = tsMaxFee
+        , tip = tsMaxFee
         , processTime = tsProcessTime
         , retractTime = tsRetractTime
         } =
         TokenStateJSON
             { owner = hashToHex tsOwner
             , root = Hex (unRoot tsRoot)
-            , maxFee = unCoin tsMaxFee
+            , tip = unCoin tsMaxFee
             , processTime = tsProcessTime
             , retractTime = tsRetractTime
             }
@@ -447,14 +447,14 @@ instance ToSchema TokenStateJSON where
                 .~ fromList
                     [ ("owner", textSchema)
                     , ("root", hexSchema)
-                    , ("max_fee", intSchema)
+                    , ("tip", intSchema)
                     , ("process_time", intSchema)
                     , ("retract_time", intSchema)
                     ]
             & required
                 .~ [ "owner"
                    , "root"
-                   , "max_fee"
+                   , "tip"
                    , "process_time"
                    , "retract_time"
                    ]

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs
@@ -195,7 +195,7 @@ tokenIdPrism =
         )
 
 -- | Encode/decode 'TokenState' as a 5-element CBOR
--- list: @[owner, root, maxFee, processTime,
+-- list: @[owner, root, tip, processTime,
 -- retractTime]@. Ledger types are embedded as
 -- sub-encoded byte strings.
 tokenStatePrism :: Prism' ByteString TokenState
@@ -208,21 +208,21 @@ tokenStatePrism = prism' enc dec
                     (ledgerEnc owner)
                 <> encodeBytes (unRoot root)
                 <> encodeBytes
-                    (ledgerEnc maxFee)
+                    (ledgerEnc tip)
                 <> encodeInteger processTime
                 <> encodeInteger retractTime
     dec = decodeCBOR $ do
         decodeListLenOf 5
         owner' <- ledgerDec =<< decodeBytes
         root' <- Root <$> decodeBytes
-        maxFee' <- ledgerDec =<< decodeBytes
+        tip' <- ledgerDec =<< decodeBytes
         processTime' <- decodeInteger
         retractTime' <- decodeInteger
         pure
             TokenState
                 { owner = owner'
                 , root = root'
-                , maxFee = maxFee'
+                , tip = tip'
                 , processTime = processTime'
                 , retractTime = retractTime'
                 }
@@ -573,7 +573,7 @@ encodeTokenState TokenState{..} =
     encodeListLen 5
         <> encodeBytes (ledgerEnc owner)
         <> encodeBytes (unRoot root)
-        <> encodeBytes (ledgerEnc maxFee)
+        <> encodeBytes (ledgerEnc tip)
         <> encodeInteger processTime
         <> encodeInteger retractTime
 
@@ -640,14 +640,14 @@ decTokenState bs = case decodeCBOR dec bs of
         decodeListLenOf 5
         owner' <- ledgerDec =<< decodeBytes
         root' <- Root <$> decodeBytes
-        maxFee' <- ledgerDec =<< decodeBytes
+        tip' <- ledgerDec =<< decodeBytes
         processTime' <- decodeInteger
         retractTime' <- decodeInteger
         pure
             TokenState
                 { owner = owner'
                 , root = root'
-                , maxFee = maxFee'
+                , tip = tip'
                 , processTime = processTime'
                 , retractTime = retractTime'
                 }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
@@ -425,7 +425,7 @@ fromOnChainState OnChainTokenState{..} =
     TokenState
         { owner = keyHashFromBBS stateOwner
         , root = Root (unOnChainRoot stateRoot)
-        , maxFee = Coin stateMaxFee
+        , tip = Coin stateTip
         , processTime = stateProcessTime
         , retractTime = stateRetractTime
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider/NodeClient.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider/NodeClient.hs
@@ -6,11 +6,41 @@
 -- Production implementation of the 'Provider'
 -- interface. Delegates to the @cardano-node-clients@
 -- library for N2C LocalStateQuery queries.
+-- Slot conversion uses the hard-fork interpreter
+-- directly (not available in the upstream Provider).
 module Cardano.MPFS.Provider.NodeClient
     ( -- * Construction
       mkNodeClientProvider
     ) where
 
+import Data.Time.Clock (NominalDiffTime)
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime
+    )
+
+import Cardano.Slotting.Slot (SlotNo)
+import Cardano.Slotting.Time
+    ( RelativeTime (..)
+    , getRelativeTime
+    , toRelativeTime
+    )
+import Ouroboros.Consensus.Cardano.Block
+    ( BlockQuery (..)
+    )
+import Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+    ( QueryHardFork (..)
+    )
+import Ouroboros.Consensus.HardFork.History.Qry
+    ( interpretQuery
+    , wallclockToSlot
+    )
+import Ouroboros.Consensus.Ledger.Query
+    ( Query (BlockQuery, GetSystemStart)
+    )
+
+import Cardano.Node.Client.N2C.LocalStateQuery
+    ( queryLSQ
+    )
 import Cardano.Node.Client.N2C.Provider qualified as Lib
 import Cardano.Node.Client.N2C.Types (LSQChannel)
 import Cardano.Node.Client.Provider qualified as Lib
@@ -32,8 +62,48 @@ mkNodeClientProvider ch =
                 Lib.queryUTxOs libProv
             , evaluateTx =
                 Lib.evaluateTx libProv
-            , posixMsToSlot =
-                Lib.posixMsToSlot libProv
-            , posixMsCeilSlot =
-                Lib.posixMsCeilSlot libProv
+            , posixMsToSlot = \ms -> do
+                (slot, _, _) <-
+                    queryWallclockToSlot ch ms
+                pure slot
+            , posixMsCeilSlot = \ms -> do
+                (slot, timeInSlot, _) <-
+                    queryWallclockToSlot ch ms
+                pure
+                    $ if timeInSlot == 0
+                        then slot
+                        else slot + 1
             }
+
+-- | Query SystemStart and HardFork interpreter,
+-- then convert POSIX milliseconds to a slot.
+queryWallclockToSlot
+    :: LSQChannel
+    -> Integer
+    -> IO (SlotNo, NominalDiffTime, NominalDiffTime)
+queryWallclockToSlot ch ms = do
+    systemStart <-
+        queryLSQ ch GetSystemStart
+    interpreter <-
+        queryLSQ ch
+            $ BlockQuery
+            $ QueryHardFork GetInterpreter
+    let utcTime =
+            posixSecondsToUTCTime
+                $ fromIntegral ms / 1000
+        relTime =
+            toRelativeTime
+                systemStart
+                utcTime
+        clamped =
+            RelativeTime
+                $ max 0
+                $ getRelativeTime relTime
+    case interpretQuery
+        interpreter
+        (wallclockToSlot clamped) of
+        Right r -> pure r
+        Left err ->
+            error
+                $ "posixMsToSlot: "
+                    <> show err

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs
@@ -36,7 +36,7 @@ data CageConfig = CageConfig
     -- ^ Phase 1 window (ms) for oracle processing
     , defaultRetractTime :: !Integer
     -- ^ Phase 2 window (ms) for requester retract
-    , defaultMaxFee :: !Coin
+    , defaultTip :: !Coin
     -- ^ Default max fee for newly booted tokens
     , network :: !Network
     -- ^ Target network (Mainnet or Testnet)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
@@ -81,7 +81,7 @@ import Cardano.MPFS.TxBuilder.Real.Internal
 --
 -- Picks a wallet UTxO as seed for the asset name,
 -- mints +1 token at the cage policy, and creates
--- a State UTxO with empty root and maxFee.
+-- a State UTxO with empty root and tip.
 bootTokenImpl
     :: CageConfig
     -- ^ Cage script config
@@ -126,9 +126,9 @@ bootTokenImpl cfg prov addr = do
                                     (addrKeyHashBytes addr)
                             , stateRoot =
                                 OnChainRoot emptyRoot
-                            , stateMaxFee =
+                            , stateTip =
                                 let Coin c =
-                                        defaultMaxFee cfg
+                                        defaultTip cfg
                                 in  c
                             , stateProcessTime =
                                 defaultProcessTime cfg

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
@@ -15,6 +15,9 @@ import Control.Exception (SomeException, try)
 import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Ord (Down (..))
+
+import Cardano.Ledger.Plutus (Language (PlutusV3))
+import Cardano.Node.Client.Balance qualified as Upstream
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
 import Data.Time.Clock (getCurrentTime)
@@ -34,6 +37,7 @@ import Cardano.Ledger.Alonzo.TxBody
     )
 import Cardano.Ledger.Api.Tx
     ( Tx
+    , bodyTxL
     , mkBasicTx
     , witsTxL
     )
@@ -169,24 +173,11 @@ rejectRequestsImpl cfg prov _st tid addr = do
                         ( toPlcData
                             (StateDatum oldState)
                         )
-    -- 6. Build refund outputs
-    let mkRefund (_, reqOut) =
-            let Coin reqVal =
-                    reqOut ^. coinTxOutL
-                Coin mf = defaultMaxFee cfg
-                refundAddr =
-                    addrFromKeyHashBytes
-                        (network cfg)
-                        (extractOwnerBytes reqOut)
-                rawRefund = Coin (reqVal - mf)
-                draft =
-                    mkBasicTxOut
-                        refundAddr
-                        (inject rawRefund)
-                minCoin = getMinCoinTxOut pp draft
-            in  mkBasicTxOut
-                    refundAddr
-                    (inject (max rawRefund minCoin))
+    -- 6. Build refund outputs (fee-dependent)
+    let OnChainTokenState
+            { stateTip = tipAmount
+            } = oldState
+        nReqs = fromIntegral (length reqUtxos)
         extractOwnerBytes out =
             case extractCageDatum out of
                 Just (RequestDatum req) ->
@@ -199,10 +190,48 @@ rejectRequestsImpl cfg prov _st tid addr = do
                     error
                         "extractOwnerBytes: \
                         \not a request"
-        refundOuts = map mkRefund reqUtxos
-        allOuts =
-            StrictSeq.fromList
-                (newStateOut : refundOuts)
+        mkRefunds txFee =
+            let Coin fee = txFee
+                perReqFee = fee `div` nReqs
+            in  map
+                    ( \(_, reqOut) ->
+                        let Coin reqVal =
+                                reqOut ^. coinTxOutL
+                            rawRefund =
+                                Coin
+                                    ( reqVal
+                                        - tipAmount
+                                        - perReqFee
+                                    )
+                            refundAddr =
+                                addrFromKeyHashBytes
+                                    (network cfg)
+                                    ( extractOwnerBytes
+                                        reqOut
+                                    )
+                            draft =
+                                mkBasicTxOut
+                                    refundAddr
+                                    (inject rawRefund)
+                            minCoin =
+                                getMinCoinTxOut
+                                    pp
+                                    draft
+                        in  mkBasicTxOut
+                                refundAddr
+                                ( inject
+                                    ( max
+                                        rawRefund
+                                        minCoin
+                                    )
+                                )
+                    )
+                    reqUtxos
+        mkAllOuts fee =
+            Right
+                $ StrictSeq.fromList
+                $ newStateOut
+                    : mkRefunds fee
     -- 7. Build redeemers
     let script = mkCageScript cfg
         scriptHash = hashScript script
@@ -286,7 +315,8 @@ rejectRequestsImpl cfg prov _st tid addr = do
             mkBasicTxBody
                 & inputsTxBodyL
                     .~ allScriptIns
-                & outputsTxBodyL .~ allOuts
+                & outputsTxBodyL
+                    .~ StrictSeq.empty
                 & collateralInputsTxBodyL
                     .~ Set.singleton
                         (fst feeUtxo)
@@ -295,7 +325,7 @@ rejectRequestsImpl cfg prov _st tid addr = do
                 & vldtTxBodyL .~ vldt
                 & scriptIntegrityHashTxBodyL
                     .~ integrity
-        tx =
+        templateTx =
             mkBasicTx body
                 & witsTxL . scriptTxWitsL
                     .~ Map.singleton
@@ -303,12 +333,65 @@ rejectRequestsImpl cfg prov _st tid addr = do
                         script
                 & witsTxL . rdmrsTxWitsL
                     .~ redeemers
-    evaluateAndBalance
-        prov
+    -- Evaluate scripts, patch ExUnits, balance
+    let allIns =
+            Set.insert (fst feeUtxo) allScriptIns
+        txForEval =
+            templateTx
+                & bodyTxL . inputsTxBodyL
+                    .~ allIns
+    evalResult <- evaluateTx prov txForEval
+    let failures =
+            [ (p, e)
+            | (p, Left e) <-
+                Map.toList evalResult
+            ]
+    if null failures
+        then pure ()
+        else
+            error
+                $ "rejectRequests: script eval \
+                  \failed: "
+                    <> show failures
+    let Redeemers rdmrMap =
+            templateTx
+                ^. witsTxL . rdmrsTxWitsL
+        patchedRdmrs =
+            Map.mapWithKey
+                ( \purpose (dat, eu) ->
+                    case Map.lookup
+                        purpose
+                        evalResult of
+                        Just (Right eu') ->
+                            (dat, eu')
+                        _ -> (dat, eu)
+                )
+                rdmrMap
+        newRedeemers = Redeemers patchedRdmrs
+        newIntegrity =
+            Upstream.computeScriptIntegrity
+                PlutusV3
+                pp
+                newRedeemers
+        patchedTx =
+            templateTx
+                & bodyTxL . inputsTxBodyL
+                    .~ allIns
+                & witsTxL . rdmrsTxWitsL
+                    .~ newRedeemers
+                & bodyTxL
+                    . scriptIntegrityHashTxBodyL
+                    .~ newIntegrity
+    case Upstream.balanceFeeLoop
         pp
-        (feeUtxo : stateUtxo : reqUtxos)
-        addr
-        tx
+        mkAllOuts
+        1
+        patchedTx of
+        Left err ->
+            error
+                $ "rejectRequests: fee loop: "
+                    <> show err
+        Right balanced -> pure balanced
   where
     when False _ = pure ()
     when True act = act

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -7,7 +7,7 @@
 -- deleting a key in a token's trie. No script
 -- execution occurs — the transaction simply pays to
 -- the cage address with an inline 'RequestDatum'.
--- The locked ADA includes the token's @maxFee@.
+-- The locked ADA includes the token's @tip@.
 module Cardano.MPFS.TxBuilder.Real.Request
     ( requestInsertImpl
     , requestDeleteImpl
@@ -37,6 +37,7 @@ import Cardano.Ledger.Api.Tx.Out
     , datumTxOutL
     , getMinCoinTxOut
     , mkBasicTxOut
+    , valueTxOutL
     )
 import Cardano.Ledger.BaseTypes (Inject (..))
 
@@ -68,7 +69,7 @@ requestInsertImpl
     -> Provider IO
     -- ^ Blockchain query interface
     -> State IO
-    -- ^ Token state (to look up maxFee)
+    -- ^ Token state (to look up tip)
     -> TokenId
     -- ^ Token whose trie to modify
     -> ByteString
@@ -81,7 +82,7 @@ requestInsertImpl
 requestInsertImpl cfg prov st tid key value addr =
     do
         mTs <- getToken (tokens st) tid
-        TokenState{maxFee = Coin mf} <- case mTs of
+        TokenState{tip = Coin mf} <- case mTs of
             Nothing ->
                 error
                     "requestInsert: unknown token"
@@ -147,7 +148,7 @@ requestDeleteImpl
     -> Provider IO
     -- ^ Blockchain query interface
     -> State IO
-    -- ^ Token state (to look up maxFee)
+    -- ^ Token state (to look up tip)
     -> TokenId
     -- ^ Token whose trie to modify
     -> ByteString
@@ -159,7 +160,7 @@ requestDeleteImpl
     -> IO (Tx ConwayEra)
 requestDeleteImpl cfg prov st tid key val addr = do
     mTs <- getToken (tokens st) tid
-    TokenState{maxFee = Coin mf} <- case mTs of
+    TokenState{tip = Coin mf} <- case mTs of
         Nothing ->
             error "requestDelete: unknown token"
         Just x -> pure x
@@ -221,7 +222,7 @@ requestUpdateImpl
     -> Provider IO
     -- ^ Blockchain query interface
     -> State IO
-    -- ^ Token state (to look up maxFee)
+    -- ^ Token state (to look up tip)
     -> TokenId
     -- ^ Token whose trie to modify
     -> ByteString
@@ -243,7 +244,7 @@ requestUpdateImpl
     newVal
     addr = do
         mTs <- getToken (tokens st) tid
-        TokenState{maxFee = Coin mf} <- case mTs of
+        TokenState{tip = Coin mf} <- case mTs of
             Nothing ->
                 error
                     "requestUpdate: unknown token"
@@ -307,11 +308,16 @@ requestUpdateImpl
 --
 -- 1. The locked amount >= minUTxO for the request
 --    output (which carries an inline datum).
--- 2. After the oracle deducts @maxFee@, the
+-- 2. After the oracle deducts @tip@, the
 --    remaining ADA (the refund) >= minUTxO for the
 --    refund output (a plain payment).
 --
--- Returns @max(reqMinUTxO, maxFee + refundMinUTxO)@.
+-- The actual tx fee share is NOT included here —
+-- the user decides how much extra to lock. If the
+-- refund after fee+tip is below minUTxO, the update
+-- tx builder will skip or fail the request.
+--
+-- Returns @max(reqMinUTxO, tip + refundMinUTxO)@.
 requestLockedAda
     :: PParams ConwayEra
     -- ^ Protocol parameters
@@ -320,14 +326,26 @@ requestLockedAda
     -> TxOut ConwayEra
     -- ^ Draft refund output (plain address)
     -> Integer
-    -- ^ maxFee (lovelace)
+    -- ^ tip (lovelace)
     -> Coin
-requestLockedAda pp reqDraft refDraft mf =
-    let Coin reqMin =
-            getMinCoinTxOut pp reqDraft
-        Coin refMin =
+requestLockedAda pp reqDraft refDraft tip =
+    let Coin refMin =
             getMinCoinTxOut pp refDraft
-    in  Coin (max reqMin (mf + refMin))
+        -- Fee buffer: generous estimate of the
+        -- per-request fee share in an update tx.
+        -- Excess becomes a larger refund.
+        feeBuffer = 600_000
+        locked = tip + feeBuffer + refMin
+        -- Ensure the request output itself meets
+        -- minUTxO with the computed value.
+        adjusted =
+            getMinCoinTxOut
+                pp
+                ( reqDraft
+                    & valueTxOutL
+                        .~ inject (Coin locked)
+                )
+    in  max adjusted (Coin locked)
 
 -- | Get current POSIX time in milliseconds.
 currentPosixMs :: IO Integer

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+
 -- |
 -- Module      : Cardano.MPFS.TxBuilder.Real.Update
 -- Description : Update token transaction
@@ -14,12 +17,11 @@ module Cardano.MPFS.TxBuilder.Real.Update
     ) where
 
 import Control.Exception (SomeException, try)
+import Data.Void (Void)
 import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Ord (Down (..))
-import Data.Sequence.Strict qualified as StrictSeq
-import Data.Set qualified as Set
 import Data.Time.Clock (getCurrentTime)
 import Data.Time.Clock.POSIX
     ( utcTimeToPOSIXSeconds
@@ -27,25 +29,15 @@ import Data.Time.Clock.POSIX
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.Allegra.Scripts
-    ( ValidityInterval (..)
-    )
-import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
-import Cardano.Ledger.Alonzo.TxBody
-    ( reqSignerHashesTxBodyL
-    , scriptIntegrityHashTxBodyL
-    )
 import Cardano.Ledger.Api.Tx
     ( Tx
-    , mkBasicTx
-    , witsTxL
+    , bodyTxL
     )
 import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
-    , inputsTxBodyL
-    , mkBasicTxBody
-    , outputsTxBodyL
-    , vldtTxBodyL
+    ( feeTxBodyL
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
     )
 import Cardano.Ledger.Api.Tx.Out
     ( TxOut
@@ -55,20 +47,6 @@ import Cardano.Ledger.Api.Tx.Out
     , mkBasicTxOut
     , valueTxOutL
     )
-import Cardano.Ledger.Api.Tx.Wits
-    ( Redeemers (..)
-    , rdmrsTxWitsL
-    , scriptTxWitsL
-    )
-import Cardano.Ledger.BaseTypes
-    ( Inject (..)
-    , StrictMaybe (SJust, SNothing)
-    )
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
-import Cardano.Ledger.Core (hashScript)
-import Cardano.Ledger.TxIn (TxIn)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -87,6 +65,7 @@ import Cardano.MPFS.Core.Types
     , ConwayEra
     , Root (..)
     , TokenId
+    , TxIn
     )
 import Cardano.MPFS.Provider
     ( Provider (..)
@@ -101,236 +80,10 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
+import Cardano.Node.Client.TxBuild qualified as Tx
 
--- | Build an update-token transaction.
---
--- Consumes the state UTxO and all pending request
--- UTxOs, processes each request through the trie,
--- and outputs a new state UTxO with updated root.
-updateTokenImpl
-    :: CageConfig
-    -- ^ Cage script config
-    -> Provider IO
-    -- ^ Blockchain query interface
-    -> State IO
-    -- ^ Token and request state
-    -> TrieManager IO
-    -- ^ Trie manager (for speculative proof generation)
-    -> TokenId
-    -- ^ Token to process requests for
-    -> Addr
-    -- ^ Oracle's address (pays fee, receives fee income)
-    -> IO (Tx ConwayEra)
-updateTokenImpl cfg prov _st tm tid addr = do
-    -- 1. Query cage UTxOs
-    let scriptAddr = cageAddrFromCfg cfg (network cfg)
-    cageUtxos <- queryUTxOs prov scriptAddr
-    -- 2. Find state UTxO
-    let policyId = cagePolicyIdFromCfg cfg
-    stateUtxo <- case findStateUtxo policyId tid cageUtxos of
-        Nothing ->
-            error
-                "updateToken: state UTxO not found"
-        Just x -> pure x
-    let (stateIn, stateOut) = stateUtxo
-    -- 3. Find request UTxOs for this token
-    let reqUtxos =
-            sortOn fst
-                $ findRequestUtxos tid cageUtxos
-    when (null reqUtxos)
-        $ error "updateToken: no pending requests"
-    -- 4. Get wallet UTxO for fees
-    pp <- queryProtocolParams prov
-    walletUtxos <- queryUTxOs prov addr
-    feeUtxo <- case sortOn
-        (Down . (^. coinTxOutL) . snd)
-        walletUtxos of
-        [] -> error "updateToken: no UTxOs"
-        (u : _) -> pure u
-    -- 5. Compute proofs speculatively (no mutation)
-    (proofs, newRoot) <-
-        withSpeculativeTrie tm tid $ \trie -> do
-            ps <-
-                mapM
-                    (processRequest trie)
-                    reqUtxos
-            r <- getRoot trie
-            pure (ps, r)
-    -- 7. Build new state output
-    let oldState = case extractCageDatum stateOut of
-            Just (StateDatum s) -> s
-            _ ->
-                error
-                    "updateToken: invalid state datum"
-        OnChainTokenState
-            { stateOwner = BuiltinByteString ownerBs
-            } = oldState
-        newStateDatum =
-            StateDatum
-                oldState
-                    { stateRoot =
-                        OnChainRoot (unRoot newRoot)
-                    }
-        newStateOut =
-            mkBasicTxOut
-                scriptAddr
-                (stateOut ^. valueTxOutL)
-                & datumTxOutL
-                    .~ mkInlineDatum
-                        (toPlcData newStateDatum)
-    -- 8. Build refund outputs (one per request)
-    let mkRefund (_, reqOut) =
-            let Coin reqVal =
-                    reqOut ^. coinTxOutL
-                Coin mf = defaultMaxFee cfg
-                refundAddr =
-                    addrFromKeyHashBytes
-                        (network cfg)
-                        (extractOwnerBytes reqOut)
-                rawRefund = Coin (reqVal - mf)
-                draft =
-                    mkBasicTxOut
-                        refundAddr
-                        (inject rawRefund)
-                minCoin = getMinCoinTxOut pp draft
-            in  mkBasicTxOut
-                    refundAddr
-                    (inject (max rawRefund minCoin))
-        extractOwnerBytes out =
-            case extractCageDatum out of
-                Just (RequestDatum req) ->
-                    let OnChainRequest
-                            { requestOwner =
-                                BuiltinByteString bs
-                            } = req
-                    in  bs
-                _ ->
-                    error
-                        "extractOwnerBytes: \
-                        \not a request"
-        refundOuts = map mkRefund reqUtxos
-        allOuts =
-            StrictSeq.fromList
-                (newStateOut : refundOuts)
-    -- 9. Build redeemers
-    let script = mkCageScript cfg
-        scriptHash = hashScript script
-        reqIns = map fst reqUtxos
-        allScriptIns =
-            Set.fromList (stateIn : reqIns)
-        allInputs =
-            Set.insert (fst feeUtxo) allScriptIns
-        stateRef = txInToRef stateIn
-        stateIx =
-            spendingIndex stateIn allInputs
-        modifyRedeemer = Modify proofs
-        contributeEntries =
-            map
-                ( \rIn ->
-                    let ix =
-                            spendingIndex
-                                rIn
-                                allInputs
-                        rdm = Contribute stateRef
-                    in  ( ConwaySpending (AsIx ix)
-                        ,
-                            ( toLedgerData rdm
-                            , placeholderExUnits
-                            )
-                        )
-                )
-                reqIns
-        redeemers =
-            Redeemers
-                $ Map.fromList
-                $ ( ConwaySpending
-                        (AsIx stateIx)
-                  ,
-                      ( toLedgerData modifyRedeemer
-                      , placeholderExUnits
-                      )
-                  )
-                    : contributeEntries
-        integrity =
-            computeScriptIntegrity pp redeemers
-        ownerKh =
-            addrWitnessKeyHash ownerBs
-        -- Phase 1: upper bound must be before
-        -- the earliest submitted_at + process_time.
-        -- Extract submitted_at from each request
-        -- and take the minimum deadline.
-        extractSubmittedAt (_, rOut) =
-            case extractCageDatum rOut of
-                Just (RequestDatum r) ->
-                    requestSubmittedAt r
-                _ -> 0
-        earliestDeadline =
-            minimum
-                $ map
-                    ( \u ->
-                        extractSubmittedAt u
-                            + stateProcessTime oldState
-                    )
-                    reqUtxos
-    -- The deadline might be past the node's
-    -- forecast horizon (PastHorizon) on short-
-    -- lived devnets. Fall back to the current
-    -- time which is always within the horizon
-    -- and before the far-future deadline.
-    mUpperSlot <-
-        try @SomeException
-            (posixMsToSlot prov earliestDeadline)
-    upperSlot <- case mUpperSlot of
-        Right s -> pure s
-        Left _ -> do
-            nowUtc <- getCurrentTime
-            let posixSec =
-                    utcTimeToPOSIXSeconds nowUtc
-            -- Try now+30s, now+5s, now+2s
-            -- as fallback chain (devnet
-            -- horizon may be very short)
-            trySlots prov
-                $ map
-                    ( \d ->
-                        round
-                            ((posixSec + d) * 1000)
-                    )
-                    [30, 5, 2]
-    let
-        vldt =
-            ValidityInterval
-                SNothing
-                (SJust upperSlot)
-        body =
-            mkBasicTxBody
-                & inputsTxBodyL
-                    .~ allScriptIns
-                & outputsTxBodyL .~ allOuts
-                & collateralInputsTxBodyL
-                    .~ Set.singleton
-                        (fst feeUtxo)
-                & reqSignerHashesTxBodyL
-                    .~ Set.singleton ownerKh
-                & vldtTxBodyL .~ vldt
-                & scriptIntegrityHashTxBodyL
-                    .~ integrity
-        tx =
-            mkBasicTx body
-                & witsTxL . scriptTxWitsL
-                    .~ Map.singleton
-                        scriptHash
-                        script
-                & witsTxL . rdmrsTxWitsL
-                    .~ redeemers
-    evaluateAndBalance
-        prov
-        pp
-        (feeUtxo : stateUtxo : reqUtxos)
-        addr
-        tx
-  where
-    when False _ = pure ()
-    when True act = act
+-- | Empty query GADT (no context needed).
+data NoCtx a
 
 -- | Try converting successive POSIX ms values to
 -- slots, returning the first that succeeds.
@@ -347,6 +100,220 @@ trySlots p (ms : rest) = do
     case r of
         Right s -> pure s
         Left _ -> trySlots p rest
+
+-- | Build an update-token transaction (fair fee).
+--
+-- Uses the TxBuild DSL for convergent fee/refund
+-- balancing. Conservation equation:
+-- sum(refunds) = sum(inputs) - fee - N * tip
+updateTokenImpl
+    :: CageConfig
+    -> Provider IO
+    -> State IO
+    -> TrieManager IO
+    -> TokenId
+    -> Addr
+    -> IO (Tx ConwayEra)
+updateTokenImpl cfg prov _st tm tid addr = do
+    let scriptAddr =
+            cageAddrFromCfg cfg (network cfg)
+    cageUtxos <- queryUTxOs prov scriptAddr
+    let policyId = cagePolicyIdFromCfg cfg
+    stateUtxo <- case findStateUtxo
+        policyId
+        tid
+        cageUtxos of
+        Nothing ->
+            error
+                "updateToken: state UTxO \
+                \not found"
+        Just x -> pure x
+    let (stateIn, stateOut) = stateUtxo
+        reqUtxos =
+            sortOn fst
+                $ findRequestUtxos tid cageUtxos
+    when (null reqUtxos)
+        $ error "updateToken: no pending requests"
+    pp <- queryProtocolParams prov
+    walletUtxos <- queryUTxOs prov addr
+    feeUtxo <- case sortOn
+        (Down . (^. coinTxOutL) . snd)
+        walletUtxos of
+        [] -> error "updateToken: no UTxOs"
+        (u : _) -> pure u
+    -- Compute proofs
+    (proofs, newRoot) <-
+        withSpeculativeTrie tm tid $ \trie -> do
+            ps <-
+                mapM
+                    (processRequest trie)
+                    reqUtxos
+            r <- getRoot trie
+            pure (ps, r)
+    let oldState =
+            case extractCageDatum stateOut of
+                Just (StateDatum s) -> s
+                _ ->
+                    error
+                        "updateToken: invalid \
+                        \state datum"
+        OnChainTokenState
+            { stateOwner =
+                BuiltinByteString ownerBs
+            , stateTip = tipAmount
+            } = oldState
+        newStateDatum =
+            StateDatum
+                oldState
+                    { stateRoot =
+                        OnChainRoot (unRoot newRoot)
+                    }
+        newStateOut =
+            mkBasicTxOut
+                scriptAddr
+                (stateOut ^. valueTxOutL)
+                & datumTxOutL
+                    .~ mkInlineDatum
+                        (toPlcData newStateDatum)
+        stateRef = txInToRef stateIn
+        script = mkCageScript cfg
+        ownerKh = addrWitnessKeyHash ownerBs
+        nReqs =
+            fromIntegral (length reqUtxos)
+                :: Integer
+    -- Validity interval
+    let extractSubmittedAt (_, rOut) =
+            case extractCageDatum rOut of
+                Just (RequestDatum r) ->
+                    requestSubmittedAt r
+                _ -> 0
+        earliestDeadline =
+            minimum
+                $ map
+                    ( \u ->
+                        extractSubmittedAt u
+                            + stateProcessTime
+                                oldState
+                    )
+                    reqUtxos
+    mUpperSlot <-
+        try @SomeException
+            (posixMsToSlot prov earliestDeadline)
+    upperSlot <- case mUpperSlot of
+        Right s -> pure s
+        Left _ -> do
+            nowUtc <- getCurrentTime
+            let posixSec =
+                    utcTimeToPOSIXSeconds nowUtc
+            trySlots prov
+                $ map
+                    ( \d ->
+                        round
+                            ((posixSec + d) * 1000)
+                    )
+                    [30, 5, 2]
+    -- Build with DSL
+    let evalTx tx = do
+            r <- evaluateTx prov tx
+            pure
+                $ Map.map
+                    ( \case
+                        Left e -> Left (show e)
+                        Right eu -> Right eu
+                    )
+                    r
+        prog = do
+            -- Spend state UTxO
+            _ <-
+                Tx.spendScript
+                    stateIn
+                    (Modify proofs)
+            -- Spend request UTxOs
+            mapM_
+                ( \(rIn, _) ->
+                    Tx.spendScript
+                        rIn
+                        (Contribute stateRef)
+                )
+                reqUtxos
+            -- State output (unchanged value)
+            _ <- Tx.output newStateOut
+            -- Fee-dependent refund outputs
+            Coin fee <- Tx.peek $ \tx ->
+                let f = tx ^. bodyTxL . feeTxBodyL
+                in  if f > Coin 0
+                        then Tx.Ok f
+                        else Tx.Iterate f
+            let perReqFee = fee `div` nReqs
+            mapM_
+                ( \(_, reqOut) -> do
+                    let Coin reqVal =
+                            reqOut ^. coinTxOutL
+                        rawRefund =
+                            Coin
+                                ( reqVal
+                                    - tipAmount
+                                    - perReqFee
+                                )
+                        refundAddr =
+                            addrFromKeyHashBytes
+                                (network cfg)
+                                ( extractOwnerBytes
+                                    reqOut
+                                )
+                        draft =
+                            mkBasicTxOut
+                                refundAddr
+                                (inject rawRefund)
+                        minCoin =
+                            getMinCoinTxOut
+                                pp
+                                draft
+                    Tx.output
+                        $ mkBasicTxOut
+                            refundAddr
+                            ( inject
+                                ( max
+                                    rawRefund
+                                    minCoin
+                                )
+                            )
+                )
+                reqUtxos
+            -- Constraints
+            Tx.attachScript script
+            Tx.requireSignature ownerKh
+            Tx.collateral (fst feeUtxo)
+            Tx.validTo upperSlot
+    result <-
+        Tx.build
+            pp
+            (Tx.InterpretIO (const (pure undefined)))
+            evalTx
+            (feeUtxo : stateUtxo : reqUtxos)
+            addr
+            (prog :: Tx.TxBuild NoCtx Void ())
+    case result of
+        Right tx -> pure tx
+        Left err ->
+            error
+                $ "updateToken: build failed: "
+                    <> show err
+  where
+    when False _ = pure ()
+    when True act = act
+    extractOwnerBytes out =
+        case extractCageDatum out of
+            Just (RequestDatum req) ->
+                let OnChainRequest
+                        { requestOwner =
+                            BuiltinByteString bs
+                        } = req
+                in  bs
+            _ ->
+                error
+                    "extractOwnerBytes: \
+                    \not a request"
 
 -- | Process a single request: apply the operation
 -- to the trie and get proof steps.

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Generators.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Generators.hs
@@ -125,7 +125,7 @@ genPosixTime =
         <$> choose (0 :: Int, 2_000_000_000)
 
 -- | Generate a 'TokenState' with random owner,
--- root, maxFee, processTime, and retractTime.
+-- root, tip, processTime, and retractTime.
 genTokenState :: Gen TokenState
 genTokenState =
     TokenState
@@ -191,7 +191,7 @@ genCageEvent = do
         , pure (CageBurn tid)
         ]
 
--- | Generate a maxFee in the range
+-- | Generate a tip in the range
 -- 500,000 .. 5,000,000 lovelace.
 genMaxFee :: Gen Coin
 genMaxFee = Coin <$> choose (500_000, 5_000_000)

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
@@ -76,7 +76,7 @@ spec = describe "GET /tokens/:id" $ do
                     `shouldBe` True
                 KM.member "root" obj
                     `shouldBe` True
-                KM.member "max_fee" obj
+                KM.member "tip" obj
                     `shouldBe` True
                 KM.member "process_time" obj
                     `shouldBe` True

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
@@ -60,7 +60,7 @@ mkDummyTokenState = do
         TokenState
             { owner = kh
             , root = Root (BS.replicate 32 0)
-            , maxFee = Coin 1_000_000
+            , tip = Coin 1_000_000
             , processTime = 60_000
             , retractTime = 30_000
             }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ArmageddonSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ArmageddonSpec.hs
@@ -594,7 +594,7 @@ tokStateA =
     TokenState
         { owner = testKeyHash
         , root = Root (BS.replicate 32 0)
-        , maxFee = Coin 1_000_000
+        , tip = Coin 1_000_000
         , processTime = 100
         , retractTime = 200
         }
@@ -604,7 +604,7 @@ tokStateB =
     TokenState
         { owner = testKeyHash
         , root = Root (BS.replicate 32 0)
-        , maxFee = Coin 2_000_000
+        , tip = Coin 2_000_000
         , processTime = 150
         , retractTime = 250
         }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/FollowerSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/FollowerSpec.hs
@@ -962,8 +962,8 @@ mkStateOut tid ts =
                 , stateRoot =
                     OnChainRoot
                         (unRoot (root ts))
-                , stateMaxFee =
-                    let Coin c = maxFee ts in c
+                , stateTip =
+                    let Coin c = tip ts in c
                 , stateProcessTime =
                     processTime ts
                 , stateRetractTime =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
@@ -482,7 +482,7 @@ fixTokenState =
     TokenState
         { owner = fixKeyHash
         , root = Root (BS.replicate 32 0)
-        , maxFee = Coin 1_000_000
+        , tip = Coin 1_000_000
         , processTime = 60
         , retractTime = 120
         }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/RollbackSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/RollbackSpec.hs
@@ -289,7 +289,7 @@ tokStateA =
     TokenState
         { owner = testKeyHash
         , root = rootA
-        , maxFee = Coin 1_000_000
+        , tip = Coin 1_000_000
         , processTime = 100
         , retractTime = 200
         }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
@@ -396,7 +396,7 @@ toOnChainOp (Update o n) = OpUpdate o n
 mkStateDatum :: TokenState -> Root -> CageDatum
 mkStateDatum TokenState{..} r =
     let KeyHash ownerH = owner
-        Coin mf = maxFee
+        Coin mf = tip
     in  StateDatum
             OnChainTokenState
                 { stateOwner =
@@ -404,7 +404,7 @@ mkStateDatum TokenState{..} r =
                         (hashToBytes ownerH)
                 , stateRoot =
                     OnChainRoot (unRoot r)
-                , stateMaxFee = mf
+                , stateTip = mf
                 , stateProcessTime = processTime
                 , stateRetractTime = retractTime
                 }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
@@ -1192,7 +1192,7 @@ tokStateA =
     TokenState
         { owner = testKeyHash
         , root = Root (BS.replicate 32 0)
-        , maxFee = Coin 1_000_000
+        , tip = Coin 1_000_000
         , processTime = 100
         , retractTime = 200
         }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
@@ -275,7 +275,7 @@ spec = do
                             BuiltinByteString "own"
                         , stateRoot =
                             OnChainRoot "rt"
-                        , stateMaxFee = 1000
+                        , stateTip = 1000
                         , stateProcessTime = 300
                         , stateRetractTime = 600
                         }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -198,7 +198,7 @@ testCageConfig =
         , cfgScriptHash = cageScriptHashLedger
         , defaultProcessTime = 300_000
         , defaultRetractTime = 600_000
-        , defaultMaxFee = Coin 1_000_000
+        , defaultTip = Coin 1_000_000
         , network = Testnet
         }
 
@@ -311,7 +311,7 @@ mkStateTxOut =
                     , stateRoot =
                         OnChainRoot
                             (BS.replicate 32 0)
-                    , stateMaxFee = 1_000_000
+                    , stateTip = 1_000_000
                     , stateProcessTime = 300_000
                     , stateRetractTime = 600_000
                     }
@@ -470,12 +470,12 @@ requestInsertSpec =
             length outList
                 `shouldSatisfy` (>= 2)
 
-        it "cage output has maxFee (zeroPP)" $ do
+        it "cage output has tip (zeroPP)" $ do
             tx <- runRequestInsert
             case toOutList tx of
                 (cageOut : _) -> do
                     let outCoin = cageOut ^. coinTxOutL
-                    -- zeroPP: minUTxO=0, so locked=maxFee
+                    -- zeroPP: minUTxO=0, so locked=tip
                     outCoin `shouldBe` Coin 1_000_000
                 [] -> expectationFailure "no outputs"
 
@@ -508,12 +508,12 @@ requestDeleteSpec =
             length outList
                 `shouldSatisfy` (>= 2)
 
-        it "cage output has maxFee (zeroPP)" $ do
+        it "cage output has tip (zeroPP)" $ do
             tx <- runRequestDelete
             case toOutList tx of
                 (cageOut : _) -> do
                     let outCoin = cageOut ^. coinTxOutL
-                    -- zeroPP: minUTxO=0, so locked=maxFee
+                    -- zeroPP: minUTxO=0, so locked=tip
                     outCoin `shouldBe` Coin 1_000_000
                 [] -> expectationFailure "no outputs"
 
@@ -707,7 +707,7 @@ bootTokenWithScript scriptBytes = do
                     computeScriptHash scriptBytes
                 , defaultProcessTime = 300_000
                 , defaultRetractTime = 600_000
-                , defaultMaxFee = Coin 1_000_000
+                , defaultTip = Coin 1_000_000
                 , network = Testnet
                 }
 
@@ -808,7 +808,7 @@ requestLockedAdaProps =
                                                 draft
                                     in  la >= reqMin
 
-        it "locked >= maxFee + refund minUTxO"
+        it "locked >= tip + refund minUTxO"
             $ property
             $ forAll genTokenId
             $ \tid ->
@@ -1198,7 +1198,7 @@ updateTxProps =
                 (refund : _) -> do
                     let Coin c =
                             refund ^. coinTxOutL
-                    -- request had 3M, maxFee=1M
+                    -- request had 3M, tip=1M
                     c `shouldBe` 2_000_000
                 _ ->
                     expectationFailure "no refund output"
@@ -1431,7 +1431,7 @@ bootTxPropsWithScript scriptBytes = do
                     computeScriptHash scriptBytes
                 , defaultProcessTime = 300_000
                 , defaultRetractTime = 600_000
-                , defaultMaxFee = Coin 1_000_000
+                , defaultTip = Coin 1_000_000
                 , network = Testnet
                 }
 
@@ -1564,7 +1564,7 @@ runRetractRequestWith = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
@@ -1629,7 +1629,7 @@ runUpdateTokenWith = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
@@ -1687,7 +1687,7 @@ runEndTokenWith = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
@@ -1760,7 +1760,7 @@ mkTestFixture = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
@@ -1798,7 +1798,7 @@ mkRealisticFixture = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
@@ -1858,7 +1858,7 @@ runRealisticUpdateWith = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
@@ -1911,7 +1911,7 @@ runTightUpdate = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
@@ -1964,7 +1964,7 @@ runRealisticRetractWith = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
@@ -2025,7 +2025,7 @@ runRealisticEndWith = do
             TokenState
                 { owner = testKh
                 , root = Root (BS.replicate 32 0)
-                , maxFee = Coin 1_000_000
+                , tip = Coin 1_000_000
                 , processTime = 300_000
                 , retractTime = 600_000
                 }

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -349,9 +349,6 @@
         "TokenStateJSON": {
             "description": "On-chain token state",
             "properties": {
-                "max_fee": {
-                    "type": "integer"
-                },
                 "owner": {
                     "type": "string"
                 },
@@ -363,12 +360,15 @@
                 },
                 "root": {
                     "$ref": "#/definitions/Hex"
+                },
+                "tip": {
+                    "type": "integer"
                 }
             },
             "required": [
                 "owner",
                 "root",
-                "max_fee",
+                "tip",
                 "process_time",
                 "retract_time"
             ],

--- a/flake.lock
+++ b/flake.lock
@@ -29,12 +29,29 @@
       },
       "original": {
         "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "type": "github"
+      }
+    },
+    "CHaP_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771121711,
+        "narHash": "sha256-1ebLeCCnwuU1y/nLbBQTXtQUK1OBQmxclnJZbfffzG0=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
         "ref": "repo",
         "repo": "cardano-haskell-packages",
         "type": "github"
       }
     },
-    "CHaP_3": {
+    "CHaP_4": {
       "flake": false,
       "locked": {
         "lastModified": 1771121711,
@@ -51,7 +68,41 @@
         "type": "github"
       }
     },
-    "CHaP_4": {
+    "CHaP_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770297836,
+        "narHash": "sha256-Jnfz4OjZG+xvnCQ0KeUS7kaVAu7MsSgvwqFyyZjN+Hw=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "aae41da34344a6ad7cae51770df4ed1714b7a9c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
+    "CHaP_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771121711,
+        "narHash": "sha256-1ebLeCCnwuU1y/nLbBQTXtQUK1OBQmxclnJZbfffzG0=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "type": "github"
+      }
+    },
+    "CHaP_7": {
       "flake": false,
       "locked": {
         "lastModified": 1770297836,
@@ -117,6 +168,54 @@
       }
     },
     "HTTP_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_7": {
       "flake": false,
       "locked": {
         "lastModified": 1451647621,
@@ -221,6 +320,57 @@
         "type": "github"
       }
     },
+    "blst_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.14",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
+    "blst_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.14",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
+    "blst_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.14",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -273,6 +423,57 @@
       }
     },
     "cabal-32_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_7": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -357,6 +558,57 @@
         "type": "github"
       }
     },
+    "cabal-34_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-36": {
       "flake": false,
       "locked": {
@@ -425,9 +677,90 @@
         "type": "github"
       }
     },
+    "cabal-36_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cardano-automation": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
+        "haskellNix": [
+          "cardano-mpfs-onchain",
+          "cardano-node-clients",
+          "cardano-node",
+          "haskellNix"
+        ],
+        "nixpkgs": [
+          "cardano-mpfs-onchain",
+          "cardano-node-clients",
+          "cardano-node",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741965132,
+        "narHash": "sha256-SjNEfsLa+2FKS4GlszaH0fO/QGJbooNFMYU1GVdJToo=",
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "rev": "78d16a837d74a72822041ee1b970daa73ac83b9e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "type": "github"
+      }
+    },
+    "cardano-automation_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
         "haskellNix": [
           "cardano-node-clients",
           "cardano-node",
@@ -455,7 +788,7 @@
     },
     "cardano-mpfs-cage": {
       "inputs": {
-        "CHaP": "CHaP_2",
+        "CHaP": "CHaP_3",
         "flake-parts": "flake-parts_2",
         "haskellNix": "haskellNix",
         "iohkNix": "iohkNix",
@@ -483,27 +816,41 @@
     },
     "cardano-mpfs-onchain": {
       "inputs": {
+        "CHaP": "CHaP_2",
         "cardano-mpfs-cage": "cardano-mpfs-cage",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "cardano-node": [
+          "cardano-mpfs-onchain",
+          "cardano-node-clients",
+          "cardano-node"
+        ],
+        "cardano-node-clients": "cardano-node-clients",
+        "flake-utils": "flake-utils_2",
+        "haskellNix": "haskellNix_4",
+        "iohkNix": "iohkNix_4",
+        "nixpkgs": [
+          "cardano-mpfs-onchain",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
       },
       "locked": {
-        "lastModified": 1773393609,
-        "narHash": "sha256-VzNh4WJ1/BBDFnUdlzuNlNVqEtQB5/B4icXrWWh/grY=",
-        "owner": "paolino",
+        "lastModified": 1775842090,
+        "narHash": "sha256-B/QyM8NS4c8v2538pVUSy++rWHQsW6XYrA7D/Puw9DU=",
+        "owner": "cardano-foundation",
         "repo": "cardano-mpfs-onchain",
-        "rev": "2784fa9dc8e523f7bc1cdc5c21ed4b57f23da4b8",
+        "rev": "8b73389d933180c02a6d8097dce5066aff781bf9",
         "type": "github"
       },
       "original": {
-        "owner": "paolino",
+        "owner": "cardano-foundation",
+        "ref": "001-fair-fee-model",
         "repo": "cardano-mpfs-onchain",
         "type": "github"
       }
     },
     "cardano-node": {
       "inputs": {
-        "CHaP": "CHaP_4",
+        "CHaP": "CHaP_5",
         "cardano-automation": "cardano-automation",
         "customConfig": "customConfig",
         "em": "em",
@@ -514,6 +861,7 @@
         "incl": "incl",
         "iohkNix": "iohkNix_2",
         "nixpkgs": [
+          "cardano-mpfs-onchain",
           "cardano-node-clients",
           "cardano-node",
           "haskellNix",
@@ -538,12 +886,42 @@
     },
     "cardano-node-clients": {
       "inputs": {
-        "CHaP": "CHaP_3",
+        "CHaP": "CHaP_4",
         "cardano-node": "cardano-node",
         "flake-parts": "flake-parts_3",
         "haskellNix": "haskellNix_3",
         "iohkNix": "iohkNix_3",
         "mkdocs": "mkdocs",
+        "nixpkgs": [
+          "cardano-mpfs-onchain",
+          "cardano-node-clients",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775814554,
+        "narHash": "sha256-5eD8ESDEveIwcqOO/GUexD7avqwAUc6dZYjuI8oACFk=",
+        "owner": "lambdasistemi",
+        "repo": "cardano-node-clients",
+        "rev": "a37cbd62170740efc86dae1a1cf242a8608e4b78",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lambdasistemi",
+        "repo": "cardano-node-clients",
+        "rev": "a37cbd62170740efc86dae1a1cf242a8608e4b78",
+        "type": "github"
+      }
+    },
+    "cardano-node-clients_2": {
+      "inputs": {
+        "CHaP": "CHaP_6",
+        "cardano-node": "cardano-node_2",
+        "flake-parts": "flake-parts_5",
+        "haskellNix": "haskellNix_6",
+        "iohkNix": "iohkNix_6",
+        "mkdocs": "mkdocs_2",
         "nixpkgs": [
           "cardano-node-clients",
           "haskellNix",
@@ -561,6 +939,41 @@
       "original": {
         "owner": "lambdasistemi",
         "repo": "cardano-node-clients",
+        "type": "github"
+      }
+    },
+    "cardano-node_2": {
+      "inputs": {
+        "CHaP": "CHaP_7",
+        "cardano-automation": "cardano-automation_2",
+        "customConfig": "customConfig_2",
+        "em": "em_2",
+        "empty-flake": "empty-flake_2",
+        "flake-compat": "flake-compat_6",
+        "hackageNix": "hackageNix_2",
+        "haskellNix": "haskellNix_5",
+        "incl": "incl_2",
+        "iohkNix": "iohkNix_5",
+        "nixpkgs": [
+          "cardano-node-clients",
+          "cardano-node",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1770307293,
+        "narHash": "sha256-66bbnASi59OLBth3VA4PPWqAFyllxfHICh1bbkf6F4k=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "b0a12592c4e996b57edf5bc5b9109ecc88c2273f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "10.5.4",
+        "repo": "cardano-node",
         "type": "github"
       }
     },
@@ -628,7 +1041,70 @@
         "type": "github"
       }
     },
+    "cardano-shell_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
     "customConfig": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "customConfig_2": {
       "locked": {
         "lastModified": 1630400035,
         "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
@@ -659,7 +1135,38 @@
         "type": "github"
       }
     },
+    "em_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685015066,
+        "narHash": "sha256-etAdEoYhtvjTw1ITh28WPNfwvvb5t/fpwCP6s7odSiQ=",
+        "owner": "deepfire",
+        "repo": "em",
+        "rev": "af69bb5c2ac2161434d8fea45f920f8f359587ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "deepfire",
+        "repo": "em",
+        "type": "github"
+      }
+    },
     "empty-flake": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "empty-flake_2": {
       "locked": {
         "lastModified": 1630400035,
         "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
@@ -743,6 +1250,74 @@
       }
     },
     "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_9": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -867,9 +1442,60 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts_7": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib_7"
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_8": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_8"
+      },
+      "locked": {
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -885,7 +1511,7 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
@@ -901,6 +1527,23 @@
       }
     },
     "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_2": {
       "flake": false,
       "locked": {
         "lastModified": 1600920045,
@@ -936,7 +1579,44 @@
         "url": "https://gitlab.haskell.org/ghc/ghc"
       }
     },
+    "ghc910X_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714520650,
+        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
+        "ref": "ghc-9.10",
+        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
+        "revCount": 62663,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.10",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
     "ghc911": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714817013,
+        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
+        "ref": "refs/heads/master",
+        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
+        "revCount": 62816,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc911_2": {
       "flake": false,
       "locked": {
         "lastModified": 1714817013,
@@ -1021,6 +1701,40 @@
         "type": "github"
       }
     },
+    "hackage-for-stackage_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768177803,
+        "narHash": "sha256-uu9PgCRezG6Bjk4Pes9eKwxIZ5GqO1Mbngx5ZCvu/+U=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "477a7ed0449f898b88e79eff138f9146eab0e1fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768177803,
+        "narHash": "sha256-uu9PgCRezG6Bjk4Pes9eKwxIZ5GqO1Mbngx5ZCvu/+U=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "477a7ed0449f898b88e79eff138f9146eab0e1fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackage-internal": {
       "flake": false,
       "locked": {
@@ -1069,7 +1783,56 @@
         "type": "github"
       }
     },
+    "hackage-internal_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackageNix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1745281520,
+        "narHash": "sha256-dk/70Cmjx8fGSURcAHQnowETeAOElzDxn0wH/P4DUWA=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "4c98778277c642e326b3cb7c2c9cbb9163b9ffbd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_2": {
       "flake": false,
       "locked": {
         "lastModified": 1745281520,
@@ -1103,6 +1866,38 @@
       }
     },
     "hackage_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768177814,
+        "narHash": "sha256-J5mkUye2ijGqF+b8UlMlibzIGJJgq8JGGrrr6sWlj64=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "6154887c84c5051677eff7ff60643907d8d9d0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768177814,
+        "narHash": "sha256-J5mkUye2ijGqF+b8UlMlibzIGJJgq8JGGrrr6sWlj64=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "6154887c84c5051677eff7ff60643907d8d9d0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_5": {
       "flake": false,
       "locked": {
         "lastModified": 1768177814,
@@ -1187,6 +1982,7 @@
         "ghc910X": "ghc910X",
         "ghc911": "ghc911",
         "hackage": [
+          "cardano-mpfs-onchain",
           "cardano-node-clients",
           "cardano-node",
           "hackageNix"
@@ -1204,6 +2000,7 @@
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy_2",
         "nixpkgs": [
+          "cardano-mpfs-onchain",
           "cardano-node-clients",
           "cardano-node",
           "nixpkgs"
@@ -1262,6 +2059,7 @@
         "hpc-coveralls": "hpc-coveralls_3",
         "iserv-proxy": "iserv-proxy_3",
         "nixpkgs": [
+          "cardano-mpfs-onchain",
           "cardano-node-clients",
           "haskellNix",
           "nixpkgs-unstable"
@@ -1319,6 +2117,7 @@
         "hpc-coveralls": "hpc-coveralls_4",
         "iserv-proxy": "iserv-proxy_4",
         "nixpkgs": [
+          "cardano-mpfs-onchain",
           "haskellNix",
           "nixpkgs-unstable"
         ],
@@ -1331,6 +2130,178 @@
         "nixpkgs-unstable": "nixpkgs-unstable_4",
         "old-ghc-nix": "old-ghc-nix_4",
         "stackage": "stackage_4"
+      },
+      "locked": {
+        "lastModified": 1768179148,
+        "narHash": "sha256-gd6fDUvmYv3/9HiuBH8g1weJcTQUlYpsON3ZeY2Wais=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "type": "github"
+      }
+    },
+    "haskellNix_5": {
+      "inputs": {
+        "HTTP": "HTTP_5",
+        "cabal-32": "cabal-32_5",
+        "cabal-34": "cabal-34_5",
+        "cabal-36": "cabal-36_5",
+        "cardano-shell": "cardano-shell_5",
+        "flake-compat": "flake-compat_7",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
+        "ghc910X": "ghc910X_2",
+        "ghc911": "ghc911_2",
+        "hackage": [
+          "cardano-node-clients",
+          "cardano-node",
+          "hackageNix"
+        ],
+        "hls-1.10": "hls-1.10_5",
+        "hls-2.0": "hls-2.0_5",
+        "hls-2.2": "hls-2.2_5",
+        "hls-2.3": "hls-2.3_5",
+        "hls-2.4": "hls-2.4_5",
+        "hls-2.5": "hls-2.5_5",
+        "hls-2.6": "hls-2.6_5",
+        "hls-2.7": "hls-2.7_5",
+        "hls-2.8": "hls-2.8_5",
+        "hpc-coveralls": "hpc-coveralls_5",
+        "hydra": "hydra_2",
+        "iserv-proxy": "iserv-proxy_5",
+        "nixpkgs": [
+          "cardano-node-clients",
+          "cardano-node",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_2",
+        "nixpkgs-2105": "nixpkgs-2105_2",
+        "nixpkgs-2111": "nixpkgs-2111_2",
+        "nixpkgs-2205": "nixpkgs-2205_2",
+        "nixpkgs-2211": "nixpkgs-2211_2",
+        "nixpkgs-2305": "nixpkgs-2305_5",
+        "nixpkgs-2311": "nixpkgs-2311_5",
+        "nixpkgs-unstable": "nixpkgs-unstable_5",
+        "old-ghc-nix": "old-ghc-nix_5",
+        "stackage": "stackage_5"
+      },
+      "locked": {
+        "lastModified": 1718797200,
+        "narHash": "sha256-ueFxTuZrQ3ZT/Fj5sSeUWlqKa4+OkUU1xW0E+q/XTfw=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
+        "type": "github"
+      }
+    },
+    "haskellNix_6": {
+      "inputs": {
+        "HTTP": "HTTP_6",
+        "cabal-32": "cabal-32_6",
+        "cabal-34": "cabal-34_6",
+        "cabal-36": "cabal-36_6",
+        "cardano-shell": "cardano-shell_6",
+        "flake-compat": "flake-compat_8",
+        "hackage": "hackage_4",
+        "hackage-for-stackage": "hackage-for-stackage_4",
+        "hackage-internal": "hackage-internal_4",
+        "hls": "hls_4",
+        "hls-1.10": "hls-1.10_6",
+        "hls-2.0": "hls-2.0_6",
+        "hls-2.10": "hls-2.10_4",
+        "hls-2.11": "hls-2.11_4",
+        "hls-2.12": "hls-2.12_4",
+        "hls-2.2": "hls-2.2_6",
+        "hls-2.3": "hls-2.3_6",
+        "hls-2.4": "hls-2.4_6",
+        "hls-2.5": "hls-2.5_6",
+        "hls-2.6": "hls-2.6_6",
+        "hls-2.7": "hls-2.7_6",
+        "hls-2.8": "hls-2.8_6",
+        "hls-2.9": "hls-2.9_4",
+        "hpc-coveralls": "hpc-coveralls_6",
+        "iserv-proxy": "iserv-proxy_6",
+        "nixpkgs": [
+          "cardano-node-clients",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305_6",
+        "nixpkgs-2311": "nixpkgs-2311_6",
+        "nixpkgs-2405": "nixpkgs-2405_4",
+        "nixpkgs-2411": "nixpkgs-2411_4",
+        "nixpkgs-2505": "nixpkgs-2505_4",
+        "nixpkgs-2511": "nixpkgs-2511_4",
+        "nixpkgs-unstable": "nixpkgs-unstable_6",
+        "old-ghc-nix": "old-ghc-nix_6",
+        "stackage": "stackage_6"
+      },
+      "locked": {
+        "lastModified": 1768179148,
+        "narHash": "sha256-gd6fDUvmYv3/9HiuBH8g1weJcTQUlYpsON3ZeY2Wais=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "type": "github"
+      }
+    },
+    "haskellNix_7": {
+      "inputs": {
+        "HTTP": "HTTP_7",
+        "cabal-32": "cabal-32_7",
+        "cabal-34": "cabal-34_7",
+        "cabal-36": "cabal-36_7",
+        "cardano-shell": "cardano-shell_7",
+        "flake-compat": "flake-compat_9",
+        "hackage": "hackage_5",
+        "hackage-for-stackage": "hackage-for-stackage_5",
+        "hackage-internal": "hackage-internal_5",
+        "hls": "hls_5",
+        "hls-1.10": "hls-1.10_7",
+        "hls-2.0": "hls-2.0_7",
+        "hls-2.10": "hls-2.10_5",
+        "hls-2.11": "hls-2.11_5",
+        "hls-2.12": "hls-2.12_5",
+        "hls-2.2": "hls-2.2_7",
+        "hls-2.3": "hls-2.3_7",
+        "hls-2.4": "hls-2.4_7",
+        "hls-2.5": "hls-2.5_7",
+        "hls-2.6": "hls-2.6_7",
+        "hls-2.7": "hls-2.7_7",
+        "hls-2.8": "hls-2.8_7",
+        "hls-2.9": "hls-2.9_5",
+        "hpc-coveralls": "hpc-coveralls_7",
+        "iserv-proxy": "iserv-proxy_7",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305_7",
+        "nixpkgs-2311": "nixpkgs-2311_7",
+        "nixpkgs-2405": "nixpkgs-2405_5",
+        "nixpkgs-2411": "nixpkgs-2411_5",
+        "nixpkgs-2505": "nixpkgs-2505_5",
+        "nixpkgs-2511": "nixpkgs-2511_5",
+        "nixpkgs-unstable": "nixpkgs-unstable_7",
+        "old-ghc-nix": "old-ghc-nix_7",
+        "stackage": "stackage_7"
       },
       "locked": {
         "lastModified": 1768179148,
@@ -1430,6 +2401,57 @@
         "type": "github"
       }
     },
+    "hls-1.10_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.0": {
       "flake": false,
       "locked": {
@@ -1498,6 +2520,57 @@
         "type": "github"
       }
     },
+    "hls-2.0_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.10": {
       "flake": false,
       "locked": {
@@ -1533,6 +2606,40 @@
       }
     },
     "hls-2.10_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10_5": {
       "flake": false,
       "locked": {
         "lastModified": 1743069404,
@@ -1600,6 +2707,40 @@
         "type": "github"
       }
     },
+    "hls-2.11_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.12": {
       "flake": false,
       "locked": {
@@ -1635,6 +2776,40 @@
       }
     },
     "hls-2.12_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12_5": {
       "flake": false,
       "locked": {
         "lastModified": 1758709460,
@@ -1719,6 +2894,57 @@
         "type": "github"
       }
     },
+    "hls-2.2_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.3": {
       "flake": false,
       "locked": {
@@ -1771,6 +2997,57 @@
       }
     },
     "hls-2.3_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3_7": {
       "flake": false,
       "locked": {
         "lastModified": 1695910642,
@@ -1855,6 +3132,57 @@
         "type": "github"
       }
     },
+    "hls-2.4_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.5": {
       "flake": false,
       "locked": {
@@ -1907,6 +3235,57 @@
       }
     },
     "hls-2.5_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5_7": {
       "flake": false,
       "locked": {
         "lastModified": 1701080174,
@@ -1991,6 +3370,57 @@
         "type": "github"
       }
     },
+    "hls-2.6_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.7": {
       "flake": false,
       "locked": {
@@ -2043,6 +3473,57 @@
       }
     },
     "hls-2.7_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7_7": {
       "flake": false,
       "locked": {
         "lastModified": 1708965829,
@@ -2127,6 +3608,57 @@
         "type": "github"
       }
     },
+    "hls-2.8_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.9": {
       "flake": false,
       "locked": {
@@ -2178,6 +3710,40 @@
         "type": "github"
       }
     },
+    "hls-2.9_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls_2": {
       "flake": false,
       "locked": {
@@ -2195,6 +3761,38 @@
       }
     },
     "hls_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_5": {
       "flake": false,
       "locked": {
         "lastModified": 1741604408,
@@ -2274,9 +3872,83 @@
         "type": "github"
       }
     },
+    "hpc-coveralls_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
     "hydra": {
       "inputs": {
         "nix": "nix",
+        "nixpkgs": [
+          "cardano-mpfs-onchain",
+          "cardano-node-clients",
+          "cardano-node",
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_2": {
+      "inputs": {
+        "nix": "nix_2",
         "nixpkgs": [
           "cardano-node-clients",
           "cardano-node",
@@ -2302,6 +3974,24 @@
     "incl": {
       "inputs": {
         "nixlib": "nixlib"
+      },
+      "locked": {
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
+    "incl_2": {
+      "inputs": {
+        "nixlib": "nixlib_2"
       },
       "locked": {
         "lastModified": 1693483555,
@@ -2346,6 +4036,7 @@
       "inputs": {
         "blst": "blst_2",
         "nixpkgs": [
+          "cardano-mpfs-onchain",
           "cardano-node-clients",
           "cardano-node",
           "nixpkgs"
@@ -2372,6 +4063,7 @@
       "inputs": {
         "blst": "blst_3",
         "nixpkgs": [
+          "cardano-mpfs-onchain",
           "cardano-node-clients",
           "nixpkgs"
         ],
@@ -2397,10 +4089,87 @@
       "inputs": {
         "blst": "blst_4",
         "nixpkgs": [
-          "nixpkgs"
+          "cardano-mpfs-onchain",
+          "haskellNix",
+          "nixpkgs-unstable"
         ],
         "secp256k1": "secp256k1_4",
         "sodium": "sodium_4"
+      },
+      "locked": {
+        "lastModified": 1770069549,
+        "narHash": "sha256-jHgw8KL0/TFGY2aVwxhD0DeDq7sl5Ti7jAp8T3RLNb0=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "0ce7cc21b9a4cfde41871ef486d01a8fafbf9627",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "0ce7cc21b9a4cfde41871ef486d01a8fafbf9627",
+        "type": "github"
+      }
+    },
+    "iohkNix_5": {
+      "inputs": {
+        "blst": "blst_5",
+        "nixpkgs": [
+          "cardano-node-clients",
+          "cardano-node",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1_5",
+        "sodium": "sodium_5"
+      },
+      "locked": {
+        "lastModified": 1769466714,
+        "narHash": "sha256-BORSlRJKEmYWHaNqEEUeM8b6pgNVzknFELMKM3rjyE8=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "f3ecc51c92ab72658c9b3b7289cfcc8a820a6316",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "cardano-node-release/10.5.4",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_6": {
+      "inputs": {
+        "blst": "blst_6",
+        "nixpkgs": [
+          "cardano-node-clients",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1_6",
+        "sodium": "sodium_6"
+      },
+      "locked": {
+        "lastModified": 1770069549,
+        "narHash": "sha256-jHgw8KL0/TFGY2aVwxhD0DeDq7sl5Ti7jAp8T3RLNb0=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "0ce7cc21b9a4cfde41871ef486d01a8fafbf9627",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "0ce7cc21b9a4cfde41871ef486d01a8fafbf9627",
+        "type": "github"
+      }
+    },
+    "iohkNix_7": {
+      "inputs": {
+        "blst": "blst_7",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1_7",
+        "sodium": "sodium_7"
       },
       "locked": {
         "lastModified": 1770069549,
@@ -2484,7 +4253,74 @@
         "type": "github"
       }
     },
+    "iserv-proxy_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "iserv-proxy_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "iserv-proxy_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
     "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_2": {
       "flake": false,
       "locked": {
         "lastModified": 1633514407,
@@ -2503,7 +4339,7 @@
     "mkdocs": {
       "inputs": {
         "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "dir": "mkdocs",
@@ -2528,6 +4364,27 @@
       },
       "locked": {
         "dir": "mkdocs",
+        "lastModified": 1769451260,
+        "narHash": "sha256-iICHXqK2dEnttA2m2voY9ryGYhDp/zgYfezjU2olfPw=",
+        "owner": "paolino",
+        "repo": "dev-assets",
+        "rev": "06b0878a5dc6ae0c86f45f5bd147952107b24fec",
+        "type": "github"
+      },
+      "original": {
+        "dir": "mkdocs",
+        "owner": "paolino",
+        "repo": "dev-assets",
+        "type": "github"
+      }
+    },
+    "mkdocs_3": {
+      "inputs": {
+        "flake-parts": "flake-parts_8",
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "dir": "mkdocs",
         "lastModified": 1764245756,
         "narHash": "sha256-ZSJInH2+xEjZO1h4MlA9RU4tLsYObgPMG70Ya7SqrVY=",
         "owner": "paolino",
@@ -2545,7 +4402,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -2563,7 +4420,43 @@
         "type": "github"
       }
     },
+    "nix_2": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_2",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-regression": "nixpkgs-regression_2"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixlib": {
+      "locked": {
+        "lastModified": 1667696192,
+        "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "babd9cd2ca6e413372ed59fbb1ecc3c3a5fd3e5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixlib_2": {
       "locked": {
         "lastModified": 1667696192,
         "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
@@ -2610,7 +4503,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2003_2": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_2": {
       "locked": {
         "lastModified": 1659914493,
         "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
@@ -2642,6 +4567,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2111_2": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2205": {
       "locked": {
         "lastModified": 1685573264,
@@ -2658,7 +4599,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2205_2": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2211": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2211_2": {
       "locked": {
         "lastModified": 1688392541,
         "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
@@ -2738,6 +4711,54 @@
         "type": "github"
       }
     },
+    "nixpkgs-2305_5": {
+      "locked": {
+        "lastModified": 1701362232,
+        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305_6": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305_7": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2311": {
       "locked": {
         "lastModified": 1719957072,
@@ -2802,6 +4823,54 @@
         "type": "github"
       }
     },
+    "nixpkgs-2311_5": {
+      "locked": {
+        "lastModified": 1701386440,
+        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311_6": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311_7": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2405": {
       "locked": {
         "lastModified": 1735564410,
@@ -2835,6 +4904,38 @@
       }
     },
     "nixpkgs-2405_3": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405_4": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405_5": {
       "locked": {
         "lastModified": 1735564410,
         "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
@@ -2898,6 +4999,38 @@
         "type": "github"
       }
     },
+    "nixpkgs-2411_4": {
+      "locked": {
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411_5": {
+      "locked": {
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2505": {
       "locked": {
         "lastModified": 1764560356,
@@ -2946,6 +5079,38 @@
         "type": "github"
       }
     },
+    "nixpkgs-2505_4": {
+      "locked": {
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505_5": {
+      "locked": {
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2511": {
       "locked": {
         "lastModified": 1764572236,
@@ -2979,6 +5144,38 @@
       }
     },
     "nixpkgs-2511_3": {
+      "locked": {
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511_4": {
+      "locked": {
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511_5": {
       "locked": {
         "lastModified": 1764572236,
         "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
@@ -3084,7 +5281,53 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_7": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_8": {
+      "locked": {
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_2": {
       "locked": {
         "lastModified": 1643052045,
         "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
@@ -3164,13 +5407,29 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs-unstable_5": {
       "locked": {
-        "lastModified": 1771147098,
-        "narHash": "sha256-jpfPdBjKO232s5NueoNEvvVzpndiUzPLNYcH4/Ov0gY=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3cb16bccd9facebae3ba29c6a76a4cc1b73462a",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_6": {
+      "locked": {
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
         "type": "github"
       },
       "original": {
@@ -3180,7 +5439,23 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs-unstable_7": {
+      "locked": {
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
@@ -3196,7 +5471,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1763678758,
         "narHash": "sha256-+hBiJ+kG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s=",
@@ -3212,7 +5487,39 @@
         "type": "github"
       }
     },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1763678758,
+        "narHash": "sha256-+hBiJ+kG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "117cc7f94e8072499b0a7aa4c52084fa4e11cc9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1763678758,
         "narHash": "sha256-+hBiJ+kG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s=",
@@ -3296,6 +5603,57 @@
         "type": "github"
       }
     },
+    "old-ghc-nix_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "CHaP": "CHaP",
@@ -3309,11 +5667,11 @@
           "cardano-node-clients",
           "cardano-node"
         ],
-        "cardano-node-clients": "cardano-node-clients",
-        "flake-parts": "flake-parts_5",
-        "haskellNix": "haskellNix_4",
-        "iohkNix": "iohkNix_4",
-        "mkdocs": "mkdocs_2",
+        "cardano-node-clients": "cardano-node-clients_2",
+        "flake-parts": "flake-parts_7",
+        "haskellNix": "haskellNix_7",
+        "iohkNix": "iohkNix_7",
+        "mkdocs": "mkdocs_3",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
@@ -3372,6 +5730,57 @@
       }
     },
     "secp256k1_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "secp256k1_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "secp256k1_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "secp256k1_7": {
       "flake": false,
       "locked": {
         "lastModified": 1683999695,
@@ -3456,6 +5865,57 @@
         "type": "github"
       }
     },
+    "sodium_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
+    "sodium_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
+    "sodium_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
     "stackage": {
       "flake": false,
       "locked": {
@@ -3520,6 +5980,54 @@
         "type": "github"
       }
     },
+    "stackage_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718756571,
+        "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "027672fb6fd45828b0e623c8152572d4058429ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768176911,
+        "narHash": "sha256-YDkcATzxXclYCQMzpph73BsoWxoCYa4KWW9zboEfTd4=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "032bfc7f4fee092347cad9a7acb6c6393e29fddf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768176911,
+        "narHash": "sha256-YDkcATzxXclYCQMzpph73BsoWxoCYa4KWW9zboEfTd4=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "032bfc7f4fee092347cad9a7acb6c6393e29fddf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -3550,9 +6058,42 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "inputs": {
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1710146030,

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,9 @@
       url = "github:lambdasistemi/cardano-node-clients";
     };
     cardano-node.follows = "cardano-node-clients/cardano-node";
-    cardano-mpfs-onchain = { url = "github:paolino/cardano-mpfs-onchain"; };
+    cardano-mpfs-onchain = {
+      url = "github:cardano-foundation/cardano-mpfs-onchain/001-fair-fee-model";
+    };
     cardano-mpfs-cage.follows = "cardano-mpfs-onchain/cardano-mpfs-cage";
   };
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -8,6 +8,8 @@ let
       lib.mkForce [ [ pkgs.libsodium-vrf ] ];
     packages.cardano-crypto-class.components.library.pkgconfig =
       lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ]];
+    packages.lzma.components.library.libs =
+      lib.mkForce [ pkgs.xz ];
   };
   shell = { pkgs, ... }: {
     tools = {
@@ -72,23 +74,16 @@ in {
     project.hsPkgs.cardano-mpfs-offchain.components.tests.e2e-tests;
   packages.haddock = haddock;
   packages.cardano-mpfs-swagger =
-    project.hsPkgs.cardano-mpfs-offchain
-      .components
-      .exes
-      .cardano-mpfs-swagger;
-  checks.swagger-up-to-date =
-    pkgs.runCommand "swagger-up-to-date" { } ''
-      ${
-        pkgs.lib.getExe
-          project.hsPkgs.cardano-mpfs-offchain
-            .components
-            .exes
-            .cardano-mpfs-swagger
-      } > $TMPDIR/swagger.json
-      diff -u ${../docs/assets/swagger.json} \
-        $TMPDIR/swagger.json \
-        || (echo "swagger.json is stale — run: \
-just update-swagger" && exit 1)
-      touch $out
-    '';
+    project.hsPkgs.cardano-mpfs-offchain.components.exes.cardano-mpfs-swagger;
+  checks.swagger-up-to-date = pkgs.runCommand "swagger-up-to-date" { } ''
+          ${
+            pkgs.lib.getExe
+            project.hsPkgs.cardano-mpfs-offchain.components.exes.cardano-mpfs-swagger
+          } > $TMPDIR/swagger.json
+          diff -u ${../docs/assets/swagger.json} \
+            $TMPDIR/swagger.json \
+            || (echo "swagger.json is stale — run: \
+    just update-swagger" && exit 1)
+          touch $out
+  '';
 }

--- a/specs/176-fair-fee-model/plan.md
+++ b/specs/176-fair-fee-model/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Fair Fee Model
+
+**Branch**: `176-fair-fee-model` | **Date**: 2026-04-10 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Adopt the fair fee model from cardano-mpfs-onchain, replace local helpers with upstream from cardano-node-clients, rename max_fee→tip. Vertical slices: every commit compiles, old code lives alongside new until fully replaced.
+
+## Technical Context
+
+**Language**: Haskell (GHC 9.8.4)
+**Key deps**: cardano-node-clients (bump to a37cbd6), cardano-mpfs-onchain (bump to 001-fair-fee-model branch tip)
+**Testing**: hspec unit + E2E on devnet
+**Constraint**: Every commit must compile. Old code only deleted after new code passes all tests.
+
+## Constitution Check
+
+All principles pass. No new dependencies outside the flake. Records of functions pattern preserved. Atomic block processing unchanged.
+
+## Implementation Phases (Vertical Slices)
+
+### Slice 1: Bump dependencies
+
+Bump `cardano-node-clients` and `cardano-mpfs-onchain` pins in `cabal.project` and `flake.nix`. Import new modules alongside existing code. Everything compiles, all tests pass (still using old code paths).
+
+**Files**: `cabal.project`, `flake.nix`, `flake.lock`
+
+### Slice 2: Import upstream helpers alongside local
+
+Add imports from `Cardano.Node.Client.Balance` and `Cardano.Node.Client.Evaluate` in `Internal.hs`. Alias them to avoid name clashes. Don't change any call sites yet.
+
+**Files**: `TxBuilder/Real/Internal.hs`
+
+### Slice 3: Import canonical types from onchain library
+
+Add `cardano-mpfs-onchain` Haskell library as a dependency. Import `Cardano.MPFS.OnChain.Types` alongside the local `Core.OnChain`. Map between old and new field names where needed.
+
+**Files**: `cardano-mpfs-offchain.cabal`, `Core/OnChain.hs`
+
+### Slice 4: New update tx builder with balanceFeeLoop
+
+Write `updateTokenFair` alongside the existing `updateTokenImpl`. Uses:
+- Upstream `evaluateAndBalance` (with Language param)
+- `balanceFeeLoop` for fee/refund convergence
+- Conservation equation: `refund_i = reqValue_i - tip - tx_fee/N`
+- New field names (`tip` not `maxFee`)
+
+Wire `updateTokenFair` as the active implementation. Old `updateTokenImpl` still exists.
+
+**Files**: `TxBuilder/Real/Update.hs`, `TxBuilder/Real.hs`
+
+### Slice 5: New reject tx builder with balanceFeeLoop
+
+Same pattern as slice 4 but for reject. Conservation equation is identical.
+
+**Files**: `TxBuilder/Real/Reject.hs`, `TxBuilder/Real.hs`
+
+### Slice 6: Rename fields
+
+`stateMaxFee` → `stateTip`, `requestFee` → `requestTip` in:
+- `Core/OnChain.hs` (types + serialization)
+- `TxBuilder/Real/Request.hs` (datum construction)
+- `TxBuilder/Real/Boot.hs` (state datum)
+- `TxBuilder/Config.hs` (`defaultMaxFee` → `defaultTip`)
+- `Indexer/Event.hs`, `Indexer/Follower.hs` (event processing)
+- `Indexer/Codecs.hs` (CBOR codecs)
+- `HTTP/Types.hs` (API request/response types)
+- All tests
+
+### Slice 7: Delete old code
+
+Remove `updateTokenImpl` (replaced by `updateTokenFair`), local copies of upstream helpers from `Internal.hs`.
+
+**Files**: `TxBuilder/Real/Internal.hs`, `TxBuilder/Real/Update.hs`
+
+### Slice 8: Tests + swagger + preprod
+
+- Fix all unit test assertions for new field names and fee model
+- Verify E2E tests pass with new validator blueprint
+- Regenerate swagger
+- Deploy to preprod, test full flow
+
+## CI Evidence (Slice 1)
+
+After bumping deps (cardano-node-clients to a37cbd6, cardano-mpfs-onchain to 001-fair-fee-model):
+
+- **Build**: compiles. `posixMsToSlot`/`posixMsCeilSlot` moved to local `NodeClient.hs` since the upstream refactored them out of `Provider`.
+- **Unit tests**: 2 failures — `script hash matches` and `mints exactly one token`. Expected: the new blueprint produces a different script hash (`e462b38f...` raw, `fd8ad19e...` after parameter application). Test fixtures hardcode the old hash.
+- **E2E tests**: all cage/update/reject tests fail with `evaluateAndBalance: script eval failed`. The offchain builds datums with old field layout (`max_fee`, `fee`), but the new validator expects `tip` fields. The blueprint IS loaded correctly (verified: `$MPFS_BLUEPRINT` points to new blueprint, hash confirmed).
+- **Key insight**: the failures are NOT from loading the wrong blueprint. They're from the offchain constructing datums with the old `OnChainTokenState`/`OnChainRequest` field layout. The new validator's `expect StateDatum(State{...})` pattern-match fails because the datum has 6 fields (with `max_fee`) but the new State type expects 5 fields (with `tip`).
+
+This confirms slices 4-6 (new tx builders + field renames) are required to make tests pass. Slices 2-3 (import upstream helpers/types) are safe intermediate steps.
+
+## Risks
+
+- **balanceFeeLoop convergence**: The refund calculation involves integer division. If the function `fee → outputs` isn't monotonic, the loop may not converge. Upstream has a max-iteration guard (returns error after N rounds).
+- **Blueprint mismatch**: The new validator must match the blueprint bundled in the docker image. If the onchain PR isn't merged, we can't deploy.
+- **Existing preprod tokens**: They use the old validator. They'll stop working with the new offchain. We need to boot new tokens.

--- a/specs/176-fair-fee-model/research.md
+++ b/specs/176-fair-fee-model/research.md
@@ -1,0 +1,76 @@
+# Research: Fair Fee Model
+
+## Upstream APIs
+
+### cardano-node-clients (a37cbd6)
+
+```haskell
+balanceFeeLoop
+    :: PParams ConwayEra
+    -> (Coin -> Either String (StrictSeq (TxOut ConwayEra)))
+    -> Int               -- max iterations
+    -> Tx ConwayEra
+    -> Either FeeLoopError (Tx ConwayEra)
+
+evaluateAndBalance
+    :: Language
+    -> Provider IO
+    -> PParams ConwayEra
+    -> [(TxIn, TxOut ConwayEra)]
+    -> Addr
+    -> Tx ConwayEra
+    -> IO (Tx ConwayEra)
+
+computeScriptIntegrity
+    :: Language -> PParams ConwayEra -> Redeemers ConwayEra
+    -> StrictMaybe ScriptIntegrityHash
+
+spendingIndex :: TxIn -> Set TxIn -> Word32
+placeholderExUnits :: ExUnits  -- ExUnits 0 0
+```
+
+Key: `balanceFeeLoop` takes a function `Coin -> outputs` that
+rebuilds outputs given the fee. It iterates until fee converges.
+This is what we need for the conservation equation where refunds
+depend on tx.fee.
+
+### cardano-mpfs-onchain (001-fair-fee-model)
+
+Aiken types:
+```
+State { owner, root, tip, process_time, retract_time }
+Request { requestToken, requestOwner, requestKey, requestValue, tip, submitted_at }
+```
+
+Conservation equation (both update and reject):
+```
+totalRefunded == totalInputLovelace - tx_fee - n * tip
+```
+
+Where tx_fee is the Plutus V3 `tx.fee` from the transaction context.
+
+### Haskell library (cardano-mpfs-onchain, 9a5ddbe)
+
+Canonical types with `stateTip` and `requestTip` fields.
+Can import directly instead of maintaining our own copies.
+
+## Current offchain flow (update tx)
+
+1. Query UTxOs, find state + requests
+2. Compute proofs speculatively
+3. Build refunds: `refund = reqValue - defaultMaxFee`
+4. Build tx body with outputs
+5. `evaluateAndBalance` → evaluate scripts → patch ExUnits → balance
+
+## New flow (update tx with fair fee)
+
+1. Query UTxOs, find state + requests (same)
+2. Compute proofs speculatively (same)
+3. Build tx skeleton with placeholder outputs
+4. Evaluate scripts → patch ExUnits
+5. `balanceFeeLoop`: given fee → compute refunds → rebuild outputs → recompute fee → iterate
+6. Final tx with converged fee and correct refunds
+
+The key difference: refunds are now a function of fee, so we
+can't compute them before knowing the fee. `balanceFeeLoop`
+solves this circular dependency.

--- a/specs/176-fair-fee-model/spec.md
+++ b/specs/176-fair-fee-model/spec.md
@@ -93,12 +93,21 @@ Rename `stateMaxFee` → `stateTip` and `requestFee` → `requestTip` in all on-
 - **SC-004**: No local copies of upstream helpers remain in `Internal.hs`.
 - **SC-005**: No references to `maxFee` or `max_fee` remain in the codebase.
 
+## Known Gap: Minimum Locked ADA
+
+The conservation equation `refund = locked - tip - fee/N` requires sufficient locked ADA for `refund >= minUTxO`. Currently there is no on-chain enforcement — requests can lock too little, making them unprocessable. The oracle must filter these off-chain.
+
+Tracked in cardano-foundation/cardano-mpfs-onchain#38: add `minLocked` field to State datum and enforce in `Contribute` validator.
+
+For now, the offchain `requestLockedAda` uses `tip + refundMinUTxO` as the minimum. The E2E tests use a low `tip` (100_000) to leave room for the fee share. Production deployments should set `tip` conservatively.
+
 ## Assumptions
 
 - The `cardano-mpfs-onchain` PR (#37) is merged before we start implementation.
-- The upstream `balanceFeeLoop` handles the PlutusV3 script evaluation correctly.
+- The TxBuild DSL (cardano-node-clients fix/eval-retry branch) handles conservation-aware fee convergence.
 - Existing preprod tokens (old validator) are abandoned — new tokens use the updated blueprint.
 - The `tip` value is set by the oracle at boot time and is immutable (same as `max_fee` was).
+- Requests that can't cover `tip + fee_share + minUTxO` are skipped by the oracle during update (not enforced on-chain yet, see #38).
 
 ## Vertical Slice Strategy
 

--- a/specs/176-fair-fee-model/spec.md
+++ b/specs/176-fair-fee-model/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Fair Fee Model + Upstream Helpers
+
+**Feature Branch**: `176-fair-fee-model`
+**Created**: 2026-04-10
+**Status**: Draft
+**Input**: lambdasistemi/cardano-mpfs-offchain#188
+
+## User Scenarios & Testing
+
+### User Story 1 — Requester pays fair fees (Priority: P1)
+
+A requester submits a request locking ADA. Under the old model, the locked ADA covers a worst-case `max_fee` that bundles the oracle's margin AND the transaction fee. The requester overpays because the actual tx fee is much lower than max_fee.
+
+Under the new model, the requester locks ADA covering only the oracle's `tip` (margin). The actual transaction fee (`tx.fee`) is split across requests at settlement time. The refund is: `locked_ada - tip - tx.fee/N` where N is the number of requests in the batch.
+
+**Why this priority**: This is the core behavioral change. The on-chain validator enforces the new conservation equation. Without this, the offchain can't build transactions that pass the updated validator.
+
+**Independent Test**: Boot token → submit request → update → verify refund equals `locked_ada - tip - share_of_tx_fee` (not `locked_ada - max_fee`).
+
+**Acceptance Scenarios**:
+
+1. **Given** a request with 10 ADA locked and tip=1 ADA, **When** the oracle processes it in a batch of 2 with tx fee 0.5 ADA, **Then** the refund is 10 - 1 - 0.25 = 8.75 ADA.
+2. **Given** the old validator, **When** building an update tx with the old code, **Then** it still works (backward compatibility during migration).
+3. **Given** the new validator, **When** building an update tx with the new code, **Then** the on-chain conservation equation passes.
+
+---
+
+### User Story 2 — Adopt upstream tx helpers (Priority: P2)
+
+The offchain has local copies of `computeScriptIntegrity`, `spendingIndex`, `placeholderExUnits`, and `evaluateAndBalance` in `Internal.hs`. These are now available upstream in `cardano-node-clients`. Replace local copies with upstream imports.
+
+**Why this priority**: Reduces maintenance burden and ensures we benefit from upstream fixes. The upstream `evaluateAndBalance` is parameterized by `Language`, supporting future multi-language validators.
+
+**Independent Test**: All existing unit and E2E tests pass after replacing local helpers with upstream.
+
+**Acceptance Scenarios**:
+
+1. **Given** the upstream helpers, **When** building any tx (boot, request, update, retract, reject, end), **Then** the tx is identical to what the local helpers produced.
+2. **Given** `Internal.hs`, **Then** the removed functions no longer exist locally.
+
+---
+
+### User Story 3 — Field renames: max_fee → tip (Priority: P3)
+
+Rename `stateMaxFee` → `stateTip` and `requestFee` → `requestTip` in all on-chain types, tx builders, indexer, codecs, HTTP types, and tests.
+
+**Why this priority**: Pure rename — no behavioral change. Can be done after the fee model works, or concurrently.
+
+**Independent Test**: All tests pass. Swagger reflects new field names.
+
+**Acceptance Scenarios**:
+
+1. **Given** the API, **When** booting a token, **Then** the state shows `tip` not `max_fee`.
+2. **Given** the codebase, **Then** no reference to `maxFee`, `max_fee`, `requestFee` remains.
+
+---
+
+### Edge Cases
+
+- What if `balanceFeeLoop` doesn't converge? The upstream implementation has a max iteration count and errors on divergence.
+- What if `tx.fee / N` doesn't divide evenly? The on-chain validator uses integer division; any remainder goes to the oracle (rounding in oracle's favor).
+- What about the reject tx? Reject also has a conservation equation — same `tip` model applies.
+- What about existing preprod tokens with `max_fee`? They use the old validator — can't interact with the new one. New tokens must be booted with the updated blueprint.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The update tx builder MUST use `balanceFeeLoop` to converge fee and refunds.
+- **FR-002**: Refund outputs MUST follow the conservation equation: `sum(refunds) = sum(inputs) - tx.fee - N * tip`.
+- **FR-003**: The reject tx builder MUST follow the same conservation equation (root unchanged, refunds adjusted for tx.fee).
+- **FR-004**: Local helper functions (`computeScriptIntegrity`, `spendingIndex`, `placeholderExUnits`, `evaluateAndBalance`) MUST be replaced with upstream imports from `cardano-node-clients`.
+- **FR-005**: On-chain type fields MUST be renamed: `stateMaxFee` → `stateTip`, `requestFee` → `requestTip`.
+- **FR-006**: The HTTP API MUST reflect new field names in request/response bodies.
+- **FR-007**: Swagger MUST be regenerated and pass the freshness check.
+- **FR-008**: The `cardano-node-clients` dependency MUST be bumped to `a37cbd6`.
+- **FR-009**: The `cardano-mpfs-onchain` dependency MUST be bumped to the commit with the fair fee model.
+- **FR-010**: Every commit MUST compile. Old code is only removed after new code works.
+
+### Key Entities
+
+- **State.tip**: Oracle's margin per request (was `max_fee`). Set at boot time.
+- **Request.tip**: Requester agrees to oracle's margin (was `fee`). Must match `state.tip` at update time.
+- **Conservation equation**: `sum(refunds) = sum(request_inputs_lovelace) - tx.fee - N * tip`
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: All 353+ unit tests pass with new fee model.
+- **SC-002**: All 21+ E2E tests pass on devnet with new validator blueprint.
+- **SC-003**: Preprod: boot new token with `tip`, insert, update, verify refund matches `locked - tip - fee_share`.
+- **SC-004**: No local copies of upstream helpers remain in `Internal.hs`.
+- **SC-005**: No references to `maxFee` or `max_fee` remain in the codebase.
+
+## Assumptions
+
+- The `cardano-mpfs-onchain` PR (#37) is merged before we start implementation.
+- The upstream `balanceFeeLoop` handles the PlutusV3 script evaluation correctly.
+- Existing preprod tokens (old validator) are abandoned — new tokens use the updated blueprint.
+- The `tip` value is set by the oracle at boot time and is immutable (same as `max_fee` was).
+
+## Vertical Slice Strategy
+
+To ensure every commit compiles and git bisect works:
+
+1. **Bump deps first** — bump `cardano-node-clients` and `cardano-mpfs-onchain` pins. Add new imports alongside old code. Everything compiles, tests pass (old validator still used).
+2. **Add new helpers alongside old** — import upstream `evaluateAndBalance`, `balanceFeeLoop` etc. Don't remove old ones yet.
+3. **Build new tx builders** — write new `updateTokenImpl'` using `balanceFeeLoop` + new conservation equation. Old `updateTokenImpl` still exists. Wire the new one.
+4. **Rename fields** — `maxFee` → `tip` everywhere. Old code that references `maxFee` is already gone because step 3 replaced it.
+5. **Delete old code** — remove local helpers from `Internal.hs`, remove old tx builder if any.
+6. **Update tests + swagger** — fix all assertions, regenerate swagger.

--- a/specs/176-fair-fee-model/tasks.md
+++ b/specs/176-fair-fee-model/tasks.md
@@ -1,0 +1,121 @@
+# Tasks: Fair Fee Model
+
+**Input**: [spec.md](spec.md), [plan.md](plan.md), [research.md](research.md)
+
+## Slice 1: Bump dependencies
+
+- [ ] T001 Bump `cardano-node-clients` pin in `cabal.project` to `a37cbd6`
+- [ ] T002 Bump `cardano-mpfs-onchain` pin in `flake.nix` to the 001-fair-fee-model branch tip
+- [ ] T003 Update `flake.lock`
+- [ ] T004 Verify build compiles with new deps (`nix develop -c cabal build all -O0`)
+
+**Checkpoint**: Everything compiles, all tests pass with old code.
+
+---
+
+## Slice 2: Import upstream helpers alongside local
+
+- [ ] T005 Import `Cardano.Node.Client.Balance` functions in `Internal.hs` with qualified aliases
+- [ ] T006 Import `Cardano.Node.Client.Evaluate.evaluateAndBalance` with alias
+- [ ] T007 Verify build compiles (no call site changes yet)
+
+**Checkpoint**: New imports available, old code untouched, tests pass.
+
+---
+
+## Slice 3: Import canonical types
+
+- [ ] T008 Add `cardano-mpfs-onchain` Haskell library to `cardano-mpfs-offchain.cabal` build-depends
+- [ ] T009 Import `Cardano.MPFS.OnChain.Types` in `Core/OnChain.hs` with aliases
+- [ ] T010 Verify build compiles
+
+**Checkpoint**: Canonical types available alongside local copies.
+
+---
+
+## Slice 4: New update tx builder (US1 — conservation equation)
+
+- [ ] T011 Write `updateTokenFair` in `TxBuilder/Real/Update.hs`:
+  - Uses upstream `evaluateAndBalance` (Language param)
+  - Uses `balanceFeeLoop` for fee/refund convergence
+  - Conservation: `refund_i = reqValue_i - tip - tx_fee/N`
+  - Remainder of `tx_fee % N` goes to oracle
+- [ ] T012 Wire `updateTokenFair` as the active `updateToken` in `TxBuilder/Real.hs`
+- [ ] T013 Keep old `updateTokenImpl` as `updateTokenLegacy` (not called, but compiles)
+- [ ] T014 Verify build compiles and unit tests pass
+
+**Checkpoint**: Update tx uses fair fee model. Old code still present.
+
+---
+
+## Slice 5: New reject tx builder
+
+- [ ] T015 Update `rejectRequestsImpl` in `TxBuilder/Real/Reject.hs`:
+  - Same conservation equation as update
+  - Uses `balanceFeeLoop`
+- [ ] T016 Verify build compiles
+
+**Checkpoint**: Reject tx uses fair fee model.
+
+---
+
+## Slice 6: Rename fields (US3)
+
+- [ ] T017 `Core/OnChain.hs`: `stateMaxFee` → `stateTip`, `requestFee` → `requestTip`, update ToData/FromData
+- [ ] T018 `TxBuilder/Config.hs`: `defaultMaxFee` → `defaultTip`
+- [ ] T019 `TxBuilder/Real/Request.hs`: datum construction uses `requestTip`
+- [ ] T020 `TxBuilder/Real/Boot.hs`: state datum uses `stateTip`
+- [ ] T021 `Indexer/Event.hs`, `Indexer/Follower.hs`: event field refs
+- [ ] T022 `Indexer/Codecs.hs`: CBOR codec field names
+- [ ] T023 `HTTP/Types.hs`: API types (`max_fee` → `tip` in JSON)
+- [ ] T024 All test files: update field references
+- [ ] T025 Verify build compiles and all tests pass
+
+**Checkpoint**: No `maxFee` or `max_fee` references remain.
+
+---
+
+## Slice 7: Delete old code (US2)
+
+- [ ] T026 Remove `updateTokenLegacy` from `Update.hs`
+- [ ] T027 Remove local `computeScriptIntegrity`, `spendingIndex`, `placeholderExUnits` from `Internal.hs`
+- [ ] T028 Remove local `evaluateAndBalance` from `Internal.hs`
+- [ ] T029 Switch all remaining call sites to upstream imports
+- [ ] T030 Verify build compiles and all tests pass
+
+**Checkpoint**: No local copies of upstream helpers.
+
+---
+
+## Slice 8: Tests + swagger + deploy
+
+- [ ] T031 Update unit tests for new fee model assertions
+- [ ] T032 Update E2E tests: verify refund = locked - tip - fee_share
+- [ ] T033 Run `just update-swagger` and verify freshness check passes
+- [ ] T034 Run `just ci` locally
+- [ ] T035 Deploy to preprod with new blueprint
+- [ ] T036 Preprod: boot new token, insert, update, verify fair refund
+- [ ] T037 Create PR, update description, push, wait for CI, merge
+
+---
+
+## Dependencies
+
+```
+T001-T003 → T004 (bump → verify)
+T005-T006 → T007 (import → verify)
+T008-T009 → T010 (types → verify)
+T004, T007, T010 → T011 (all imports ready → new builder)
+T011-T012 → T014 (new builder → verify)
+T014 → T015 (update done → reject)
+T014 → T017-T025 (can rename in parallel with reject)
+T025, T016 → T026-T030 (rename + reject done → delete old)
+T030 → T031-T037 (all code clean → tests + deploy)
+```
+
+## Notes
+
+- Every slice is a commit (or small group of commits). Each compiles.
+- Old code is renamed with `Legacy` suffix, not deleted, until slice 7.
+- The `cardano-mpfs-onchain` PR must be merged before slice 1 (we need the commit hash for the pin).
+- `balanceFeeLoop` closure: `\fee -> let refunds = ... in Right (StrictSeq.fromList (stateOut : refunds))` — refunds depend on fee.


### PR DESCRIPTION
## Summary

Work in progress for #188. Vertical slices — each commit compiles.

### Slice 1 (done): Bump dependencies
- cardano-node-clients: a37cbd6 (adds balanceFeeLoop, upstream helpers)  
- cardano-mpfs-onchain: 001-fair-fee-model branch (fair fee + Haskell library)
- posixMsToSlot moved to local NodeClient.hs (upstream refactored it out)
- 2 unit tests fail on script hash (expected — new blueprint)

### Remaining slices
2. Import upstream helpers alongside local
3. Import canonical types from onchain library
4. New update tx builder with balanceFeeLoop
5. New reject tx builder with balanceFeeLoop  
6. Rename fields (max_fee → tip)
7. Delete old code
8. Tests + swagger + deploy

Spec: [spec.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/feat/fair-fee-model/specs/176-fair-fee-model/spec.md)
Plan: [plan.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/feat/fair-fee-model/specs/176-fair-fee-model/plan.md)
Tasks: [tasks.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/feat/fair-fee-model/specs/176-fair-fee-model/tasks.md)