### PR TITLE
chore: bump cardano-node-clients to 7a95704

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -68,8 +68,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-node-clients
-  tag: 5ada87b332cc601f4fcc30cdf3e9991183770aef
-  --sha256: 148spf0snd7s66bgaf86ps3asvhv8awi348sa2hh1mdijdpmqwxq
+  tag: fdf6fe1c8afc6f1e20c66b25fd5f28e1b46e6519
+  --sha256: 1sykch5944i117n110zs5rpa7pxx8s4ymflwx94vmb1fffw6hdi7
 
 source-repository-package
   type: git

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitterSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitterSpec.hs
@@ -39,7 +39,10 @@ import Cardano.MPFS.Submitter
     , Submitter (..)
     )
 import Cardano.MPFS.Submitter.N2C (mkN2CSubmitter)
-import Cardano.Node.Client.Balance (balanceTx)
+import Cardano.Node.Client.Balance
+    ( BalanceResult (..)
+    , balanceTx
+    )
 import Cardano.Node.Client.E2E.Setup
     ( addKeyWitness
     , genesisAddr
@@ -91,7 +94,7 @@ spec =
                                     error
                                         $ "balanceTx failed: "
                                             <> show err
-                                Right balanced -> do
+                                Right BalanceResult{balancedTx = balanced} -> do
                                     let signed =
                                             addKeyWitness
                                                 genesisSignKey

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
@@ -181,7 +181,10 @@ import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
-import Cardano.Node.Client.Balance (balanceTx)
+import Cardano.Node.Client.Balance
+    ( BalanceResult (..)
+    , balanceTx
+    )
 import Cardano.Slotting.Slot (SlotNo)
 
 -- | Empty MPF root (32 zero bytes).
@@ -283,7 +286,7 @@ evaluateAndBalance prov pp inputUtxos changeAddr tx =
                 error
                     $ "evaluateAndBalance: "
                         <> show err
-            Right balanced -> pure balanced
+            Right br -> pure (balancedTx br)
 
 -- | Build the cage 'Script' from config bytes.
 mkCageScript

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -57,7 +57,10 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Node.Client.Balance (balanceTx)
+import Cardano.Node.Client.Balance
+    ( BalanceResult (..)
+    , balanceTx
+    )
 
 -- | Build a request-insert transaction.
 requestInsertImpl
@@ -192,7 +195,7 @@ requestImpl cfg prov st tid key op addr = do
         Left err ->
             error
                 $ "requestImpl: " <> show err
-        Right balanced -> pure balanced
+        Right br -> pure (balancedTx br)
 
 -- | Compute the ADA to lock in a request output.
 --

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/BalanceSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/BalanceSpec.hs
@@ -54,6 +54,7 @@ import Cardano.MPFS.Generators
     )
 import Cardano.Node.Client.Balance
     ( BalanceError (..)
+    , BalanceResult (..)
     , balanceTx
     )
 
@@ -134,7 +135,7 @@ propChangeCorrect =
                         emptyTx
             in  case result of
                     Left _ -> False
-                    Right tx ->
+                    Right BalanceResult{balancedTx = tx} ->
                         let fee =
                                 tx
                                     ^. bodyTxL
@@ -175,7 +176,7 @@ propFeeSet =
                         emptyTx
             in  case result of
                     Left _ -> False
-                    Right tx ->
+                    Right BalanceResult{balancedTx = tx} ->
                         let fee =
                                 tx
                                     ^. bodyTxL


### PR DESCRIPTION
## Summary

Bump `cardano-node-clients` pin from `5ada87b` to `fdf6fe1` (latest main), picking up:

- [#52](https://github.com/lambdasistemi/cardano-node-clients/pull/52) — eval budget ExUnits fix
- [#57](https://github.com/lambdasistemi/cardano-node-clients/pull/57) — surface terminal eval failures
- [#58](https://github.com/lambdasistemi/cardano-node-clients/pull/58) — typed balance errors
- [#59](https://github.com/lambdasistemi/cardano-node-clients/pull/59) — Peek convergence
- [#60](https://github.com/lambdasistemi/cardano-node-clients/pull/60) — explicit change output (`BalanceResult`)
- [#62](https://github.com/lambdasistemi/cardano-node-clients/pull/62) — skip Peek re-iteration when fee is zero

Adapts all `balanceTx` callers (lib, test, e2e) to the new `BalanceResult` return type from #60.

## Test plan

- [x] Format + hlint clean
- [x] `updateToken` unit tests pass (5/5, previously hung due to #62)
- [x] `balanceTx` callers verified