### PR TITLE
fix: pin cardano-node-clients to merged main commit

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -68,7 +68,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-node-clients
-  tag: dcad2ebf4c15d4c07d0885d0d4ddcfb5712758b7
+  tag: b9d4a4dd5d6edbcf1c2a845ccade163726e19765
   --sha256: 1sv91a6g9817fklpkn8fm5gwcql1p98w9xvg2c0xs4fy1z11cz7x
 
 -- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API

--- a/flake.lock
+++ b/flake.lock
@@ -551,11 +551,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773679061,
-        "narHash": "sha256-UmpnkFrGnJSpCqKd1a/cDZYA/tlw0Wr+VC5mFZENLxY=",
+        "lastModified": 1776072244,
+        "narHash": "sha256-YiYXu5kWqC1lsea2xnvfasN3e7lINrmy/urgKWOjKoU=",
         "owner": "lambdasistemi",
         "repo": "cardano-node-clients",
-        "rev": "1104f7cb47fee3169074da1c803ff633b85c43f7",
+        "rev": "b9d4a4dd5d6edbcf1c2a845ccade163726e19765",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Normalize the `cardano-node-clients` dependency so downstream no longer pins an unmerged upstream PR commit.

This updates both dependency paths to the merged upstream `main` commit `b9d4a4dd5d6edbcf1c2a845ccade163726e19765`:

- `cabal.project` `source-repository-package`
- `flake.lock` input `cardano-node-clients`

## Why this change

Before this PR, `cardano-mpfs-offchain` depended on `cardano-node-clients` commit `dcad2ebf4c15d4c07d0885d0d4ddcfb5712758b7` in `cabal.project`.

That commit came from open upstream PR `lambdasistemi/cardano-node-clients#33`, which meant downstream was effectively depending on a feature-branch SHA instead of a merged upstream commit. That is brittle and makes dependency provenance harder to reason about.

Upstream PR `#33` is now merged on `main` as commit `b9d4a4dd5d6edbcf1c2a845ccade163726e19765`, so downstream should pin that merged commit instead.

## Notes

- This is a dependency-normalization PR only. No local application code changed.
- `flake.lock` previously pointed at older merged commit `1104f7cb47fee3169074da1c803ff633b85c43f7`; it is refreshed here for consistency with the `cabal.project` pin.

## Verification

- Verified upstream `cardano-node-clients#33` is merged.
- Verified the previous `cabal.project` pin `dcad2eb...` was not on `origin/main`.
- Verified the new pin `b9d4a4d...` is the merged upstream `main` commit.
