### PR TITLE
docs: update for cage merge

### DIFF
--- a/NAVIGATION.md
+++ b/NAVIGATION.md
@@ -28,14 +28,15 @@ Pure types and logic with no IO dependencies.
 | Module | Description |
 |--------|-------------|
 | [`Core.Types`][s-core-types] | `TokenId`, `Root`, `Request`, `TokenState`, `Operation`, `BlockId`, ledger re-exports |
-| [`Core.OnChain`][s-core-onchain] | Plutus datum/redeemer encodings, `cageScriptHash`, `cageAddr`, `deriveAssetName` |
-| [`Core.Proof`][s-core-proof] | MPF proof to on-chain `ProofStep` conversion, Aiken-compatible CBOR serialization |
-| [`Core.Blueprint`][s-core-blueprint] | CIP-57 blueprint loading, schema validation, UPLC script extraction |
+| [`Core.OnChain`][s-core-onchain] | Re-exports from [`cardano-mpfs-cage`][cage] + offchain-specific `cageScriptHash`, `cageAddr` |
+| [`Core.Proof`][s-core-proof] | Re-exports from [`cardano-mpfs-cage`][cage]: `serializeProof`, `toProofSteps` |
+| [`Core.Blueprint`][s-core-blueprint] | Re-exports from [`cardano-mpfs-cage`][cage]: blueprint loading, schema validation |
 
 [s-core-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Types%22&type=code
 [s-core-onchain]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.OnChain%22&type=code
 [s-core-proof]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Proof%22&type=code
 [s-core-blueprint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Blueprint%22&type=code
+[cage]: https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/main/haskell
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -274,8 +274,8 @@ graph LR
     P2["Phase 2 ✓\nTx Builders +\nBalance"]
     P3["Phase 3 ✓\nE2E Tests"]
     P4["Phase 4 ✓\nIndexer +\nPersistence"]
-    P5["Phase 5\nHTTP Service"]
-    P6["Phase 6\nDeployment"]
+    P5["Phase 5 ✓\nHTTP Service"]
+    P6["Phase 6 ✓\nDeployment"]
 
     P0 --> P1 --> P2 --> P3 --> P4 --> P5 --> P6
 
@@ -284,6 +284,8 @@ graph LR
     style P2 fill:#2d6,color:#fff
     style P3 fill:#2d6,color:#fff
     style P4 fill:#2d6,color:#fff
+    style P5 fill:#2d6,color:#fff
+    style P6 fill:#2d6,color:#fff
 ```
 
 ### Phase 0 — MPF Library ✓
@@ -347,17 +349,17 @@ graph LR
 - Application wiring with shared RocksDB instance
 - 197 unit tests (14 CageFollower, 27 persistent trie)
 
-### Phase 5 — HTTP Service
+### Phase 5 — HTTP Service ✓
 
-- Servant HTTP API matching TypeScript interface
+- Servant HTTP API
 - Endpoints: facts, proofs, tokens, requests
 - Swagger/OpenAPI documentation
-- Submitter with retry logic
+- Submitter with N2C LocalTxSubmission
 
-### Phase 6 — Deployment
+### Phase 6 — Deployment ✓
 
 - Docker image via Nix
-- Deploy to plutimus.com
+- Deployed to plutimus.com
 - Integration with production Cardano node
 
 ## Open Questions

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -129,9 +129,9 @@ All modules live under `Cardano.MPFS`.
 | Module | Purpose |
 |--------|---------|
 | [`Core.Types`][s-types] | `TokenId`, `Root`, `Request`, `TokenState`, `CageConfig` |
-| [`Core.OnChain`][s-onchain] | Datum/redeemer encodings, `cagePolicyId`, `cageAddress`, PlutusV3 script |
-| [`Core.Blueprint`][s-blueprint] | CIP-57 blueprint schema loading and validation |
-| [`Core.Proof`][s-proof] | MPF proof to on-chain `ProofStep` conversion |
+| [`Core.OnChain`][s-onchain] | Re-exports from [cage][cage-lib] + offchain-specific `cagePolicyId`, `cageAddr` |
+| [`Core.Blueprint`][s-blueprint] | Re-exports from [cage][cage-lib]: blueprint loading, validation |
+| [`Core.Proof`][s-proof] | Re-exports from [cage][cage-lib]: proof serialization |
 | [`Core.Balance`][s-balance] | `balanceTx` — fee estimation fixpoint loop |
 
 [s-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Types%22&type=code
@@ -139,6 +139,7 @@ All modules live under `Cardano.MPFS`.
 [s-blueprint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Blueprint%22&type=code
 [s-proof]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Proof%22&type=code
 [s-balance]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Balance%22&type=code
+[cage-lib]: https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/main/haskell
 
 ### Interfaces — record-of-functions singletons
 


### PR DESCRIPTION
Core.OnChain, Core.Proof, Core.Blueprint are now thin re-export modules
from [cardano-mpfs-cage](https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/main/haskell).
Update documentation to reflect this.

- NAVIGATION.md: mark Core modules as re-exports, link to cage
- overview.md: same in Module Hierarchy table
- PLAN.md: mark Phase 5 + 6 complete