### PR TITLE
feat: add cardano-mpfs-client verifier package

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ transactions; the client signs and submits via `POST /tx/submit`.
 
 Swagger UI is served at `/swagger-ui`.
 
+## Verification client
+
+The `cardano-mpfs-client` package (under `cardano-mpfs-client/`) is the
+canonical consumer of the proof-bearing responses. Its library exposes
+`verifyVerificationSnapshot` and its `mpfs-verify` CLI reads a JSON
+response from a file or stdin and prints pass/fail with the baked-in
+`utxo_root` and `chainpoint`:
+
+```bash
+curl -s https://host/status | cabal run mpfs-verify
+```
+
+Further verifier entry points are added alongside the response shapes
+they consume as the proof-carrying slices land.
+
 ## Building
 
 ```bash

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ index-state:
 
 packages:
   cardano-mpfs-offchain/
+  cardano-mpfs-client/
 
 repository cardano-haskell-packages
   url: https://chap.intersectmbo.org/

--- a/cardano-mpfs-client/LICENSE
+++ b/cardano-mpfs-client/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-mpfs-client/app/Main.hs
+++ b/cardano-mpfs-client/app/Main.hs
@@ -1,0 +1,84 @@
+-- |
+-- Module      : Main
+-- Description : mpfs-verify CLI entry point.
+--
+-- Reads a proof-bearing JSON response from a file or stdin, extracts
+-- the 'VerificationSnapshot' it carries, and runs the offline snapshot
+-- verifier. Prints a pass/fail result with the baked-in @utxo_root@
+-- and @chainpoint@. Later slices extend this to cover witnessed UTxO
+-- and trie proofs as their response shapes ship.
+module Main (main) where
+
+import Cardano.MPFS.Client
+    ( ChainPoint (..)
+    , Hex (..)
+    , VerificationSnapshot (..)
+    , VerifyError
+    , statusSnapshot
+    , verifyVerificationSnapshot
+    )
+import Data.Aeson (Value, eitherDecodeStrict)
+import Data.Aeson.Types qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import System.Environment (getArgs)
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (hPutStrLn, stderr, stdin)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    bs <- case args of
+        [] -> BS.hGetContents stdin
+        [path] -> BS.readFile path
+        _ -> usage >> exitFailure
+    case eitherDecodeStrict bs of
+        Left e -> fail' ("invalid JSON: " <> T.pack e)
+        Right value -> dispatch value
+
+usage :: IO ()
+usage =
+    hPutStrLn
+        stderr
+        "Usage: mpfs-verify [FILE]\n\n\
+        \Reads a proof-bearing JSON response (default: stdin) and\n\
+        \verifies the snapshot it carries."
+
+dispatch :: Value -> IO ()
+dispatch value =
+    case Aeson.parse statusSnapshot value of
+        Aeson.Error msg ->
+            fail' ("could not read snapshot: " <> T.pack msg)
+        Aeson.Success Nothing ->
+            fail' "no utxo_root present; the indexed snapshot is not ready"
+        Aeson.Success (Just snap) -> report snap
+
+report :: VerificationSnapshot -> IO ()
+report snap@VerificationSnapshot{..} =
+    case verifyVerificationSnapshot snap of
+        Left err -> failVerify err snap
+        Right () -> do
+            TIO.putStrLn "pass"
+            TIO.putStrLn $ "  utxo_root:  " <> unHex utxoRoot
+            TIO.putStrLn
+                $ "  chainpoint: slot "
+                    <> T.pack (show (slot chainpoint))
+                    <> " block "
+                    <> unHex (blockId chainpoint)
+            exitSuccess
+
+failVerify :: VerifyError -> VerificationSnapshot -> IO ()
+failVerify err VerificationSnapshot{..} = do
+    TIO.hPutStrLn stderr "fail"
+    TIO.hPutStrLn stderr $ "  utxo_root:  " <> unHex utxoRoot
+    TIO.hPutStrLn stderr
+        $ "  chainpoint: slot "
+            <> T.pack (show (slot chainpoint))
+            <> " block "
+            <> unHex (blockId chainpoint)
+    TIO.hPutStrLn stderr $ "  reason:     " <> T.pack (show err)
+    exitFailure
+
+fail' :: T.Text -> IO a
+fail' msg = TIO.hPutStrLn stderr msg >> exitFailure

--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -1,0 +1,77 @@
+cabal-version: 3.4
+name:          cardano-mpfs-client
+version:       0.0.0
+synopsis:      Verification client for Cardano MPFS proof-bearing API
+description:
+  Offline verifier for the proof-bearing responses exposed by
+  cardano-mpfs-offchain. Provides a Haskell library and a
+  @mpfs-verify@ CLI so wallets and signers can enforce
+  "verify before sign" on every response.
+
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Paolo Veronelli
+maintainer:    paolo.veronelli@gmail.com
+category:      Cardano
+build-type:    Simple
+
+common warnings
+  ghc-options:
+    -Wall -Werror -Wunused-imports -Wunused-packages
+    -Wmissing-export-lists -Wname-shadowing
+    -Wdeferred-out-of-scope-variables -Wpartial-type-signatures
+    -Wredundant-constraints
+
+  default-extensions:
+    DerivingStrategies
+    DuplicateRecordFields
+    OverloadedStrings
+    RecordWildCards
+    StrictData
+
+library
+  import:           warnings
+  default-language: GHC2021
+  hs-source-dirs:   lib
+  build-depends:
+    , aeson              >=2.1  && <2.3
+    , base               >=4.18 && <5
+    , base16-bytestring  >=1.0  && <1.1
+    , bytestring         >=0.11 && <0.13
+    , text               >=2.0  && <2.2
+
+  exposed-modules:
+    Cardano.MPFS.Client
+    Cardano.MPFS.Client.Snapshot
+    Cardano.MPFS.Client.Verify
+
+executable mpfs-verify
+  import:           warnings
+  default-language: GHC2021
+  hs-source-dirs:   app
+  main-is:          Main.hs
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-mpfs-client
+    , text
+
+  ghc-options:      -threaded -with-rtsopts=-N
+
+test-suite unit-tests
+  import:           warnings
+  type:             exitcode-stdio-1.0
+  default-language: GHC2021
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-mpfs-client
+    , hspec                >=2.11 && <2.12
+    , text
+
+  other-modules:    Cardano.MPFS.Client.SnapshotSpec
+  ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
@@ -1,0 +1,28 @@
+-- |
+-- Module      : Cardano.MPFS.Client
+-- Description : Public surface of the MPFS verification client.
+--
+-- Re-exports the snapshot JSON contract and offline verifiers for
+-- consumers that want one import.
+module Cardano.MPFS.Client
+    ( -- * Snapshot
+      VerificationSnapshot (..)
+    , ChainPoint (..)
+    , Hex (..)
+    , statusSnapshot
+
+      -- * Verification
+    , VerifyError (..)
+    , verifyVerificationSnapshot
+    ) where
+
+import Cardano.MPFS.Client.Snapshot
+    ( ChainPoint (..)
+    , Hex (..)
+    , VerificationSnapshot (..)
+    , statusSnapshot
+    )
+import Cardano.MPFS.Client.Verify
+    ( VerifyError (..)
+    , verifyVerificationSnapshot
+    )

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Snapshot.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Snapshot.hs
@@ -1,0 +1,96 @@
+-- |
+-- Module      : Cardano.MPFS.Client.Snapshot
+-- Description : Verification snapshot parsing for proof-bearing responses.
+--
+-- Every proof-bearing response served by cardano-mpfs-offchain carries a
+-- 'VerificationSnapshot' that identifies the indexed state against which
+-- its proofs are valid. This module defines the JSON contract for that
+-- snapshot as consumed by the verification client.
+module Cardano.MPFS.Client.Snapshot
+    ( VerificationSnapshot (..)
+    , ChainPoint (..)
+    , Hex (..)
+    , statusSnapshot
+    ) where
+
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , Value (Null)
+    , object
+    , withObject
+    , (.:)
+    , (.:?)
+    , (.=)
+    )
+import Data.Aeson.Types (Parser)
+import Data.Text (Text)
+import Data.Word (Word64)
+
+-- | A hex-encoded byte string as carried by the MPFS API. The wrapper
+-- preserves the on-wire representation; verifiers are responsible for
+-- decoding when they need the raw bytes.
+newtype Hex = Hex {unHex :: Text}
+    deriving stock (Eq, Show)
+
+instance FromJSON Hex where
+    parseJSON = fmap Hex . parseJSON
+
+instance ToJSON Hex where
+    toJSON = toJSON . unHex
+
+-- | Indexed chain point: the slot and block id the snapshot was
+-- materialised at.
+data ChainPoint = ChainPoint
+    { slot :: Word64
+    , blockId :: Hex
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON ChainPoint where
+    parseJSON = withObject "ChainPoint" $ \o ->
+        ChainPoint <$> o .: "slot" <*> o .: "block_id"
+
+instance ToJSON ChainPoint where
+    toJSON ChainPoint{..} =
+        object ["slot" .= slot, "block_id" .= blockId]
+
+-- | The snapshot identifier baked into every proof-bearing response.
+--
+-- The 'utxo_root' is the UTxO-CSMT root the bundled UTxO proofs verify
+-- against; the 'chainpoint' is the indexed chain point at which that
+-- root was observed.
+data VerificationSnapshot = VerificationSnapshot
+    { utxoRoot :: Hex
+    , chainpoint :: ChainPoint
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON VerificationSnapshot where
+    parseJSON = withObject "VerificationSnapshot" $ \o ->
+        VerificationSnapshot <$> o .: "utxo_root" <*> o .: "chainpoint"
+
+instance ToJSON VerificationSnapshot where
+    toJSON VerificationSnapshot{..} =
+        object ["utxo_root" .= utxoRoot, "chainpoint" .= chainpoint]
+
+-- | Extract a snapshot from a @GET /status@ response.
+--
+-- @/status@ predates the proof-bearing response shape and stores the
+-- snapshot fields flattened at the top level: @utxo_root@ is optional
+-- (absent while the CSMT view is still warming up), and the chain
+-- point lives under @tip_slot@/@tip_block_id@ with the snapshot
+-- actually taken at @checkpoint_slot@/@checkpoint_block_id@.
+statusSnapshot :: Value -> Parser (Maybe VerificationSnapshot)
+statusSnapshot = withObject "StatusResponse" $ \o -> do
+    mRoot <- o .:? "utxo_root"
+    case mRoot of
+        Nothing -> pure Nothing
+        Just Null -> pure Nothing
+        Just rootVal -> do
+            root <- parseJSON rootVal
+            cp <-
+                ChainPoint
+                    <$> o .: "checkpoint_slot"
+                    <*> o .: "checkpoint_block_id"
+            pure $ Just (VerificationSnapshot root cp)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
@@ -1,0 +1,63 @@
+-- |
+-- Module      : Cardano.MPFS.Client.Verify
+-- Description : Offline verifiers for MPFS proof-bearing responses.
+--
+-- This slice ships the snapshot-level verifier. Verifiers for
+-- 'WitnessedUtxo', 'FactWitness', and 'UnsignedTxWitnessBundle' are
+-- added by later slices alongside the server-side response types they
+-- consume.
+module Cardano.MPFS.Client.Verify
+    ( VerifyError (..)
+    , verifyVerificationSnapshot
+    ) where
+
+import Cardano.MPFS.Client.Snapshot
+    ( ChainPoint (..)
+    , Hex (..)
+    , VerificationSnapshot (..)
+    )
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Text (Text)
+import Data.Text.Encoding qualified as T
+
+-- | Structured error returned when a proof-bearing bundle fails
+-- verification. Each case is tagged so the CLI and future verifiers can
+-- render consistent pass/fail messages.
+data VerifyError
+    = -- | Field name and the offending value that failed hex decoding.
+      MalformedHex Text Text
+    | -- | Field name, expected byte length, actual byte length.
+      WrongHexLength Text Int Int
+    | EmptyBlockId
+    deriving stock (Eq, Show)
+
+-- | Structural check for the snapshot that every proof-bearing response
+-- must carry. Confirms the @utxo_root@ decodes as a 32-byte hash and
+-- the chain-point block id decodes as a non-empty hash. Does not
+-- contact any external service.
+verifyVerificationSnapshot
+    :: VerificationSnapshot -> Either VerifyError ()
+verifyVerificationSnapshot VerificationSnapshot{..} = do
+    checkHash32 "utxo_root" utxoRoot
+    let ChainPoint{blockId} = chainpoint
+    checkNonEmptyHash "chainpoint.block_id" blockId
+
+checkHash32 :: Text -> Hex -> Either VerifyError ()
+checkHash32 field h = do
+    bs <- decodeHex field h
+    let got = BS.length bs
+    if got == 32
+        then Right ()
+        else Left (WrongHexLength field 32 got)
+
+checkNonEmptyHash :: Text -> Hex -> Either VerifyError ()
+checkNonEmptyHash field h = do
+    bs <- decodeHex field h
+    if BS.null bs then Left EmptyBlockId else Right ()
+
+decodeHex :: Text -> Hex -> Either VerifyError BS.ByteString
+decodeHex field (Hex txt) =
+    case Base16.decode (T.encodeUtf8 txt) of
+        Right bs -> Right bs
+        Left _ -> Left (MalformedHex field txt)

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/SnapshotSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/SnapshotSpec.hs
@@ -1,0 +1,117 @@
+module Cardano.MPFS.Client.SnapshotSpec (spec) where
+
+import Cardano.MPFS.Client
+    ( ChainPoint (..)
+    , Hex (..)
+    , VerificationSnapshot (..)
+    , VerifyError (..)
+    , statusSnapshot
+    , verifyVerificationSnapshot
+    )
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
+import Data.ByteString.Lazy.Char8 qualified as BL
+import Data.Maybe (fromMaybe)
+import Data.Text qualified as T
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec = do
+    describe "VerificationSnapshot JSON" $ do
+        it "round-trips via aeson" $ do
+            let snap = mkSnapshot root32 block32 42
+                encoded = Aeson.encode snap
+            Aeson.eitherDecode encoded `shouldBe` Right snap
+
+        it "parses a slice-2-shaped response" $ do
+            let body =
+                    BL.concat
+                        [ "{\"anything\":1,"
+                        , "\"utxo_root\":\""
+                        , BL.pack (T.unpack root32)
+                        , "\",\"chainpoint\":{\"slot\":100,"
+                        , "\"block_id\":\""
+                        , BL.pack (T.unpack block32)
+                        , "\"}}"
+                        ]
+            Aeson.eitherDecode body
+                `shouldBe` Right (mkSnapshot root32 block32 100)
+
+    describe "statusSnapshot extractor" $ do
+        it "returns Nothing when utxo_root is absent"
+            $ parse statusSnapshot (statusJSON Nothing)
+            `shouldBe` Right Nothing
+
+        it "returns Nothing when utxo_root is null"
+            $ parse statusSnapshot (statusJSON (Just "null"))
+            `shouldBe` Right Nothing
+
+        it "extracts the checkpoint as the snapshot chain point"
+            $ parse statusSnapshot (statusJSON (Just (quote root32)))
+            `shouldBe` Right (Just (mkSnapshot root32 block32 77))
+
+    describe "verifyVerificationSnapshot" $ do
+        it "accepts a well-formed snapshot"
+            $ verifyVerificationSnapshot (mkSnapshot root32 block32 1)
+            `shouldBe` Right ()
+
+        it "rejects a root that is not 32 bytes"
+            $ verifyVerificationSnapshot (mkSnapshot rootShort block32 1)
+            `shouldSatisfy` isWrongLength "utxo_root"
+
+        it "rejects a malformed-hex root"
+            $ verifyVerificationSnapshot (mkSnapshot rootBad block32 1)
+            `shouldSatisfy` isMalformed "utxo_root"
+
+        it "rejects an empty chainpoint block id"
+            $ verifyVerificationSnapshot (mkSnapshot root32 "" 1)
+            `shouldSatisfy` (== Left EmptyBlockId)
+
+mkSnapshot :: T.Text -> T.Text -> Word -> VerificationSnapshot
+mkSnapshot r b s =
+    VerificationSnapshot
+        { utxoRoot = Hex r
+        , chainpoint =
+            ChainPoint{slot = fromIntegral s, blockId = Hex b}
+        }
+
+root32, block32, rootShort, rootBad :: T.Text
+root32 = T.replicate 64 "a"
+block32 = T.replicate 64 "b"
+rootShort = T.replicate 10 "a"
+rootBad = "zzzz"
+
+statusJSON :: Maybe BL.ByteString -> BL.ByteString
+statusJSON mRoot =
+    BL.concat
+        [ "{\"tip_slot\":100,"
+        , "\"tip_block_id\":\""
+        , BL.pack (T.unpack block32)
+        , "\",\"checkpoint_slot\":77,"
+        , "\"checkpoint_block_id\":\""
+        , BL.pack (T.unpack block32)
+        , "\",\"utxo_root\":"
+        , fromMaybe "null" mRoot
+        , "}"
+        ]
+
+quote :: T.Text -> BL.ByteString
+quote t = BL.concat ["\"", BL.pack (T.unpack t), "\""]
+
+parse
+    :: (Aeson.Value -> Aeson.Parser a)
+    -> BL.ByteString
+    -> Either String a
+parse p bs = do
+    v <- Aeson.eitherDecode bs
+    case Aeson.parse p v of
+        Aeson.Error e -> Left e
+        Aeson.Success a -> Right a
+
+isWrongLength :: T.Text -> Either VerifyError () -> Bool
+isWrongLength fld (Left (WrongHexLength f _ _)) = f == fld
+isWrongLength _ _ = False
+
+isMalformed :: T.Text -> Either VerifyError () -> Bool
+isMalformed fld (Left (MalformedHex f _)) = f == fld
+isMalformed _ _ = False

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Cardano.MPFS.Client.SnapshotSpec qualified as SnapshotSpec
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec SnapshotSpec.spec


### PR DESCRIPTION
## Summary

Closes #218.

Slice 1b of the proof-carrying API feature (umbrella #208): ship a
standalone Haskell verification client that consumers (wallets,
signers, E2E tests) can run to validate proof-bearing responses
offline.

This slice ships the snapshot contract and verifier only — the
building block that every proof-bearing response depends on. Verifiers
for `WitnessedUtxo`, `FactWitness`, and `UnsignedTxWitnessBundle` are
added by later slices, alongside the server response shapes they
consume, so each shape is verifiable from the moment it ships.

## What changed

### New package: `cardano-mpfs-client/`

Standalone Haskell package with minimal dependencies (no servant,
swagger, ledger, RocksDB) so downstream consumers can depend on it
without pulling the whole server.

- `Cardano.MPFS.Client.Snapshot` — JSON contract for
  `VerificationSnapshot` (`utxo_root` + `chainpoint{slot, block_id}`)
  and an adapter (`statusSnapshot`) that extracts a snapshot from a
  `GET /status` response where the fields live at the top level.
- `Cardano.MPFS.Client.Verify` — `verifyVerificationSnapshot`, a
  structural check that the root decodes as a 32-byte hash and the
  chainpoint block id is a non-empty hash. Pure `Either VerifyError ()`
  so callers can report pass/fail deterministically.
- `Cardano.MPFS.Client` — public facade re-exporting both modules.

### New executable: `mpfs-verify`

CLI that reads a JSON response from a file or stdin, extracts the
snapshot (direct parse or the `/status` adapter), and prints:

```
pass
  utxo_root:  <hex>
  chainpoint: slot <n> block <hex>
