### PR TITLE
docs: fix inaccuracies across README, overview, and navigation

### DIFF
--- a/NAVIGATION.md
+++ b/NAVIGATION.md
@@ -132,7 +132,7 @@ Per-token MPF trie backends. Each cage token has an isolated trie.
 ## Transaction Building
 
 Real `TxBuilder` implementations for all cage protocol operations.
-Each builds a full `Tx ConwayEra` with PlutusV3 script witnesses.
+Each builds a full transaction with PlutusV3 script witnesses.
 
 | Module | Description |
 |--------|-------------|

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # cardano-mpfs-offchain
 
-Off-chain companion to
+Off-chain service for
 [cardano-mpfs-onchain](https://github.com/cardano-foundation/cardano-mpfs-onchain)
---- indexing, transaction building, and submission for Cardano Merkle
+--- indexing, transaction building, and HTTP API for Cardano Merkle
 Patricia Forestry.
 
-## Packages
-
-| Package | Description |
-|---|---|
-| `merkle-patricia-forestry` | 16-ary hex Patricia trie with Blake2b-256, compatible with the [Aiken on-chain implementation](https://github.com/aiken-lang/merkle-patricia-forestry) |
-| `cardano-mpfs-offchain` | Off-chain service layer: N2C node client, UTxO provider, transaction balancing, submission, and skeleton indexer |
+Connects to a Cardano node via N2C, indexes cage UTxOs into RocksDB,
+and exposes a REST API for building and submitting cage transactions.
+On-chain types and proof serialization come from the
+[cage library](https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/main/haskell)
+in the onchain repo.
 
 ## HTTP API
 
@@ -48,6 +47,15 @@ just unit-offchain   # offchain unit tests
 just e2e             # E2E tests (requires cardano-node in PATH)
 just update-swagger  # regenerate docs/assets/swagger.json
 ```
+
+## Dependencies
+
+| Package | Source | Role |
+|---------|--------|------|
+| [cardano-mpfs-cage](https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/main/haskell) | cardano-mpfs-onchain | On-chain types, proof serialization, blueprint loading |
+| [cardano-node-clients](https://github.com/lambdasistemi/cardano-node-clients) | lambdasistemi | TxBuild DSL, N2C provider, fee balancing |
+| [haskell-mts](https://github.com/lambdasistemi/haskell-mts) | lambdasistemi | MPF trie (pure + RocksDB backends) |
+| [chain-follower](https://github.com/lambdasistemi/chain-follower) | lambdasistemi | ChainSync protocol client |
 
 ## Documentation
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -89,32 +89,32 @@ processing each block in a single atomic transaction. The `Provider`,
 
 ```mermaid
 graph TD
-    OFFCHAIN["cardano-mpfs-offchain<br/>Service interfaces + N2C client"]
-    MPF["merkle-patricia-forestry<br/>MPF trie library"]
-    ONCHAIN["cardano-mpfs-onchain<br/>Aiken validators"]
+    OFFCHAIN["cardano-mpfs-offchain<br/>Service: indexer + HTTP API"]
+    CAGE["cardano-mpfs-cage<br/>On-chain types, proofs,<br/>tx builders"]
+    CLIENTS["cardano-node-clients<br/>TxBuild DSL, N2C provider,<br/>fee balancing"]
+    MTS["haskell-mts<br/>MPF trie library"]
+    ONCHAIN["cardano-mpfs-onchain<br/>Aiken validators + cage lib"]
     LEDGER["cardano-ledger<br/>Conway era types"]
-    OUROBOROS["ouroboros-network<br/>N2C protocols"]
-    PLUTUS["plutus-core / plutus-tx<br/>PlutusData encoding"]
 
-    OFFCHAIN --> MPF
+    OFFCHAIN --> CAGE
+    OFFCHAIN --> CLIENTS
+    OFFCHAIN --> MTS
     OFFCHAIN --> LEDGER
-    OFFCHAIN --> OUROBOROS
-    OFFCHAIN --> PLUTUS
-    OFFCHAIN -.->|"on-chain types<br/>& script hash"| ONCHAIN
+    CAGE -.->|"lives in"| ONCHAIN
 
     style OFFCHAIN fill:#e1f5fe
-    style MPF fill:#e8f5e9
+    style CAGE fill:#fff3e0
+    style CLIENTS fill:#e8f5e9
+    style MTS fill:#e8f5e9
     style ONCHAIN fill:#fff3e0
     style LEDGER fill:#f3e5f5
-    style OUROBOROS fill:#f3e5f5
-    style PLUTUS fill:#f3e5f5
 ```
 
 | Color | Meaning |
 |-------|---------|
 | Blue | This project |
-| Green | MPF trie library (same repo) |
-| Orange | On-chain Aiken validators (separate repo) |
+| Orange | On-chain repo (validators + cage library) |
+| Green | lambdasistemi libraries |
 | Purple | Cardano ecosystem dependencies |
 
 ## Module Hierarchy
@@ -132,13 +132,11 @@ All modules live under `Cardano.MPFS`.
 | [`Core.OnChain`][s-onchain] | Re-exports from [cage][cage-lib] + offchain-specific `cagePolicyId`, `cageAddr` |
 | [`Core.Blueprint`][s-blueprint] | Re-exports from [cage][cage-lib]: blueprint loading, validation |
 | [`Core.Proof`][s-proof] | Re-exports from [cage][cage-lib]: proof serialization |
-| [`Core.Balance`][s-balance] | `balanceTx` — fee estimation fixpoint loop |
 
 [s-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Types%22&type=code
 [s-onchain]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.OnChain%22&type=code
 [s-blueprint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Blueprint%22&type=code
 [s-proof]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Proof%22&type=code
-[s-balance]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Balance%22&type=code
 [cage-lib]: https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/main/haskell
 
 ### Interfaces — record-of-functions singletons
@@ -203,22 +201,15 @@ All modules live under `Cardano.MPFS`.
 [s-idx-rollback]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Rollback%22&type=code
 [s-inverseop]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageInverseOp%22&type=code
 
-### NodeClient — N2C protocol clients
+### Node integration — thin wrappers over [cardano-node-clients](https://github.com/lambdasistemi/cardano-node-clients)
 
 | Module | Purpose |
 |--------|---------|
-| [`NodeClient.Connection`][s-nc-conn] | [`runNodeClient`][s-runnc] — multiplexed N2C connection |
-| [`NodeClient.LocalStateQuery`][s-nc-lsq] | LSQ protocol client for UTxOs and PParams |
-| [`NodeClient.LocalTxSubmission`][s-nc-ltxs] | Tx submission protocol client |
-| [`NodeClient.Codecs`][s-nc-codecs] | N2C codec bundle |
-| [`NodeClient.Types`][s-nc-types] | `LSQChannel`, `LTxSChannel` |
+| [`Provider.NodeClient`][s-prov-nc] | N2C-backed `Provider` (UTxOs, PParams, script eval, slot conversion) |
+| [`Submitter.N2C`][s-sub-n2c] | N2C-backed `Submitter` (LocalTxSubmission) |
 
-[s-nc-conn]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Connection%22&type=code
-[s-runnc]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=runNodeClient+path%3ANodeClient&type=code
-[s-nc-lsq]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.LocalStateQuery%22&type=code
-[s-nc-ltxs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.LocalTxSubmission%22&type=code
-[s-nc-codecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Codecs%22&type=code
-[s-nc-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.NodeClient.Types%22&type=code
+[s-prov-nc]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Provider.NodeClient%22&type=code
+[s-sub-n2c]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Submitter.N2C%22&type=code
 
 ### TxBuilder — cage protocol transactions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,19 @@
 # Cardano MPFS Offchain
 
-Haskell offchain companion to
+Off-chain service for
 [cardano-mpfs-onchain](https://github.com/cardano-foundation/cardano-mpfs-onchain)
---- indexing, transaction building, and submission for Cardano Merkle
+--- indexing, transaction building, and HTTP API for Cardano Merkle
 Patricia Forestry.
 
-## Packages
-
-| Package | Description |
-|---|---|
-| `merkle-patricia-forestry` | 16-ary hex Patricia trie with Blake2b-256, compatible with the [Aiken on-chain implementation](https://github.com/aiken-lang/merkle-patricia-forestry) |
-| `cardano-mpfs-offchain` | Off-chain service layer: N2C node client, UTxO provider, transaction balancing, submission, and skeleton indexer |
+Connects to a Cardano node via N2C, indexes cage UTxOs into RocksDB,
+and exposes a REST API for building and submitting cage transactions.
+On-chain types and proof serialization come from the
+[cage library](https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/main/haskell).
 
 ## Documentation
 
-- [Architecture Overview](architecture/overview.md) --- system diagram, phases, design principles
+- [Architecture Overview](architecture/overview.md) --- system diagram, dependency graph, module hierarchy
+- [Block Processing](architecture/block-processing.md) --- one block = one RocksDB transaction
 - [Data Sources](architecture/data-sources.md) --- N2C connection, mini-protocols, data flow
 - [Singletons](architecture/singletons.md) --- record-of-functions interfaces
 - [Testing](architecture/testing.md) --- unit tests, E2E tests with cardano-node subprocess


### PR DESCRIPTION
- README: remove fake package table (`merkle-patricia-forestry` is an external dep, not shipped here), add proper dependency table with links
- docs/index.md: same cleanup, add block-processing link
- overview.md: fix External Dependencies diagram (MPF is external, add cage and cardano-node-clients as distinct nodes), remove nonexistent `Core.Balance`, fix NodeClient section to reference actual modules (`Provider.NodeClient`, `Submitter.N2C`)
- NAVIGATION.md: remove `Tx ConwayEra` type reference