### PR TITLE
fix: update docs URL from paolino to lambdasistemi

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ just update-swagger  # regenerate docs/assets/swagger.json
 
 ## Documentation
 
-https://paolino.github.io/cardano-mpfs-offchain/
+https://lambdasistemi.github.io/cardano-mpfs-offchain/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Cardano MPFS Offchain
-site_url: https://paolino.github.io/cardano-mpfs-offchain/
+site_url: https://lambdasistemi.github.io/cardano-mpfs-offchain/
 repo_url: https://github.com/lambdasistemi/cardano-mpfs-offchain
 
 theme:


### PR DESCRIPTION
README.md and mkdocs.yml pointed to https://paolino.github.io/cardano-mpfs-offchain/ which returns 404. Updated to https://lambdasistemi.github.io/cardano-mpfs-offchain/ which is live.