### PR TITLE
docs: add proof-carrying API spec and plan

### DIFF
--- a/specs/177-proof-carrying-api/plan.md
+++ b/specs/177-proof-carrying-api/plan.md
@@ -11,9 +11,12 @@ can mostly assemble bundles in the HTTP layer using existing `Context`
 proof hooks, while transaction endpoints likely require a richer
 `TxBuilder` return type so the server can return the unsigned
 transaction plus the exact UTxO and MPF witnesses the builder relied on.
-The first milestone is explicitly the HTTP client read-verification
-scenario: discover the root via `GET /status`, fetch proof-bearing token
-data, and verify it offline before tackling transaction-signing flows.
+The design correction is that proof-bearing JSON must carry its own
+`utxo_root` and indexed `chainpoint`; verification must not depend on a
+separate metadata-discovery call. The first milestone is explicitly the
+HTTP client read-verification scenario: fetch proof-bearing token data,
+read the baked-in root and chain point, and verify it offline before
+tackling transaction-signing flows.
 
 ## Technical Context
 
@@ -29,7 +32,8 @@ queries
 **Performance Goals**: Preserve current synchronous request model while
 adding proof generation bounded by the number of bundled UTxOs and trie
 facts in the response
-**Constraints**: One indexed snapshot per response, unsigned txs only,
+**Constraints**: One indexed root plus one indexed chain point per
+response, unsigned txs only,
 direct `/utxo/*` debugging endpoints remain valid, Swagger JSON must stay
 fresh
 **Scale/Scope**: 13 affected endpoints (`GET /status`, 4 token query
@@ -106,7 +110,9 @@ Add the shared proof-bearing response types in `HTTP.Types` and extend
 `StatusResponse` with the current UTxO-CSMT root. Wire `statusHandler`
 to surface the root from `Context.utxoRoot` alongside existing chain tip
 and checkpoint metadata. Treat `GET /utxo/root` as an explicitly
-supported sibling endpoint, not incidental duplication.
+supported sibling endpoint, not incidental duplication. Define the
+shared `VerificationSnapshot` shape so later proof-bearing responses bake
+in `utxo_root` and indexed `chainpoint`.
 
 **Files**: `HTTP/API.hs`, `HTTP/Types.hs`, `HTTP/Server.hs`,
 `test/Cardano/MPFS/HTTP/StatusSpec.hs`
@@ -127,18 +133,20 @@ structured objects:
 
 Use the existing `Context.resolveUtxo`, `Context.utxoProof`, and trie
 proof code to attach witnessed state/request UTxOs and MPF proofs to the
-business payloads.
+business payloads. Each proof-bearing response object must include the
+exact `utxo_root` and indexed `chainpoint` it targets.
 
 **Files**: `HTTP/API.hs`, `HTTP/Types.hs`, `HTTP/Server.hs`,
 `test/Cardano/MPFS/HTTP/TokenSpec.hs`,
 `test/Cardano/MPFS/HTTP/TrieSpec.hs`,
 `test/Cardano/MPFS/HTTP/RequestsSpec.hs`
 
-**Goal**: Clients can verify all read-side responses offline against one
-reported snapshot.
+**Goal**: Clients can verify all read-side responses offline using the
+snapshot baked into each response.
 
 **Milestone**: After slices 1 and 2, the first client-side scenario is
-complete without touching transaction-signing flows.
+complete without touching transaction-signing flows: read a proof-bearing
+response, extract `utxo_root` and `chainpoint`, and verify.
 
 ### Slice 3: Rich transaction builder boundary
 
@@ -147,7 +155,7 @@ a proof-bearing bundle type that can carry:
 
 - the unsigned transaction
 - the set of consumed inputs as witnessed UTxOs
-- snapshot metadata
+- baked-in `utxo_root` and indexed `chainpoint`
 - optional trie proof payloads for trie-dependent operations
 
 Update mocks and the top-level wiring in `TxBuilder/Real.hs`.
@@ -175,6 +183,7 @@ at most, minimal state context:
 
 Boot omits MPF sections entirely; the others include them only when the
 builder actually relies on trie/state facts that the client must trust.
+All of them still carry `utxo_root` and indexed `chainpoint`.
 
 **Files**: `TxBuilder/Real/Boot.hs`,
 `TxBuilder/Real/Request.hs`,
@@ -208,7 +217,8 @@ Regenerate `docs/assets/swagger.json`, make the freshness check pass,
 and add contract-style tests that cross-check inline proof data against
 the existing direct `/utxo/*` endpoints for the same indexed snapshot.
 That includes explicit root-consistency checks between `GET /status` and
-`GET /utxo/root`.
+`GET /utxo/root`, and explicit checks that proof-bearing JSON already
+contains the root and chain point needed for external matching.
 
 **Files**: `docs/assets/swagger.json`,
 `HTTP/Types.hs`, `HTTP/Swagger.hs`,
@@ -218,8 +228,8 @@ That includes explicit root-consistency checks between `GET /status` and
 
 - **Snapshot drift during response assembly**: If the indexer advances
   between reading data and building proofs, the response can mix roots.
-  The implementation must capture one snapshot root per response and
-  reject or retry inconsistent bundles.
+  The implementation must capture one `utxo_root` plus one indexed
+  `chainpoint` per response and reject or retry inconsistent bundles.
 - **TxBuilder boundary expansion**: Changing the builder return type
   touches every tx endpoint and the mock builder. The migration should be
   staged so each commit still compiles.

--- a/specs/177-proof-carrying-api/plan.md
+++ b/specs/177-proof-carrying-api/plan.md
@@ -11,6 +11,9 @@ can mostly assemble bundles in the HTTP layer using existing `Context`
 proof hooks, while transaction endpoints likely require a richer
 `TxBuilder` return type so the server can return the unsigned
 transaction plus the exact UTxO and MPF witnesses the builder relied on.
+The first milestone is explicitly the HTTP client read-verification
+scenario: discover the root via `GET /status`, fetch proof-bearing token
+data, and verify it offline before tackling transaction-signing flows.
 
 ## Technical Context
 
@@ -132,6 +135,9 @@ business payloads.
 **Goal**: Clients can verify all read-side responses offline against one
 reported snapshot.
 
+**Milestone**: After slices 1 and 2, the first client-side scenario is
+complete without touching transaction-signing flows.
+
 ### Slice 3: Rich transaction builder boundary
 
 Replace the current `TxBuilder` return type of bare `Tx ConwayEra` with
@@ -149,7 +155,8 @@ Update mocks and the top-level wiring in `TxBuilder/Real.hs`.
 
 **Why this slice exists**: Parsing the final tx in `HTTP.Server` is not
 enough to reconstruct MPF proof intent or stable proof-to-request
-association for batched flows.
+association for batched flows. It starts only after the read-side
+HTTP-client scenario is accepted.
 
 ### Slice 4: Simple tx endpoints on the new bundle type
 

--- a/specs/177-proof-carrying-api/plan.md
+++ b/specs/177-proof-carrying-api/plan.md
@@ -105,13 +105,15 @@ facts justified the unsigned transaction.
 Add the shared proof-bearing response types in `HTTP.Types` and extend
 `StatusResponse` with the current UTxO-CSMT root. Wire `statusHandler`
 to surface the root from `Context.utxoRoot` alongside existing chain tip
-and checkpoint metadata.
+and checkpoint metadata. Treat `GET /utxo/root` as an explicitly
+supported sibling endpoint, not incidental duplication.
 
 **Files**: `HTTP/API.hs`, `HTTP/Types.hs`, `HTTP/Server.hs`,
 `test/Cardano/MPFS/HTTP/StatusSpec.hs`
 
 **Goal**: Establish the verification snapshot contract before changing
-the token and tx endpoints.
+the token and tx endpoints, and make `/status` and `/utxo/root` agree as
+the same source of truth.
 
 ### Slice 2: Proof-bearing query endpoints
 
@@ -205,6 +207,8 @@ every contributing request before signing.
 Regenerate `docs/assets/swagger.json`, make the freshness check pass,
 and add contract-style tests that cross-check inline proof data against
 the existing direct `/utxo/*` endpoints for the same indexed snapshot.
+That includes explicit root-consistency checks between `GET /status` and
+`GET /utxo/root`.
 
 **Files**: `docs/assets/swagger.json`,
 `HTTP/Types.hs`, `HTTP/Swagger.hs`,

--- a/specs/177-proof-carrying-api/plan.md
+++ b/specs/177-proof-carrying-api/plan.md
@@ -1,0 +1,220 @@
+# Implementation Plan: Proof-Carrying API Responses
+
+**Branch**: `177-proof-carrying-api` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/177-proof-carrying-api/spec.md`
+
+## Summary
+
+Upgrade the affected query and transaction-building endpoints from bare
+state/hex/CBOR payloads to proof-bearing JSON objects. Query endpoints
+can mostly assemble bundles in the HTTP layer using existing `Context`
+proof hooks, while transaction endpoints likely require a richer
+`TxBuilder` return type so the server can return the unsigned
+transaction plus the exact UTxO and MPF witnesses the builder relied on.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.8.4)
+**Primary Dependencies**: servant, swagger2, cardano-ledger,
+cardano-utxo-csmt, cardano-mpfs-onchain
+**Storage**: RocksDB-backed index/state plus persistent trie manager
+**Testing**: hspec unit tests, HTTP endpoint specs, E2E devnet tests,
+Swagger freshness check via `just update-swagger`
+**Target Platform**: Linux server (Nix-built service and Docker image)
+**Project Type**: web-service for unsigned transaction building and trie
+queries
+**Performance Goals**: Preserve current synchronous request model while
+adding proof generation bounded by the number of bundled UTxOs and trie
+facts in the response
+**Constraints**: One indexed snapshot per response, unsigned txs only,
+direct `/utxo/*` debugging endpoints remain valid, Swagger JSON must stay
+fresh
+**Scale/Scope**: 13 affected endpoints (`GET /status`, 4 token query
+endpoints, 8 tx-building endpoints) plus shared schemas, docs, and
+tests
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Ledger-Native Types | Pass | Witness bundles should reuse existing `TxIn`, `TxOut`, and serialized ledger CBOR rather than invent shadow chain types |
+| II. Records of Functions | Pass | `TxBuilder` may return a richer product type, but remains a record-of-functions boundary |
+| III. Atomic Block Processing | N/A | No block application or RocksDB write-batch changes |
+| IV. External Signing | Pass | Responses remain unsigned; richer metadata helps clients verify before signing |
+| V. Aiken Compatibility | Pass | MPF proofs reuse existing trie proof encoding; UTxO proofs come from the indexed CSMT state |
+| VI. Test Locally First | Pass | HTTP, unit, E2E, and Swagger freshness checks all run locally |
+| VII. Nix Reproducibility | Pass | No new non-flake tooling required |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/177-proof-carrying-api/
+├── spec.md
+├── research.md
+└── plan.md
+```
+
+### Source Code Changes
+
+```text
+cardano-mpfs-offchain/lib/Cardano/MPFS/
+├── Context.hs                 # Existing UTxO proof hooks used by HTTP/query layer
+├── TxBuilder.hs               # Builder interface likely returns proof-bearing bundles
+├── TxBuilder/Real.hs          # Wire richer builder results
+├── TxBuilder/Real/Boot.hs     # Boot witness bundle (wallet inputs only)
+├── TxBuilder/Real/Request.hs  # Request insert/delete/update witness bundles
+├── TxBuilder/Real/Update.hs   # Update bundle with request/state MPF proofs
+├── TxBuilder/Real/Retract.hs  # Retract bundle with request/state witnesses
+├── TxBuilder/Real/Reject.hs   # Reject bundle for batched Phase 3 requests
+├── TxBuilder/Real/End.hs      # End bundle with consumed inputs
+├── HTTP/API.hs                # Response types for affected endpoints change from scalars to objects
+├── HTTP/Types.hs              # Shared proof-bearing response schemas
+├── HTTP/Server.hs             # Assemble query bundles and serialize tx bundles
+└── HTTP/Swagger.hs            # Swagger description updates if schema naming/notes need tightening
+
+cardano-mpfs-offchain/test/Cardano/MPFS/
+├── HTTP/StatusSpec.hs         # `GET /status` root + snapshot contract
+├── HTTP/TokenSpec.hs          # `GET /tokens/:id`
+├── HTTP/TrieSpec.hs           # `GET /facts/:key`, `GET /proofs/:key`
+├── HTTP/RequestsSpec.hs       # `GET /requests`
+└── TxBuilderSpec.hs           # Rich tx bundle shape and proof association
+
+cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/
+├── HTTPLifecycleSpec.hs       # Inline proof contracts and direct `/utxo/*` cross-checks
+└── CageFlowSpec.hs            # Update/request/reject/end flows with proof-bearing tx responses
+
+docs/
+└── assets/swagger.json        # Regenerated API contract
+```
+
+**Structure Decision**: Keep the implementation inside the existing
+single Haskell service. Query proof bundling lives primarily in
+`HTTP.*`; transaction proof bundling crosses `TxBuilder` and `HTTP.*`
+because the builder is the only layer that knows which inputs and trie
+facts justified the unsigned transaction.
+
+## Implementation Phases
+
+### Slice 1: Shared response model + status root
+
+Add the shared proof-bearing response types in `HTTP.Types` and extend
+`StatusResponse` with the current UTxO-CSMT root. Wire `statusHandler`
+to surface the root from `Context.utxoRoot` alongside existing chain tip
+and checkpoint metadata.
+
+**Files**: `HTTP/API.hs`, `HTTP/Types.hs`, `HTTP/Server.hs`,
+`test/Cardano/MPFS/HTTP/StatusSpec.hs`
+
+**Goal**: Establish the verification snapshot contract before changing
+the token and tx endpoints.
+
+### Slice 2: Proof-bearing query endpoints
+
+Convert the affected token query endpoints from scalar payloads to
+structured objects:
+
+- `GET /tokens/:id`
+- `GET /tokens/:id/facts/:key`
+- `GET /tokens/:id/proofs/:key`
+- `GET /tokens/:id/requests`
+
+Use the existing `Context.resolveUtxo`, `Context.utxoProof`, and trie
+proof code to attach witnessed state/request UTxOs and MPF proofs to the
+business payloads.
+
+**Files**: `HTTP/API.hs`, `HTTP/Types.hs`, `HTTP/Server.hs`,
+`test/Cardano/MPFS/HTTP/TokenSpec.hs`,
+`test/Cardano/MPFS/HTTP/TrieSpec.hs`,
+`test/Cardano/MPFS/HTTP/RequestsSpec.hs`
+
+**Goal**: Clients can verify all read-side responses offline against one
+reported snapshot.
+
+### Slice 3: Rich transaction builder boundary
+
+Replace the current `TxBuilder` return type of bare `Tx ConwayEra` with
+a proof-bearing bundle type that can carry:
+
+- the unsigned transaction
+- the set of consumed inputs as witnessed UTxOs
+- snapshot metadata
+- optional trie proof payloads for trie-dependent operations
+
+Update mocks and the top-level wiring in `TxBuilder/Real.hs`.
+
+**Files**: `TxBuilder.hs`, `TxBuilder/Real.hs`,
+`Mock/TxBuilder.hs`, `test/Cardano/MPFS/TxBuilderSpec.hs`
+
+**Why this slice exists**: Parsing the final tx in `HTTP.Server` is not
+enough to reconstruct MPF proof intent or stable proof-to-request
+association for batched flows.
+
+### Slice 4: Simple tx endpoints on the new bundle type
+
+Migrate the tx endpoints that only need witnessed consumed inputs and,
+at most, minimal state context:
+
+- `POST /tx/boot`
+- `POST /tx/request/insert`
+- `POST /tx/request/delete`
+- `POST /tx/request/update`
+- `POST /tx/retract`
+- `POST /tx/reject`
+- `POST /tx/end`
+
+Boot omits MPF sections entirely; the others include them only when the
+builder actually relies on trie/state facts that the client must trust.
+
+**Files**: `TxBuilder/Real/Boot.hs`,
+`TxBuilder/Real/Request.hs`,
+`TxBuilder/Real/Retract.hs`,
+`TxBuilder/Real/Reject.hs`,
+`TxBuilder/Real/End.hs`,
+`HTTP/API.hs`, `HTTP/Types.hs`, `HTTP/Server.hs`,
+`test/Cardano/MPFS/TxBuilderSpec.hs`,
+`e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs`
+
+### Slice 5: `POST /tx/update` proof bundle
+
+Handle the hardest endpoint separately. `POST /tx/update` batches
+pending requests and applies trie changes, so the response must carry:
+
+- witnessed state input
+- witnessed request inputs
+- MPF proofs for every request key/value the update relied on
+- deterministic association between each request and its proof data
+
+**Files**: `TxBuilder/Real/Update.hs`, `HTTP/Types.hs`,
+`HTTP/Server.hs`, `test/Cardano/MPFS/TxBuilderSpec.hs`,
+`e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs`
+
+**Goal**: A client can inspect a batched update transaction and verify
+every contributing request before signing.
+
+### Slice 6: Swagger + end-to-end contract checks
+
+Regenerate `docs/assets/swagger.json`, make the freshness check pass,
+and add contract-style tests that cross-check inline proof data against
+the existing direct `/utxo/*` endpoints for the same indexed snapshot.
+
+**Files**: `docs/assets/swagger.json`,
+`HTTP/Types.hs`, `HTTP/Swagger.hs`,
+`e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs`
+
+## Risks
+
+- **Snapshot drift during response assembly**: If the indexer advances
+  between reading data and building proofs, the response can mix roots.
+  The implementation must capture one snapshot root per response and
+  reject or retry inconsistent bundles.
+- **TxBuilder boundary expansion**: Changing the builder return type
+  touches every tx endpoint and the mock builder. The migration should be
+  staged so each commit still compiles.
+- **Batch response size**: `update` and `reject` can include many
+  witnessed inputs. The API contract must keep proof-to-item association
+  explicit even when payloads get large.
+- **Swagger churn**: Several endpoints currently return `Hex`; changing
+  them to objects affects schema names, examples, and the freshness
+  check in one sweep.

--- a/specs/177-proof-carrying-api/research.md
+++ b/specs/177-proof-carrying-api/research.md
@@ -20,6 +20,26 @@ This means the feature does not require new indexer persistence or new
 cryptographic formats for UTxO proofs. The missing work is bundling these
 proofs into the higher-level API responses.
 
+## Root Endpoint Duplication Is Intentional
+
+The service already exposes `GET /utxo/root`, and this should stay true
+even after `GET /status` starts returning the same root.
+
+Decision: treat the duplication as intentional, not accidental.
+
+Why:
+
+- `GET /status` is the ergonomic entry point for the high-level
+  proof-carrying client flow.
+- `GET /utxo/root` is the low-level debugging and compatibility endpoint
+  that mirrors the underlying CSMT source of truth more directly.
+- In isolated deployments, a client may have no separate CSMT service to
+  consult, so this service must still be able to act as the Merkle-root
+  source.
+
+Constraint: both endpoints must read from the same indexed state, and
+tests should assert they return the same root for the same snapshot.
+
 ## Query Endpoints Need Structured Response Objects
 
 The affected query endpoints currently return scalar or flat payloads:

--- a/specs/177-proof-carrying-api/research.md
+++ b/specs/177-proof-carrying-api/research.md
@@ -1,0 +1,119 @@
+# Research: Proof-Carrying API Responses
+
+## Existing Proof Primitives Already Exist
+
+The offchain context already exposes the primitives needed for UTxO
+verification:
+
+- `resolveUtxo :: TxIn -> m (Maybe ByteString)`
+- `utxoProof :: TxIn -> m (Maybe ByteString)`
+- `utxoRoot :: m (Maybe ByteString)`
+
+The HTTP layer already exposes direct debugging endpoints for the same
+data:
+
+- `GET /utxo/:txId/:txIx`
+- `GET /utxo/:txId/:txIx/proof`
+- `GET /utxo/root`
+
+This means the feature does not require new indexer persistence or new
+cryptographic formats for UTxO proofs. The missing work is bundling these
+proofs into the higher-level API responses.
+
+## Query Endpoints Need Structured Response Objects
+
+The affected query endpoints currently return scalar or flat payloads:
+
+- `GET /tokens/:id` → `TokenStateJSON`
+- `GET /tokens/:id/facts/:key` → `Hex`
+- `GET /tokens/:id/proofs/:key` → `Hex`
+- `GET /tokens/:id/requests` → `[RequestJSON]`
+- `GET /status` → chain tip + checkpoint only
+
+That shape cannot carry:
+
+- the verification snapshot (`utxo_root`, checkpoint metadata)
+- the resolved `TxOut` bytes for the relevant UTxO
+- the UTxO-CSMT inclusion proof
+- the MPF inclusion proof alongside the business payload
+
+Decision: change the existing affected endpoints to structured JSON
+objects rather than adding parallel `/v2` endpoints.
+
+Why rejected:
+
+- Parallel endpoints would duplicate Swagger surface area and test
+  coverage.
+- The issue asks to augment existing responses, not add an alternate API.
+- Direct UTxO proof endpoints already exist for low-level debugging, so
+  a second high-level API family would be redundant.
+
+## Transaction Responses Need Builder-Level Metadata
+
+Current transaction endpoints serialize a bare `Tx ConwayEra` to hex in
+`HTTP.Server`, while `TxBuilder` returns only `m (Tx ConwayEra)`.
+
+That is enough to sign and submit, but not enough to produce a
+trust-minimized verification bundle because the HTTP layer cannot recover
+all of the logical facts the builder used, especially:
+
+- which token state UTxO was trusted
+- which request UTxOs were selected from a larger set
+- which trie keys/values need MPF proofs
+- how bundled proofs map to individual requests in batched update/reject
+  flows
+
+Decision: enrich the transaction-builder boundary to return a structured
+bundle, not just the unsigned transaction.
+
+Likely shape:
+
+- unsigned transaction
+- witnessed consumed inputs (`TxIn`, resolved `TxOut`, UTxO proof)
+- snapshot metadata (`utxo_root`, checkpoint identifiers)
+- optional MPF proof section for trie-dependent operations
+
+Alternative rejected: parse the finished transaction in `HTTP.Server`
+and then derive proofs there. That can recover spent `TxIn`s, but it
+cannot reliably reconstruct the builder's logical proof intent for MPF
+data.
+
+## Snapshot Consistency Must Be Explicit
+
+The issue requires clients to verify responses against an independently
+obtained UTxO-CSMT root. The service already exposes `/utxo/root`, but
+inline proof-bearing responses need their own snapshot metadata so a
+client can reject mixed-root bundles.
+
+Decision: every proof-bearing response should carry the root (and, where
+already available, checkpoint metadata) for the indexed snapshot that
+the bundled proofs target.
+
+Consequence:
+
+- `GET /status` becomes the primary discovery endpoint for the current
+  root.
+- Inline query and transaction responses should either carry the same
+  root directly or include equivalent snapshot metadata that unambiguously
+  identifies it.
+
+## No Indexer Write-Path Changes Required
+
+The feature changes the HTTP contract and transaction-builder interface,
+not the block-processing or RocksDB write path.
+
+That keeps the constitutional risk low:
+
+- Atomic block processing is unchanged.
+- The server still returns unsigned transactions only.
+- Proof bytes come from existing UTxO-CSMT and trie code paths rather
+  than a new custom proof format.
+
+## Boot Is a Special Case
+
+`POST /tx/boot` still needs proof-bearing input witnesses for consumed
+wallet UTxOs, but it has no pre-existing trie state to prove.
+
+Decision: boot responses include UTxO witnesses and snapshot metadata,
+but omit MPF proof sections entirely instead of inventing empty
+placeholders.

--- a/specs/177-proof-carrying-api/research.md
+++ b/specs/177-proof-carrying-api/research.md
@@ -52,7 +52,7 @@ The affected query endpoints currently return scalar or flat payloads:
 
 That shape cannot carry:
 
-- the verification snapshot (`utxo_root`, checkpoint metadata)
+- the verification snapshot (`utxo_root`, indexed `chainpoint`)
 - the resolved `TxOut` bytes for the relevant UTxO
 - the UTxO-CSMT inclusion proof
 - the MPF inclusion proof alongside the business payload
@@ -90,7 +90,7 @@ Likely shape:
 
 - unsigned transaction
 - witnessed consumed inputs (`TxIn`, resolved `TxOut`, UTxO proof)
-- snapshot metadata (`utxo_root`, checkpoint identifiers)
+- snapshot metadata (`utxo_root`, indexed `chainpoint`)
 - optional MPF proof section for trie-dependent operations
 
 Alternative rejected: parse the finished transaction in `HTTP.Server`
@@ -100,22 +100,25 @@ data.
 
 ## Snapshot Consistency Must Be Explicit
 
-The issue requires clients to verify responses against an independently
-obtained UTxO-CSMT root. The service already exposes `/utxo/root`, but
-inline proof-bearing responses need their own snapshot metadata so a
-client can reject mixed-root bundles.
+The design originally relied too much on discovering the root via
+`GET /status` and then applying that out-of-band to proof-bearing
+responses. That is wrong for client verification and external-provider
+matching.
 
-Decision: every proof-bearing response should carry the root (and, where
-already available, checkpoint metadata) for the indexed snapshot that
-the bundled proofs target.
+Decision: every proof-bearing response must carry the exact `utxo_root`
+and indexed `chainpoint` for the snapshot the bundled proofs target.
+The response JSON itself becomes the primary verification artifact.
 
 Consequence:
 
-- `GET /status` becomes the primary discovery endpoint for the current
-  root.
-- Inline query and transaction responses should either carry the same
-  root directly or include equivalent snapshot metadata that unambiguously
-  identifies it.
+- Clients do not need a separate discovery call before verifying a
+  proof-bearing response.
+- External trusted providers can match on `chainpoint` and compare the
+  baked-in `utxo_root` directly.
+- `GET /status` and `GET /utxo/root` remain useful comparison/debugging
+  endpoints, but verification does not depend on fetching metadata from
+  them first.
+- Tests must reject mixed-root and mixed-chainpoint bundles.
 
 ## No Indexer Write-Path Changes Required
 
@@ -134,6 +137,6 @@ That keeps the constitutional risk low:
 `POST /tx/boot` still needs proof-bearing input witnesses for consumed
 wallet UTxOs, but it has no pre-existing trie state to prove.
 
-Decision: boot responses include UTxO witnesses and snapshot metadata,
-but omit MPF proof sections entirely instead of inventing empty
-placeholders.
+Decision: boot responses include UTxO witnesses, `utxo_root`, and the
+indexed `chainpoint`, but omit MPF proof sections entirely instead of
+inventing empty placeholders.

--- a/specs/177-proof-carrying-api/spec.md
+++ b/specs/177-proof-carrying-api/spec.md
@@ -11,36 +11,41 @@
 
 A wallet, oracle, or downstream indexer reads token state, facts, and
 pending requests from an untrusted offchain service. Each response must
-carry the UTxO witness and MPF proof material needed to verify the
-returned data against an independently obtained UTxO-CSMT root.
+carry the UTxO witness, the UTxO root, the indexed chain point, and MPF
+proof material needed to verify the returned data against an
+independently checked UTxO-CSMT root.
 
 **Why this priority**: Trust-minimized reads are the foundation for the
 rest of the API. If the server can lie about state or facts, every
 downstream decision built on that data is unsafe.
 
-**Independent Test**: Call `GET /status` to obtain the current indexed
-root, then call `GET /tokens/:id`, `GET /tokens/:id/facts/:key`,
-`GET /tokens/:id/proofs/:key`, and `GET /tokens/:id/requests`. Verify
-offline that every returned UTxO exists in the indexed set and every
-fact proof matches the reported token root.
+**Independent Test**: Call `GET /tokens/:id`,
+`GET /tokens/:id/facts/:key`, `GET /tokens/:id/proofs/:key`, and
+`GET /tokens/:id/requests`. Verify offline that each response carries
+its own `utxo_root` and `chainpoint`, every returned UTxO exists in the
+indexed set, and every fact proof matches the reported token root.
 
 **Acceptance Scenarios**:
 
 1. **Given** an existing token, **When** the client calls
    `GET /tokens/:id`, **Then** the response includes the returned token
-   state plus the state UTxO witness and its UTxO-CSMT inclusion proof.
+   state plus the state UTxO witness, its UTxO-CSMT inclusion proof, the
+   `utxo_root`, and the indexed `chainpoint`.
 2. **Given** an existing key/value in the trie, **When** the client
    calls `GET /tokens/:id/facts/:key`, **Then** the response includes
-   the fact value, the state UTxO witness/proof, and an MPF inclusion
-   proof tying that key/value to the reported root.
+   the fact value, the state UTxO witness/proof, the `utxo_root`, the
+   indexed `chainpoint`, and an MPF inclusion proof tying that key/value
+   to the reported root.
 3. **Given** an existing key/value in the trie, **When** the client
    calls `GET /tokens/:id/proofs/:key`, **Then** the response includes
-   the MPF proof and the state UTxO witness/proof needed to trust the
-   root the proof is checked against.
+   the MPF proof, the state UTxO witness/proof, the `utxo_root`, and
+   the indexed `chainpoint` needed to trust the root the proof is
+   checked against.
 4. **Given** pending requests for a token, **When** the client calls
    `GET /tokens/:id/requests`, **Then** each returned request includes
-   the request UTxO reference, resolved TxOut, and UTxO-CSMT inclusion
-   proof, with no ambiguity about which proof belongs to which request.
+   the request UTxO reference, resolved TxOut, UTxO-CSMT inclusion
+   proof, `utxo_root`, and indexed `chainpoint`, with no ambiguity about
+   which proof belongs to which request.
 
 ---
 
@@ -49,7 +54,9 @@ fact proof matches the reported token root.
 An external signer asks the service to build an unsigned transaction.
 Because signing happens client-side and the offchain service is
 untrusted, the response must explain every input the transaction spends
-and every trie fact the transaction logic depends on.
+and every trie fact the transaction logic depends on, and it must carry
+the `utxo_root` plus indexed `chainpoint` for the exact snapshot the
+proofs target.
 
 **Why this priority**: External signing is a project constitution
 principle. Returning bare CBOR is not enough if the client cannot verify
@@ -57,27 +64,27 @@ what it is being asked to sign.
 
 **Independent Test**: Call each affected transaction-building endpoint
 and confirm the response contains the unsigned transaction plus a
-verification bundle for every spent input and every trie-dependent datum
-used by the builder.
+verification bundle with `utxo_root`, indexed `chainpoint`, every spent
+input, and every trie-dependent datum used by the builder.
 
 **Acceptance Scenarios**:
 
 1. **Given** `POST /tx/update`, **When** the client builds an update
    transaction, **Then** the response includes the unsigned transaction,
    every spent input resolved as a TxOut with a UTxO-CSMT inclusion
-   proof, and MPF proofs for the state root and request keys used to
-   justify the update.
+   proof, the `utxo_root`, the indexed `chainpoint`, and MPF proofs for
+   the state root and request keys used to justify the update.
 2. **Given** `POST /tx/request/insert`, `POST /tx/request/delete`,
    `POST /tx/request/update`, `POST /tx/retract`, `POST /tx/reject`, or
    `POST /tx/end`, **When** the client builds a transaction, **Then**
    the response includes the unsigned transaction plus proof-bearing
-   input witnesses sufficient to verify every consumed UTxO before
-   signing.
+   input witnesses, `utxo_root`, and indexed `chainpoint` sufficient to
+   verify every consumed UTxO before signing.
 3. **Given** `POST /tx/boot`, **When** the client builds the initial
    boot transaction, **Then** the response includes the unsigned
    transaction and proof-bearing witnesses for all consumed wallet
-   inputs, and no MPF proof section is required because no pre-existing
-   trie data is read.
+   inputs, the `utxo_root`, the indexed `chainpoint`, and no MPF proof
+   section because no pre-existing trie data is read.
 4. **Given** a transaction builder consumes multiple requests in one
    batch, **When** the response is returned, **Then** proofs remain
    associated with the exact inputs and logical request keys they
@@ -85,32 +92,40 @@ used by the builder.
 
 ---
 
-### User Story 3 - Client discovers the verification root and contracts (Priority: P3)
+### User Story 3 - Client discovers verification contracts and compares roots (Priority: P3)
 
-An integrator needs a single place to discover the current UTxO-CSMT
-root and the JSON contracts for all proof-bearing responses.
+An integrator needs clear JSON contracts for all proof-bearing responses
+and a way to compare each response's baked-in root and chain point
+against trusted external providers.
 
-**Why this priority**: Clients cannot validate proofs reliably if they
-cannot identify the root they should check against or the exact meaning
-of each proof field.
+**Why this priority**: Clients cannot validate proofs reliably if the
+root and chain point are not embedded in the proof-bearing JSON itself,
+or if the contract leaves ambiguity about how to compare them with an
+external trusted source.
 
-**Independent Test**: Call `GET /status` and inspect the Swagger/OpenAPI
-docs. Confirm the root is present and every proof-bearing endpoint is
-documented with a structured response schema.
+**Independent Test**: Inspect the Swagger/OpenAPI docs and call one
+proof-bearing query endpoint plus one proof-bearing transaction
+endpoint. Confirm both responses embed `utxo_root` and `chainpoint`, and
+that those values can be compared with `GET /status` and `GET /utxo/root`.
 
 **Acceptance Scenarios**:
 
-1. **Given** a healthy service, **When** the client calls `GET /status`,
-   **Then** the response includes the current UTxO-CSMT root together
-   with chain/checkpoint metadata that identifies the indexed snapshot.
+1. **Given** a proof-bearing response, **When** the client reads its
+   JSON, **Then** the response itself includes `utxo_root` and
+   `chainpoint` for the exact snapshot the bundled proofs target.
 2. **Given** updated Swagger/OpenAPI docs, **When** an integrator
    inspects the API contract, **Then** every proof-bearing endpoint
-   documents the response object and the meaning of each proof field.
-3. **Given** the direct UTxO verification endpoints already exist,
+   documents the response object and the meaning of each proof field,
+   including `utxo_root` and `chainpoint`.
+3. **Given** a trusted external provider keyed by chain point, **When**
+   the client compares a proof-bearing response's `utxo_root` and
+   `chainpoint` against that provider, **Then** it can confirm the root
+   match without inferring snapshot metadata from a separate call.
+4. **Given** the direct UTxO verification endpoints already exist,
    **When** the client cross-checks inline proofs against `GET
    /utxo/root` and `GET /utxo/:txId/:txIx/proof`, **Then** the witness
-   bytes agree for the same indexed snapshot.
-4. **Given** a debugging or isolated deployment scenario, **When** the
+   bytes and baked-in root agree for the same indexed snapshot.
+5. **Given** a debugging or isolated deployment scenario, **When** the
    client uses `GET /utxo/root` instead of `GET /status`, **Then** it
    can obtain the same UTxO-CSMT root from the same indexed source of
    truth without depending on a separate CSMT service.
@@ -119,7 +134,7 @@ documented with a structured response schema.
 
 - The indexer may advance between reading state/request data and
   generating proofs. A response must be self-consistent for one indexed
-  snapshot; mixed-root bundles are invalid.
+  snapshot; mixed-root or mixed-chainpoint bundles are invalid.
 - `GET /tokens/:id/facts/:key` and `GET /tokens/:id/proofs/:key` keep
   their existing not-found behavior for absent keys. Non-membership
   proofs are out of scope.
@@ -145,8 +160,8 @@ documented with a structured response schema.
   request together with the request UTxO witness and its UTxO-CSMT
   inclusion proof.
 - **FR-005**: Every proof-bearing query response MUST identify the
-  UTxO-CSMT root, checkpoint, or equivalent snapshot metadata needed to
-  verify all bundled proofs against one indexed state.
+  exact `utxo_root` and indexed `chainpoint` needed to verify all
+  bundled proofs against one indexed state.
 - **FR-006**: `POST /tx/boot`, `POST /tx/request/insert`,
   `POST /tx/request/delete`, `POST /tx/request/update`,
   `POST /tx/update`, `POST /tx/retract`, `POST /tx/reject`, and
@@ -155,34 +170,41 @@ documented with a structured response schema.
 - **FR-007**: Every transaction response MUST include every consumed
   `TxIn` resolved to its `TxOut` plus a UTxO-CSMT inclusion proof for
   that input.
-- **FR-008**: Transaction responses MUST include MPF inclusion proofs
+- **FR-008**: Every transaction response MUST include the exact
+  `utxo_root` and indexed `chainpoint` for the snapshot used to build
+  its proof bundle.
+- **FR-009**: Transaction responses MUST include MPF inclusion proofs
   for every token state root or request key/value that the client must
   trust before signing.
-- **FR-009**: Endpoints that do not read trie data, such as boot, MUST
+- **FR-010**: Endpoints that do not read trie data, such as boot, MUST
   omit MPF proof material rather than invent placeholder proofs.
-- **FR-010**: `GET /status` MUST expose the current UTxO-CSMT root hash
-  alongside the existing tip and checkpoint fields.
-- **FR-011**: Swagger/OpenAPI MUST describe all new proof-bearing
+- **FR-011**: `GET /status` MUST expose the current UTxO-CSMT root hash
+  alongside chain/checkpoint fields that let clients compare it with the
+  baked-in values carried by proof-bearing responses.
+- **FR-012**: Swagger/OpenAPI MUST describe all new proof-bearing
   response objects and document which fields are verified against the
-  UTxO-CSMT root versus the MPF root.
-- **FR-012**: A client MUST be able to verify all proof-bearing query
-  and transaction responses offline against an independently obtained
-  UTxO-CSMT root without trusting the server's narrative.
-- **FR-013**: Responses that contain multiple requests, inputs, or
+  UTxO-CSMT root versus the MPF root, including the semantics of the
+  baked-in `chainpoint`.
+- **FR-013**: A client MUST be able to verify all proof-bearing query
+  and transaction responses offline using the `utxo_root` and
+  `chainpoint` carried inside the response, and compare them with an
+  independently trusted provider if desired.
+- **FR-014**: Responses that contain multiple requests, inputs, or
   proofs MUST preserve deterministic association between each business
   object and its proof bundle.
-- **FR-014**: Existing direct UTxO proof endpoints (`GET /utxo/:txId/:txIx`,
+- **FR-015**: Existing direct UTxO proof endpoints (`GET /utxo/:txId/:txIx`,
   `GET /utxo/:txId/:txIx/proof`, `GET /utxo/root`) MUST remain usable
   for cross-checking and debugging.
-- **FR-015**: `GET /utxo/root` MUST remain a first-class root-discovery
+- **FR-016**: `GET /utxo/root` MUST remain a first-class root-discovery
   endpoint that returns the same indexed UTxO-CSMT root as `GET /status`,
   so debugging and isolated deployments can use this service as the root
   source of truth even without a separate CSMT endpoint.
 
 ### Key Entities
 
-- **VerificationSnapshot**: The UTxO-CSMT root plus checkpoint metadata
-  that identifies the indexed state against which proofs are valid.
+- **VerificationSnapshot**: The exact `utxo_root` plus indexed
+  `chainpoint` that identifies the snapshot against which the bundled
+  proofs are valid.
 - **WitnessedUtxo**: A consumed or returned UTxO represented by its
   `TxIn`, resolved `TxOut`, and UTxO-CSMT inclusion proof.
 - **FactWitness**: A token state witness plus an MPF inclusion proof
@@ -198,14 +220,17 @@ documented with a structured response schema.
 
 - **SC-001**: A client can verify `GET /tokens/:id`,
   `GET /tokens/:id/facts/:key`, `GET /tokens/:id/proofs/:key`, and
-  `GET /tokens/:id/requests` entirely offline against an independently
-  sourced UTxO-CSMT root.
+  `GET /tokens/:id/requests` entirely offline using the `utxo_root` and
+  `chainpoint` embedded in each response.
 - **SC-002**: A client can verify every input and trie-dependent datum
   returned by the affected transaction-building endpoints before signing
   any CBOR.
-- **SC-003**: `GET /status` exposes the same UTxO-CSMT root that direct
+- **SC-003**: A client can compare any proof-bearing response's
+  `utxo_root` and `chainpoint` with an external trusted provider without
+  making a separate metadata-discovery call first.
+- **SC-004**: `GET /status` exposes the same UTxO-CSMT root that direct
   `GET /utxo/root` returns for the same indexed snapshot.
-- **SC-004**: Swagger/OpenAPI and HTTP tests cover the new response
+- **SC-005**: Swagger/OpenAPI and HTTP tests cover the new response
   contracts for every affected endpoint.
 
 ## Assumptions

--- a/specs/177-proof-carrying-api/spec.md
+++ b/specs/177-proof-carrying-api/spec.md
@@ -1,0 +1,215 @@
+# Feature Specification: Proof-Carrying API Responses
+
+**Feature Branch**: `177-proof-carrying-api`
+**Created**: 2026-04-17
+**Status**: Draft
+**Input**: lambdasistemi/cardano-mpfs-offchain#208
+
+## User Scenarios & Testing
+
+### User Story 1 - Client verifies token state and facts (Priority: P1)
+
+A wallet, oracle, or downstream indexer reads token state, facts, and
+pending requests from an untrusted offchain service. Each response must
+carry the UTxO witness and MPF proof material needed to verify the
+returned data against an independently obtained UTxO-CSMT root.
+
+**Why this priority**: Trust-minimized reads are the foundation for the
+rest of the API. If the server can lie about state or facts, every
+downstream decision built on that data is unsafe.
+
+**Independent Test**: Call `GET /status` to obtain the current indexed
+root, then call `GET /tokens/:id`, `GET /tokens/:id/facts/:key`,
+`GET /tokens/:id/proofs/:key`, and `GET /tokens/:id/requests`. Verify
+offline that every returned UTxO exists in the indexed set and every
+fact proof matches the reported token root.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing token, **When** the client calls
+   `GET /tokens/:id`, **Then** the response includes the returned token
+   state plus the state UTxO witness and its UTxO-CSMT inclusion proof.
+2. **Given** an existing key/value in the trie, **When** the client
+   calls `GET /tokens/:id/facts/:key`, **Then** the response includes
+   the fact value, the state UTxO witness/proof, and an MPF inclusion
+   proof tying that key/value to the reported root.
+3. **Given** an existing key/value in the trie, **When** the client
+   calls `GET /tokens/:id/proofs/:key`, **Then** the response includes
+   the MPF proof and the state UTxO witness/proof needed to trust the
+   root the proof is checked against.
+4. **Given** pending requests for a token, **When** the client calls
+   `GET /tokens/:id/requests`, **Then** each returned request includes
+   the request UTxO reference, resolved TxOut, and UTxO-CSMT inclusion
+   proof, with no ambiguity about which proof belongs to which request.
+
+---
+
+### User Story 2 - Client verifies unsigned transactions before signing (Priority: P2)
+
+An external signer asks the service to build an unsigned transaction.
+Because signing happens client-side and the offchain service is
+untrusted, the response must explain every input the transaction spends
+and every trie fact the transaction logic depends on.
+
+**Why this priority**: External signing is a project constitution
+principle. Returning bare CBOR is not enough if the client cannot verify
+what it is being asked to sign.
+
+**Independent Test**: Call each affected transaction-building endpoint
+and confirm the response contains the unsigned transaction plus a
+verification bundle for every spent input and every trie-dependent datum
+used by the builder.
+
+**Acceptance Scenarios**:
+
+1. **Given** `POST /tx/update`, **When** the client builds an update
+   transaction, **Then** the response includes the unsigned transaction,
+   every spent input resolved as a TxOut with a UTxO-CSMT inclusion
+   proof, and MPF proofs for the state root and request keys used to
+   justify the update.
+2. **Given** `POST /tx/request/insert`, `POST /tx/request/delete`,
+   `POST /tx/request/update`, `POST /tx/retract`, `POST /tx/reject`, or
+   `POST /tx/end`, **When** the client builds a transaction, **Then**
+   the response includes the unsigned transaction plus proof-bearing
+   input witnesses sufficient to verify every consumed UTxO before
+   signing.
+3. **Given** `POST /tx/boot`, **When** the client builds the initial
+   boot transaction, **Then** the response includes the unsigned
+   transaction and proof-bearing witnesses for all consumed wallet
+   inputs, and no MPF proof section is required because no pre-existing
+   trie data is read.
+4. **Given** a transaction builder consumes multiple requests in one
+   batch, **When** the response is returned, **Then** proofs remain
+   associated with the exact inputs and logical request keys they
+   justify.
+
+---
+
+### User Story 3 - Client discovers the verification root and contracts (Priority: P3)
+
+An integrator needs a single place to discover the current UTxO-CSMT
+root and the JSON contracts for all proof-bearing responses.
+
+**Why this priority**: Clients cannot validate proofs reliably if they
+cannot identify the root they should check against or the exact meaning
+of each proof field.
+
+**Independent Test**: Call `GET /status` and inspect the Swagger/OpenAPI
+docs. Confirm the root is present and every proof-bearing endpoint is
+documented with a structured response schema.
+
+**Acceptance Scenarios**:
+
+1. **Given** a healthy service, **When** the client calls `GET /status`,
+   **Then** the response includes the current UTxO-CSMT root together
+   with chain/checkpoint metadata that identifies the indexed snapshot.
+2. **Given** updated Swagger/OpenAPI docs, **When** an integrator
+   inspects the API contract, **Then** every proof-bearing endpoint
+   documents the response object and the meaning of each proof field.
+3. **Given** the direct UTxO verification endpoints already exist,
+   **When** the client cross-checks inline proofs against `GET
+   /utxo/root` and `GET /utxo/:txId/:txIx/proof`, **Then** the witness
+   bytes agree for the same indexed snapshot.
+
+### Edge Cases
+
+- The indexer may advance between reading state/request data and
+  generating proofs. A response must be self-consistent for one indexed
+  snapshot; mixed-root bundles are invalid.
+- `GET /tokens/:id/facts/:key` and `GET /tokens/:id/proofs/:key` keep
+  their existing not-found behavior for absent keys. Non-membership
+  proofs are out of scope.
+- Batch endpoints may touch many request UTxOs. Response size can grow,
+  but proof-to-item association must remain deterministic.
+- Existing clients that expect scalar `Hex` payloads on affected
+  endpoints must migrate to structured JSON response bodies. Compatibility
+  shims or versioned endpoints are out of scope for this feature.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `GET /tokens/:id` MUST return token state together with the
+  state UTxO witness and its UTxO-CSMT inclusion proof.
+- **FR-002**: `GET /tokens/:id/facts/:key` MUST return the fact value
+  together with the state UTxO witness/proof and the MPF inclusion proof
+  for the requested key/value.
+- **FR-003**: `GET /tokens/:id/proofs/:key` MUST return the MPF
+  inclusion proof together with the state UTxO witness/proof needed to
+  trust the root that the proof targets.
+- **FR-004**: `GET /tokens/:id/requests` MUST return each pending
+  request together with the request UTxO witness and its UTxO-CSMT
+  inclusion proof.
+- **FR-005**: Every proof-bearing query response MUST identify the
+  UTxO-CSMT root, checkpoint, or equivalent snapshot metadata needed to
+  verify all bundled proofs against one indexed state.
+- **FR-006**: `POST /tx/boot`, `POST /tx/request/insert`,
+  `POST /tx/request/delete`, `POST /tx/request/update`,
+  `POST /tx/update`, `POST /tx/retract`, `POST /tx/reject`, and
+  `POST /tx/end` MUST return structured JSON objects that include the
+  unsigned transaction plus proof-bearing verification metadata.
+- **FR-007**: Every transaction response MUST include every consumed
+  `TxIn` resolved to its `TxOut` plus a UTxO-CSMT inclusion proof for
+  that input.
+- **FR-008**: Transaction responses MUST include MPF inclusion proofs
+  for every token state root or request key/value that the client must
+  trust before signing.
+- **FR-009**: Endpoints that do not read trie data, such as boot, MUST
+  omit MPF proof material rather than invent placeholder proofs.
+- **FR-010**: `GET /status` MUST expose the current UTxO-CSMT root hash
+  alongside the existing tip and checkpoint fields.
+- **FR-011**: Swagger/OpenAPI MUST describe all new proof-bearing
+  response objects and document which fields are verified against the
+  UTxO-CSMT root versus the MPF root.
+- **FR-012**: A client MUST be able to verify all proof-bearing query
+  and transaction responses offline against an independently obtained
+  UTxO-CSMT root without trusting the server's narrative.
+- **FR-013**: Responses that contain multiple requests, inputs, or
+  proofs MUST preserve deterministic association between each business
+  object and its proof bundle.
+- **FR-014**: Existing direct UTxO proof endpoints (`GET /utxo/:txId/:txIx`,
+  `GET /utxo/:txId/:txIx/proof`, `GET /utxo/root`) MUST remain usable
+  for cross-checking and debugging.
+
+### Key Entities
+
+- **VerificationSnapshot**: The UTxO-CSMT root plus checkpoint metadata
+  that identifies the indexed state against which proofs are valid.
+- **WitnessedUtxo**: A consumed or returned UTxO represented by its
+  `TxIn`, resolved `TxOut`, and UTxO-CSMT inclusion proof.
+- **FactWitness**: A token state witness plus an MPF inclusion proof
+  tying a key/value to the token's reported root.
+- **UnsignedTxWitnessBundle**: An unsigned transaction plus the full set
+  of witnessed inputs and any MPF proofs required before signing.
+- **WitnessedRequest**: A pending request together with the request UTxO
+  witness that proves the request existed in the indexed UTxO set.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A client can verify `GET /tokens/:id`,
+  `GET /tokens/:id/facts/:key`, `GET /tokens/:id/proofs/:key`, and
+  `GET /tokens/:id/requests` entirely offline against an independently
+  sourced UTxO-CSMT root.
+- **SC-002**: A client can verify every input and trie-dependent datum
+  returned by the affected transaction-building endpoints before signing
+  any CBOR.
+- **SC-003**: `GET /status` exposes the same UTxO-CSMT root that direct
+  `GET /utxo/root` returns for the same indexed snapshot.
+- **SC-004**: Swagger/OpenAPI and HTTP tests cover the new response
+  contracts for every affected endpoint.
+
+## Assumptions
+
+- `cardano-utxo-csmt` can already produce inclusion proofs, or exposing
+  them is available as part of the dependency work referenced in issue
+  `#208`.
+- Non-membership proofs are out of scope. This feature only covers data
+  that currently exists and is returned successfully.
+- `GET /tokens` and `GET /tokens/:id/root` are unchanged in this
+  feature. Clients that require trust-minimized reads use the
+  proof-bearing endpoints listed above.
+- Changing the JSON shape of the affected endpoints is acceptable for
+  this feature, and downstream clients will be updated to consume the new
+  object responses.

--- a/specs/177-proof-carrying-api/spec.md
+++ b/specs/177-proof-carrying-api/spec.md
@@ -110,6 +110,10 @@ documented with a structured response schema.
    **When** the client cross-checks inline proofs against `GET
    /utxo/root` and `GET /utxo/:txId/:txIx/proof`, **Then** the witness
    bytes agree for the same indexed snapshot.
+4. **Given** a debugging or isolated deployment scenario, **When** the
+   client uses `GET /utxo/root` instead of `GET /status`, **Then** it
+   can obtain the same UTxO-CSMT root from the same indexed source of
+   truth without depending on a separate CSMT service.
 
 ### Edge Cases
 
@@ -170,6 +174,10 @@ documented with a structured response schema.
 - **FR-014**: Existing direct UTxO proof endpoints (`GET /utxo/:txId/:txIx`,
   `GET /utxo/:txId/:txIx/proof`, `GET /utxo/root`) MUST remain usable
   for cross-checking and debugging.
+- **FR-015**: `GET /utxo/root` MUST remain a first-class root-discovery
+  endpoint that returns the same indexed UTxO-CSMT root as `GET /status`,
+  so debugging and isolated deployments can use this service as the root
+  source of truth even without a separate CSMT endpoint.
 
 ### Key Entities
 
@@ -210,6 +218,9 @@ documented with a structured response schema.
 - `GET /tokens` and `GET /tokens/:id/root` are unchanged in this
   feature. Clients that require trust-minimized reads use the
   proof-bearing endpoints listed above.
+- Keeping both `GET /status` and `GET /utxo/root` as root-discovery
+  surfaces is acceptable duplication because they serve different client
+  workflows while remaining backed by the same indexed state.
 - Changing the JSON shape of the affected endpoints is acceptable for
   this feature, and downstream clients will be updated to consume the new
   object responses.

--- a/specs/177-proof-carrying-api/tasks.md
+++ b/specs/177-proof-carrying-api/tasks.md
@@ -4,7 +4,7 @@
 
 ## Slice 1: Shared response model + status root (US3, #210)
 
-- [ ] T001 Add shared proof-bearing response types to `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`
+- [ ] T001 Add shared proof-bearing response types to `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, including a reusable snapshot shape with baked-in `utxo_root` and indexed `chainpoint`
 - [ ] T002 Change `GET /status` response schema in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs` and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` to include the UTxO-CSMT root
 - [ ] T003 Update `statusHandler` in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` to read `Context.utxoRoot`
 - [ ] T004 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs` for the new status contract and root agreement with `GET /utxo/root`
@@ -21,10 +21,11 @@
 - [ ] T007 Change `GET /tokens/:id/facts/:key` to return the fact plus state witness and MPF proof in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs`
 - [ ] T008 Change `GET /tokens/:id/proofs/:key` to return the MPF proof plus state witness in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs`
 - [ ] T009 Change `GET /tokens/:id/requests` to return witnessed pending requests in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs`
-- [ ] T010 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs` for the token-state witness contract
-- [ ] T011 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs` for fact/proof response objects
-- [ ] T012 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs` for witnessed request responses
-- [ ] T013 Verify the HTTP test suite passes for token, trie, and request endpoints
+- [ ] T010 Ensure every read-side proof-bearing response embeds its own `utxo_root` and indexed `chainpoint`, rather than relying on a prior `GET /status` call
+- [ ] T011 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs` for the token-state witness contract
+- [ ] T012 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs` for fact/proof response objects
+- [ ] T013 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs` for witnessed request responses
+- [ ] T014 Verify the HTTP test suite passes for token, trie, and request endpoints
 
 **Checkpoint**: Read-side responses are verifiable offline against one
 reported snapshot.
@@ -36,12 +37,13 @@ implement end-to-end before starting transaction-bundle refactors.
 
 ## Slice 3: Rich transaction builder boundary (US2 foundation, #212)
 
-- [ ] T014 Add a proof-bearing unsigned-transaction bundle type to `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs`
-- [ ] T015 Change the `TxBuilder` record in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs` to return the new bundle type instead of bare `Tx ConwayEra`
-- [ ] T016 Update the real wiring in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs` to propagate bundle results
-- [ ] T017 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs` to compile with the new interface
-- [ ] T018 Add or update bundle-shape tests in `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs`
-- [ ] T019 Verify unit tests compile after the interface change
+- [ ] T015 Add a proof-bearing unsigned-transaction bundle type to `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs`
+- [ ] T016 Change the `TxBuilder` record in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs` to return the new bundle type instead of bare `Tx ConwayEra`
+- [ ] T017 Ensure the bundle type always carries baked-in `utxo_root` and indexed `chainpoint`
+- [ ] T018 Update the real wiring in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs` to propagate bundle results
+- [ ] T019 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs` to compile with the new interface
+- [ ] T020 Add or update bundle-shape tests in `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs`
+- [ ] T021 Verify unit tests compile after the interface change
 
 **Checkpoint**: The builder boundary can carry unsigned txs plus their
 verification metadata.
@@ -50,16 +52,16 @@ verification metadata.
 
 ## Slice 4: Simple proof-bearing tx endpoints (US2, #213)
 
-- [ ] T020 Implement witnessed-input bundle generation for `POST /tx/boot` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs`
-- [ ] T021 Implement witnessed-input bundle generation for `POST /tx/request/insert`, `POST /tx/request/delete`, and `POST /tx/request/update` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs`
-- [ ] T022 Implement witnessed-input bundle generation for `POST /tx/retract` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs`
-- [ ] T023 Implement witnessed-input bundle generation for `POST /tx/reject` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs`
-- [ ] T024 Implement witnessed-input bundle generation for `POST /tx/end` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs`
-- [ ] T025 Change transaction endpoint response schemas in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs` and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` for boot, request, retract, reject, and end
-- [ ] T026 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` to serialize bundle responses instead of bare hex CBOR for those endpoints
-- [ ] T027 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` with coverage for proof-bearing bundles on the simple tx endpoints
-- [ ] T028 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` to verify inline bundle data and cross-check against `/utxo/*`
-- [ ] T029 Verify unit and E2E coverage for the simple tx endpoints
+- [ ] T022 Implement witnessed-input bundle generation for `POST /tx/boot` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs`
+- [ ] T023 Implement witnessed-input bundle generation for `POST /tx/request/insert`, `POST /tx/request/delete`, and `POST /tx/request/update` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs`
+- [ ] T024 Implement witnessed-input bundle generation for `POST /tx/retract` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs`
+- [ ] T025 Implement witnessed-input bundle generation for `POST /tx/reject` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs`
+- [ ] T026 Implement witnessed-input bundle generation for `POST /tx/end` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs`
+- [ ] T027 Change transaction endpoint response schemas in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs` and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` for boot, request, retract, reject, and end
+- [ ] T028 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` to serialize bundle responses instead of bare hex CBOR for those endpoints
+- [ ] T029 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` with coverage for proof-bearing bundles on the simple tx endpoints
+- [ ] T030 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` to verify inline bundle data and cross-check against `/utxo/*`
+- [ ] T031 Verify unit and E2E coverage for the simple tx endpoints
 
 **Checkpoint**: All tx-building endpoints except `POST /tx/update`
 return proof-bearing bundles.
@@ -68,11 +70,11 @@ return proof-bearing bundles.
 
 ## Slice 5: `POST /tx/update` proof bundle (US2, #214)
 
-- [ ] T030 Implement proof-bearing update bundles in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs`, including witnessed state input, witnessed request inputs, and MPF proofs for contributing request keys
-- [ ] T031 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` for the `POST /tx/update` response object
-- [ ] T032 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` to verify proof-to-request association in batched update bundles
-- [ ] T033 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs` to verify update bundles before signing
-- [ ] T034 Verify update bundle tests pass
+- [ ] T032 Implement proof-bearing update bundles in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs`, including witnessed state input, witnessed request inputs, baked-in `utxo_root`, baked-in indexed `chainpoint`, and MPF proofs for contributing request keys
+- [ ] T033 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` for the `POST /tx/update` response object
+- [ ] T034 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` to verify proof-to-request association in batched update bundles
+- [ ] T035 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs` to verify update bundles before signing
+- [ ] T036 Verify update bundle tests pass
 
 **Checkpoint**: The hardest batch update flow is fully verifiable before
 signing.
@@ -81,11 +83,11 @@ signing.
 
 ## Slice 6: Swagger + contract checks (US3, #215)
 
-- [ ] T035 Update Swagger `ToSchema` coverage in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` and tighten docs in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Swagger.hs` if needed
-- [ ] T036 Regenerate `docs/assets/swagger.json` with `just update-swagger`
-- [ ] T037 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` with cross-endpoint contract checks for snapshot/root consistency, including `/status` versus `/utxo/root`
-- [ ] T038 Run `just ci`
-- [ ] T039 Update the PR description, push, and wait for CI before merge
+- [ ] T037 Update Swagger `ToSchema` coverage in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` and tighten docs in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Swagger.hs` if needed
+- [ ] T038 Regenerate `docs/assets/swagger.json` with `just update-swagger`
+- [ ] T039 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` with cross-endpoint contract checks for snapshot/root consistency, including `/status` versus `/utxo/root` and baked-in `chainpoint` matching
+- [ ] T040 Run `just ci`
+- [ ] T041 Update the PR description, push, and wait for CI before merge
 
 **Checkpoint**: The proof-bearing API contract is documented, tested,
 and ready for review.
@@ -96,19 +98,20 @@ and ready for review.
 
 ```text
 T001-T004 -> T005
-T005 -> T006-T013
-T013 -> T014-T019
-T014-T019 -> T020-T029
-T014-T019 -> T030-T034
-T020-T029 -> T035-T039
-T030-T034 -> T035-T039
+T005 -> T006-T014
+T014 -> T015-T021
+T015-T021 -> T022-T031
+T015-T021 -> T032-T036
+T022-T031 -> T037-T041
+T032-T036 -> T037-T041
 ```
 
 ## Notes
 
 - Slice 1 is the narrowest vertical slice and should land first.
 - Slices 1 and 2 together are the first client-visible milestone:
-  `GET /status` plus proof-carrying token read endpoints.
+  proof-carrying token read endpoints whose JSON already contains
+  `utxo_root` and `chainpoint`.
 - `GET /utxo/root` remains a first-class sibling root endpoint for
   debugging and isolated deployments; tests should keep it aligned with
   `/status`.

--- a/specs/177-proof-carrying-api/tasks.md
+++ b/specs/177-proof-carrying-api/tasks.md
@@ -7,7 +7,7 @@
 - [ ] T001 Add shared proof-bearing response types to `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`
 - [ ] T002 Change `GET /status` response schema in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs` and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` to include the UTxO-CSMT root
 - [ ] T003 Update `statusHandler` in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` to read `Context.utxoRoot`
-- [ ] T004 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs` for the new status contract
+- [ ] T004 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs` for the new status contract and root agreement with `GET /utxo/root`
 - [ ] T005 Verify the HTTP test suite still compiles and `StatusSpec` passes
 
 **Checkpoint**: Clients can discover the verification snapshot from
@@ -83,7 +83,7 @@ signing.
 
 - [ ] T035 Update Swagger `ToSchema` coverage in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` and tighten docs in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Swagger.hs` if needed
 - [ ] T036 Regenerate `docs/assets/swagger.json` with `just update-swagger`
-- [ ] T037 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` with cross-endpoint contract checks for snapshot/root consistency
+- [ ] T037 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` with cross-endpoint contract checks for snapshot/root consistency, including `/status` versus `/utxo/root`
 - [ ] T038 Run `just ci`
 - [ ] T039 Update the PR description, push, and wait for CI before merge
 
@@ -109,6 +109,9 @@ T030-T034 -> T035-T039
 - Slice 1 is the narrowest vertical slice and should land first.
 - Slices 1 and 2 together are the first client-visible milestone:
   `GET /status` plus proof-carrying token read endpoints.
+- `GET /utxo/root` remains a first-class sibling root endpoint for
+  debugging and isolated deployments; tests should keep it aligned with
+  `/status`.
 - Slice 3 is the main architectural refactor; it starts only after the
   read-side milestone is settled, and slices 4 and 5 depend on it even
   if they touch different endpoint families.

--- a/specs/177-proof-carrying-api/tasks.md
+++ b/specs/177-proof-carrying-api/tasks.md
@@ -29,6 +29,9 @@
 **Checkpoint**: Read-side responses are verifiable offline against one
 reported snapshot.
 
+**First milestone**: This is the first HTTP-client scenario we should
+implement end-to-end before starting transaction-bundle refactors.
+
 ---
 
 ## Slice 3: Rich transaction builder boundary (US2 foundation, #212)
@@ -94,7 +97,7 @@ and ready for review.
 ```text
 T001-T004 -> T005
 T005 -> T006-T013
-T005 -> T014-T019
+T013 -> T014-T019
 T014-T019 -> T020-T029
 T014-T019 -> T030-T034
 T020-T029 -> T035-T039
@@ -104,8 +107,11 @@ T030-T034 -> T035-T039
 ## Notes
 
 - Slice 1 is the narrowest vertical slice and should land first.
-- Slice 3 is the main architectural refactor; slices 4 and 5 depend on
-  it even if they touch different endpoint families.
+- Slices 1 and 2 together are the first client-visible milestone:
+  `GET /status` plus proof-carrying token read endpoints.
+- Slice 3 is the main architectural refactor; it starts only after the
+  read-side milestone is settled, and slices 4 and 5 depend on it even
+  if they touch different endpoint families.
 - `POST /tx/update` is intentionally isolated from the other tx
   endpoints because batching and proof association make it the highest
   risk implementation area.

--- a/specs/177-proof-carrying-api/tasks.md
+++ b/specs/177-proof-carrying-api/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Proof-Carrying API Responses
+
+**Input**: [spec.md](spec.md), [plan.md](plan.md), [research.md](research.md)
+
+## Slice 1: Shared response model + status root (US3, #210)
+
+- [ ] T001 Add shared proof-bearing response types to `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`
+- [ ] T002 Change `GET /status` response schema in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs` and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` to include the UTxO-CSMT root
+- [ ] T003 Update `statusHandler` in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` to read `Context.utxoRoot`
+- [ ] T004 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs` for the new status contract
+- [ ] T005 Verify the HTTP test suite still compiles and `StatusSpec` passes
+
+**Checkpoint**: Clients can discover the verification snapshot from
+`GET /status`.
+
+---
+
+## Slice 2: Proof-bearing query endpoints (US1, #211)
+
+- [ ] T006 Change `GET /tokens/:id` to a structured proof-bearing response in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs`
+- [ ] T007 Change `GET /tokens/:id/facts/:key` to return the fact plus state witness and MPF proof in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs`
+- [ ] T008 Change `GET /tokens/:id/proofs/:key` to return the MPF proof plus state witness in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs`
+- [ ] T009 Change `GET /tokens/:id/requests` to return witnessed pending requests in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs`
+- [ ] T010 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs` for the token-state witness contract
+- [ ] T011 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs` for fact/proof response objects
+- [ ] T012 Update `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs` for witnessed request responses
+- [ ] T013 Verify the HTTP test suite passes for token, trie, and request endpoints
+
+**Checkpoint**: Read-side responses are verifiable offline against one
+reported snapshot.
+
+---
+
+## Slice 3: Rich transaction builder boundary (US2 foundation, #212)
+
+- [ ] T014 Add a proof-bearing unsigned-transaction bundle type to `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs`
+- [ ] T015 Change the `TxBuilder` record in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs` to return the new bundle type instead of bare `Tx ConwayEra`
+- [ ] T016 Update the real wiring in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs` to propagate bundle results
+- [ ] T017 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs` to compile with the new interface
+- [ ] T018 Add or update bundle-shape tests in `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs`
+- [ ] T019 Verify unit tests compile after the interface change
+
+**Checkpoint**: The builder boundary can carry unsigned txs plus their
+verification metadata.
+
+---
+
+## Slice 4: Simple proof-bearing tx endpoints (US2, #213)
+
+- [ ] T020 Implement witnessed-input bundle generation for `POST /tx/boot` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs`
+- [ ] T021 Implement witnessed-input bundle generation for `POST /tx/request/insert`, `POST /tx/request/delete`, and `POST /tx/request/update` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs`
+- [ ] T022 Implement witnessed-input bundle generation for `POST /tx/retract` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs`
+- [ ] T023 Implement witnessed-input bundle generation for `POST /tx/reject` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs`
+- [ ] T024 Implement witnessed-input bundle generation for `POST /tx/end` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs`
+- [ ] T025 Change transaction endpoint response schemas in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs` and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` for boot, request, retract, reject, and end
+- [ ] T026 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` to serialize bundle responses instead of bare hex CBOR for those endpoints
+- [ ] T027 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` with coverage for proof-bearing bundles on the simple tx endpoints
+- [ ] T028 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` to verify inline bundle data and cross-check against `/utxo/*`
+- [ ] T029 Verify unit and E2E coverage for the simple tx endpoints
+
+**Checkpoint**: All tx-building endpoints except `POST /tx/update`
+return proof-bearing bundles.
+
+---
+
+## Slice 5: `POST /tx/update` proof bundle (US2, #214)
+
+- [ ] T030 Implement proof-bearing update bundles in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs`, including witnessed state input, witnessed request inputs, and MPF proofs for contributing request keys
+- [ ] T031 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` for the `POST /tx/update` response object
+- [ ] T032 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` to verify proof-to-request association in batched update bundles
+- [ ] T033 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs` to verify update bundles before signing
+- [ ] T034 Verify update bundle tests pass
+
+**Checkpoint**: The hardest batch update flow is fully verifiable before
+signing.
+
+---
+
+## Slice 6: Swagger + contract checks (US3, #215)
+
+- [ ] T035 Update Swagger `ToSchema` coverage in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` and tighten docs in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Swagger.hs` if needed
+- [ ] T036 Regenerate `docs/assets/swagger.json` with `just update-swagger`
+- [ ] T037 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` with cross-endpoint contract checks for snapshot/root consistency
+- [ ] T038 Run `just ci`
+- [ ] T039 Update the PR description, push, and wait for CI before merge
+
+**Checkpoint**: The proof-bearing API contract is documented, tested,
+and ready for review.
+
+---
+
+## Dependencies
+
+```text
+T001-T004 -> T005
+T005 -> T006-T013
+T005 -> T014-T019
+T014-T019 -> T020-T029
+T014-T019 -> T030-T034
+T020-T029 -> T035-T039
+T030-T034 -> T035-T039
+```
+
+## Notes
+
+- Slice 1 is the narrowest vertical slice and should land first.
+- Slice 3 is the main architectural refactor; slices 4 and 5 depend on
+  it even if they touch different endpoint families.
+- `POST /tx/update` is intentionally isolated from the other tx
+  endpoints because batching and proof association make it the highest
+  risk implementation area.
+- The direct `/utxo/*` endpoints remain part of the verification story
+  and should be used by tests as the cross-check oracle for inline
+  bundles.


### PR DESCRIPTION
## Summary

This PR adds the Speckit design artifacts for [issue #208](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/208): trust-minimized API responses with UTxO existence proofs and MPF inclusion proofs.

It still does not implement the feature. It now includes the execution breakdown as both `tasks.md` and a set of child issues, with one important design correction: every proof-bearing response must bake in the exact `utxo_root` and indexed `chainpoint` it targets.

## What Changed

### Spec

Added `specs/177-proof-carrying-api/spec.md`.

The spec defines three user-facing slices:
- trust-minimized query responses for token state, facts, proofs, and requests
- proof-bearing unsigned transaction responses before client-side signing
- verification contracts that let clients compare baked-in roots against trusted providers

The spec now fixes several ambiguity points from the original issue and from earlier drafts of this PR:
- the affected existing endpoints move to structured JSON objects instead of returning bare `Hex`/scalar payloads
- every proof-bearing response must be self-consistent for a single indexed snapshot
- non-membership proofs stay out of scope for this feature
- `GET /utxo/root` remains intentionally exposed as a first-class root-discovery endpoint alongside `GET /status`
- most importantly: the proof-bearing JSON itself must carry `utxo_root` and `chainpoint`; verification must not depend on a separate metadata-discovery call first

### Research

Added `specs/177-proof-carrying-api/research.md`.

The research records the main design decisions behind the plan:
- reuse the existing `Context` proof hooks and `/utxo/*` endpoints rather than changing indexer persistence
- do not add parallel `/v2` endpoints for proof-carrying responses
- enrich the transaction-builder boundary instead of trying to recover all proof intent from a finished transaction inside `HTTP.Server`
- treat `POST /tx/boot` as a special case: UTxO witnesses yes, MPF proof section no
- treat the `GET /status` / `GET /utxo/root` duplication as intentional: the former is an ergonomic high-level comparison endpoint, the latter is the low-level debugging/compatibility root source
- treat proof-bearing JSON as the primary verification artifact by baking in both `utxo_root` and indexed `chainpoint`

### Plan

Added `specs/177-proof-carrying-api/plan.md`.

The implementation is staged in six slices:
1. shared response model plus `GET /status` root
2. proof-bearing query endpoints
3. richer `TxBuilder` return type for proof bundles
4. simple tx endpoints on the new bundle type
5. dedicated `POST /tx/update` proof bundle work
6. Swagger regeneration and end-to-end contract checks

The first milestone is now precise:
- fetch a proof-bearing read response
- read its baked-in `utxo_root` and `chainpoint`
- verify it offline
- optionally compare it against `GET /status`, `GET /utxo/root`, or an external trusted provider

### Tasks + Ticket Split

Added `specs/177-proof-carrying-api/tasks.md`.

The work is split into native GitHub issues with dependencies:
- #210 shared response models + status root
- #211 proof-carrying query endpoints
- #212 `TxBuilder` proof-bundle boundary
- #213 proof-carrying tx endpoints except update
- #214 proof-carrying `POST /tx/update`
- #215 Swagger + contract checks

Issue #208 is now the umbrella issue and is blocked by those child issues. The child tickets are added to the Planning board as `Work / MPFS`.

The dependency graph still enforces the read-side-first order:
- `#211` depends on `#210`
- `#212` depends on both `#210` and `#211`
- transaction-bundle work starts only after the read-side milestone is settled

## Reviewer Focus

Please review the following design calls before implementation starts:
- changing the existing affected endpoints instead of adding parallel proof-carrying endpoints
- requiring every proof-bearing response to carry its own `utxo_root` and indexed `chainpoint`
- treating proof-bearing JSON as the primary verification artifact, with `/status` and `/utxo/root` as comparison/debugging endpoints rather than prerequisites
- keeping `GET /utxo/root` as an explicit sibling root endpoint rather than considering it accidental duplication
- expanding the `TxBuilder` boundary only after the read-side contract is settled
- treating boot/request-style txs as endpoints that may legitimately omit MPF proof sections when no trie facts are read
- the issue split itself, especially the decision to isolate `POST /tx/update` into its own ticket

## Testing

- Not run. This PR adds spec/plan/research/tasks markdown only.

Refs #208
