### PR TITLE
feat: add verification snapshot types and expose utxo root in status

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -166,6 +166,7 @@ statusHandler ctx = do
         liftIO
             $ St.getCheckpoint
                 (St.checkpoints (state ctx))
+    mRoot <- liftIO $ utxoRoot ctx
     pure
         StatusResponse
             { tipSlot =
@@ -182,6 +183,7 @@ statusHandler ctx = do
                 fmap (unSlotNo . fst) mcp
             , checkpointBlockId =
                 fmap (Hex . unBlockId . snd) mcp
+            , currentUtxoRoot = fmap Hex mRoot
             }
 
 tokensHandler

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -14,6 +14,10 @@ module Cardano.MPFS.HTTP.Types
     ( -- * Status
       StatusResponse (..)
 
+      -- * Proof-bearing snapshot
+    , ChainPointJSON (..)
+    , VerificationSnapshot (..)
+
       -- * Tokens
     , TokenIdJSON (..)
     , TokenStateJSON (..)
@@ -94,6 +98,12 @@ data StatusResponse = StatusResponse
     -- ^ Last processed checkpoint slot
     , checkpointBlockId :: Maybe Hex
     -- ^ Last processed checkpoint block hash
+    , currentUtxoRoot :: Maybe Hex
+    -- ^ Current UTxO-CSMT root hash for the indexed
+    -- snapshot at the checkpoint above. 'Nothing' if
+    -- the CSMT is not yet available. Matches the root
+    -- returned by @GET \/utxo\/root@ and the
+    -- @utxo_root@ baked into proof-bearing responses.
     }
     deriving (Eq, Show)
 
@@ -105,7 +115,60 @@ instance ToJSON StatusResponse where
             , "checkpoint_slot" .= checkpointSlot
             , "checkpoint_block_id"
                 .= checkpointBlockId
+            , "utxo_root" .= currentUtxoRoot
             ]
+
+-- | Indexed chain point baked into proof-bearing
+-- responses. Identifies the exact block at which
+-- the bundled proofs are valid.
+data ChainPointJSON = ChainPointJSON
+    { cpSlot :: Word64
+    -- ^ Slot of the indexed chain point
+    , cpBlockId :: Hex
+    -- ^ Block hash at that slot (hex)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON ChainPointJSON where
+    toJSON ChainPointJSON{..} =
+        object
+            [ "slot" .= cpSlot
+            , "block_id" .= cpBlockId
+            ]
+
+instance FromJSON ChainPointJSON where
+    parseJSON = withObject "ChainPointJSON" $ \o ->
+        ChainPointJSON
+            <$> o .: "slot"
+            <*> o .: "block_id"
+
+-- | Verification snapshot: the exact UTxO-CSMT root
+-- plus indexed chain point against which a
+-- proof-bearing response's bundled proofs are valid.
+-- Every proof-bearing response embeds one of these so
+-- clients can verify offline without a separate
+-- @GET \/status@ call.
+data VerificationSnapshot = VerificationSnapshot
+    { vsUtxoRoot :: Hex
+    -- ^ UTxO-CSMT root hash
+    , vsChainPoint :: ChainPointJSON
+    -- ^ Indexed chain point
+    }
+    deriving (Eq, Show)
+
+instance ToJSON VerificationSnapshot where
+    toJSON VerificationSnapshot{..} =
+        object
+            [ "utxo_root" .= vsUtxoRoot
+            , "chainpoint" .= vsChainPoint
+            ]
+
+instance FromJSON VerificationSnapshot where
+    parseJSON =
+        withObject "VerificationSnapshot" $ \o ->
+            VerificationSnapshot
+                <$> o .: "utxo_root"
+                <*> o .: "chainpoint"
 
 -- | Hex-encoded token identifier for JSON transport.
 newtype TokenIdJSON = TokenIdJSON
@@ -406,15 +469,64 @@ instance ToSchema StatusResponse where
                         ( "checkpoint_block_id"
                         , maybeHex
                         )
+                    , ("utxo_root", maybeHex)
                     ]
             & required
                 .~ [ "tip_slot"
                    , "tip_block_id"
                    , "checkpoint_slot"
                    , "checkpoint_block_id"
+                   , "utxo_root"
                    ]
             & description
-                ?~ "Indexer chain tip and checkpoint"
+                ?~ "Indexer chain tip, checkpoint, \
+                   \and current UTxO-CSMT root"
+
+instance ToSchema ChainPointJSON where
+    declareNamedSchema _ = do
+        word64Schema <-
+            declareSchemaRef (Proxy @Word64)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "ChainPointJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("slot", word64Schema)
+                    , ("block_id", hexSchema)
+                    ]
+            & required .~ ["slot", "block_id"]
+            & description
+                ?~ "Indexed chain point baked into \
+                   \proof-bearing responses"
+
+instance ToSchema VerificationSnapshot where
+    declareNamedSchema _ = do
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        chainPointSchema <-
+            declareSchemaRef (Proxy @ChainPointJSON)
+        pure
+            $ Swagger.NamedSchema
+                (Just "VerificationSnapshot")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("utxo_root", hexSchema)
+                    , ("chainpoint", chainPointSchema)
+                    ]
+            & required
+                .~ ["utxo_root", "chainpoint"]
+            & description
+                ?~ "UTxO-CSMT root and indexed chain \
+                   \point against which bundled \
+                   \proofs are valid"
 
 instance ToSchema TokenIdJSON where
     declareNamedSchema _ =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
@@ -82,6 +82,14 @@ getStatus ctx =
         )
         (mkApp ctx)
 