```

On failure it writes the same header plus the typed reason to stderr
and exits non-zero. Signal usable directly from `curl`, shell
pipelines, and E2E test harnesses.

### Tests

`cardano-mpfs-client:unit-tests` — 9 hspec cases covering:

- snapshot JSON round-trip via aeson
- snapshot extraction embedded in a slice-2-shaped body
- `/status` extractor handling absent, `null`, and populated roots
- positive verify
- wrong-length root → `WrongHexLength`
- malformed-hex root → `MalformedHex`
- empty chainpoint block id → `EmptyBlockId`

### Wiring

- `cabal.project` picks up the new package.
- `README.md` adds a "Verification client" section describing the
  library and CLI with a `curl | mpfs-verify` example.

## Follow-ups

- Later slices (#211, #213, #214) add the per-shape verifier
  functions (`verifyWitnessedUtxo`, `verifyFactWitness`,
  `verifyUnsignedTxWitnessBundle`) alongside the server response
  types they consume.
- Wallet integration is tracked in
  [cardano-foundation/cardano-wallet#5260](https://github.com/cardano-foundation/cardano-wallet/issues/5260):
  `cardano-wallet sign` refuses to proceed unless the inbound bundle
  verifies.

## Test plan

- [x] `cabal build cardano-mpfs-client` — library, CLI, tests compile
- [x] `cabal test cardano-mpfs-client:unit-tests` — 9/9 pass
- [x] `mpfs-verify` smoke test on a hand-built `/status` body
- [x] `just format-check` and `just hlint` — clean