### PR TITLE
docs: add verification client slice to proof-carrying api plan

### DIFF
--- a/specs/177-proof-carrying-api/plan.md
+++ b/specs/177-proof-carrying-api/plan.md
@@ -121,6 +121,28 @@ in `utxo_root` and indexed `chainpoint`.
 the token and tx endpoints, and make `/status` and `/utxo/root` agree as
 the same source of truth.
 
+### Slice 1b: Verification client library and CLI
+
+Build a `cardano-mpfs-client` Haskell package whose library reuses
+`cardano-utxo-csmt` and the existing MPF proof verifier to check every
+proof-bearing response shape offline. Expose a `mpfs-verify` CLI that
+accepts a proof-bearing JSON response and prints a pass/fail result
+with the `utxo_root` and `chainpoint` it verified against. Wire the
+library into the E2E HTTP and cage-flow specs so every shipped
+response is verified by a real consumer before signing.
+
+**Files**: `cardano-mpfs-client/` (new package), `README.md`,
+`cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs`,
+`cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs`
+
+**Goal**: The "verify before sign" scenario has a real implementation,
+not only tests hand-rolled against individual endpoints. Every later
+slice must keep its responses verifiable by this client.
+
+**Follow-up outside this feature**: Integrate `cardano-mpfs-client`
+into `cardano-wallet` so `sign` refuses to proceed unless the inbound
+proof-bearing bundle verifies. Tracked as a separate issue.
+
 ### Slice 2: Proof-bearing query endpoints
 
 Convert the affected token query endpoints from scalar payloads to

--- a/specs/177-proof-carrying-api/spec.md
+++ b/specs/177-proof-carrying-api/spec.md
@@ -199,6 +199,15 @@ that those values can be compared with `GET /status` and `GET /utxo/root`.
   endpoint that returns the same indexed UTxO-CSMT root as `GET /status`,
   so debugging and isolated deployments can use this service as the root
   source of truth even without a separate CSMT endpoint.
+- **FR-017**: This feature MUST ship a reusable verification client
+  library (and companion CLI) that can verify every proof-bearing
+  response shape offline. The library is the canonical consumer of the
+  new response contracts and is the artifact that wallets/signers
+  integrate to enforce "verify before sign and submit."
+- **FR-018**: E2E tests MUST use the verification client library to
+  validate every proof-bearing response before making assertions, so
+  that the server-side response contracts and the client-side
+  verification logic remain co-evolved.
 
 ### Key Entities
 

--- a/specs/177-proof-carrying-api/tasks.md
+++ b/specs/177-proof-carrying-api/tasks.md
@@ -15,6 +15,46 @@
 
 ---
 
+## Slice 1b: Verification client library and CLI
+
+Implements the downstream consumer that exercises every proof-bearing
+response shape as soon as it ships. Without this the server side has
+no end-to-end oracle and clients have no turnkey way to verify bundles
+before signing.
+
+- [ ] TC01 Add a new `cardano-mpfs-client` package under
+  `cardano-mpfs-client/` with a Haskell library exposing
+  `verifyVerificationSnapshot`, `verifyWitnessedUtxo`,
+  `verifyFactWitness`, and `verifyUnsignedTxWitnessBundle`
+- [ ] TC02 Reuse `cardano-utxo-csmt` proof verification and the
+  existing MPF proof verifier; do not reimplement
+- [ ] TC03 Add a `mpfs-verify` CLI inside the same package that
+  accepts a proof-bearing JSON response (stdin or file) and prints a
+  pass/fail result with the `utxo_root` and `chainpoint` it verified
+  against
+- [ ] TC04 Unit tests for the verifier covering positive,
+  root-mismatch, chainpoint-mismatch, and malformed-proof cases
+- [ ] TC05 Wire the verifier into
+  `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs`
+  so every proof-bearing read response is verified by the real client
+  before the test assertions run
+- [ ] TC06 Wire the verifier into
+  `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs`
+  so every proof-bearing tx response is verified before signing
+- [ ] TC07 Document the client in `README.md` and link it from the
+  Swagger description
+
+**Checkpoint**: Every proof-bearing response shape has a real consumer
+that verifies it offline, and E2E tests refuse to proceed if the
+bundles fail verification.
+
+**Why this slice exists**: The user-critical scenario is
+"verify-before-sign." Building the verifier in parallel with the
+response-shape slices forces each shape to remain verifiable, and
+produces the library the wallet sign tool will consume in a follow-up.
+
+---
+
 ## Slice 2: Proof-bearing query endpoints (US1, #211)
 
 - [ ] T006 Change `GET /tokens/:id` to a structured proof-bearing response in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs`
@@ -98,12 +138,17 @@ and ready for review.
 
 ```text
 T001-T004 -> T005
+T005 -> TC01-TC04
 T005 -> T006-T014
+T006-T014 -> TC05
 T014 -> T015-T021
 T015-T021 -> T022-T031
 T015-T021 -> T032-T036
+T022-T031 -> TC06
+T032-T036 -> TC06
 T022-T031 -> T037-T041
 T032-T036 -> T037-T041
+TC01-TC07 -> T037-T041
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary

The `specs/177-proof-carrying-api/` artifacts described proof-bearing responses but did not commit to a reusable consumer. The verify-before-sign workflow (which is the whole point of the feature) was implicit and risked slipping.

This PR adds an explicit client-side deliverable to the plan.

## Changes

### New slice 1b: verification client library and CLI

Adds `cardano-mpfs-client` package (library + `mpfs-verify` CLI) that:
- verifies every proof-bearing response shape offline against its baked-in `utxo_root` and `chainpoint`,
- reuses `cardano-utxo-csmt` and the existing MPF proof verifier (no reimplementation),
- is wired into E2E specs so every response we ship is exercised by a real consumer before the test assertions run.

### Spec additions (FR-017, FR-018)

- Verification client is a first-class shippable artifact.
- E2E tests must route proof-bearing responses through the verifier before asserting.

### Plan addition (slice 1b)

Positioned between slice 1 (response surface) and slice 2 (read endpoints). The library is built once the snapshot contract is stable (post-slice-1), then used as the oracle for all later slices.

### Task dependencies

```
T001-T004 -> T005
T005 -> TC01-TC04            # client library unit tests
T005 -> T006-T014            # read endpoints
T006-T014 -> TC05            # wire verifier into HTTPLifecycleSpec
T015-T021 -> T022-T031 / T032-T036
T022-T036 -> TC06            # wire verifier into CageFlowSpec
TC01-TC07 -> T037-T041       # swagger + final contract checks
```

## Out of scope (tracked separately)

- Integrating `cardano-mpfs-client` into `cardano-wallet` so `sign` refuses to proceed unless the inbound bundle verifies. Separate tracking issue.

## Spec references

- [specs/177-proof-carrying-api/spec.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/docs/177-add-client-slice/specs/177-proof-carrying-api/spec.md)
- [specs/177-proof-carrying-api/plan.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/docs/177-add-client-slice/specs/177-proof-carrying-api/plan.md)
- [specs/177-proof-carrying-api/tasks.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/docs/177-add-client-slice/specs/177-proof-carrying-api/tasks.md)

Umbrella: #208