### PR TITLE
fix: remove stale cardano-mpfs-cage flake input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
     cardano-mpfs-onchain = {
       url = "github:cardano-foundation/cardano-mpfs-onchain";
     };
-    cardano-mpfs-cage.follows = "cardano-mpfs-onchain/cardano-mpfs-cage";
   };
 
   outputs = inputs@{ self, nixpkgs, flake-parts, haskellNix, mkdocs, asciinema


### PR DESCRIPTION
The offchain flake had `cardano-mpfs-cage.follows = "cardano-mpfs-onchain/cardano-mpfs-cage"` but cardano-mpfs-onchain no longer has a cardano-mpfs-cage input (removed in [PR #43](https://github.com/cardano-foundation/cardano-mpfs-onchain/pull/43)). This would break `nix flake update`.

Local CI passes (360 tests, format, hlint).