+getUtxoRoot :: Context IO -> IO SResponse
+getUtxoRoot ctx =
+    runSession
+        ( request
+            (setPath defaultRequest "/utxo/root")
+        )
+        (mkApp ctx)
+
 spec :: Spec
 spec = describe "GET /status" $ do
     it "returns 200 with expected fields" $ do
@@ -97,6 +105,8 @@ spec = describe "GET /status" $ do
                 KM.member "checkpoint_slot" obj
                     `shouldBe` True
                 KM.member "checkpoint_block_id" obj
+                    `shouldBe` True
+                KM.member "utxo_root" obj
                     `shouldBe` True
             _ ->
                 expectationFailure
@@ -125,3 +135,39 @@ spec = describe "GET /status" $ do
             _ ->
                 expectationFailure
                     "Expected JSON object"
+
+    it "returns null utxo_root when CSMT unavailable" $ do
+        ctx <- mkTestContext
+        resp <- getStatus ctx
+        case decode (simpleBody resp) of
+            Just (Object obj) ->
+                KM.lookup "utxo_root" obj
+                    `shouldBe` Just Null
+            _ ->
+                expectationFailure
+                    "Expected JSON object"
+
+    it "agrees with /utxo/root when CSMT available" $ do
+        let rootBs = "\x01\x02\x03"
+            ctxWith =
+                fmap
+                    ( \c ->
+                        c{utxoRoot = pure (Just rootBs)}
+                    )
+                    mkTestContext
+        ctx <- ctxWith
+        statusResp <- getStatus ctx
+        utxoRootResp <- getUtxoRoot ctx
+        simpleStatus utxoRootResp `shouldBe` status200
+        let statusRoot = case decode (simpleBody statusResp) of
+                Just (Object obj) ->
+                    KM.lookup "utxo_root" obj
+                _ -> Nothing
+            directRoot = decode (simpleBody utxoRootResp)
+        case (statusRoot, directRoot) of
+            (Just rootVal, Just directVal) ->
+                rootVal `shouldBe` directVal
+            _ ->
+                expectationFailure
+                    "Expected both endpoints to return a \
+                    \utxo root"

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -291,7 +291,7 @@
             "type": "object"
         },
         "StatusResponse": {
-            "description": "Indexer chain tip and checkpoint",
+            "description": "Indexer chain tip, checkpoint, and current UTxO-CSMT root",
             "properties": {
                 "checkpoint_block_id": {
                     "$ref": "#/definitions/Hex"
@@ -310,13 +310,17 @@
                     "maximum": 1.8446744073709551615e19,
                     "minimum": 0,
                     "type": "integer"
+                },
+                "utxo_root": {
+                    "$ref": "#/definitions/Hex"
                 }
             },
             "required": [
                 "tip_slot",
                 "tip_block_id",
                 "checkpoint_slot",
-                "checkpoint_block_id"
+                "checkpoint_block_id",
+                "utxo_root"
             ],
             "type": "object"
         },


### PR DESCRIPTION
## Summary

Slice 1 of the proof-carrying API rollout (specs/177-proof-carrying-api/tasks.md, umbrella #208). Lays down the shared verification-snapshot contract that every later slice will embed in its proof-bearing responses, and aligns `GET /status` with `GET /utxo/root` so both expose the same indexed CSMT root.

Closes #210.

## What changed

### Shared proof-bearing types (`HTTP/Types.hs`)

- `ChainPointJSON { slot, block_id }` — the indexed chain point baked into proof-bearing responses. Distinct from `StatusResponse`'s nullable checkpoint fields because proof-bearing responses always target a concrete point.
- `VerificationSnapshot { utxo_root, chainpoint }` — the snapshot contract. Slices 2–5 will embed one of these in every proof-bearing response so clients can verify offline without a prior `GET /status` call.
- Swagger `ToSchema` and `FromJSON` instances on both (FromJSON for client reuse).

### `GET /status` now exposes `utxo_root` (`HTTP/Server.hs`, `HTTP/Types.hs`)

- `StatusResponse` gains `utxo_root :: Maybe Hex` (required in the JSON schema, nullable when the CSMT is not yet available). The Haskell field is named `currentUtxoRoot` to avoid a `DuplicateRecordFields` selector clash with `Context.utxoRoot`; the JSON key stays `utxo_root`.
- `statusHandler` now reads `Context.utxoRoot` alongside the existing checkpoint lookup.
- `GET /status` and `GET /utxo/root` agree for the same indexed snapshot.

### Tests (`test/Cardano/MPFS/HTTP/StatusSpec.hs`)

- `utxo_root` field must be present in every `/status` response.
- `utxo_root` is `null` when CSMT is unavailable.
- `/status.utxo_root` agrees with `/utxo/root` when the CSMT is populated.

## Out of scope

- Proof-bearing read endpoints (#211, slice 2)
- `TxBuilder` bundle rewrite (#212, slice 3)
- Tx endpoint bundles (#213/#214, slices 4–5)
- Swagger regeneration and end-to-end contract checks (#215, slice 6)

## Verification

- `cabal test cardano-mpfs-offchain:unit-tests -O0`: 362/362 pass (5/5 in `StatusSpec`).
- `fourmolu -m check` clean on the three touched files.
- `hlint` clean.

## Spec references

- Spec: [specs/177-proof-carrying-api/spec.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/specs/177-proof-carrying-api/spec.md)
- Plan: [specs/177-proof-carrying-api/plan.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/specs/177-proof-carrying-api/plan.md)
- Tasks: [specs/177-proof-carrying-api/tasks.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/specs/177-proof-carrying-api/tasks.md) (T001–T005)