### PR TITLE
feat: proof-bearing token query endpoints (#211)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,11 +1,20 @@
 <!-- Sync Impact Report
-Version: 0.0.0 → 1.0.0
-Added: All principles (new constitution)
-Templates requiring updates:
-  - plan-template.md: no changes needed (Constitution Check section is generic)
-  - spec-template.md: no changes needed
-  - tasks-template.md: no changes needed
-Follow-up: none
+Version: 1.0.0 → 1.1.0
+Added:
+  - Principle VIII. Pure Offline Verification
+  - Principle IX. One Verifier, Many Targets
+  - Principle X. Lean as Source of Truth
+Rationale: The proof-bearing API (#208) is only useful if the client can
+actually run the verifier. That imposes three architectural constraints
+on the project that were implicit before and are now normative: the
+verifier must be pure, it must be written once and compiled to every
+client runtime, and its shape must be formally specified in Lean before
+it is implemented.
+Templates requiring updates: none — these principles scope the
+cardano-mpfs-client boundary, not the service boundary.
+Follow-up: before slice 4 lands, prove GHC-WASM / GHC-JS backends can
+compile the current cardano-mpfs-client deps; pin or swap any dep that
+fails.
 -->
 
 # Cardano MPFS Offchain Constitution
@@ -53,6 +62,79 @@ devnet. Docker and external services are not required for testing.
 All builds, tests, and CI MUST run inside `nix develop`. No system-level
 dependencies outside the flake. CI mirrors local `just ci` exactly.
 
+### VIII. Pure Offline Verification
+
+Every verifier shipped to clients MUST be a pure function
+`Hex -> Bundle -> Either VerifyError a`, with no `IO`, no network, no
+disk, no timeouts, and no non-determinism. Given one trusted
+`utxo_root`, a client MUST be able to answer "does this proof-bearing
+response check out?" without making any further call.
+
+This is what makes the proof-bearing API load-bearing. The server is
+untrusted infrastructure; trust collapses to the single `utxo_root` the
+client obtains independently. Every further check — UTxO-CSMT inclusion,
+MPF inclusion/non-inclusion, nested sub-trie traversal, unsigned-tx
+input cover — MUST be expressible as a pure fold over the proof data.
+
+Verifier implementations MUST compose as `Kleisli (Either VerifyError)`
+arrows. Any verifier that needs `IO` is the wrong shape and MUST be
+redesigned; any dependency that forces `IO` into the verifier MUST be
+swapped or vendored.
+
+### IX. One Verifier, Many Targets
+
+There MUST be exactly one implementation of every client-side verifier,
+written in Haskell in the `cardano-mpfs-client` package, compiled to
+every runtime a client might live in:
+
+- GHC native — server, CLI, Haskell tests
+- GHC-WASM — browsers, Node, embedded wallets, hardware signers
+- GHC-JS backend — environments that cannot load WASM
+
+Re-implementing a verifier in TypeScript, JavaScript, Rust, or any other
+language is forbidden. Parallel implementations diverge silently; a
+security fix in one lags the others for months; every wallet vendor ends
+up shipping a different buggy verifier, which defeats the whole trust
+model.
+
+Consequences for `cardano-mpfs-client`:
+
+- No `IO`, no `unix`, no `process`, no native C FFI beyond pure hashing.
+- Every new dep MUST be checked against the GHC-WASM and GHC-JS
+  compatibility matrix before it is added; if it does not cross-compile,
+  it does not go in.
+- CI MUST build the WASM and JS artifacts on every commit and run a
+  cross-target QuickCheck suite asserting that GHC-native, GHC-WASM, and
+  GHC-JS produce byte-identical `Either VerifyError a` outputs for the
+  same input. A disagreement between targets is a merge block.
+- Every release MUST publish the npm package alongside the Hackage
+  package; a release that ships Haskell but not WASM/JS is incomplete.
+
+### X. Lean as Source of Truth
+
+The verifier's state machine MUST be formalized in Lean before it is
+implemented in Haskell. The Lean artifacts (predicates on the proof
+graph, preservation theorems, the fold that discharges proofs) are the
+authoritative specification; the Haskell implementation exists to match
+them.
+
+Process:
+
+1. Invariants are discussed and written in prose in the plan / spec.
+2. The invariants are translated to Lean 4 predicates and theorems.
+3. Theorems compile with no `sorry` and no custom axioms.
+4. The Haskell implementation is written with the same signature shape
+   as the Lean functions.
+5. A QuickCheck property `prop_matchesLeanReference` generates random
+   inputs and asserts the Haskell implementation agrees with the
+   Lean-extracted reference.
+6. Cross-target QuickCheck (Principle IX) extends the same properties to
+   the compiled WASM and JS artifacts.
+
+When the implementation reveals a gap, the fix goes into Lean first and
+propagates back down the stack. The code does not race ahead of the
+proof.
+
 ## Cardano Constraints
 
 - Conway era only — no backward compatibility with older eras
@@ -76,4 +158,4 @@ require a version bump, rationale, and propagation check across dependent
 templates. Complexity beyond what a principle allows MUST be justified in
 the plan's Complexity Tracking table.
 
-**Version**: 1.0.0 | **Ratified**: 2026-03-27 | **Last Amended**: 2026-03-27
+**Version**: 1.1.0 | **Ratified**: 2026-03-27 | **Last Amended**: 2026-04-20

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -332,6 +332,7 @@ test-suite e2e-tests
     , cardano-ledger-byron
     , cardano-ledger-core
     , cardano-ledger-mary
+    , cardano-mpfs-client
     , cardano-mpfs-offchain
     , cardano-node-clients
     , cardano-node-clients:devnet
@@ -346,6 +347,7 @@ test-suite e2e-tests
     , process
     , stm
     , temporary
+    , text
     , vector
     , wai
     , wai-extra
@@ -357,5 +359,6 @@ test-suite e2e-tests
     Cardano.MPFS.E2E.CrashRecoverySpec
     Cardano.MPFS.E2E.HTTPLifecycleSpec
     Cardano.MPFS.E2E.IndexerSpec
+    Cardano.MPFS.E2E.ProofsSpec
     Cardano.MPFS.E2E.ProviderSpec
     Cardano.MPFS.E2E.SubmitterSpec

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -66,6 +66,7 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types
     ( Coin (..)
     , ConwayEra
+    , LocatedTokenState (..)
     , Root (..)
     , TokenId (..)
     , TokenState (..)
@@ -162,7 +163,7 @@ cageFlowSpec scriptBytes =
                     extractTokenId cfg signedBoot
 
             -- Step 2: Poll until boot auto-indexed
-            ts <-
+            LocatedTokenState _ ts <-
                 pollOrFail 30 "boot"
                     $ getToken
                         (tokens (state ctx))
@@ -329,7 +330,7 @@ deleteFlowSpec scriptBytes =
                                     (tokens (state ctx))
                                     tokenId
                             pure $ case mTs of
-                                Just t
+                                Just (LocatedTokenState _ t)
                                     | root t
                                         /= Root
                                             ( BS.replicate
@@ -361,7 +362,7 @@ deleteFlowSpec scriptBytes =
                             else pure (Just rs)
 
                 -- Save pre-delete root
-                Just preDelTs <-
+                Just (LocatedTokenState _ preDelTs) <-
                     getToken
                         (tokens (state ctx))
                         tokenId
@@ -381,7 +382,7 @@ deleteFlowSpec scriptBytes =
                                     (tokens (state ctx))
                                     tokenId
                             pure $ case mTs of
-                                Just t
+                                Just (LocatedTokenState _ t)
                                     | root t
                                         /= preDelRoot ->
                                         Just ()
@@ -429,7 +430,7 @@ deleteFlowSpec scriptBytes =
                             else pure Nothing
 
                 -- Save pre-batch root
-                Just preBatchTs <-
+                Just (LocatedTokenState _ preBatchTs) <-
                     getToken
                         (tokens (state ctx))
                         tokenId
@@ -449,7 +450,7 @@ deleteFlowSpec scriptBytes =
                                     (tokens (state ctx))
                                     tokenId
                             pure $ case mTs of
-                                Just t
+                                Just (LocatedTokenState _ t)
                                     | root t
                                         /= preBatchRoot ->
                                         Just ()
@@ -496,7 +497,7 @@ deleteFlowSpec scriptBytes =
                             else pure Nothing
 
                 -- Save pre-mixed root
-                Just preMixedTs <-
+                Just (LocatedTokenState _ preMixedTs) <-
                     getToken
                         (tokens (state ctx))
                         tokenId
@@ -515,7 +516,7 @@ deleteFlowSpec scriptBytes =
                             (tokens (state ctx))
                             tokenId
                     pure $ case mTs of
-                        Just t
+                        Just (LocatedTokenState _ t)
                             | root t
                                 /= preMixedRoot ->
                                 Just ()
@@ -570,7 +571,7 @@ rejectFlowSpec scriptBytes =
                 threadDelay 32_000_000
 
                 -- Record root before reject
-                Just preRejectTs <-
+                Just (LocatedTokenState _ preRejectTs) <-
                     getToken
                         (tokens (state ctx))
                         tokenId
@@ -600,7 +601,7 @@ rejectFlowSpec scriptBytes =
                                     )
                                     tokenId
                             pure $ case mTs of
-                                Just t
+                                Just (LocatedTokenState _ t)
                                     | root t
                                         == preRejectRoot ->
                                         Just ()

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -78,6 +78,8 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types
     ( Coin (..)
     , ConwayEra
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -211,10 +213,14 @@ cageFlowSpec bpPath scriptBytes =
                         , retractTime =
                             30_000
                         }
+            let bootStateTxIn =
+                    TxIn
+                        (txIdTx signedBoot)
+                        (TxIx 1)
             putToken
                 (tokens (state ctx))
                 tokenId
-                ts
+                (LocatedTokenState bootStateTxIn ts)
 
             -- Assert: cage address has UTxO
             cageUtxos <-
@@ -353,8 +359,7 @@ cageFlowSpec bpPath scriptBytes =
                         }
             putRequest
                 (requests (state ctx))
-                req2TxIn
-                req2
+                (LocatedRequest req2TxIn req2)
 
             cageUtxos4 <-
                 queryUTxOs

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -55,6 +55,8 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types
     ( Coin (..)
     , ConwayEra
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -158,7 +160,7 @@ chainsyncSpecs scriptBytes = do
                     expectationFailure
                         "token not auto-indexed \
                         \within timeout"
-                Just ts -> do
+                Just (LocatedTokenState _ ts) -> do
                     owner ts
                         `shouldBe` keyHashFromSignKey
                             genesisSignKey
@@ -222,7 +224,7 @@ chainsyncSpecs scriptBytes = do
                         Just rs ->
                             rs
                                 `shouldSatisfy` any
-                                    ( \r ->
+                                    ( \(LocatedRequest _ r) ->
                                         requestKey r
                                             == "hello"
                                             && requestValue

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -17,6 +17,7 @@ module Cardano.MPFS.E2E.HTTPLifecycleSpec
 
 import Control.Concurrent (threadDelay)
 import Data.Aeson (decode)
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.Types (Value (..))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
@@ -294,11 +295,13 @@ requestCount app tidHex = do
                 <> "/requests"
     simpleStatus resp `shouldBe` status200
     case decode (simpleBody resp) of
-        Just (Array arr) ->
-            pure (V.length arr)
+        Just (Object o)
+            | Just (Array arr) <-
+                KeyMap.lookup "requests" o ->
+                pure (V.length arr)
         _ -> do
             expectationFailure
-                "Expected JSON array"
+                "Expected { requests: [...] } envelope"
             pure 0
 
 -- | @GET \/tokens@ — count indexed tokens.

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -54,6 +54,8 @@ import Cardano.MPFS.Core.Types
     ( Addr
     , Coin (..)
     , ConwayEra
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -172,20 +174,20 @@ indexerSpecs scriptBytes = do
                     signedBoot
             length events `shouldBe` 1
             case events of
-                [CageBoot tid ts] -> do
+                [CageBoot tid stRef ts] -> do
                     -- Apply event
                     _ <-
                         applyCageEvent
                             (state ctx)
                             (trieManager ctx)
-                            (CageBoot tid ts)
+                            (CageBoot tid stRef ts)
                     -- Verify state
                     mTs <-
                         getToken
                             (tokens (state ctx))
                             tid
                     mTs `shouldSatisfy` \case
-                        Just ts' ->
+                        Just (LocatedTokenState _ ts') ->
                             owner ts'
                                 == keyHashFromSignKey
                                     genesisSignKey
@@ -254,7 +256,7 @@ indexerSpecs scriptBytes = do
                             (requests (state ctx))
                             txIn
                     mReq `shouldSatisfy` \case
-                        Just r ->
+                        Just (LocatedRequest _ r) ->
                             requestKey r == "hello"
                                 && requestValue r
                                     == Insert "world"
@@ -310,8 +312,7 @@ indexerSpecs scriptBytes = do
                         }
             putRequest
                 (requests (state ctx))
-                reqTxIn
-                req
+                (LocatedRequest reqTxIn req)
 
             -- Snapshot before update
             preUtxos <-
@@ -349,7 +350,7 @@ indexerSpecs scriptBytes = do
                     ]
             length updates `shouldBe` 1
             case updates of
-                [evt@(CageUpdate _ newRoot consumed)] ->
+                [evt@(CageUpdate _ _ newRoot consumed)] ->
                     do
                         -- Root changed from empty
                         newRoot
@@ -375,7 +376,7 @@ indexerSpecs scriptBytes = do
                                 (tokens (state ctx))
                                 tid
                         case mTs of
-                            Just ts ->
+                            Just (LocatedTokenState _ ts) ->
                                 root ts
                                     `shouldBe` newRoot
                             Nothing ->
@@ -456,8 +457,7 @@ indexerSpecs scriptBytes = do
                         }
             putRequest
                 (requests (state ctx))
-                reqTxIn
-                req
+                (LocatedRequest reqTxIn req)
 
             -- Wait for Phase 2 (process_time = 15s)
             threadDelay 17_000_000
@@ -694,7 +694,7 @@ indexerSpecs scriptBytes = do
                     (pure . resolver)
                     signedBoot
             case events of
-                [evt@(CageBoot tid _ts)] -> do
+                [evt@(CageBoot tid _stRef _ts)] -> do
                     -- Compute inverse BEFORE apply
                     let inverses =
                             inversesOf
@@ -778,8 +778,7 @@ indexerSpecs scriptBytes = do
                         }
             putRequest
                 (requests (state ctx))
-                reqTxIn1
-                req1
+                (LocatedRequest reqTxIn1 req1)
 
             -- Submit request 2
             signedReq2 <-
@@ -809,8 +808,7 @@ indexerSpecs scriptBytes = do
                         }
             putRequest
                 (requests (state ctx))
-                reqTxIn2
-                req2
+                (LocatedRequest reqTxIn2 req2)
 
             -- Snapshot before update
             preUtxos <-

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -1,0 +1,501 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.E2E.ProofsSpec
+-- Description : Verify proof-bearing read endpoints end-to-end
+-- License     : Apache-2.0
+--
+-- Boot a token, insert a fact, process it, then call the
+-- four proof-bearing read endpoints against a real devnet.
+-- For each response we:
+--
+--   * parse the embedded verification snapshot;
+--   * run 'verifyVerificationSnapshot' from
+--     @cardano-mpfs-client@ (structural check on the
+--     @utxo_root@ length and @chainpoint.block_id@);
+--   * assert the fields that the bundled UTxO-CSMT and
+--     MPF proofs live in are non-empty hex.
+--
+-- This gives us a minimum-viable end-to-end contract
+-- check: the server emits proof-bearing envelopes that
+-- the released verification client can parse and
+-- structurally validate.
+module Cardano.MPFS.E2E.ProofsSpec
+    ( spec
+    ) where
+
+import Control.Concurrent (threadDelay)
+import Data.Aeson
+    ( FromJSON (..)
+    , Value
+    , decode
+    , withObject
+    , (.:)
+    )
+import Data.Aeson.Key (Key)
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.Types (parseEither)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Short qualified as SBS
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Lens.Micro ((^.))
+import Network.HTTP.Types (status200)
+import Network.Wai (Application)
+import Network.Wai.Test
+    ( SResponse (..)
+    , defaultRequest
+    , request
+    , runSession
+    , setPath
+    )
+import System.Environment (lookupEnv)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , runIO
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import Cardano.Crypto.Hash.Class qualified as Crypto
+import Cardano.Ledger.Api.Tx (Tx, bodyTxL, txIdTx)
+import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
+import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.Mary.Value
+    ( AssetName (..)
+    , MultiAsset (..)
+    )
+import Cardano.Ledger.TxIn (TxId (..))
+
+import Cardano.Chain.Slotting (EpochSlots (..))
+import Control.Tracer (nullTracer)
+
+import Cardano.MPFS.Application
+    ( AppConfig (..)
+    , withApplication
+    )
+import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Core.Blueprint
+    ( applyVersion
+    , extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Core.Types
+    ( Coin (..)
+    , ConwayEra
+    , TokenId (..)
+    )
+import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.Submitter
+    ( SubmitResult (..)
+    , Submitter (..)
+    )
+import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( cagePolicyIdFromCfg
+    , computeScriptHash
+    )
+import Cardano.Node.Client.E2E.Devnet (withCardanoNode)
+import Cardano.Node.Client.E2E.Setup
+    ( addKeyWitness
+    , genesisAddr
+    , genesisDir
+    , genesisSignKey
+    )
+
+import Cardano.MPFS.Client
+    ( Hex (..)
+    , VerificationSnapshot
+    , verifyVerificationSnapshot
+    )
+
+-- | Skips when @MPFS_BLUEPRINT@ is not set.
+spec :: Spec
+spec = describe "Proof-bearing reads E2E" $ do
+    mPath <- runIO $ lookupEnv "MPFS_BLUEPRINT"
+    case mPath of
+        Nothing ->
+            it "skipped (no MPFS_BLUEPRINT)"
+                $ pure @IO ()
+        Just path -> do
+            ebp <- runIO $ loadBlueprint path
+            case ebp of
+                Left err ->
+                    it ("blueprint: " <> err)
+                        $ expectationFailure err
+                Right bp ->
+                    case extractCompiledCode
+                        "cage."
+                        bp of
+                        Nothing ->
+                            it "no compiled code"
+                                $ expectationFailure
+                                    "cage script \
+                                    \not found"
+                        Just sb ->
+                            proofsSpec
+                                $ applyVersion 1 sb
+
+-- -------------------------------------------------
+-- Scenario
+-- -------------------------------------------------
+
+-- | Await timeout in seconds. Devnet slots are 100ms.
+awaitTimeout :: Int
+awaitTimeout = 60
+
+-- | Fact key and value used throughout the scenario.
+factKey :: ByteString
+factKey = "hello"
+
+factValue :: ByteString
+factValue = "world"
+
+proofsSpec :: SBS.ShortByteString -> Spec
+proofsSpec scriptBytes =
+    it "all four reads carry a verifiable snapshot"
+        $ withE2E scriptBytes
+        $ \cfg ctx -> do
+            let app = mkApp ctx
+                tb = txBuilder ctx
+                submit =
+                    signSubmitAwait
+                        awaitTimeout
+                        app
+                        ctx
+
+            -- Boot → insert → update to land the fact
+            bootTx <-
+                submit $ bootToken tb genesisAddr
+            let tid = extractTokenId cfg bootTx
+                tidHex = tokenIdHex tid
+                keyHex = B16.encode factKey
+
+            _ <-
+                submit
+                    $ requestInsert
+                        tb
+                        tid
+                        factKey
+                        factValue
+                        genesisAddr
+            _ <-
+                submit
+                    $ updateToken
+                        tb
+                        tid
+                        genesisAddr
+
+            -- Add a second pending request so the
+            -- /requests endpoint returns a non-empty
+            -- witnessed list.
+            _ <-
+                submit
+                    $ requestInsert
+                        tb
+                        tid
+                        "bye"
+                        "moon"
+                        genesisAddr
+
+            -- Pull every proof-bearing read.
+            tokenObj <- getJSON app ("/tokens/" <> tidHex)
+            factObj <-
+                getJSON app
+                    $ "/tokens/"
+                        <> tidHex
+                        <> "/facts/"
+                        <> keyHex
+            proofObj <-
+                getJSON app
+                    $ "/tokens/"
+                        <> tidHex
+                        <> "/proofs/"
+                        <> keyHex
+            requestsObj <-
+                getJSON app
+                    $ "/tokens/"
+                        <> tidHex
+                        <> "/requests"
+
+            -- Every response carries the same snapshot
+            -- shape and that snapshot passes the client
+            -- structural verifier.
+            tokenSnap <- extractSnapshot tokenObj
+            factSnap <- extractSnapshot factObj
+            proofSnap <- extractSnapshot proofObj
+            reqsSnap <- extractSnapshot requestsObj
+
+            mapM_
+                assertSnapshotValid
+                [tokenSnap, factSnap, proofSnap, reqsSnap]
+
+            -- Each response ships the proofs the client
+            -- will later consume — assert they are
+            -- present as non-empty hex.
+            assertWitnessedUtxo
+                =<< lookupObj tokenObj "state"
+            assertFactEnvelope factObj
+            assertProofEnvelope proofObj
+
+            assertRequestsEnvelope requestsObj
+
+-- -------------------------------------------------
+-- Assertions on response shape
+-- -------------------------------------------------
+
+-- | Verify a 'VerificationSnapshot' with the offline
+-- verifier shipped by @cardano-mpfs-client@.
+assertSnapshotValid :: VerificationSnapshot -> IO ()
+assertSnapshotValid snap =
+    case verifyVerificationSnapshot snap of
+        Right () -> pure ()
+        Left err ->
+            expectationFailure
+                $ "snapshot verification failed: "
+                    <> show err
+
+-- | Pull the @snapshot@ field out of a response object.
+extractSnapshot :: Value -> IO VerificationSnapshot
+extractSnapshot v =
+    case parseEither snapshotField v of
+        Right s -> pure s
+        Left err ->
+            do
+                expectationFailure
+                    $ "snapshot parse: " <> err
+                error "unreachable"
+  where
+    snapshotField =
+        withObject "response" $ \o ->
+            o .: "snapshot"
+
+-- | Every witnessed UTxO envelope must ship
+-- @tx_in@, @tx_out@ and @utxo_proof@ as non-empty hex.
+assertWitnessedUtxo :: Value -> IO ()
+assertWitnessedUtxo v = do
+    utxo <- lookupObj v "utxo"
+    _ <- lookupObj utxo "tx_in"
+    txOut <- lookupHex utxo "tx_out"
+    txOut `shouldSatisfy` (not . T.null)
+    proof <- lookupHex utxo "utxo_proof"
+    proof `shouldSatisfy` (not . T.null)
+
+-- | The @/facts/:key@ envelope carries the stored
+-- MPF value, the state witness, and the MPF proof.
+-- MPFS stores values as 32-byte content hashes, so we
+-- only assert the @value@ field is non-empty hex.
+assertFactEnvelope :: Value -> IO ()
+assertFactEnvelope v = do
+    val <- lookupHex v "value"
+    val `shouldSatisfy` (not . T.null)
+    fact <- lookupObj v "fact"
+    state <- lookupObj fact "state"
+    assertWitnessedUtxo state
+    mpfProof <- lookupHex fact "mpf_proof"
+    mpfProof `shouldSatisfy` (not . T.null)
+
+-- | The @/proofs/:key@ envelope carries the state
+-- witness and the MPF proof (no value).
+assertProofEnvelope :: Value -> IO ()
+assertProofEnvelope v = do
+    fact <- lookupObj v "fact"
+    state <- lookupObj fact "state"
+    assertWitnessedUtxo state
+    mpfProof <- lookupHex fact "mpf_proof"
+    mpfProof `shouldSatisfy` (not . T.null)
+
+-- | The @/requests@ envelope must contain at least one
+-- witnessed request with both its UTxO witness and a
+-- decoded request payload.
+assertRequestsEnvelope :: Value -> IO ()
+assertRequestsEnvelope v = do
+    requests <- lookupArr v "requests"
+    case requests of
+        [] ->
+            expectationFailure
+                "expected at least one witnessed \
+                \request"
+        (wreq : _) -> do
+            assertWitnessedUtxo wreq
+            _ <- lookupObj wreq "request"
+            pure ()
+
+-- -------------------------------------------------
+-- JSON plumbing
+-- -------------------------------------------------
+
+lookupObj :: Value -> Key -> IO Value
+lookupObj = parseField
+
+lookupHex :: Value -> Key -> IO Text
+lookupHex v k = do
+    Hex t <- parseField v k
+    pure t
+
+lookupArr :: Value -> Key -> IO [Value]
+lookupArr = parseField
+
+parseField :: (FromJSON a) => Value -> Key -> IO a
+parseField v k =
+    case parseEither
+        (withObject "obj" (.: k))
+        v of
+        Right x -> pure x
+        Left err ->
+            do
+                expectationFailure
+                    $ "field "
+                        <> Key.toString k
+                        <> ": "
+                        <> err
+                error "unreachable"
+
+-- -------------------------------------------------
+-- DSL (mirrors HTTPLifecycleSpec)
+-- -------------------------------------------------
+
+signSubmitAwait
+    :: Int
+    -> Application
+    -> Context IO
+    -> IO (Tx ConwayEra)
+    -> IO (Tx ConwayEra)
+signSubmitAwait timeout app ctx buildTx = do
+    unsigned <- buildTx
+    let signed =
+            addKeyWitness genesisSignKey unsigned
+    result <- submitTx (submitter ctx) signed
+    assertSubmitted result
+    awaitTx timeout app (txIdTx signed)
+    pure signed
+
+awaitTx :: Int -> Application -> TxId -> IO ()
+awaitTx timeout app tid = do
+    resp <- getRaw app path
+    simpleStatus resp `shouldBe` status200
+  where
+    path =
+        "/tx/"
+            <> txIdHex tid
+            <> "?timeout="
+            <> bshow timeout
+    bshow =
+        BS.pack
+            . map (fromIntegral . fromEnum)
+            . show
+
+getJSON :: Application -> ByteString -> IO Value
+getJSON app path = do
+    resp <- getRaw app path
+    simpleStatus resp `shouldBe` status200
+    case decode (simpleBody resp) of
+        Just v -> pure v
+        Nothing ->
+            do
+                expectationFailure
+                    $ "non-JSON response: "
+                        <> show (simpleBody resp)
+                error "unreachable"
+
+getRaw :: Application -> ByteString -> IO SResponse
+getRaw app path =
+    runSession
+        (request (setPath defaultRequest path))
+        app
+
+assertSubmitted :: SubmitResult -> IO ()
+assertSubmitted (Submitted _) = pure ()
+assertSubmitted (Rejected reason) =
+    expectationFailure
+        $ "Tx rejected: " <> show reason
+
+-- | Hex-encode a 'TokenId' for URL paths.
+tokenIdHex :: TokenId -> ByteString
+tokenIdHex (TokenId (AssetName sbs)) =
+    B16.encode (SBS.fromShort sbs)
+
+-- | Raw 32-byte hash as hex for URL paths.
+txIdHex :: TxId -> ByteString
+txIdHex (TxId sh) =
+    B16.encode
+        $ Crypto.hashToBytes
+        $ extractHash sh
+
+-- | Extract the sole minted 'TokenId'.
+extractTokenId
+    :: CageConfig -> Tx ConwayEra -> TokenId
+extractTokenId cfg tx =
+    let MultiAsset ma =
+            tx ^. bodyTxL . mintTxBodyL
+        pid = cagePolicyIdFromCfg cfg
+        assets = Map.toList (ma Map.! pid)
+    in  case assets of
+            [(an, _)] -> TokenId an
+            _ ->
+                error
+                    "extractTokenId: \
+                    \unexpected mint"
+
+-- -------------------------------------------------
+-- Bracket
+-- -------------------------------------------------
+
+withE2E
+    :: SBS.ShortByteString
+    -> (CageConfig -> Context IO -> IO a)
+    -> IO a
+withE2E scriptBytes action = do
+    gDir <- genesisDir
+    withCardanoNode gDir $ \sock _startMs ->
+        withSystemTempDirectory
+            "mpfs-proofs-e2e"
+            $ \tmpDir -> do
+                let cfg = cageCfg scriptBytes
+                    appCfg =
+                        AppConfig
+                            { epochSlots =
+                                EpochSlots 4320
+                            , shelleyGenesisPath =
+                                gDir
+                                    </> "shelley-genesis.json"
+                            , socketPath = sock
+                            , dbPath = tmpDir </> "db"
+                            , channelCapacity = 16
+                            , cageConfig = cfg
+                            , byronGenesisPath =
+                                Nothing
+                            , followerEnabled = True
+                            , appTracer = nullTracer
+                            }
+                withApplication appCfg $ \ctx -> do
+                    _ <-
+                        queryProtocolParams
+                            (provider ctx)
+                    threadDelay 10_000_000
+                    action cfg ctx
+
+cageCfg :: SBS.ShortByteString -> CageConfig
+cageCfg scriptBytes =
+    CageConfig
+        { cageScriptBytes = scriptBytes
+        , cfgScriptHash =
+            computeScriptHash scriptBytes
+        , defaultProcessTime = 5_000
+        , defaultRetractTime = 5_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }

--- a/cardano-mpfs-offchain/e2e-test/main.hs
+++ b/cardano-mpfs-offchain/e2e-test/main.hs
@@ -8,6 +8,7 @@ import Cardano.MPFS.E2E.ChainSyncSpec qualified as ChainSyncSpec
 import Cardano.MPFS.E2E.CrashRecoverySpec qualified as CrashRecoverySpec
 import Cardano.MPFS.E2E.HTTPLifecycleSpec qualified as HTTPLifecycleSpec
 import Cardano.MPFS.E2E.IndexerSpec qualified as IndexerSpec
+import Cardano.MPFS.E2E.ProofsSpec qualified as ProofsSpec
 import Cardano.MPFS.E2E.ProviderSpec qualified as ProviderSpec
 import Cardano.MPFS.E2E.SubmitterSpec qualified as SubmitterSpec
 
@@ -20,4 +21,5 @@ main = hspec $ do
     IndexerSpec.spec
     ChainSyncSpec.spec
     HTTPLifecycleSpec.spec
+    ProofsSpec.spec
     CrashRecoverySpec.spec

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs
@@ -41,9 +41,11 @@ module Cardano.MPFS.Core.Types
 
       -- * Requests
     , Request (..)
+    , LocatedRequest (..)
 
       -- * Token state
     , TokenState (..)
+    , LocatedTokenState (..)
 
       -- * Facts
     , Fact (..)
@@ -103,6 +105,18 @@ data Operation
         -- ^ New value to store
     deriving (Eq, Show)
 
+-- | A pending request together with the reference
+-- of the UTxO currently carrying it on-chain. The
+-- UTxO body ('TxOut') is recoverable via a
+-- 'resolveUtxo' hook.
+data LocatedRequest = LocatedRequest
+    { requestRef :: !TxIn
+    -- ^ Reference of the UTxO carrying this request
+    , request :: !Request
+    -- ^ The request payload
+    }
+    deriving (Eq, Show)
+
 -- | A request to modify a token's trie.
 data Request = Request
     { requestToken :: !TokenId
@@ -117,6 +131,18 @@ data Request = Request
     -- ^ Fee the requester agrees to pay
     , requestSubmittedAt :: !Integer
     -- ^ POSIXTime (ms) when the request was created
+    }
+    deriving (Eq, Show)
+
+-- | On-chain token state together with the
+-- reference of the UTxO currently carrying it.
+-- The UTxO body ('TxOut') is recoverable via a
+-- 'resolveUtxo' hook.
+data LocatedTokenState = LocatedTokenState
+    { tokenStateRef :: !TxIn
+    -- ^ Reference of the UTxO holding this state
+    , tokenState :: !TokenState
+    -- ^ The state payload
     }
     deriving (Eq, Show)
 

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
@@ -74,7 +74,7 @@ import Cardano.MPFS.HTTP.Types
     , InsertRequest
     , ProofResponse
     , RejectRequest
-    , RequestJSON
+    , RequestsResponse
     , RetractRequest
     , StatusResponse
     , SubmitRequest
@@ -140,12 +140,14 @@ type TokenProofAPI =
         :> Get '[JSON] ProofResponse
 
 -- | @GET \/tokens\/:id\/requests@ — list pending
--- requests for a token.
+-- requests for a token together with their UTxO
+-- witnesses and the verification snapshot the
+-- bundled proofs target.
 type TokenRequestsAPI =
     "tokens"
         :> Capture "id" TokenIdJSON
         :> "requests"
-        :> Get '[JSON] [RequestJSON]
+        :> Get '[JSON] RequestsResponse
 
 -- | @GET \/utxo\/:txId\/:txIx@ — resolve a TxIn to
 -- its CBOR-encoded TxOut (hex).

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
@@ -70,7 +70,9 @@ import Cardano.MPFS.HTTP.Types
     ( BootRequest
     , DeleteRequest
     , EndRequest
+    , FactResponse
     , InsertRequest
+    , ProofResponse
     , RejectRequest
     , RequestJSON
     , RetractRequest
@@ -116,22 +118,26 @@ type TokenRootAPI =
         :> Get '[JSON] Hex
 
 -- | @GET \/tokens\/:id\/facts\/:key@ — look up a
--- value by key.
+-- value by key, returning the value, the state
+-- witness it belongs to, and an MPF inclusion proof
+-- against that state's trie root.
 type TokenFactAPI =
     "tokens"
         :> Capture "id" TokenIdJSON
         :> "facts"
         :> Capture "key" Hex
-        :> Get '[JSON] Hex
+        :> Get '[JSON] FactResponse
 
--- | @GET \/tokens\/:id\/proofs\/:key@ — generate a
--- Merkle proof for a key.
+-- | @GET \/tokens\/:id\/proofs\/:key@ — produce an
+-- MPF inclusion proof for a key together with the
+-- state witness it targets and the verification
+-- snapshot.
 type TokenProofAPI =
     "tokens"
         :> Capture "id" TokenIdJSON
         :> "proofs"
         :> Capture "key" Hex
-        :> Get '[JSON] Hex
+        :> Get '[JSON] ProofResponse
 
 -- | @GET \/tokens\/:id\/requests@ — list pending
 -- requests for a token.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
@@ -77,7 +77,7 @@ import Cardano.MPFS.HTTP.Types
     , StatusResponse
     , SubmitRequest
     , TokenIdJSON
-    , TokenStateJSON
+    , TokenResponse
     , UpdateRequest
     , UpdateValueRequest
     )
@@ -100,11 +100,13 @@ type StatusAPI = "status" :> Get '[JSON] StatusResponse
 -- | @GET \/tokens@ — list all known token IDs.
 type TokensAPI = "tokens" :> Get '[JSON] [TokenIdJSON]
 
--- | @GET \/tokens\/:id@ — get a token's state.
+-- | @GET \/tokens\/:id@ — get a token's state
+-- together with its UTxO witness and the
+-- verification snapshot the bundled proof targets.
 type TokenAPI =
     "tokens"
         :> Capture "id" TokenIdJSON
-        :> Get '[JSON] TokenStateJSON
+        :> Get '[JSON] TokenResponse
 
 -- | @GET \/tokens\/:id\/root@ — get trie root hash.
 type TokenRootAPI =

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -64,6 +64,8 @@ import Cardano.MPFS.Core.Types
     ( Addr
     , BlockId (..)
     , ConwayEra
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Root (..)
     , SlotNo (..)
     )
@@ -204,7 +206,8 @@ tokenHandler ctx (TokenIdJSON tid) = do
             $ St.getToken (St.tokens (state ctx)) tid
     case mts of
         Nothing -> throwError err404
-        Just ts -> pure (tokenStateToJSON ts)
+        Just LocatedTokenState{tokenState} ->
+            pure (tokenStateToJSON tokenState)
 
 tokenRootHandler
     :: Context IO
@@ -255,7 +258,7 @@ tokenRequestsHandler ctx (TokenIdJSON tid) = do
             $ St.requestsByToken
                 (St.requests (state ctx))
                 tid
-    pure (map requestToJSON reqs)
+    pure (map (requestToJSON . request) reqs)
 
 -- ---------------------------------------------------------
 -- UTxO CSMT handlers

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -69,6 +69,7 @@ import Cardano.MPFS.Core.Types
     , LocatedTokenState (..)
     , Root (..)
     , SlotNo (..)
+    , TokenId
     )
 import Cardano.MPFS.HTTP.API (API)
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
@@ -81,7 +82,10 @@ import Cardano.MPFS.HTTP.Types
     , ChainPointJSON (..)
     , DeleteRequest (..)
     , EndRequest (..)
+    , FactResponse (..)
+    , FactWitness (..)
     , InsertRequest (..)
+    , ProofResponse (..)
     , RejectRequest (..)
     , RequestJSON
     , RetractRequest (..)
@@ -231,6 +235,19 @@ tokenHandler ctx (TokenIdJSON tid) = do
                                 }
                         }
 
+-- | Look up an indexed token state by id, or @404@.
+requireToken
+    :: Context IO
+    -> TokenId
+    -> Handler LocatedTokenState
+requireToken ctx tid = do
+    mts <-
+        liftIO
+            $ St.getToken (St.tokens (state ctx)) tid
+    case mts of
+        Nothing -> throwError err404
+        Just lts -> pure lts
+
 -- | Read the current 'VerificationSnapshot' from
 -- context, or 503 if the indexer has not yet
 -- produced a UTxO-CSMT root or a checkpoint.
@@ -293,22 +310,76 @@ tokenFactHandler
     :: Context IO
     -> TokenIdJSON
     -> Hex
-    -> Handler Hex
+    -> Handler FactResponse
 tokenFactHandler ctx (TokenIdJSON tid) (Hex k) = do
+    LocatedTokenState
+        { tokenStateRef
+        , tokenState = ts
+        } <-
+        requireToken ctx tid
+    snapshot <- requireSnapshot ctx
+    witness <- requireUtxoWitness ctx tokenStateRef
     mv <-
         liftIO
             $ Trie.withTrie (trieManager ctx) tid
             $ \trie -> Trie.lookup trie k
-    case mv of
+    v <- case mv of
+        Just v -> pure v
         Nothing -> throwError err404
-        Just v -> pure (Hex v)
+    proof <- requireMpfProof ctx tid k
+    pure
+        FactResponse
+            { frSnapshot = snapshot
+            , frValue = Hex v
+            , frFact =
+                FactWitness
+                    { fwState =
+                        WitnessedTokenState
+                            { wtsUtxo = witness
+                            , wtsState =
+                                tokenStateToJSON ts
+                            }
+                    , fwMpfProof = proof
+                    }
+            }
 
 tokenProofHandler
     :: Context IO
     -> TokenIdJSON
     -> Hex
-    -> Handler Hex
+    -> Handler ProofResponse
 tokenProofHandler ctx (TokenIdJSON tid) (Hex k) = do
+    LocatedTokenState
+        { tokenStateRef
+        , tokenState = ts
+        } <-
+        requireToken ctx tid
+    snapshot <- requireSnapshot ctx
+    witness <- requireUtxoWitness ctx tokenStateRef
+    proof <- requireMpfProof ctx tid k
+    pure
+        ProofResponse
+            { prSnapshot = snapshot
+            , prFact =
+                FactWitness
+                    { fwState =
+                        WitnessedTokenState
+                            { wtsUtxo = witness
+                            , wtsState =
+                                tokenStateToJSON ts
+                            }
+                    , fwMpfProof = proof
+                    }
+            }
+
+-- | Compute an MPF inclusion proof for a key under
+-- a token's trie, or @404@ if absent.
+requireMpfProof
+    :: Context IO
+    -> TokenId
+    -> ByteString
+    -> Handler Hex
+requireMpfProof ctx tid k = do
     mp <-
         liftIO
             $ Trie.withTrie (trieManager ctx) tid

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -87,7 +87,7 @@ import Cardano.MPFS.HTTP.Types
     , InsertRequest (..)
     , ProofResponse (..)
     , RejectRequest (..)
-    , RequestJSON
+    , RequestsResponse (..)
     , RetractRequest (..)
     , StatusResponse (..)
     , SubmitRequest (..)
@@ -96,6 +96,7 @@ import Cardano.MPFS.HTTP.Types
     , UpdateRequest (..)
     , UpdateValueRequest (..)
     , VerificationSnapshot (..)
+    , WitnessedRequest (..)
     , WitnessedTokenState (..)
     , WitnessedUtxo (..)
     , parseAddr
@@ -391,14 +392,38 @@ requireMpfProof ctx tid k = do
 tokenRequestsHandler
     :: Context IO
     -> TokenIdJSON
-    -> Handler [RequestJSON]
+    -> Handler RequestsResponse
 tokenRequestsHandler ctx (TokenIdJSON tid) = do
+    _ <- requireToken ctx tid
+    snapshot <- requireSnapshot ctx
     reqs <-
         liftIO
             $ St.requestsByToken
                 (St.requests (state ctx))
                 tid
-    pure (map (requestToJSON . request) reqs)
+    witnessed <- traverse (witnessRequest ctx) reqs
+    pure
+        RequestsResponse
+            { rrSnapshot = snapshot
+            , rrRequests = witnessed
+            }
+
+-- | Build a 'WitnessedRequest' from a 'LocatedRequest'
+-- by resolving its UTxO witness against the snapshot's
+-- @utxo_root@. @404@ if the witness cannot be assembled.
+witnessRequest
+    :: Context IO
+    -> LocatedRequest
+    -> Handler WitnessedRequest
+witnessRequest
+    ctx
+    LocatedRequest{requestRef, request = req} = do
+        witness <- requireUtxoWitness ctx requestRef
+        pure
+            WitnessedRequest
+                { wrUtxo = witness
+                , wrRequest = requestToJSON req
+                }
 
 -- ---------------------------------------------------------
 -- UTxO CSMT handlers

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -31,6 +31,7 @@ import Servant
     , err400
     , err404
     , err502
+    , err503
     , errBody
     , serve
     , throwError
@@ -77,6 +78,7 @@ import Cardano.MPFS.HTTP.Swagger
     )
 import Cardano.MPFS.HTTP.Types
     ( BootRequest (..)
+    , ChainPointJSON (..)
     , DeleteRequest (..)
     , EndRequest (..)
     , InsertRequest (..)
@@ -86,12 +88,16 @@ import Cardano.MPFS.HTTP.Types
     , StatusResponse (..)
     , SubmitRequest (..)
     , TokenIdJSON (..)
-    , TokenStateJSON
+    , TokenResponse (..)
     , UpdateRequest (..)
     , UpdateValueRequest (..)
+    , VerificationSnapshot (..)
+    , WitnessedTokenState (..)
+    , WitnessedUtxo (..)
     , parseAddr
     , requestToJSON
     , tokenStateToJSON
+    , txInToJSON
     )
 import Cardano.UTxOCSMT.Application.Metrics
     ( Metrics (..)
@@ -199,15 +205,78 @@ tokensHandler ctx = do
 tokenHandler
     :: Context IO
     -> TokenIdJSON
-    -> Handler TokenStateJSON
+    -> Handler TokenResponse
 tokenHandler ctx (TokenIdJSON tid) = do
     mts <-
         liftIO
             $ St.getToken (St.tokens (state ctx)) tid
     case mts of
         Nothing -> throwError err404
-        Just LocatedTokenState{tokenState} ->
-            pure (tokenStateToJSON tokenState)
+        Just
+            LocatedTokenState
+                { tokenStateRef
+                , tokenState = ts
+                } -> do
+                snapshot <- requireSnapshot ctx
+                witness <-
+                    requireUtxoWitness ctx tokenStateRef
+                pure
+                    TokenResponse
+                        { trSnapshot = snapshot
+                        , trState =
+                            WitnessedTokenState
+                                { wtsUtxo = witness
+                                , wtsState =
+                                    tokenStateToJSON ts
+                                }
+                        }
+
+-- | Read the current 'VerificationSnapshot' from
+-- context, or 503 if the indexer has not yet
+-- produced a UTxO-CSMT root or a checkpoint.
+requireSnapshot
+    :: Context IO -> Handler VerificationSnapshot
+requireSnapshot ctx = do
+    mRoot <- liftIO $ utxoRoot ctx
+    mCp <-
+        liftIO
+            $ St.getCheckpoint
+                (St.checkpoints (state ctx))
+    case (mRoot, mCp) of
+        (Just r, Just (SlotNo s, BlockId b)) ->
+            pure
+                VerificationSnapshot
+                    { vsUtxoRoot = Hex r
+                    , vsChainPoint =
+                        ChainPointJSON
+                            { cpSlot = s
+                            , cpBlockId = Hex b
+                            }
+                    }
+        _ ->
+            throwError
+                err503
+                    { errBody =
+                        "Verification snapshot \
+                        \not yet available"
+                    }
+
+-- | Resolve a 'TxIn' to a 'WitnessedUtxo', or
+-- @404@ if the UTxO or its CSMT proof is missing.
+requireUtxoWitness
+    :: Context IO -> TxIn -> Handler WitnessedUtxo
+requireUtxoWitness ctx txIn = do
+    mOut <- liftIO $ resolveUtxo ctx txIn
+    mProof <- liftIO $ utxoProof ctx txIn
+    case (mOut, mProof) of
+        (Just out, Just proof) ->
+            pure
+                WitnessedUtxo
+                    { wuTxIn = txInToJSON txIn
+                    , wuTxOut = Hex out
+                    , wuProof = Hex proof
+                    }
+        _ -> throwError err404
 
 tokenRootHandler
     :: Context IO

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -27,6 +27,20 @@ module Cardano.MPFS.HTTP.Types
     , RequestJSON (..)
     , requestToJSON
 
+      -- * UTxO witnesses
+    , TxInJSON (..)
+    , txInToJSON
+    , WitnessedUtxo (..)
+
+      -- * Proof-bearing read responses
+    , WitnessedTokenState (..)
+    , WitnessedRequest (..)
+    , FactWitness (..)
+    , TokenResponse (..)
+    , FactResponse (..)
+    , ProofResponse (..)
+    , RequestsResponse (..)
+
       -- * Transaction requests
     , BootRequest (..)
     , InsertRequest (..)
@@ -72,8 +86,11 @@ import GHC.IsList (IsList (..))
 import Servant.API (FromHttpApiData (..))
 
 import Cardano.Ledger.Address (decodeAddrEither)
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Hashes (extractHash)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (AssetName (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 
@@ -230,6 +247,15 @@ instance ToJSON TokenStateJSON where
             , "retract_time" .= retractTime
             ]
 
+instance FromJSON TokenStateJSON where
+    parseJSON = withObject "TokenStateJSON" $ \o ->
+        TokenStateJSON
+            <$> o .: "owner"
+            <*> o .: "root"
+            <*> o .: "tip"
+            <*> o .: "process_time"
+            <*> o .: "retract_time"
+
 -- | Convert internal 'TokenState' to JSON type.
 tokenStateToJSON :: TokenState -> TokenStateJSON
 tokenStateToJSON
@@ -284,6 +310,17 @@ instance ToJSON RequestJSON where
             , "submitted_at" .= rjSubmittedAt
             ]
 
+instance FromJSON RequestJSON where
+    parseJSON = withObject "RequestJSON" $ \o ->
+        RequestJSON
+            <$> o .: "token"
+            <*> o .: "owner"
+            <*> o .: "key"
+            <*> o .: "operation"
+            <*> o .: "value"
+            <*> o .: "fee"
+            <*> o .: "submitted_at"
+
 -- | Convert internal 'Request' to JSON type.
 requestToJSON :: Request -> RequestJSON
 requestToJSON
@@ -309,6 +346,242 @@ requestToJSON
                 , rjFee = unCoin fee
                 , rjSubmittedAt = sat
                 }
+
+-- ---------------------------------------------------------
+-- UTxO witnesses
+-- ---------------------------------------------------------
+
+-- | JSON representation of a 'TxIn' as a
+-- @{ tx_id, tx_ix }@ object.
+data TxInJSON = TxInJSON
+    { tjTxId :: Hex
+    -- ^ Transaction id (32-byte blake2b, hex)
+    , tjTxIx :: Word64
+    -- ^ Output index within the transaction
+    }
+    deriving (Eq, Show)
+
+instance ToJSON TxInJSON where
+    toJSON TxInJSON{..} =
+        object
+            [ "tx_id" .= tjTxId
+            , "tx_ix" .= tjTxIx
+            ]
+
+instance FromJSON TxInJSON where
+    parseJSON = withObject "TxInJSON" $ \o ->
+        TxInJSON
+            <$> o .: "tx_id"
+            <*> o .: "tx_ix"
+
+-- | Convert a ledger 'TxIn' to its JSON form.
+txInToJSON :: TxIn -> TxInJSON
+txInToJSON (TxIn (TxId sh) (TxIx ix)) =
+    TxInJSON
+        { tjTxId =
+            Hex (Crypto.hashToBytes (extractHash sh))
+        , tjTxIx = fromIntegral ix
+        }
+
+-- | A witnessed UTxO: reference, resolved @TxOut@,
+-- and the UTxO-CSMT inclusion proof that ties the
+-- pair into the snapshot's @utxo_root@.
+data WitnessedUtxo = WitnessedUtxo
+    { wuTxIn :: TxInJSON
+    -- ^ UTxO reference
+    , wuTxOut :: Hex
+    -- ^ CBOR-encoded @TxOut@ body (hex)
+    , wuProof :: Hex
+    -- ^ UTxO-CSMT inclusion proof (hex)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON WitnessedUtxo where
+    toJSON WitnessedUtxo{..} =
+        object
+            [ "tx_in" .= wuTxIn
+            , "tx_out" .= wuTxOut
+            , "utxo_proof" .= wuProof
+            ]
+
+instance FromJSON WitnessedUtxo where
+    parseJSON = withObject "WitnessedUtxo" $ \o ->
+        WitnessedUtxo
+            <$> o .: "tx_in"
+            <*> o .: "tx_out"
+            <*> o .: "utxo_proof"
+
+-- ---------------------------------------------------------
+-- Proof-bearing read responses
+-- ---------------------------------------------------------
+
+-- | Decoded token state together with the UTxO
+-- witness that proves it resides at the indexed
+-- snapshot's @utxo_root@.
+data WitnessedTokenState = WitnessedTokenState
+    { wtsUtxo :: WitnessedUtxo
+    -- ^ UTxO witness for the state output
+    , wtsState :: TokenStateJSON
+    -- ^ Decoded on-chain state payload
+    }
+    deriving (Eq, Show)
+
+instance ToJSON WitnessedTokenState where
+    toJSON WitnessedTokenState{..} =
+        object
+            [ "utxo" .= wtsUtxo
+            , "state" .= wtsState
+            ]
+
+instance FromJSON WitnessedTokenState where
+    parseJSON =
+        withObject "WitnessedTokenState" $ \o ->
+            WitnessedTokenState
+                <$> o .: "utxo"
+                <*> o .: "state"
+
+-- | A pending request together with the UTxO
+-- witness proving it existed in the indexed
+-- snapshot.
+data WitnessedRequest = WitnessedRequest
+    { wrUtxo :: WitnessedUtxo
+    -- ^ UTxO witness for the request output
+    , wrRequest :: RequestJSON
+    -- ^ Decoded request payload
+    }
+    deriving (Eq, Show)
+
+instance ToJSON WitnessedRequest where
+    toJSON WitnessedRequest{..} =
+        object
+            [ "utxo" .= wrUtxo
+            , "request" .= wrRequest
+            ]
+
+instance FromJSON WitnessedRequest where
+    parseJSON =
+        withObject "WitnessedRequest" $ \o ->
+            WitnessedRequest
+                <$> o .: "utxo"
+                <*> o .: "request"
+
+-- | A fact witness: the state witness that carries
+-- the trie root plus an MPF inclusion proof binding a
+-- key (and optional value) to that root.
+data FactWitness = FactWitness
+    { fwState :: WitnessedTokenState
+    -- ^ State witness carrying the MPF root
+    , fwMpfProof :: Hex
+    -- ^ MPF inclusion proof (hex)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON FactWitness where
+    toJSON FactWitness{..} =
+        object
+            [ "state" .= fwState
+            , "mpf_proof" .= fwMpfProof
+            ]
+
+instance FromJSON FactWitness where
+    parseJSON = withObject "FactWitness" $ \o ->
+        FactWitness
+            <$> o .: "state"
+            <*> o .: "mpf_proof"
+
+-- | Response envelope for @GET \/tokens\/:id@.
+data TokenResponse = TokenResponse
+    { trSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target
+    , trState :: WitnessedTokenState
+    -- ^ State + UTxO witness
+    }
+    deriving (Eq, Show)
+
+instance ToJSON TokenResponse where
+    toJSON TokenResponse{..} =
+        object
+            [ "snapshot" .= trSnapshot
+            , "state" .= trState
+            ]
+
+instance FromJSON TokenResponse where
+    parseJSON = withObject "TokenResponse" $ \o ->
+        TokenResponse
+            <$> o .: "snapshot"
+            <*> o .: "state"
+
+-- | Response envelope for
+-- @GET \/tokens\/:id\/facts\/:key@.
+data FactResponse = FactResponse
+    { frSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target
+    , frValue :: Hex
+    -- ^ The fact value (hex)
+    , frFact :: FactWitness
+    -- ^ State witness + MPF proof
+    }
+    deriving (Eq, Show)
+
+instance ToJSON FactResponse where
+    toJSON FactResponse{..} =
+        object
+            [ "snapshot" .= frSnapshot
+            , "value" .= frValue
+            , "fact" .= frFact
+            ]
+
+instance FromJSON FactResponse where
+    parseJSON = withObject "FactResponse" $ \o ->
+        FactResponse
+            <$> o .: "snapshot"
+            <*> o .: "value"
+            <*> o .: "fact"
+
+-- | Response envelope for
+-- @GET \/tokens\/:id\/proofs\/:key@.
+data ProofResponse = ProofResponse
+    { prSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target
+    , prFact :: FactWitness
+    -- ^ State witness + MPF proof
+    }
+    deriving (Eq, Show)
+
+instance ToJSON ProofResponse where
+    toJSON ProofResponse{..} =
+        object
+            [ "snapshot" .= prSnapshot
+            , "fact" .= prFact
+            ]
+
+instance FromJSON ProofResponse where
+    parseJSON = withObject "ProofResponse" $ \o ->
+        ProofResponse
+            <$> o .: "snapshot"
+            <*> o .: "fact"
+
+-- | Response envelope for @GET \/tokens\/:id\/requests@.
+data RequestsResponse = RequestsResponse
+    { rrSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target
+    , rrRequests :: [WitnessedRequest]
+    -- ^ Witnessed pending requests
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RequestsResponse where
+    toJSON RequestsResponse{..} =
+        object
+            [ "snapshot" .= rrSnapshot
+            , "requests" .= rrRequests
+            ]
+
+instance FromJSON RequestsResponse where
+    parseJSON = withObject "RequestsResponse" $ \o ->
+        RequestsResponse
+            <$> o .: "snapshot"
+            <*> o .: "requests"
 
 -- | Parse a hex-encoded serialized address.
 parseAddr :: Hex -> Either String Addr
@@ -818,3 +1091,209 @@ instance ToSchema SubmitRequest where
             & required .~ ["tx"]
             & description
                 ?~ "Submit a signed transaction"
+
+instance ToSchema TxInJSON where
+    declareNamedSchema _ = do
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        word64Schema <-
+            declareSchemaRef (Proxy @Word64)
+        pure
+            $ Swagger.NamedSchema (Just "TxInJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("tx_id", hexSchema)
+                    , ("tx_ix", word64Schema)
+                    ]
+            & required .~ ["tx_id", "tx_ix"]
+            & description ?~ "UTxO reference"
+
+instance ToSchema WitnessedUtxo where
+    declareNamedSchema _ = do
+        txInSchema <-
+            declareSchemaRef (Proxy @TxInJSON)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "WitnessedUtxo")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("tx_in", txInSchema)
+                    , ("tx_out", hexSchema)
+                    , ("utxo_proof", hexSchema)
+                    ]
+            & required
+                .~ [ "tx_in"
+                   , "tx_out"
+                   , "utxo_proof"
+                   ]
+            & description
+                ?~ "UTxO reference, CBOR body, and \
+                   \UTxO-CSMT inclusion proof"
+
+instance ToSchema WitnessedTokenState where
+    declareNamedSchema _ = do
+        utxoSchema <-
+            declareSchemaRef (Proxy @WitnessedUtxo)
+        stateSchema <-
+            declareSchemaRef (Proxy @TokenStateJSON)
+        pure
+            $ Swagger.NamedSchema
+                (Just "WitnessedTokenState")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("utxo", utxoSchema)
+                    , ("state", stateSchema)
+                    ]
+            & required .~ ["utxo", "state"]
+            & description
+                ?~ "Token state plus UTxO witness"
+
+instance ToSchema WitnessedRequest where
+    declareNamedSchema _ = do
+        utxoSchema <-
+            declareSchemaRef (Proxy @WitnessedUtxo)
+        requestSchema <-
+            declareSchemaRef (Proxy @RequestJSON)
+        pure
+            $ Swagger.NamedSchema
+                (Just "WitnessedRequest")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("utxo", utxoSchema)
+                    , ("request", requestSchema)
+                    ]
+            & required .~ ["utxo", "request"]
+            & description
+                ?~ "Pending request plus UTxO witness"
+
+instance ToSchema FactWitness where
+    declareNamedSchema _ = do
+        stateSchema <-
+            declareSchemaRef
+                (Proxy @WitnessedTokenState)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema (Just "FactWitness")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("state", stateSchema)
+                    , ("mpf_proof", hexSchema)
+                    ]
+            & required .~ ["state", "mpf_proof"]
+            & description
+                ?~ "State witness plus MPF inclusion \
+                   \proof"
+
+instance ToSchema TokenResponse where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        stateSchema <-
+            declareSchemaRef
+                (Proxy @WitnessedTokenState)
+        pure
+            $ Swagger.NamedSchema
+                (Just "TokenResponse")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("state", stateSchema)
+                    ]
+            & required .~ ["snapshot", "state"]
+            & description
+                ?~ "Proof-bearing token state response"
+
+instance ToSchema FactResponse where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        factSchema <-
+            declareSchemaRef (Proxy @FactWitness)
+        pure
+            $ Swagger.NamedSchema
+                (Just "FactResponse")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("value", hexSchema)
+                    , ("fact", factSchema)
+                    ]
+            & required
+                .~ ["snapshot", "value", "fact"]
+            & description
+                ?~ "Proof-bearing fact value response"
+
+instance ToSchema ProofResponse where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        factSchema <-
+            declareSchemaRef (Proxy @FactWitness)
+        pure
+            $ Swagger.NamedSchema
+                (Just "ProofResponse")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("fact", factSchema)
+                    ]
+            & required .~ ["snapshot", "fact"]
+            & description
+                ?~ "Proof-bearing MPF proof response"
+
+instance ToSchema RequestsResponse where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        reqListSchema <-
+            declareSchemaRef
+                (Proxy @[WitnessedRequest])
+        pure
+            $ Swagger.NamedSchema
+                (Just "RequestsResponse")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("requests", reqListSchema)
+                    ]
+            & required
+                .~ ["snapshot", "requests"]
+            & description
+                ?~ "Proof-bearing pending requests \
+                   \response"

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs
@@ -33,6 +33,7 @@ module Cardano.MPFS.Indexer.Codecs
     , composedRollbackPrism
     , tokenIdPrism
     , tokenStatePrism
+    , locatedTokenStatePrism
     , txInPrism
     , requestPrism
     , unitPrism
@@ -95,6 +96,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
 
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -130,7 +132,7 @@ allCodecs =
         [ CageTokens
             :=> Codecs
                 { keyCodec = tokenIdPrism
-                , valueCodec = tokenStatePrism
+                , valueCodec = locatedTokenStatePrism
                 }
         , CageRequests
             :=> Codecs
@@ -225,6 +227,35 @@ tokenStatePrism = prism' enc dec
                 , tip = tip'
                 , processTime = processTime'
                 , retractTime = retractTime'
+                }
+
+-- | Encode/decode 'LocatedTokenState' as a
+-- 2-element CBOR list @[tokenStateRef, tokenState]@.
+-- The ref is embedded as a ledger-CBOR byte string
+-- and the state reuses 'tokenStatePrism'.
+locatedTokenStatePrism
+    :: Prism' ByteString LocatedTokenState
+locatedTokenStatePrism = prism' enc dec
+  where
+    enc LocatedTokenState{..} =
+        toStrictByteString
+            $ encodeListLen 2
+                <> encodeBytes
+                    (ledgerEnc tokenStateRef)
+                <> encodeBytes
+                    ( toStrictByteString
+                        $ encodeTokenState
+                            tokenState
+                    )
+    dec = decodeCBOR $ do
+        decodeListLenOf 2
+        ref <- ledgerDec =<< decodeBytes
+        tsBytes <- decodeBytes
+        ts <- decTokenState tsBytes
+        pure
+            LocatedTokenState
+                { tokenStateRef = ref
+                , tokenState = ts
                 }
 
 -- | Encode/decode 'TxIn' via its ledger CBOR
@@ -530,10 +561,11 @@ encodeInvOps ops =
 
 encodeInvOp :: CageInverseOp -> Encoding
 encodeInvOp = \case
-    InvRestoreToken tid ts ->
-        encodeListLen 3
+    InvRestoreToken tid txIn ts ->
+        encodeListLen 4
             <> encodeWord8 0
             <> encodeBytes (encTokenId tid)
+            <> encodeBytes (ledgerEnc txIn)
             <> encodeBytes
                 ( toStrictByteString
                     $ encodeTokenState ts
@@ -551,10 +583,11 @@ encodeInvOp = \case
         encodeListLen 2
             <> encodeWord8 3
             <> encodeBytes (ledgerEnc txIn)
-    InvRestoreRoot tid root ->
-        encodeListLen 3
+    InvRestoreRoot tid txIn root ->
+        encodeListLen 4
             <> encodeWord8 4
             <> encodeBytes (encTokenId tid)
+            <> encodeBytes (ledgerEnc txIn)
             <> encodeBytes (unRoot root)
     InvTrieInsert tid k v ->
         encodeListLen 4
@@ -601,11 +634,12 @@ decodeInvOp = do
     len <- decodeListLen
     tag <- decodeWord8
     case (tag, len) of
-        (0, 3) -> do
+        (0, 4) -> do
             tid <- decTokenId =<< decodeBytes
+            txIn <- ledgerDec =<< decodeBytes
             tsBytes <- decodeBytes
             ts <- decTokenState tsBytes
-            pure $ InvRestoreToken tid ts
+            pure $ InvRestoreToken tid txIn ts
         (1, 2) ->
             InvRemoveToken
                 <$> (decTokenId =<< decodeBytes)
@@ -617,10 +651,11 @@ decodeInvOp = do
         (3, 2) ->
             InvRemoveRequest
                 <$> (ledgerDec =<< decodeBytes)
-        (4, 3) -> do
+        (4, 4) -> do
             tid <- decTokenId =<< decodeBytes
+            txIn <- ledgerDec =<< decodeBytes
             r <- Root <$> decodeBytes
-            pure $ InvRestoreRoot tid r
+            pure $ InvRestoreRoot tid txIn r
         (5, 4) -> do
             tid <- decTokenId =<< decodeBytes
             k <- decodeBytes

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs
@@ -62,10 +62,10 @@ import MPF.Interface (HexIndirect, HexKey)
 
 import Cardano.MPFS.Core.Types
     ( BlockId
+    , LocatedTokenState
     , Request
     , SlotNo
     , TokenId
-    , TokenState
     , TxIn
     )
 import Cardano.MPFS.Indexer.ComposedInv (ComposedInv)
@@ -97,10 +97,11 @@ data CageCheckpoint = CageCheckpoint
 -- state. Covers cage state and per-token trie
 -- storage.
 data AllColumns x where
-    -- | Token state: maps token identifiers to
-    -- their on-chain state.
+    -- | Located token state: maps token identifiers
+    -- to their on-chain state together with the
+    -- reference of the UTxO currently carrying it.
     CageTokens
-        :: AllColumns (KV TokenId TokenState)
+        :: AllColumns (KV TokenId LocatedTokenState)
     -- | Pending requests: maps UTxO references to
     -- request details.
     CageRequests

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
@@ -116,19 +116,22 @@ import Cardano.MPFS.Core.Types
 -- | A cage-protocol event detected in a transaction.
 data CageEvent
     = -- | Mint with cage policyId: new token created.
-      -- Carries the new 'TokenId' and its initial
-      -- 'TokenState' from the output datum.
-      CageBoot !TokenId !TokenState
+      -- Carries the new 'TokenId', the 'TxIn' of the
+      -- continuing-state output, and the initial
+      -- 'TokenState' from that output's datum.
+      CageBoot !TokenId !TxIn !TokenState
     | -- | Output to cage address with a 'RequestDatum'.
       -- Carries the UTxO reference and decoded 'Request'.
       CageRequest !TxIn !Request
     | -- | Oracle processes requests: consumes request
       -- UTxOs and updates the trie root. Carries the
-      -- token, new root, and consumed request UTxOs.
-      CageUpdate !TokenId !Root ![TxIn]
+      -- token, the new state 'TxIn', new root, and
+      -- consumed request UTxOs.
+      CageUpdate !TokenId !TxIn !Root ![TxIn]
     | -- | Oracle rejects expired Phase 3 requests.
-      -- Root unchanged, requests consumed.
-      CageReject !TokenId ![TxIn]
+      -- Root unchanged; carries the new state 'TxIn'
+      -- and the consumed request UTxOs.
+      CageReject !TokenId !TxIn ![TxIn]
     | -- | Requester cancels a pending request.
       CageRetract !TxIn
     | -- | Burn cage token: token permanently removed.
@@ -137,16 +140,20 @@ data CageEvent
 
 -- | Inverse of a cage event, used for rollback.
 data CageInverseOp
-    = -- | Re-insert a deleted token
-      InvRestoreToken !TokenId !TokenState
+    = -- | Re-insert a deleted token, together with
+      -- the 'TxIn' of the UTxO that carried it.
+      InvRestoreToken !TokenId !TxIn !TokenState
     | -- | Remove an inserted token
       InvRemoveToken !TokenId
     | -- | Re-insert a deleted request
       InvRestoreRequest !TxIn !Request
     | -- | Remove an inserted request
       InvRemoveRequest !TxIn
-    | -- | Restore a token's previous root
-      InvRestoreRoot !TokenId !Root
+    | -- | Restore a token's previous state location
+      -- and root (undo update or reject). 'TxIn' is
+      -- the previous state UTxO; 'Root' is the root
+      -- at that point.
+      InvRestoreRoot !TokenId !TxIn !Root
     | -- | Restore key→value in token's trie (undo delete/update)
       InvTrieInsert !TokenId !ByteString !ByteString
     | -- | Remove key from token's trie (undo insert)
@@ -187,26 +194,38 @@ detectCageEvents scriptHash resolvedInputs tx =
         | qty == 1 =
             -- Boot: find StateDatum in outputs
             let tid = TokenId assetName
+                thisTxId = txIdTx tx
                 outputs =
-                    toList
-                        (body ^. outputsTxBodyL)
-                mState = findStateDatum outputs
+                    zip
+                        [0 ..]
+                        ( toList
+                            (body ^. outputsTxBodyL)
+                        )
+                mState =
+                    findStateDatum
+                        thisTxId
+                        outputs
             in  case mState of
-                    Just ts -> [CageBoot tid ts]
+                    Just (txIn, ts) ->
+                        [CageBoot tid txIn ts]
                     Nothing -> []
         | qty == -1 =
             [CageBurn (TokenId assetName)]
         | otherwise = []
 
-    findStateDatum =
+    findStateDatum thisTxId =
         foldr
-            ( \txOut acc -> case acc of
+            ( \(ix, txOut) acc -> case acc of
                 Just _ -> acc
                 Nothing ->
                     case extractDatum txOut of
                         Just (StateDatum ocs) ->
                             Just
-                                (fromOnChainState ocs)
+                                ( TxIn
+                                    thisTxId
+                                    (TxIx ix)
+                                , fromOnChainState ocs
+                                )
                         _ -> Nothing
             )
             Nothing
@@ -294,24 +313,31 @@ detectCageEvents scriptHash resolvedInputs tx =
 
     detectUpdate _stateTxIn _stateTxOut =
         -- Find the continuing output (new state)
-        let outputs =
-                toList
-                    (body ^. outputsTxBodyL)
-        in  case findStateDatumWithToken outputs of
-                Just (tid, newRoot) ->
+        let thisTxId = txIdTx tx
+            outputs =
+                zip
+                    [0 ..]
+                    ( toList
+                        (body ^. outputsTxBodyL)
+                    )
+        in  case findStateDatumWithToken
+                thisTxId
+                outputs of
+                Just (newTxIn, tid, newRoot) ->
                     let consumed =
                             findConsumedRequests
                                 tid
                     in  [ CageUpdate
                             tid
+                            newTxIn
                             newRoot
                             consumed
                         ]
                 Nothing -> []
 
-    findStateDatumWithToken =
+    findStateDatumWithToken thisTxId =
         foldr
-            ( \txOut acc -> case acc of
+            ( \(ix, txOut) acc -> case acc of
                 Just _ -> acc
                 Nothing ->
                     case txOut ^. addrTxOutL of
@@ -319,9 +345,19 @@ detectCageEvents scriptHash resolvedInputs tx =
                             | sh == scriptHash ->
                                 case extractDatum txOut of
                                     Just (StateDatum ocs) ->
-                                        extractTokenId
-                                            txOut
-                                            ocs
+                                        fmap
+                                            ( \(tid, r) ->
+                                                ( TxIn
+                                                    thisTxId
+                                                    (TxIx ix)
+                                                , tid
+                                                , r
+                                                )
+                                            )
+                                            ( extractTokenId
+                                                txOut
+                                                ocs
+                                            )
                                     _ -> Nothing
                         _ -> Nothing
             )
@@ -360,15 +396,25 @@ detectCageEvents scriptHash resolvedInputs tx =
             _ -> False
 
     detectReject _stateTxIn _stateTxOut =
-        let outputs =
-                toList
-                    (body ^. outputsTxBodyL)
-        in  case findStateDatumWithToken outputs of
-                Just (tid, _root) ->
+        let thisTxId = txIdTx tx
+            outputs =
+                zip
+                    [0 ..]
+                    ( toList
+                        (body ^. outputsTxBodyL)
+                    )
+        in  case findStateDatumWithToken
+                thisTxId
+                outputs of
+                Just (newTxIn, tid, _root) ->
                     let consumed =
                             findConsumedRequests
                                 tid
-                    in  [CageReject tid consumed]
+                    in  [ CageReject
+                            tid
+                            newTxIn
+                            consumed
+                        ]
                 Nothing -> []
 
     detectRetract txIn = [CageRetract txIn]
@@ -379,21 +425,25 @@ detectCageEvents scriptHash resolvedInputs tx =
 -- Used to record rollback information alongside
 -- cardano-utxo-csmt's rollback points.
 inversesOf
-    :: (TokenId -> Maybe TokenState)
-    -- ^ Token lookup in current state
+    :: (TokenId -> Maybe (TxIn, TokenState))
+    -- ^ Token lookup: returns state UTxO ref and state
     -> (TxIn -> Maybe Request)
     -- ^ Request lookup in current state
     -> CageEvent
     -> [CageInverseOp]
 inversesOf lookupToken lookupReq = \case
-    CageBoot tid _ts ->
+    CageBoot tid _txIn _ts ->
         [InvRemoveToken tid]
     CageRequest txIn _req ->
         [InvRemoveRequest txIn]
-    CageUpdate tid _newRoot consumed ->
+    CageUpdate tid _newTxIn _newRoot consumed ->
         let restoreRoot = case lookupToken tid of
-                Just ts ->
-                    [InvRestoreRoot tid (root ts)]
+                Just (oldTxIn, ts) ->
+                    [ InvRestoreRoot
+                        tid
+                        oldTxIn
+                        (root ts)
+                    ]
                 Nothing -> []
             restoreReqs =
                 concatMap
@@ -404,14 +454,24 @@ inversesOf lookupToken lookupReq = \case
                     )
                     consumed
         in  restoreRoot ++ restoreReqs
-    CageReject _tid consumed ->
-        concatMap
-            ( \txIn' -> case lookupReq txIn' of
-                Just req ->
-                    [InvRestoreRequest txIn' req]
+    CageReject tid _newTxIn consumed ->
+        let restoreRoot = case lookupToken tid of
+                Just (oldTxIn, ts) ->
+                    [ InvRestoreRoot
+                        tid
+                        oldTxIn
+                        (root ts)
+                    ]
                 Nothing -> []
-            )
-            consumed
+            restoreReqs =
+                concatMap
+                    ( \txIn' -> case lookupReq txIn' of
+                        Just req ->
+                            [InvRestoreRequest txIn' req]
+                        Nothing -> []
+                    )
+                    consumed
+        in  restoreRoot ++ restoreReqs
     CageRetract txIn ->
         case lookupReq txIn of
             Just req ->
@@ -419,7 +479,8 @@ inversesOf lookupToken lookupReq = \case
             Nothing -> []
     CageBurn tid ->
         case lookupToken tid of
-            Just ts -> [InvRestoreToken tid ts]
+            Just (txIn, ts) ->
+                [InvRestoreToken tid txIn ts]
             Nothing -> []
 
 -- --------------------------------------------------------

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs
@@ -57,6 +57,8 @@ import Ouroboros.Consensus.Shelley.Ledger
 
 import Cardano.MPFS.Core.Types
     ( ConwayEra
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , TokenId
@@ -190,15 +192,23 @@ computeInverse
         { tokens = Tokens{getToken}
         , requests = Requests{getRequest}
         } = \case
-        CageBoot tid _ts ->
+        CageBoot tid _txIn _ts ->
             pure [InvRemoveToken tid]
         CageRequest txIn _req ->
             pure [InvRemoveRequest txIn]
-        CageUpdate tid _newRoot consumed -> do
+        CageUpdate tid _newTxIn _newRoot consumed -> do
             mTs <- getToken tid
             let restoreRoot = case mTs of
-                    Just ts ->
-                        [InvRestoreRoot tid (root ts)]
+                    Just
+                        LocatedTokenState
+                            { tokenStateRef
+                            , tokenState
+                            } ->
+                            [ InvRestoreRoot
+                                tid
+                                tokenStateRef
+                                (root tokenState)
+                            ]
                     Nothing -> []
             restoreReqs <-
                 concat
@@ -206,40 +216,69 @@ computeInverse
                         ( \txIn -> do
                             mReq <- getRequest txIn
                             pure $ case mReq of
-                                Just req ->
-                                    [ InvRestoreRequest
-                                        txIn
-                                        req
-                                    ]
+                                Just
+                                    LocatedRequest
+                                        { request
+                                        } ->
+                                        [ InvRestoreRequest
+                                            txIn
+                                            request
+                                        ]
                                 Nothing -> []
                         )
                         consumed
             pure $ restoreRoot ++ restoreReqs
-        CageReject _tid consumed ->
-            concat
-                <$> traverse
-                    ( \txIn -> do
-                        mReq <- getRequest txIn
-                        pure $ case mReq of
-                            Just req ->
-                                [ InvRestoreRequest
-                                    txIn
-                                    req
-                                ]
-                            Nothing -> []
-                    )
-                    consumed
+        CageReject tid _newTxIn consumed -> do
+            mTs <- getToken tid
+            let restoreRoot = case mTs of
+                    Just
+                        LocatedTokenState
+                            { tokenStateRef
+                            , tokenState
+                            } ->
+                            [ InvRestoreRoot
+                                tid
+                                tokenStateRef
+                                (root tokenState)
+                            ]
+                    Nothing -> []
+            restoreReqs <-
+                concat
+                    <$> traverse
+                        ( \txIn -> do
+                            mReq <- getRequest txIn
+                            pure $ case mReq of
+                                Just
+                                    LocatedRequest
+                                        { request
+                                        } ->
+                                        [ InvRestoreRequest
+                                            txIn
+                                            request
+                                        ]
+                                Nothing -> []
+                        )
+                        consumed
+            pure $ restoreRoot ++ restoreReqs
         CageRetract txIn -> do
             mReq <- getRequest txIn
             pure $ case mReq of
-                Just req ->
-                    [InvRestoreRequest txIn req]
+                Just LocatedRequest{request} ->
+                    [InvRestoreRequest txIn request]
                 Nothing -> []
         CageBurn tid -> do
             mTs <- getToken tid
             pure $ case mTs of
-                Just ts ->
-                    [InvRestoreToken tid ts]
+                Just
+                    LocatedTokenState
+                        { tokenStateRef
+                        , tokenState
+                        } ->
+                        [ InvRestoreToken
+                            tid
+                            tokenStateRef
+                            tokenState
+                        ]
                 Nothing -> []
 
 -- | Apply a cage event to the state and trie
@@ -252,14 +291,25 @@ applyCageEvent
     -> CageEvent
     -> m [CageInverseOp]
 applyCageEvent st tm = \case
-    CageBoot tid ts -> do
-        putToken (tokens st) tid ts
+    CageBoot tid txIn ts -> do
+        putToken
+            (tokens st)
+            tid
+            LocatedTokenState
+                { tokenStateRef = txIn
+                , tokenState = ts
+                }
         createTrie tm tid
         pure []
     CageRequest txIn req -> do
-        putRequest (requests st) txIn req
+        putRequest
+            (requests st)
+            LocatedRequest
+                { requestRef = txIn
+                , request = req
+                }
         pure []
-    CageUpdate tid newRoot consumed -> do
+    CageUpdate tid newTxIn newRoot consumed -> do
         -- Apply trie mutations, collecting inverses
         trieInvs <-
             withTrie tm tid $ \trie ->
@@ -271,11 +321,14 @@ applyCageEvent st tm = \case
                                     (requests st)
                                     txIn
                             case mReq of
-                                Just req ->
-                                    applyRequestOp
-                                        tid
-                                        trie
-                                        req
+                                Just
+                                    LocatedRequest
+                                        { request
+                                        } ->
+                                        applyRequestOp
+                                            tid
+                                            trie
+                                            request
                                 Nothing -> pure []
                         )
                         consumed
@@ -283,20 +336,38 @@ applyCageEvent st tm = \case
         mapM_
             (removeRequest (requests st))
             consumed
-        -- Update token root
+        -- Update token root and move state ref
         mTs <- getToken (tokens st) tid
         case mTs of
-            Just ts ->
+            Just LocatedTokenState{tokenState} ->
                 putToken
                     (tokens st)
                     tid
-                    ts{root = newRoot}
+                    LocatedTokenState
+                        { tokenStateRef = newTxIn
+                        , tokenState =
+                            tokenState
+                                { root = newRoot
+                                }
+                        }
             Nothing -> pure ()
         pure trieInvs
-    CageReject _tid consumed -> do
+    CageReject tid newTxIn consumed -> do
         mapM_
             (removeRequest (requests st))
             consumed
+        -- Move the state ref to the continuing UTxO
+        mTs <- getToken (tokens st) tid
+        case mTs of
+            Just LocatedTokenState{tokenState} ->
+                putToken
+                    (tokens st)
+                    tid
+                    LocatedTokenState
+                        { tokenStateRef = newTxIn
+                        , tokenState = tokenState
+                        }
+            Nothing -> pure ()
         pure []
     CageRetract txIn -> do
         removeRequest (requests st) txIn
@@ -383,24 +454,41 @@ applyCageInverses
 applyCageInverses st tm = mapM_ applyInv
   where
     applyInv = \case
-        InvRestoreToken tid ts -> do
-            putToken (tokens st) tid ts
+        InvRestoreToken tid txIn ts -> do
+            putToken
+                (tokens st)
+                tid
+                LocatedTokenState
+                    { tokenStateRef = txIn
+                    , tokenState = ts
+                    }
             unhideTrie tm tid
         InvRemoveToken tid -> do
             removeToken (tokens st) tid
             deleteTrie tm tid
         InvRestoreRequest txIn req ->
-            putRequest (requests st) txIn req
+            putRequest
+                (requests st)
+                LocatedRequest
+                    { requestRef = txIn
+                    , request = req
+                    }
         InvRemoveRequest txIn ->
             removeRequest (requests st) txIn
-        InvRestoreRoot tid r -> do
+        InvRestoreRoot tid oldTxIn r -> do
             mTs <- getToken (tokens st) tid
             case mTs of
-                Just ts ->
+                Just LocatedTokenState{tokenState} ->
                     putToken
                         (tokens st)
                         tid
-                        ts{root = r}
+                        LocatedTokenState
+                            { tokenStateRef = oldTxIn
+                            , tokenState =
+                                tokenState
+                                    { root = r
+                                    }
+                            }
                 Nothing -> pure ()
         InvTrieInsert tid key val ->
             withTrie tm tid $ \trie ->

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs
@@ -45,7 +45,10 @@ import Database.KV.Transaction
     , query
     )
 
-import Cardano.MPFS.Core.Types (Request (..))
+import Cardano.MPFS.Core.Types
+    ( LocatedRequest (..)
+    , Request (..)
+    )
 import Cardano.MPFS.Indexer.Columns
     ( AllColumns (..)
     , CageCheckpoint (..)
@@ -121,8 +124,22 @@ mkTransactionalRequests
         (Transaction m cf AllColumns ops)
 mkTransactionalRequests =
     Requests
-        { getRequest = query CageRequests
-        , putRequest = insert CageRequests
+        { getRequest = \txIn -> do
+            mr <- query CageRequests txIn
+            pure
+                $ fmap
+                    ( \r ->
+                        LocatedRequest
+                            { requestRef = txIn
+                            , request = r
+                            }
+                    )
+                    mr
+        , putRequest = \LocatedRequest{..} ->
+            insert
+                CageRequests
+                requestRef
+                request
         , removeRequest = delete CageRequests
         , requestsByToken =
             iterating CageRequests . filterReqs
@@ -132,16 +149,21 @@ mkTransactionalRequests =
         me <- firstEntry
         case me of
             Nothing -> pure []
-            Just (Entry _ v) ->
-                goR tid (add tid v [])
+            Just (Entry k v) ->
+                goR tid (add tid k v [])
     goR tid acc = do
         me <- nextEntry
         case me of
             Nothing -> pure (reverse acc)
-            Just (Entry _ v) ->
-                goR tid (add tid v acc)
-    add tid v acc
-        | requestToken v == tid = v : acc
+            Just (Entry k v) ->
+                goR tid (add tid k v acc)
+    add tid k v acc
+        | requestToken v == tid =
+            LocatedRequest
+                { requestRef = k
+                , request = v
+                }
+                : acc
         | otherwise = acc
 
 -- --------------------------------------------------------

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
@@ -29,9 +29,10 @@ import Cardano.Ledger.TxIn (TxIn)
 
 import Cardano.MPFS.Core.Types
     ( BlockId
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Request (..)
     , TokenId
-    , TokenState
     )
 import Cardano.MPFS.State
     ( Checkpoints (..)
@@ -44,13 +45,16 @@ import Cardano.MPFS.State
 mkMockTokens :: IO (Tokens IO)
 mkMockTokens = do
     ref <-
-        newIORef (Map.empty :: Map TokenId TokenState)
+        newIORef
+            ( Map.empty
+                :: Map TokenId LocatedTokenState
+            )
     pure
         Tokens
             { getToken = \tid ->
                 Map.lookup tid <$> readIORef ref
-            , putToken = \tid ts ->
-                modifyIORef' ref (Map.insert tid ts)
+            , putToken = \tid lts ->
+                modifyIORef' ref (Map.insert tid lts)
             , removeToken =
                 modifyIORef' ref . Map.delete
             , listTokens =
@@ -64,17 +68,37 @@ mkMockRequests = do
         newIORef (Map.empty :: Map TxIn Request)
     pure
         Requests
-            { getRequest = \txin ->
-                Map.lookup txin <$> readIORef ref
-            , putRequest = \txin req ->
-                modifyIORef' ref (Map.insert txin req)
+            { getRequest = \txin -> do
+                m <- Map.lookup txin <$> readIORef ref
+                pure
+                    $ fmap
+                        ( \r ->
+                            LocatedRequest
+                                { requestRef = txin
+                                , request = r
+                                }
+                        )
+                        m
+            , putRequest =
+                \LocatedRequest{..} ->
+                    modifyIORef'
+                        ref
+                        ( Map.insert
+                            requestRef
+                            request
+                        )
             , removeRequest =
                 modifyIORef' ref . Map.delete
-            , requestsByToken = \tid ->
-                filter
-                    (\r -> requestToken r == tid)
-                    . Map.elems
-                    <$> readIORef ref
+            , requestsByToken = \tid -> do
+                m <- readIORef ref
+                pure
+                    [ LocatedRequest
+                        { requestRef = k
+                        , request = v
+                        }
+                    | (k, v) <- Map.toList m
+                    , requestToken v == tid
+                    ]
             }
 
 -- | Create a mock 'Checkpoints IO' backed by an

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs
@@ -32,10 +32,10 @@ module Cardano.MPFS.State
 
 import Cardano.MPFS.Core.Types
     ( BlockId
-    , Request
+    , LocatedRequest
+    , LocatedTokenState
     , SlotNo
     , TokenId
-    , TokenState
     , TxIn
     )
 
@@ -52,10 +52,10 @@ data State m = State
 
 -- | Interface for managing token state.
 data Tokens m = Tokens
-    { getToken :: TokenId -> m (Maybe TokenState)
-    -- ^ Look up a token's current state
-    , putToken :: TokenId -> TokenState -> m ()
-    -- ^ Store or update a token's state
+    { getToken :: TokenId -> m (Maybe LocatedTokenState)
+    -- ^ Look up a token's current located state
+    , putToken :: TokenId -> LocatedTokenState -> m ()
+    -- ^ Store or update a token's located state
     , removeToken :: TokenId -> m ()
     -- ^ Remove a token
     , listTokens :: m [TokenId]
@@ -65,16 +65,16 @@ data Tokens m = Tokens
 -- | Interface for managing pending requests.
 data Requests m = Requests
     { getRequest
-        :: TxIn -> m (Maybe Request)
-    -- ^ Look up a request by its UTxO reference
+        :: TxIn -> m (Maybe LocatedRequest)
+    -- ^ Look up a located request by its UTxO reference
     , putRequest
-        :: TxIn -> Request -> m ()
-    -- ^ Store a new request
+        :: LocatedRequest -> m ()
+    -- ^ Store a new located request
     , removeRequest :: TxIn -> m ()
     -- ^ Remove a fulfilled or retracted request
     , requestsByToken
-        :: TokenId -> m [Request]
-    -- ^ List all pending requests for a token
+        :: TokenId -> m [LocatedRequest]
+    -- ^ List all located pending requests for a token
     }
 
 -- | Interface for chain sync checkpoints.
@@ -106,7 +106,7 @@ hoistTokens
 hoistTokens f Tokens{..} =
     Tokens
         { getToken = f . getToken
-        , putToken = \tid ts -> f (putToken tid ts)
+        , putToken = \tid lts -> f (putToken tid lts)
         , removeToken = f . removeToken
         , listTokens = f listTokens
         }
@@ -119,8 +119,7 @@ hoistRequests
 hoistRequests f Requests{..} =
     Requests
         { getRequest = f . getRequest
-        , putRequest =
-            \txIn req -> f (putRequest txIn req)
+        , putRequest = f . putRequest
         , removeRequest = f . removeRequest
         , requestsByToken = f . requestsByToken
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -47,6 +47,7 @@ import Cardano.MPFS.Core.OnChain
 import Cardano.MPFS.Core.Types
     ( Coin (..)
     , ConwayEra
+    , LocatedTokenState (..)
     , PParams
     , TokenId
     , TokenState (..)
@@ -150,10 +151,13 @@ requestImpl
     -> IO (Tx ConwayEra)
 requestImpl cfg prov st tid key op addr = do
     mTs <- getToken (tokens st) tid
-    TokenState{tip = Coin mf} <- case mTs of
-        Nothing ->
-            error "requestImpl: unknown token"
-        Just x -> pure x
+    LocatedTokenState
+        { tokenState = TokenState{tip = Coin mf}
+        } <-
+        case mTs of
+            Nothing ->
+                error "requestImpl: unknown token"
+            Just x -> pure x
     pp <- queryProtocolParams prov
     utxos <- queryUTxOs prov addr
     feeUtxo <- case sortOn

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
@@ -66,6 +66,7 @@ import Cardano.MPFS.Core.OnChain
     )
 import Cardano.MPFS.Core.Types
     ( ConwayEra
+    , LocatedRequest (..)
     , Request (..)
     )
 import Cardano.MPFS.Provider (Provider (..))
@@ -104,7 +105,7 @@ retractRequestImpl cfg prov st reqTxIn addr = do
     req <- case mReq of
         Nothing ->
             error "retractRequest: unknown request"
-        Just x -> pure x
+        Just LocatedRequest{request = r} -> pure r
     -- 2. Query cage UTxOs to find request + state
     let scriptAddr = cageAddrFromCfg cfg (network cfg)
     cageUtxos <- queryUTxOs prov scriptAddr

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Generators.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Generators.hs
@@ -180,12 +180,16 @@ genCageEvent :: Gen CageEvent
 genCageEvent = do
     tid <- genTokenId
     oneof
-        [ CageBoot tid <$> genTokenState
+        [ CageBoot tid <$> genTxIn <*> genTokenState
         , CageRequest
             <$> genTxIn
             <*> genRequest tid
         , CageUpdate tid
-            <$> genRoot
+            <$> genTxIn
+            <*> genRoot
+            <*> listOf1 genTxIn
+        , CageReject tid
+            <$> genTxIn
             <*> listOf1 genTxIn
         , CageRetract <$> genTxIn
         , pure (CageBurn tid)
@@ -219,13 +223,15 @@ genCageInverseOp :: Gen CageInverseOp
 genCageInverseOp = do
     tid <- genTokenId
     oneof
-        [ InvRestoreToken tid <$> genTokenState
+        [ InvRestoreToken tid
+            <$> genTxIn
+            <*> genTokenState
         , pure (InvRemoveToken tid)
         , InvRestoreRequest
             <$> genTxIn
             <*> genRequest tid
         , InvRemoveRequest <$> genTxIn
-        , InvRestoreRoot tid <$> genRoot
+        , InvRestoreRoot tid <$> genTxIn <*> genRoot
         , InvTrieInsert tid <$> genBS <*> genBS
         , InvTrieDelete tid <$> genBS
         ]
@@ -251,6 +257,7 @@ genValidEventSequence = do
     concat <$> traverse genTokenEvents (zip tids tss)
   where
     genTokenEvents (tid, ts) = do
+        bootTxIn <- genTxIn
         -- Generate 0-3 requests
         numReqs <- choose (0 :: Int, 3)
         reqTxIns <- vectorOf numReqs genTxIn
@@ -271,9 +278,11 @@ genValidEventSequence = do
             if doUpdate
                 then do
                     newRoot <- genRoot
+                    newStateTxIn <- genTxIn
                     pure
                         [ CageUpdate
                             tid
+                            newStateTxIn
                             newRoot
                             available
                         ]
@@ -288,7 +297,7 @@ genValidEventSequence = do
         middle <-
             shuffle (retractEvts ++ updateEvts)
         pure
-            $ [CageBoot tid ts]
+            $ [CageBoot tid bootTxIn ts]
                 ++ requestEvts
                 ++ middle
                 ++ burnEvts

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
@@ -10,9 +10,14 @@ import Data.Aeson (decode)
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
 import Data.Vector qualified as V
-import Network.HTTP.Types (status200)
+import Network.HTTP.Types
+    ( status200
+    , status404
+    , status503
+    )
 import Network.Wai.Test
     ( SResponse (..)
     , defaultRequest
@@ -33,7 +38,10 @@ import Cardano.Ledger.Mary.Value (AssetName (..))
 
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
-    ( LocatedRequest (LocatedRequest)
+    ( BlockId (..)
+    , LocatedRequest (LocatedRequest)
+    , LocatedTokenState (..)
+    , SlotNo (..)
     , TokenId (..)
     )
 import Cardano.MPFS.Generators
@@ -42,6 +50,7 @@ import Cardano.MPFS.Generators
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
+import Cardano.MPFS.HTTP.TokensSpec (mkDummyTokenState)
 import Cardano.MPFS.State qualified as St
 
 -- | "cafe" as hex = "63616665".
@@ -52,18 +61,62 @@ cafeTid = TokenId (AssetName (SBS.toShort "cafe"))
 aabbTid :: TokenId
 aabbTid = TokenId (AssetName (SBS.toShort "aabb"))
 
+-- | Stub the verification snapshot and the UTxO
+-- witness machinery and seed a checkpoint so the
+-- proof-bearing handler can assemble its envelope.
+withSnapshot
+    :: BS.ByteString
+    -> BS.ByteString
+    -> BS.ByteString
+    -> Context IO
+    -> IO (Context IO)
+withSnapshot rootBs outBs proofBs ctx = do
+    St.putCheckpoint
+        (St.checkpoints (state ctx))
+        (SlotNo 42)
+        (BlockId "block-id-bytes")
+    pure
+        ctx
+            { utxoRoot = pure (Just rootBs)
+            , resolveUtxo = \_ -> pure (Just outBs)
+            , utxoProof = \_ -> pure (Just proofBs)
+            }
+
+-- | Seed an indexed token state for a token id so
+-- the proof-bearing handler can find a state UTxO
+-- to anchor against.
+seedTokenState :: Context IO -> TokenId -> IO ()
+seedTokenState ctx tid = do
+    ts <- mkDummyTokenState
+    txIn <- generate genTxIn
+    St.putToken
+        (St.tokens (state ctx))
+        tid
+        (LocatedTokenState txIn ts)
+
 spec :: Spec
 spec = describe "GET /tokens/:id/requests" $ do
-    it "returns empty list when no requests exist"
-        $ do
-            ctx <- mkTestContext
-            resp <- getRequests ctx "63616665"
-            simpleStatus resp `shouldBe` status200
-            assertJsonArray resp 0
+    it "returns empty list when no requests exist" $ do
+        ctx0 <- mkTestContext
+        ctx <-
+            withSnapshot "root" "tx-out" "proof" ctx0
+        seedTokenState ctx cafeTid
+        resp <- getRequests ctx "63616665"
+        simpleStatus resp `shouldBe` status200
+        assertEnvelope resp 0
 
-    it "returns a single request after insertion"
+    it
+        "returns a single witnessed request after \
+        \insertion"
         $ do
-            ctx <- mkTestContext
+            ctx0 <- mkTestContext
+            ctx <-
+                withSnapshot
+                    "root"
+                    "tx-out"
+                    "proof"
+                    ctx0
+            seedTokenState ctx cafeTid
             txIn <- generate genTxIn
             req <- generate (genRequest cafeTid)
             St.putRequest
@@ -71,12 +124,21 @@ spec = describe "GET /tokens/:id/requests" $ do
                 (LocatedRequest txIn req)
             resp <- getRequests ctx "63616665"
             simpleStatus resp `shouldBe` status200
-            assertJsonArray resp 1
-            assertRequestFields resp
+            assertEnvelope resp 1
+            assertWitnessedRequestFields resp
 
-    it "returns multiple requests for same token"
+    it
+        "returns multiple witnessed requests for same \
+        \token"
         $ do
-            ctx <- mkTestContext
+            ctx0 <- mkTestContext
+            ctx <-
+                withSnapshot
+                    "root"
+                    "tx-out"
+                    "proof"
+                    ctx0
+            seedTokenState ctx cafeTid
             txIn1 <- generate genTxIn
             txIn2 <- generate genTxIn
             req1 <- generate (genRequest cafeTid)
@@ -89,27 +151,44 @@ spec = describe "GET /tokens/:id/requests" $ do
                 (LocatedRequest txIn2 req2)
             resp <- getRequests ctx "63616665"
             simpleStatus resp `shouldBe` status200
-            assertJsonArray resp 2
+            assertEnvelope resp 2
 
-    it "filters by token — other tokens excluded"
+    it "filters by token — other tokens excluded" $ do
+        ctx0 <- mkTestContext
+        ctx <-
+            withSnapshot "root" "tx-out" "proof" ctx0
+        seedTokenState ctx cafeTid
+        seedTokenState ctx aabbTid
+        txIn1 <- generate genTxIn
+        txIn2 <- generate genTxIn
+        req1 <- generate (genRequest cafeTid)
+        req2 <- generate (genRequest aabbTid)
+        St.putRequest
+            (St.requests (state ctx))
+            (LocatedRequest txIn1 req1)
+        St.putRequest
+            (St.requests (state ctx))
+            (LocatedRequest txIn2 req2)
+        resp1 <- getRequests ctx "63616665"
+        simpleStatus resp1 `shouldBe` status200
+        assertEnvelope resp1 1
+        resp2 <- getRequests ctx "61616262"
+        simpleStatus resp2 `shouldBe` status200
+        assertEnvelope resp2 1
+
+    it "returns 404 for unknown token" $ do
+        ctx0 <- mkTestContext
+        ctx <-
+            withSnapshot "root" "tx-out" "proof" ctx0
+        resp <- getRequests ctx "63616665"
+        simpleStatus resp `shouldBe` status404
+
+    it "returns 503 when snapshot not yet available"
         $ do
             ctx <- mkTestContext
-            txIn1 <- generate genTxIn
-            txIn2 <- generate genTxIn
-            req1 <- generate (genRequest cafeTid)
-            req2 <- generate (genRequest aabbTid)
-            St.putRequest
-                (St.requests (state ctx))
-                (LocatedRequest txIn1 req1)
-            St.putRequest
-                (St.requests (state ctx))
-                (LocatedRequest txIn2 req2)
-            resp1 <- getRequests ctx "63616665"
-            simpleStatus resp1 `shouldBe` status200
-            assertJsonArray resp1 1
-            resp2 <- getRequests ctx "61616262"
-            simpleStatus resp2 `shouldBe` status200
-            assertJsonArray resp2 1
+            seedTokenState ctx cafeTid
+            resp <- getRequests ctx "63616665"
+            simpleStatus resp `shouldBe` status503
 
 -- ---------------------------------------------------------
 -- Helpers
@@ -131,41 +210,70 @@ getRequests ctx tokenHex =
         )
         (mkApp ctx)
 
--- | Assert response body is a JSON array of given
--- length.
-assertJsonArray :: SResponse -> Int -> IO ()
-assertJsonArray resp n =
+-- | Assert the response body is a 'RequestsResponse'
+-- envelope with exactly @n@ witnessed requests.
+assertEnvelope :: SResponse -> Int -> IO ()
+assertEnvelope resp n =
     case decode (simpleBody resp) of
-        Just (Array arr) ->
-            length arr `shouldBe` n
+        Just (Object obj) -> do
+            KM.member "snapshot" obj `shouldBe` True
+            case KM.lookup "requests" obj of
+                Just (Array arr) ->
+                    length arr `shouldBe` n
+                _ ->
+                    expectationFailure
+                        "requests is not an array"
         _ ->
             expectationFailure
-                "Expected JSON array"
+                "Expected JSON object"
 
--- | Assert first element has expected request
--- fields.
-assertRequestFields :: SResponse -> IO ()
-assertRequestFields resp =
+-- | Assert the first witnessed request has both the
+-- @utxo@ witness and the decoded @request@ payload.
+assertWitnessedRequestFields :: SResponse -> IO ()
+assertWitnessedRequestFields resp =
     case decode (simpleBody resp) of
-        Just (Array arr)
-            | not (V.null arr) ->
-                case V.head arr of
-                    Object obj -> do
-                        KM.member "token" obj
-                            `shouldBe` True
-                        KM.member "owner" obj
-                            `shouldBe` True
-                        KM.member "key" obj
-                            `shouldBe` True
-                        KM.member "operation" obj
-                            `shouldBe` True
-                        KM.member "fee" obj
-                            `shouldBe` True
-                        KM.member "submitted_at" obj
-                            `shouldBe` True
-                    _ ->
-                        expectationFailure
-                            "Expected JSON object"
+        Just (Object obj) ->
+            case KM.lookup "requests" obj of
+                Just (Array arr)
+                    | not (V.null arr) ->
+                        case V.head arr of
+                            Object wreq -> do
+                                KM.member "utxo" wreq
+                                    `shouldBe` True
+                                case KM.lookup
+                                    "request"
+                                    wreq of
+                                    Just (Object r) -> do
+                                        KM.member "token" r
+                                            `shouldBe` True
+                                        KM.member "owner" r
+                                            `shouldBe` True
+                                        KM.member "key" r
+                                            `shouldBe` True
+                                        KM.member
+                                            "operation"
+                                            r
+                                            `shouldBe` True
+                                        KM.member "fee" r
+                                            `shouldBe` True
+                                        KM.member
+                                            "submitted_at"
+                                            r
+                                            `shouldBe` True
+                                    _ ->
+                                        expectationFailure
+                                            "request \
+                                            \is not an \
+                                            \object"
+                            _ ->
+                                expectationFailure
+                                    "witnessed \
+                                    \request is not \
+                                    \an object"
+                _ ->
+                    expectationFailure
+                        "requests is empty or not \
+                        \an array"
         _ ->
             expectationFailure
-                "Expected non-empty JSON array"
+                "Expected JSON object"

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
@@ -32,7 +32,10 @@ import Test.QuickCheck (generate)
 import Cardano.Ledger.Mary.Value (AssetName (..))
 
 import Cardano.MPFS.Context (Context (..))
-import Cardano.MPFS.Core.Types (TokenId (..))
+import Cardano.MPFS.Core.Types
+    ( LocatedRequest (LocatedRequest)
+    , TokenId (..)
+    )
 import Cardano.MPFS.Generators
     ( genRequest
     , genTxIn
@@ -65,8 +68,7 @@ spec = describe "GET /tokens/:id/requests" $ do
             req <- generate (genRequest cafeTid)
             St.putRequest
                 (St.requests (state ctx))
-                txIn
-                req
+                (LocatedRequest txIn req)
             resp <- getRequests ctx "63616665"
             simpleStatus resp `shouldBe` status200
             assertJsonArray resp 1
@@ -81,12 +83,10 @@ spec = describe "GET /tokens/:id/requests" $ do
             req2 <- generate (genRequest cafeTid)
             St.putRequest
                 (St.requests (state ctx))
-                txIn1
-                req1
+                (LocatedRequest txIn1 req1)
             St.putRequest
                 (St.requests (state ctx))
-                txIn2
-                req2
+                (LocatedRequest txIn2 req2)
             resp <- getRequests ctx "63616665"
             simpleStatus resp `shouldBe` status200
             assertJsonArray resp 2
@@ -100,12 +100,10 @@ spec = describe "GET /tokens/:id/requests" $ do
             req2 <- generate (genRequest aabbTid)
             St.putRequest
                 (St.requests (state ctx))
-                txIn1
-                req1
+                (LocatedRequest txIn1 req1)
             St.putRequest
                 (St.requests (state ctx))
-                txIn2
-                req2
+                (LocatedRequest txIn2 req2)
             resp1 <- getRequests ctx "63616665"
             simpleStatus resp1 `shouldBe` status200
             assertJsonArray resp1 1

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
@@ -9,8 +9,13 @@ module Cardano.MPFS.HTTP.TokenSpec (spec) where
 import Data.Aeson (decode)
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
+import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
-import Network.HTTP.Types (status200, status404)
+import Network.HTTP.Types
+    ( status200
+    , status404
+    , status503
+    )
 import Network.Wai.Test
     ( SResponse (..)
     , defaultRequest
@@ -32,7 +37,9 @@ import Test.QuickCheck (generate)
 
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
-    ( LocatedTokenState (..)
+    ( BlockId (..)
+    , LocatedTokenState (..)
+    , SlotNo (..)
     , TokenId (..)
     )
 import Cardano.MPFS.Generators (genTxIn)
@@ -40,6 +47,29 @@ import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.TokensSpec (mkDummyTokenState)
 import Cardano.MPFS.State qualified as St
+
+-- | Populate a test context with a synthetic
+-- verification snapshot and UTxO witness machinery.
+withSnapshot
+    :: BS.ByteString
+    -- ^ CSMT root bytes
+    -> BS.ByteString
+    -- ^ Resolved TxOut CBOR bytes
+    -> BS.ByteString
+    -- ^ CSMT inclusion proof bytes
+    -> Context IO
+    -> IO (Context IO)
+withSnapshot rootBs outBs proofBs ctx = do
+    St.putCheckpoint
+        (St.checkpoints (state ctx))
+        (SlotNo 42)
+        (BlockId "block-id-bytes")
+    pure
+        ctx
+            { utxoRoot = pure (Just rootBs)
+            , resolveUtxo = \_ -> pure (Just outBs)
+            , utxoProof = \_ -> pure (Just proofBs)
+            }
 
 spec :: Spec
 spec = describe "GET /tokens/:id" $ do
@@ -56,39 +86,86 @@ spec = describe "GET /tokens/:id" $ do
                 (mkApp ctx)
         simpleStatus resp `shouldBe` status404
 
-    it "returns token state for known token" $ do
-        ctx <- mkTestContext
-        ts <- mkDummyTokenState
-        txIn <- generate genTxIn
-        let tid =
-                TokenId
-                    (AssetName (SBS.toShort "cafe"))
-        St.putToken
-            (St.tokens (state ctx))
-            tid
-            (LocatedTokenState txIn ts)
-        resp <-
-            runSession
-                ( request
-                    ( setPath
-                        defaultRequest
-                        "/tokens/63616665"
+    it
+        "returns 503 when snapshot not yet available"
+        $ do
+            ctx <- mkTestContext
+            ts <- mkDummyTokenState
+            txIn <- generate genTxIn
+            let tid =
+                    TokenId
+                        ( AssetName
+                            (SBS.toShort "cafe")
+                        )
+            St.putToken
+                (St.tokens (state ctx))
+                tid
+                (LocatedTokenState txIn ts)
+            resp <-
+                runSession
+                    ( request
+                        ( setPath
+                            defaultRequest
+                            "/tokens/63616665"
+                        )
                     )
-                )
-                (mkApp ctx)
-        simpleStatus resp `shouldBe` status200
-        case decode (simpleBody resp) of
-            Just (Object obj) -> do
-                KM.member "owner" obj
-                    `shouldBe` True
-                KM.member "root" obj
-                    `shouldBe` True
-                KM.member "tip" obj
-                    `shouldBe` True
-                KM.member "process_time" obj
-                    `shouldBe` True
-                KM.member "retract_time" obj
-                    `shouldBe` True
-            _ ->
-                expectationFailure
-                    "Expected JSON object"
+                    (mkApp ctx)
+            simpleStatus resp `shouldBe` status503
+
+    it
+        "returns proof-bearing envelope for a known \
+        \token"
+        $ do
+            ctx0 <- mkTestContext
+            ctx <-
+                withSnapshot "root" "tx-out" "proof" ctx0
+            ts <- mkDummyTokenState
+            txIn <- generate genTxIn
+            let tid =
+                    TokenId
+                        ( AssetName
+                            (SBS.toShort "cafe")
+                        )
+            St.putToken
+                (St.tokens (state ctx))
+                tid
+                (LocatedTokenState txIn ts)
+            resp <-
+                runSession
+                    ( request
+                        ( setPath
+                            defaultRequest
+                            "/tokens/63616665"
+                        )
+                    )
+                    (mkApp ctx)
+            simpleStatus resp `shouldBe` status200
+            case decode (simpleBody resp) of
+                Just (Object obj) -> do
+                    KM.member "snapshot" obj
+                        `shouldBe` True
+                    KM.member "state" obj
+                        `shouldBe` True
+                    case KM.lookup "snapshot" obj of
+                        Just (Object sObj) -> do
+                            KM.member "utxo_root" sObj
+                                `shouldBe` True
+                            KM.member "chainpoint" sObj
+                                `shouldBe` True
+                        _ ->
+                            expectationFailure
+                                "snapshot is not an \
+                                \object"
+                    case KM.lookup "state" obj of
+                        Just (Object stateObj) -> do
+                            KM.member "utxo" stateObj
+                                `shouldBe` True
+                            KM.member "state" stateObj
+                                `shouldBe` True
+                        _ ->
+                            expectationFailure
+                                "state is not an \
+                                \object"
+                _ ->
+                    expectationFailure
+                        "Expected JSON object"

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
@@ -28,8 +28,14 @@ import Test.Hspec
 
 import Cardano.Ledger.Mary.Value (AssetName (..))
 
+import Test.QuickCheck (generate)
+
 import Cardano.MPFS.Context (Context (..))
-import Cardano.MPFS.Core.Types (TokenId (..))
+import Cardano.MPFS.Core.Types
+    ( LocatedTokenState (..)
+    , TokenId (..)
+    )
+import Cardano.MPFS.Generators (genTxIn)
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.TokensSpec (mkDummyTokenState)
@@ -53,13 +59,14 @@ spec = describe "GET /tokens/:id" $ do
     it "returns token state for known token" $ do
         ctx <- mkTestContext
         ts <- mkDummyTokenState
+        txIn <- generate genTxIn
         let tid =
                 TokenId
                     (AssetName (SBS.toShort "cafe"))
         St.putToken
             (St.tokens (state ctx))
             tid
-            ts
+            (LocatedTokenState txIn ts)
         resp <-
             runSession
                 ( request

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
@@ -34,11 +34,12 @@ import Cardano.Ledger.Mary.Value (AssetName (..))
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
     ( Coin (..)
+    , LocatedTokenState (..)
     , Root (..)
     , TokenId (..)
     , TokenState (..)
     )
-import Cardano.MPFS.Generators (genKeyHash)
+import Cardano.MPFS.Generators (genKeyHash, genTxIn)
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.State qualified as St
@@ -81,13 +82,14 @@ spec = describe "GET /tokens" $ do
     it "returns token after insertion" $ do
         ctx <- mkTestContext
         ts <- mkDummyTokenState
+        txIn <- generate genTxIn
         let tid =
                 TokenId
                     (AssetName (SBS.toShort "deadbeef"))
         St.putToken
             (St.tokens (state ctx))
             tid
-            ts
+            (LocatedTokenState txIn ts)
         resp <- getTokens ctx
         simpleStatus resp `shouldBe` status200
         case decode (simpleBody resp) of

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs
@@ -11,12 +11,18 @@
 module Cardano.MPFS.HTTP.TrieSpec (spec) where
 
 import Data.Aeson (decode)
+import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Short qualified as SBS
 import Data.Text qualified as T
-import Network.HTTP.Types (status200, status404)
+import Network.HTTP.Types
+    ( status200
+    , status404
+    , status503
+    )
 import Network.Wai.Test
     ( SResponse (..)
     , defaultRequest
@@ -34,11 +40,20 @@ import Test.Hspec
     )
 
 import Cardano.Ledger.Mary.Value (AssetName (..))
+import Test.QuickCheck (generate)
 
 import Cardano.MPFS.Context (Context (..))
-import Cardano.MPFS.Core.Types (TokenId (..))
+import Cardano.MPFS.Core.Types
+    ( BlockId (..)
+    , LocatedTokenState (..)
+    , SlotNo (..)
+    , TokenId (..)
+    )
+import Cardano.MPFS.Generators (genTxIn)
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
+import Cardano.MPFS.HTTP.TokensSpec (mkDummyTokenState)
+import Cardano.MPFS.State qualified as St
 import Cardano.MPFS.Trie qualified as Trie
 
 -- | "cafe" token — hex "63616665".
@@ -48,6 +63,43 @@ cafeTid = TokenId (AssetName (SBS.toShort "cafe"))
 -- | Hex-encode raw bytes for URL paths.
 hex :: ByteString -> ByteString
 hex = B16.encode
+
+-- | Stub the verification snapshot and the UTxO
+-- witness machinery (root, resolveUtxo, utxoProof)
+-- and seed a checkpoint so the proof-bearing
+-- endpoints can assemble their envelopes.
+withSnapshot
+    :: BS.ByteString
+    -- ^ CSMT root bytes
+    -> BS.ByteString
+    -- ^ Resolved TxOut CBOR bytes
+    -> BS.ByteString
+    -- ^ CSMT inclusion proof bytes
+    -> Context IO
+    -> IO (Context IO)
+withSnapshot rootBs outBs proofBs ctx = do
+    St.putCheckpoint
+        (St.checkpoints (state ctx))
+        (SlotNo 42)
+        (BlockId "block-id-bytes")
+    pure
+        ctx
+            { utxoRoot = pure (Just rootBs)
+            , resolveUtxo = \_ -> pure (Just outBs)
+            , utxoProof = \_ -> pure (Just proofBs)
+            }
+
+-- | Seed an indexed token state for 'cafeTid' so
+-- the proof-bearing handlers can find a state UTxO
+-- to witness.
+seedTokenState :: Context IO -> IO ()
+seedTokenState ctx = do
+    ts <- mkDummyTokenState
+    txIn <- generate genTxIn
+    St.putToken
+        (St.tokens (state ctx))
+        cafeTid
+        (LocatedTokenState txIn ts)
 
 spec :: Spec
 spec = do
@@ -72,24 +124,58 @@ spec = do
                             "Expected JSON string"
 
     describe "GET /tokens/:id/facts/:key" $ do
-        it "returns value for existing key" $ do
-            ctx <- mkTestContext
-            Trie.createTrie (trieManager ctx) cafeTid
-            _ <-
-                Trie.withTrie
-                    (trieManager ctx)
-                    cafeTid
-                    $ \trie ->
-                        Trie.insert trie "mykey" "myval"
-            resp <-
-                getFact
-                    ctx
-                    "63616665"
-                    (hex "mykey")
-            simpleStatus resp `shouldBe` status200
+        it
+            "returns proof-bearing envelope for an \
+            \existing key"
+            $ do
+                ctx0 <- mkTestContext
+                ctx <-
+                    withSnapshot
+                        "root"
+                        "tx-out"
+                        "proof"
+                        ctx0
+                seedTokenState ctx
+                Trie.createTrie (trieManager ctx) cafeTid
+                _ <-
+                    Trie.withTrie
+                        (trieManager ctx)
+                        cafeTid
+                        $ \trie ->
+                            Trie.insert trie "mykey" "myval"
+                resp <-
+                    getFact
+                        ctx
+                        "63616665"
+                        (hex "mykey")
+                simpleStatus resp `shouldBe` status200
+                case decode (simpleBody resp) of
+                    Just (Object obj) -> do
+                        KM.member "snapshot" obj
+                            `shouldBe` True
+                        KM.member "value" obj
+                            `shouldBe` True
+                        KM.member "fact" obj
+                            `shouldBe` True
+                        case KM.lookup "fact" obj of
+                            Just (Object fObj) -> do
+                                KM.member "state" fObj
+                                    `shouldBe` True
+                                KM.member "mpf_proof" fObj
+                                    `shouldBe` True
+                            _ ->
+                                expectationFailure
+                                    "fact is not an \
+                                    \object"
+                    _ ->
+                        expectationFailure
+                            "Expected JSON object"
 
         it "returns 404 for missing key" $ do
-            ctx <- mkTestContext
+            ctx0 <- mkTestContext
+            ctx <-
+                withSnapshot "root" "tx-out" "proof" ctx0
+            seedTokenState ctx
             Trie.createTrie (trieManager ctx) cafeTid
             resp <-
                 getFact
@@ -98,31 +184,82 @@ spec = do
                     (hex "nokey")
             simpleStatus resp `shouldBe` status404
 
-    describe "GET /tokens/:id/proofs/:key" $ do
-        it "returns proof for existing key" $ do
-            ctx <- mkTestContext
-            Trie.createTrie (trieManager ctx) cafeTid
-            _ <-
-                Trie.withTrie
-                    (trieManager ctx)
-                    cafeTid
-                    $ \trie ->
-                        Trie.insert trie "pk" "pv"
+        it "returns 404 for unknown token" $ do
+            ctx0 <- mkTestContext
+            ctx <-
+                withSnapshot "root" "tx-out" "proof" ctx0
             resp <-
-                getProof
-                    ctx
-                    "63616665"
-                    (hex "pk")
-            simpleStatus resp `shouldBe` status200
-            case decode (simpleBody resp) of
-                Just (String s) ->
-                    s `shouldSatisfy` (not . T.null)
-                _ ->
-                    expectationFailure
-                        "Expected JSON string"
+                getFact ctx "63616665" (hex "k")
+            simpleStatus resp `shouldBe` status404
+
+        it
+            "returns 503 when snapshot not yet \
+            \available"
+            $ do
+                ctx <- mkTestContext
+                seedTokenState ctx
+                Trie.createTrie (trieManager ctx) cafeTid
+                _ <-
+                    Trie.withTrie
+                        (trieManager ctx)
+                        cafeTid
+                        $ \trie ->
+                            Trie.insert trie "k" "v"
+                resp <-
+                    getFact ctx "63616665" (hex "k")
+                simpleStatus resp `shouldBe` status503
+
+    describe "GET /tokens/:id/proofs/:key" $ do
+        it
+            "returns proof-bearing envelope for an \
+            \existing key"
+            $ do
+                ctx0 <- mkTestContext
+                ctx <-
+                    withSnapshot
+                        "root"
+                        "tx-out"
+                        "proof"
+                        ctx0
+                seedTokenState ctx
+                Trie.createTrie (trieManager ctx) cafeTid
+                _ <-
+                    Trie.withTrie
+                        (trieManager ctx)
+                        cafeTid
+                        $ \trie ->
+                            Trie.insert trie "pk" "pv"
+                resp <-
+                    getProof
+                        ctx
+                        "63616665"
+                        (hex "pk")
+                simpleStatus resp `shouldBe` status200
+                case decode (simpleBody resp) of
+                    Just (Object obj) -> do
+                        KM.member "snapshot" obj
+                            `shouldBe` True
+                        KM.member "fact" obj
+                            `shouldBe` True
+                        case KM.lookup "fact" obj of
+                            Just (Object fObj) -> do
+                                KM.member "state" fObj
+                                    `shouldBe` True
+                                KM.member "mpf_proof" fObj
+                                    `shouldBe` True
+                            _ ->
+                                expectationFailure
+                                    "fact is not an \
+                                    \object"
+                    _ ->
+                        expectationFailure
+                            "Expected JSON object"
 
         it "returns 404 for missing key" $ do
-            ctx <- mkTestContext
+            ctx0 <- mkTestContext
+            ctx <-
+                withSnapshot "root" "tx-out" "proof" ctx0
+            seedTokenState ctx
             Trie.createTrie (trieManager ctx) cafeTid
             resp <-
                 getProof
@@ -130,6 +267,31 @@ spec = do
                     "63616665"
                     (hex "absent")
             simpleStatus resp `shouldBe` status404
+
+        it "returns 404 for unknown token" $ do
+            ctx0 <- mkTestContext
+            ctx <-
+                withSnapshot "root" "tx-out" "proof" ctx0
+            resp <-
+                getProof ctx "63616665" (hex "k")
+            simpleStatus resp `shouldBe` status404
+
+        it
+            "returns 503 when snapshot not yet \
+            \available"
+            $ do
+                ctx <- mkTestContext
+                seedTokenState ctx
+                Trie.createTrie (trieManager ctx) cafeTid
+                _ <-
+                    Trie.withTrie
+                        (trieManager ctx)
+                        cafeTid
+                        $ \trie ->
+                            Trie.insert trie "k" "v"
+                resp <-
+                    getProof ctx "63616665" (hex "k")
+                simpleStatus resp `shouldBe` status503
 
 -- ---------------------------------------------------------
 -- Helpers

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ArmageddonSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ArmageddonSpec.hs
@@ -98,6 +98,7 @@ import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , BlockId (..)
     , Coin (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -304,7 +305,7 @@ spec = describe "Cage Runner E2E" $ do
                     TestRollbacks
                     maxBound
                     1
-                    [CageBoot tokA tokStateA]
+                    [CageBoot tokA stRefA tokStateA]
                     phase0
             case phase1 of
                 InRestoration _ -> pure ()
@@ -322,7 +323,7 @@ spec = describe "Cage Runner E2E" $ do
                     TestRollbacks
                     maxBound
                     1
-                    [CageBoot tokA tokStateA]
+                    [CageBoot tokA stRefA tokStateA]
                     phase0
             -- Runner stores one sentinel checkpoint per
             -- restoration block (empty inverses, no meta)
@@ -342,7 +343,7 @@ spec = describe "Cage Runner E2E" $ do
                     TestRollbacks
                     maxBound
                     1
-                    [CageBoot tokA tokStateA]
+                    [CageBoot tokA stRefA tokStateA]
                     phase0
             case phase1 of
                 InRestoration restoring -> do
@@ -378,7 +379,7 @@ spec = describe "Cage Runner E2E" $ do
                     TestRollbacks
                     maxBound
                     1
-                    [ CageBoot tokA tokStateA
+                    [ CageBoot tokA stRefA tokStateA
                     , CageRequest txInA reqA
                     ]
                     phase0
@@ -402,6 +403,7 @@ spec = describe "Cage Runner E2E" $ do
                             2
                             [ CageUpdate
                                 tokA
+                                newStRefA
                                 (Root "new-root")
                                 [txInA]
                             ]
@@ -449,7 +451,7 @@ spec = describe "Cage Runner E2E" $ do
                             TestRollbacks
                             maxBound
                             (s + 1)
-                            [CageBoot tokA tokStateA]
+                            [CageBoot tokA stRefA tokStateA]
                             phase0
                     case phase1 of
                         InRestoration restoring -> do
@@ -488,6 +490,7 @@ spec = describe "Cage Runner E2E" $ do
                                     (s + 3)
                                     [ CageUpdate
                                         tokA
+                                        newStRefA
                                         (Root "r")
                                         [txInA]
                                     ]
@@ -519,8 +522,8 @@ spec = describe "Cage Runner E2E" $ do
                     TestRollbacks
                     maxBound
                     1
-                    [ CageBoot tokA tokStateA
-                    , CageBoot tokB tokStateB
+                    [ CageBoot tokA stRefA tokStateA
+                    , CageBoot tokB stRefB tokStateB
                     ]
                     phase0
             case phase1 of
@@ -555,10 +558,12 @@ spec = describe "Cage Runner E2E" $ do
                             3
                             [ CageUpdate
                                 tokA
+                                newStRefA
                                 (Root "rA")
                                 [txInA]
                             , CageUpdate
                                 tokB
+                                newStRefB
                                 (Root "rB")
                                 [txInB]
                             ]
@@ -571,7 +576,12 @@ spec = describe "Cage Runner E2E" $ do
                                 tokA
                     ts
                         `shouldBe` Just
-                            tokStateA{root = Root "rA"}
+                            ( LocatedTokenState
+                                newStRefA
+                                tokStateA
+                                    { root = Root "rA"
+                                    }
+                            )
                 InFollowing _ _ ->
                     fail "expected Restoration"
 
@@ -614,6 +624,18 @@ txInA = genTestTxIn 0
 
 txInB :: TxIn
 txInB = genTestTxIn 1
+
+stRefA :: TxIn
+stRefA = genTestTxIn 10
+
+stRefB :: TxIn
+stRefB = genTestTxIn 11
+
+newStRefA :: TxIn
+newStRefA = genTestTxIn 20
+
+newStRefB :: TxIn
+newStRefB = genTestTxIn 21
 
 reqA :: Request
 reqA =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/EventSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/EventSpec.hs
@@ -44,8 +44,11 @@ spec = describe "CageEvent" $ do
     describe "inversesOf" $ do
         it "boot produces InvRemoveToken"
             $ forAll genBoot
-            $ \(tid, ts) ->
-                inversesOf noTokens noReqs (CageBoot tid ts)
+            $ \(tid, bootTxIn, ts) ->
+                inversesOf
+                    noTokens
+                    noReqs
+                    (CageBoot tid bootTxIn ts)
                     `shouldBe` [InvRemoveToken tid]
 
         it "request produces InvRemoveRequest"
@@ -72,13 +75,18 @@ spec = describe "CageEvent" $ do
 
         it "burn with known token produces InvRestoreToken"
             $ forAll genBurnKnown
-            $ \(tid, ts) ->
-                let tokens = Map.singleton tid ts
+            $ \(tid, stateTxIn, ts) ->
+                let tokens =
+                        Map.singleton tid (stateTxIn, ts)
                 in  inversesOf
                         (`Map.lookup` tokens)
                         noReqs
                         (CageBurn tid)
-                        `shouldBe` [InvRestoreToken tid ts]
+                        `shouldBe` [ InvRestoreToken
+                                        tid
+                                        stateTxIn
+                                        ts
+                                   ]
 
         it "burn with unknown token produces empty"
             $ forAll genTokenId
@@ -89,40 +97,57 @@ spec = describe "CageEvent" $ do
         it
             "update with known token+requests produces InvRestoreRoot + InvRestoreRequest"
             $ forAll genUpdateKnownFull
-            $ \(tid, ts, newRoot, txIn, req) ->
-                let tokMap = Map.singleton tid ts
-                    reqMap = Map.singleton txIn req
-                    result =
-                        inversesOf
-                            (`Map.lookup` tokMap)
-                            (`Map.lookup` reqMap)
-                            ( CageUpdate
+            $ \( tid
+                , oldStateTxIn
+                , newStateTxIn
+                , ts
+                , newRoot
+                , txIn
+                , req
+                ) ->
+                    let tokMap =
+                            Map.singleton
                                 tid
-                                newRoot
-                                [txIn]
-                            )
-                in  result
-                        `shouldBe` [ InvRestoreRoot
-                                        tid
-                                        (root ts)
-                                   , InvRestoreRequest
-                                        txIn
-                                        req
-                                   ]
+                                (oldStateTxIn, ts)
+                        reqMap = Map.singleton txIn req
+                        result =
+                            inversesOf
+                                (`Map.lookup` tokMap)
+                                (`Map.lookup` reqMap)
+                                ( CageUpdate
+                                    tid
+                                    newStateTxIn
+                                    newRoot
+                                    [txIn]
+                                )
+                    in  result
+                            `shouldBe` [ InvRestoreRoot
+                                            tid
+                                            oldStateTxIn
+                                            (root ts)
+                                       , InvRestoreRequest
+                                            txIn
+                                            req
+                                       ]
 
         it
             "update with unknown token and no requests produces empty"
             $ forAll genUpdateUnknown
-            $ \(tid, newRoot, consumed) ->
+            $ \(tid, newStateTxIn, newRoot, consumed) ->
                 inversesOf
                     noTokens
                     noReqs
-                    (CageUpdate tid newRoot consumed)
+                    ( CageUpdate
+                        tid
+                        newStateTxIn
+                        newRoot
+                        consumed
+                    )
                     `shouldBe` []
 
 -- Helpers
 
-noTokens :: TokenId -> Maybe TokenState
+noTokens :: TokenId -> Maybe (TxIn, TokenState)
 noTokens = const Nothing
 
 noReqs :: TxIn -> Maybe Request
@@ -130,8 +155,9 @@ noReqs = const Nothing
 
 -- Generators
 
-genBoot :: Gen (TokenId, TokenState)
-genBoot = (,) <$> genTokenId <*> genTokenState
+genBoot :: Gen (TokenId, TxIn, TokenState)
+genBoot =
+    (,,) <$> genTokenId <*> genTxIn <*> genTokenState
 
 genReqEvent :: Gen (TxIn, Request)
 genReqEvent = do
@@ -140,8 +166,9 @@ genReqEvent = do
     req <- genRequest tid
     pure (txIn, req)
 
-genBurnKnown :: Gen (TokenId, TokenState)
-genBurnKnown = (,) <$> genTokenId <*> genTokenState
+genBurnKnown :: Gen (TokenId, TxIn, TokenState)
+genBurnKnown =
+    (,,) <$> genTokenId <*> genTxIn <*> genTokenState
 
 genRetractKnown :: Gen (TxIn, Request)
 genRetractKnown = do
@@ -151,18 +178,37 @@ genRetractKnown = do
     pure (txIn, req)
 
 genUpdateKnownFull
-    :: Gen (TokenId, TokenState, Root, TxIn, Request)
+    :: Gen
+        ( TokenId
+        , TxIn
+        , TxIn
+        , TokenState
+        , Root
+        , TxIn
+        , Request
+        )
 genUpdateKnownFull = do
     tid <- genTokenId
+    oldStateTxIn <- genTxIn
+    newStateTxIn <- genTxIn
     ts <- genTokenState
     newRoot <- genRoot
     txIn <- genTxIn
     req <- genRequest tid
-    pure (tid, ts, newRoot, txIn, req)
+    pure
+        ( tid
+        , oldStateTxIn
+        , newStateTxIn
+        , ts
+        , newRoot
+        , txIn
+        , req
+        )
 
-genUpdateUnknown :: Gen (TokenId, Root, [TxIn])
+genUpdateUnknown :: Gen (TokenId, TxIn, Root, [TxIn])
 genUpdateUnknown =
-    (,,)
+    (,,,)
         <$> genTokenId
+        <*> genTxIn
         <*> genRoot
         <*> listOf1 genTxIn

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/FollowerSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/FollowerSpec.hs
@@ -61,6 +61,8 @@ import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , Coin (..)
     , ConwayEra
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Root (..)
     , TokenId (..)
     , TokenState (..)
@@ -129,20 +131,22 @@ unitTests = do
         it "boot inserts token and creates trie"
             $ property
             $ forAll
-                ( (,)
+                ( (,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tid, ts) -> do
+            $ \(tid, stRef, ts) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid stRef ts)
                 getToken (tokens st) tid
-                    `shouldReturn` Just ts
+                    `shouldReturn` Just
+                        (LocatedTokenState stRef ts)
 
         it "request inserts into requests"
             $ property
@@ -162,7 +166,8 @@ unitTests = do
                         tm
                         (CageRequest txIn req)
                 getRequest (requests st) txIn
-                    `shouldReturn` Just req
+                    `shouldReturn` Just
+                        (LocatedRequest txIn req)
 
         it "retract removes request"
             $ property
@@ -192,18 +197,19 @@ unitTests = do
         it "burn removes token and hides trie"
             $ property
             $ forAll
-                ( (,)
+                ( (,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tid, ts) -> do
+            $ \(tid, stRef, ts) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid stRef ts)
                 _ <-
                     applyCageEvent
                         st
@@ -215,46 +221,50 @@ unitTests = do
         it "update changes token root"
             $ property
             $ forAll
-                ( (,,)
+                ( (,,,,)
                     <$> genTokenId
+                    <*> genTxIn
+                    <*> genTxIn
                     <*> genTokenState
                     <*> genRoot
                 )
-            $ \(tid, ts, newRoot) -> do
+            $ \(tid, bootRef, newRef, ts, newRoot) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid bootRef ts)
                 _ <-
                     applyCageEvent
                         st
                         tm
                         ( CageUpdate
                             tid
+                            newRef
                             newRoot
                             []
                         )
                 mTs <- getToken (tokens st) tid
-                fmap root mTs
+                fmap (root . tokenState) mTs
                     `shouldBe` Just newRoot
 
     describe "computeInverse" $ do
         it "boot inverse is InvRemoveToken"
             $ property
             $ forAll
-                ( (,)
+                ( (,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tid, ts) -> do
+            $ \(tid, stRef, ts) -> do
                 st <- mkMockState
                 inv <-
                     computeInverse
                         st
-                        (CageBoot tid ts)
+                        (CageBoot tid stRef ts)
                 inv `shouldBe` [InvRemoveToken tid]
 
         it
@@ -262,30 +272,34 @@ unitTests = do
             \ when token exists"
             $ property
             $ forAll
-                ( (,,)
+                ( (,,,,)
                     <$> genTokenId
+                    <*> genTxIn
+                    <*> genTxIn
                     <*> genTokenState
                     <*> genRoot
                 )
-            $ \(tid, ts, newRoot) -> do
+            $ \(tid, bootRef, newRef, ts, newRoot) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid bootRef ts)
                 inv <-
                     computeInverse
                         st
                         ( CageUpdate
                             tid
+                            newRef
                             newRoot
                             []
                         )
                 inv
                     `shouldBe` [ InvRestoreRoot
                                     tid
+                                    bootRef
                                     (root ts)
                                ]
 
@@ -294,22 +308,27 @@ unitTests = do
             \ token exists"
             $ property
             $ forAll
-                ( (,)
+                ( (,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tid, ts) -> do
+            $ \(tid, stRef, ts) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid stRef ts)
                 inv <-
                     computeInverse st (CageBurn tid)
                 inv
-                    `shouldBe` [InvRestoreToken tid ts]
+                    `shouldBe` [ InvRestoreToken
+                                    tid
+                                    stRef
+                                    ts
+                               ]
 
     describe "applyCageInverses" $ do
         it
@@ -317,18 +336,19 @@ unitTests = do
             \ original state"
             $ property
             $ forAll
-                ( (,)
+                ( (,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tid, ts) -> do
+            $ \(tid, stRef, ts) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid stRef ts)
                 _ <-
                     applyCageEvent
                         st
@@ -337,25 +357,27 @@ unitTests = do
                 applyCageInverses
                     st
                     tm
-                    [InvRestoreToken tid ts]
+                    [InvRestoreToken tid stRef ts]
                 getToken (tokens st) tid
-                    `shouldReturn` Just ts
+                    `shouldReturn` Just
+                        (LocatedTokenState stRef ts)
 
         it "InvRemoveToken undoes a boot"
             $ property
             $ forAll
-                ( (,)
+                ( (,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tid, ts) -> do
+            $ \(tid, stRef, ts) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid stRef ts)
                 applyCageInverses
                     st
                     tm
@@ -366,12 +388,14 @@ unitTests = do
         it "InvRestoreRoot restores previous root"
             $ property
             $ forAll
-                ( (,,)
+                ( (,,,,)
                     <$> genTokenId
+                    <*> genTxIn
+                    <*> genTxIn
                     <*> genTokenState
                     <*> genRoot
                 )
-            $ \(tid, ts, newRoot) -> do
+            $ \(tid, bootRef, newRef, ts, newRoot) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 let origRoot = root ts
@@ -379,43 +403,49 @@ unitTests = do
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid bootRef ts)
                 _ <-
                     applyCageEvent
                         st
                         tm
                         ( CageUpdate
                             tid
+                            newRef
                             newRoot
                             []
                         )
                 applyCageInverses
                     st
                     tm
-                    [InvRestoreRoot tid origRoot]
+                    [ InvRestoreRoot
+                        tid
+                        bootRef
+                        origRoot
+                    ]
                 mTs <- getToken (tokens st) tid
-                fmap root mTs
+                fmap (root . tokenState) mTs
                     `shouldBe` Just origRoot
 
         it "full boot → inverse roundtrip"
             $ property
             $ forAll
-                ( (,)
+                ( (,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tid, ts) -> do
+            $ \(tid, stRef, ts) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 inv <-
                     computeInverse
                         st
-                        (CageBoot tid ts)
+                        (CageBoot tid stRef ts)
                 _ <-
                     applyCageEvent
                         st
                         tm
-                        (CageBoot tid ts)
+                        (CageBoot tid stRef ts)
                 applyCageInverses st tm inv
                 getToken (tokens st) tid
                     `shouldReturn` Nothing
@@ -497,18 +527,21 @@ pipelineTests =
             "booted token present if not burned"
             $ property
             $ forAll
-                ( (,,)
+                ( (,,,,)
                     <$> genTokenId
+                    <*> genTxIn
+                    <*> genTxIn
                     <*> genTokenState
                     <*> genRoot
                 )
-            $ \(tid, ts, newRoot) -> do
+            $ \(tid, bootRef, newRef, ts, newRoot) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 let events =
-                        [ CageBoot tid ts
+                        [ CageBoot tid bootRef ts
                         , CageUpdate
                             tid
+                            newRef
                             newRoot
                             []
                         ]
@@ -518,24 +551,25 @@ pipelineTests =
                         tm
                         events
                 mTs <- getToken (tokens st) tid
-                fmap root mTs
+                fmap (root . tokenState) mTs
                     `shouldBe` Just newRoot
 
         it "burned token is absent"
             $ property
             $ forAll
-                ( (,)
+                ( (,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tid, ts) -> do
+            $ \(tid, stRef, ts) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageBlockEvents
                         st
                         tm
-                        [ CageBoot tid ts
+                        [ CageBoot tid stRef ts
                         , CageBurn tid
                         ]
                 getToken (tokens st) tid
@@ -544,13 +578,15 @@ pipelineTests =
         it "independent tokens don't interfere"
             $ property
             $ forAll
-                ( (,,,)
+                ( (,,,,,)
                     <$> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                     <*> genTokenId
+                    <*> genTxIn
                     <*> genTokenState
                 )
-            $ \(tidA, tsA, tidB, tsB) ->
+            $ \(tidA, refA, tsA, tidB, refB, tsB) ->
                 tidA /= tidB ==> do
                     st <- mkMockState
                     tm <- mkPureTrieManager
@@ -558,56 +594,63 @@ pipelineTests =
                         applyCageBlockEvents
                             st
                             tm
-                            [ CageBoot tidA tsA
-                            , CageBoot tidB tsB
+                            [ CageBoot tidA refA tsA
+                            , CageBoot tidB refB tsB
                             , CageBurn tidA
                             ]
                     getToken (tokens st) tidA
                         `shouldReturn` Nothing
                     getToken (tokens st) tidB
-                        `shouldReturn` Just tsB
+                        `shouldReturn` Just
+                            ( LocatedTokenState
+                                refB
+                                tsB
+                            )
 
         it "request present after boot+request"
             $ property
             $ forAll
                 ( do
                     tid <- genTokenId
+                    stRef <- genTxIn
                     ts <- genTokenState
                     txIn <- genTxIn
                     req <- genRequest tid
-                    pure (tid, ts, txIn, req)
+                    pure (tid, stRef, ts, txIn, req)
                 )
-            $ \(tid, ts, txIn, req) -> do
+            $ \(tid, stRef, ts, txIn, req) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageBlockEvents
                         st
                         tm
-                        [ CageBoot tid ts
+                        [ CageBoot tid stRef ts
                         , CageRequest txIn req
                         ]
                 getRequest (requests st) txIn
-                    `shouldReturn` Just req
+                    `shouldReturn` Just
+                        (LocatedRequest txIn req)
 
         it "retracted request is absent"
             $ property
             $ forAll
                 ( do
                     tid <- genTokenId
+                    stRef <- genTxIn
                     ts <- genTokenState
                     txIn <- genTxIn
                     req <- genRequest tid
-                    pure (tid, ts, txIn, req)
+                    pure (tid, stRef, ts, txIn, req)
                 )
-            $ \(tid, ts, txIn, req) -> do
+            $ \(tid, stRef, ts, txIn, req) -> do
                 st <- mkMockState
                 tm <- mkPureTrieManager
                 _ <-
                     applyCageBlockEvents
                         st
                         tm
-                        [ CageBoot tid ts
+                        [ CageBoot tid stRef ts
                         , CageRequest txIn req
                         , CageRetract txIn
                         ]
@@ -796,8 +839,15 @@ detectionTests =
                                 testScriptHash
                                 []
                                 tx
-                    events
-                        `shouldBe` [CageBoot tid ts]
+                    case events of
+                        [CageBoot tid' _ ts'] -> do
+                            tid' `shouldBe` tid
+                            ts' `shouldBe` ts
+                        other ->
+                            fail
+                                $ "expected [CageBoot\
+                                  \ ...], got "
+                                    ++ show other
 
             it
                 "request roundtrips all Request\
@@ -866,7 +916,7 @@ detectionTests =
 -- ---------------------------------------------------------
 
 isBoot :: TokenId -> CageEvent -> Bool
-isBoot tid (CageBoot tid' _) = tid == tid'
+isBoot tid (CageBoot tid' _ _) = tid == tid'
 isBoot _ _ = False
 
 isRequestEvt :: CageEvent -> Bool
@@ -874,7 +924,8 @@ isRequestEvt (CageRequest _ _) = True
 isRequestEvt _ = False
 
 isUpdate :: TokenId -> CageEvent -> Bool
-isUpdate tid (CageUpdate tid' _ _) = tid == tid'
+isUpdate tid (CageUpdate tid' _ _ _) =
+    tid == tid'
 isUpdate _ _ = False
 
 -- ---------------------------------------------------------

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/InverseSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/InverseSpec.hs
@@ -19,7 +19,9 @@ import Test.QuickCheck (forAll)
 import Test.QuickCheck.Monadic (assert, monadicIO, run)
 
 import Cardano.MPFS.Core.Types
-    ( TokenState (..)
+    ( LocatedRequest (..)
+    , LocatedTokenState (..)
+    , TokenState (..)
     )
 import Cardano.MPFS.Generators
     ( genRequest
@@ -45,21 +47,35 @@ import Cardano.MPFS.State
 -- | Apply a cage event to the state interface.
 applyCageEvent :: State IO -> CageEvent -> IO ()
 applyCageEvent State{..} = \case
-    CageBoot tid ts ->
-        putToken tokens tid ts
+    CageBoot tid stRef ts ->
+        putToken
+            tokens
+            tid
+            (LocatedTokenState stRef ts)
     CageRequest txIn req ->
-        putRequest requests txIn req
-    CageUpdate tid newRoot consumed -> do
-        mts <- getToken tokens tid
-        case mts of
-            Just ts ->
+        putRequest requests (LocatedRequest txIn req)
+    CageUpdate tid newStRef newRoot consumed -> do
+        mlts <- getToken tokens tid
+        case mlts of
+            Just LocatedTokenState{tokenState = ts} ->
                 putToken
                     tokens
                     tid
-                    ts{root = newRoot}
+                    ( LocatedTokenState
+                        newStRef
+                        ts{root = newRoot}
+                    )
             Nothing -> pure ()
         mapM_ (removeRequest requests) consumed
-    CageReject _tid consumed ->
+    CageReject tid newStRef consumed -> do
+        mlts <- getToken tokens tid
+        case mlts of
+            Just LocatedTokenState{tokenState = ts} ->
+                putToken
+                    tokens
+                    tid
+                    (LocatedTokenState newStRef ts)
+            Nothing -> pure ()
         mapM_ (removeRequest requests) consumed
     CageRetract txIn ->
         removeRequest requests txIn
@@ -69,22 +85,28 @@ applyCageEvent State{..} = \case
 -- | Apply an inverse operation to the state.
 applyInverseOp :: State IO -> CageInverseOp -> IO ()
 applyInverseOp State{..} = \case
-    InvRestoreToken tid ts ->
-        putToken tokens tid ts
+    InvRestoreToken tid stRef ts ->
+        putToken
+            tokens
+            tid
+            (LocatedTokenState stRef ts)
     InvRemoveToken tid ->
         removeToken tokens tid
     InvRestoreRequest txIn req ->
-        putRequest requests txIn req
+        putRequest requests (LocatedRequest txIn req)
     InvRemoveRequest txIn ->
         removeRequest requests txIn
-    InvRestoreRoot tid newRoot -> do
-        mts <- getToken tokens tid
-        case mts of
-            Just ts ->
+    InvRestoreRoot tid oldStRef newRoot -> do
+        mlts <- getToken tokens tid
+        case mlts of
+            Just LocatedTokenState{tokenState = ts} ->
                 putToken
                     tokens
                     tid
-                    ts{root = newRoot}
+                    ( LocatedTokenState
+                        oldStRef
+                        ts{root = newRoot}
+                    )
             Nothing -> pure ()
     InvTrieInsert{} -> pure ()
     InvTrieDelete{} -> pure ()
@@ -98,19 +120,27 @@ spec = describe "Inverse operations" $ do
         $ prop "token is present after boot"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                monadicIO $ do
-                    st <- run mkMockState
-                    run
-                        $ applyCageEvent
-                            st
-                            (CageBoot tid ts)
-                    r <-
+            forAll genTxIn $ \stRef ->
+                forAll genTokenState $ \ts ->
+                    monadicIO $ do
+                        st <- run mkMockState
                         run
-                            $ getToken
-                                (tokens st)
-                                tid
-                    assert (r == Just ts)
+                            $ applyCageEvent
+                                st
+                                (CageBoot tid stRef ts)
+                        r <-
+                            run
+                                $ getToken
+                                    (tokens st)
+                                    tid
+                        assert
+                            ( r
+                                == Just
+                                    ( LocatedTokenState
+                                        stRef
+                                        ts
+                                    )
+                            )
 
     -- -----------------------------------------------
     -- Lean: request_mem_requests
@@ -132,7 +162,14 @@ spec = describe "Inverse operations" $ do
                                 $ getRequest
                                     (requests st)
                                     txIn
-                        assert (r == Just req)
+                        assert
+                            ( r
+                                == Just
+                                    ( LocatedRequest
+                                        txIn
+                                        req
+                                    )
+                            )
 
     -- -----------------------------------------------
     -- Lean: boot_preserves_requests
@@ -143,24 +180,38 @@ spec = describe "Inverse operations" $ do
         $ \txIn ->
             forAll genTokenId $ \tid ->
                 forAll (genRequest tid) $ \req ->
-                    forAll genTokenState $ \ts ->
-                        monadicIO $ do
-                            st <- run mkMockState
-                            run
-                                $ putRequest
-                                    (requests st)
-                                    txIn
-                                    req
-                            run
-                                $ applyCageEvent
-                                    st
-                                    (CageBoot tid ts)
-                            r <-
+                    forAll genTxIn $ \stRef ->
+                        forAll genTokenState $ \ts ->
+                            monadicIO $ do
+                                st <- run mkMockState
                                 run
-                                    $ getRequest
+                                    $ putRequest
                                         (requests st)
-                                        txIn
-                            assert (r == Just req)
+                                        ( LocatedRequest
+                                            txIn
+                                            req
+                                        )
+                                run
+                                    $ applyCageEvent
+                                        st
+                                        ( CageBoot
+                                            tid
+                                            stRef
+                                            ts
+                                        )
+                                r <-
+                                    run
+                                        $ getRequest
+                                            (requests st)
+                                            txIn
+                                assert
+                                    ( r
+                                        == Just
+                                            ( LocatedRequest
+                                                txIn
+                                                req
+                                            )
+                                    )
 
     -- -----------------------------------------------
     -- Lean: retract_preserves_tokens
@@ -169,25 +220,27 @@ spec = describe "Inverse operations" $ do
         $ prop "retract does not affect tokens"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                forAll genTxIn $ \txIn ->
-                    monadicIO $ do
-                        st <- run mkMockState
-                        run
-                            $ putToken
-                                (tokens st)
-                                tid
-                                ts
-                        run
-                            $ applyCageEvent
-                                st
-                                (CageRetract txIn)
-                        r <-
-                            run
-                                $ getToken
-                                    (tokens st)
-                                    tid
-                        assert (r == Just ts)
+            forAll genTxIn $ \stRef ->
+                forAll genTokenState $ \ts ->
+                    forAll genTxIn $ \txIn ->
+                        let lts = LocatedTokenState stRef ts
+                        in  monadicIO $ do
+                                st <- run mkMockState
+                                run
+                                    $ putToken
+                                        (tokens st)
+                                        tid
+                                        lts
+                                run
+                                    $ applyCageEvent
+                                        st
+                                        (CageRetract txIn)
+                                r <-
+                                    run
+                                        $ getToken
+                                            (tokens st)
+                                            tid
+                                assert (r == Just lts)
 
     -- -----------------------------------------------
     -- Lean: prop_inverseRoundTrip (boot)
@@ -196,34 +249,39 @@ spec = describe "Inverse operations" $ do
         $ prop "boot then inverse removes token"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                monadicIO $ do
-                    st <- run mkMockState
-                    let invs =
-                            inversesOf
-                                (const Nothing)
-                                (const Nothing)
-                                (CageBoot tid ts)
-                    run
-                        $ applyCageEvent
-                            st
-                            (CageBoot tid ts)
-                    r1 <-
+            forAll genTxIn $ \stRef ->
+                forAll genTokenState $ \ts ->
+                    monadicIO $ do
+                        st <- run mkMockState
+                        let invs =
+                                inversesOf
+                                    (const Nothing)
+                                    (const Nothing)
+                                    ( CageBoot
+                                        tid
+                                        stRef
+                                        ts
+                                    )
                         run
-                            $ getToken
-                                (tokens st)
-                                tid
-                    assert (isJust r1)
-                    run
-                        $ mapM_
-                            (applyInverseOp st)
-                            invs
-                    r2 <-
+                            $ applyCageEvent
+                                st
+                                (CageBoot tid stRef ts)
+                        r1 <-
+                            run
+                                $ getToken
+                                    (tokens st)
+                                    tid
+                        assert (isJust r1)
                         run
-                            $ getToken
-                                (tokens st)
-                                tid
-                    assert (isNothing r2)
+                            $ mapM_
+                                (applyInverseOp st)
+                                invs
+                        r2 <-
+                            run
+                                $ getToken
+                                    (tokens st)
+                                    tid
+                        assert (isNothing r2)
 
     -- -----------------------------------------------
     -- Lean: prop_inverseRoundTrip (request)
@@ -272,43 +330,45 @@ spec = describe "Inverse operations" $ do
         $ prop "burn then inverse restores token"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                monadicIO $ do
-                    st <- run mkMockState
-                    run
-                        $ putToken
-                            (tokens st)
-                            tid
-                            ts
-                    let lookupT t =
-                            if t == tid
-                                then Just ts
-                                else Nothing
-                        invs =
-                            inversesOf
-                                lookupT
-                                (const Nothing)
-                                (CageBurn tid)
-                    run
-                        $ applyCageEvent
-                            st
-                            (CageBurn tid)
-                    r1 <-
-                        run
-                            $ getToken
-                                (tokens st)
-                                tid
-                    assert (isNothing r1)
-                    run
-                        $ mapM_
-                            (applyInverseOp st)
-                            invs
-                    r2 <-
-                        run
-                            $ getToken
-                                (tokens st)
-                                tid
-                    assert (r2 == Just ts)
+            forAll genTxIn $ \stRef ->
+                forAll genTokenState $ \ts ->
+                    let lts = LocatedTokenState stRef ts
+                    in  monadicIO $ do
+                            st <- run mkMockState
+                            run
+                                $ putToken
+                                    (tokens st)
+                                    tid
+                                    lts
+                            let lookupT t =
+                                    if t == tid
+                                        then Just (stRef, ts)
+                                        else Nothing
+                                invs =
+                                    inversesOf
+                                        lookupT
+                                        (const Nothing)
+                                        (CageBurn tid)
+                            run
+                                $ applyCageEvent
+                                    st
+                                    (CageBurn tid)
+                            r1 <-
+                                run
+                                    $ getToken
+                                        (tokens st)
+                                        tid
+                            assert (isNothing r1)
+                            run
+                                $ mapM_
+                                    (applyInverseOp st)
+                                    invs
+                            r2 <-
+                                run
+                                    $ getToken
+                                        (tokens st)
+                                        tid
+                            assert (r2 == Just lts)
 
     -- -----------------------------------------------
     -- Lean: prop_inverseRoundTrip (retract)
@@ -326,8 +386,10 @@ spec = describe "Inverse operations" $ do
                         run
                             $ putRequest
                                 (requests st)
-                                txIn
-                                req
+                                ( LocatedRequest
+                                    txIn
+                                    req
+                                )
                         let lookupR t =
                                 if t == txIn
                                     then Just req
@@ -356,7 +418,14 @@ spec = describe "Inverse operations" $ do
                                 $ getRequest
                                     (requests st)
                                     txIn
-                        assert (r2 == Just req)
+                        assert
+                            ( r2
+                                == Just
+                                    ( LocatedRequest
+                                        txIn
+                                        req
+                                    )
+                            )
 
     -- -----------------------------------------------
     -- Lean: prop_inverseRoundTrip (update)
@@ -368,71 +437,87 @@ spec = describe "Inverse operations" $ do
             "update then inverse restores root and requests"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                forAll genRoot $ \newRoot ->
-                    forAll genTxIn $ \txIn ->
-                        forAll (genRequest tid)
-                            $ \req ->
-                                monadicIO $ do
-                                    st <-
-                                        run mkMockState
-                                    run
-                                        $ putToken
-                                            (tokens st)
-                                            tid
-                                            ts
-                                    run
-                                        $ putRequest
-                                            (requests st)
-                                            txIn
-                                            req
-                                    let lookupT t =
-                                            if t == tid
-                                                then Just ts
-                                                else Nothing
-                                        lookupR t =
-                                            if t == txIn
-                                                then Just req
-                                                else Nothing
-                                        invs =
-                                            inversesOf
-                                                lookupT
-                                                lookupR
-                                                ( CageUpdate
+            forAll genTxIn $ \oldStRef ->
+                forAll genTxIn $ \newStRef ->
+                    forAll genTokenState $ \ts ->
+                        forAll genRoot $ \newRoot ->
+                            forAll genTxIn $ \txIn ->
+                                forAll (genRequest tid)
+                                    $ \req ->
+                                        monadicIO $ do
+                                            st <- run mkMockState
+                                            run
+                                                $ putToken
+                                                    (tokens st)
                                                     tid
-                                                    newRoot
-                                                    [txIn]
+                                                    ( LocatedTokenState
+                                                        oldStRef
+                                                        ts
+                                                    )
+                                            run
+                                                $ putRequest
+                                                    (requests st)
+                                                    ( LocatedRequest
+                                                        txIn
+                                                        req
+                                                    )
+                                            let lookupT t =
+                                                    if t == tid
+                                                        then Just (oldStRef, ts)
+                                                        else Nothing
+                                                lookupR t =
+                                                    if t == txIn
+                                                        then Just req
+                                                        else Nothing
+                                                invs =
+                                                    inversesOf
+                                                        lookupT
+                                                        lookupR
+                                                        ( CageUpdate
+                                                            tid
+                                                            newStRef
+                                                            newRoot
+                                                            [txIn]
+                                                        )
+                                            run
+                                                $ applyCageEvent
+                                                    st
+                                                    ( CageUpdate
+                                                        tid
+                                                        newStRef
+                                                        newRoot
+                                                        [txIn]
+                                                    )
+                                            run
+                                                $ mapM_
+                                                    (applyInverseOp st)
+                                                    invs
+                                            r1 <-
+                                                run
+                                                    $ getToken
+                                                        (tokens st)
+                                                        tid
+                                            assert
+                                                ( r1
+                                                    == Just
+                                                        ( LocatedTokenState
+                                                            oldStRef
+                                                            ts
+                                                        )
                                                 )
-                                    run
-                                        $ applyCageEvent
-                                            st
-                                            ( CageUpdate
-                                                tid
-                                                newRoot
-                                                [txIn]
-                                            )
-                                    run
-                                        $ mapM_
-                                            (applyInverseOp st)
-                                            invs
-                                    r1 <-
-                                        run
-                                            $ getToken
-                                                (tokens st)
-                                                tid
-                                    assert
-                                        ( r1
-                                            == Just ts
-                                        )
-                                    r2 <-
-                                        run
-                                            $ getRequest
-                                                (requests st)
-                                                txIn
-                                    assert
-                                        ( r2
-                                            == Just req
-                                        )
+                                            r2 <-
+                                                run
+                                                    $ getRequest
+                                                        (requests st)
+                                                        txIn
+                                            assert
+                                                ( r2
+                                                    == Just
+                                                        ( LocatedRequest
+                                                            txIn
+                                                            req
+                                                        )
+                                                )
 
     -- -----------------------------------------------
     -- Lean: prop_bootBurnRoundTrip
@@ -442,23 +527,24 @@ spec = describe "Inverse operations" $ do
             "boot then burn restores empty state"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                monadicIO $ do
-                    st <- run mkMockState
-                    run
-                        $ applyCageEvent
-                            st
-                            (CageBoot tid ts)
-                    run
-                        $ applyCageEvent
-                            st
-                            (CageBurn tid)
-                    r <-
+            forAll genTxIn $ \stRef ->
+                forAll genTokenState $ \ts ->
+                    monadicIO $ do
+                        st <- run mkMockState
                         run
-                            $ getToken
-                                (tokens st)
-                                tid
-                    assert (isNothing r)
+                            $ applyCageEvent
+                                st
+                                (CageBoot tid stRef ts)
+                        run
+                            $ applyCageEvent
+                                st
+                                (CageBurn tid)
+                        r <-
+                            run
+                                $ getToken
+                                    (tokens st)
+                                    tid
+                        assert (isNothing r)
 
     -- -----------------------------------------------
     -- Lean: prop_requestRetractRoundTrip

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
@@ -73,6 +73,8 @@ import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , BlockId (..)
     , Coin (..)
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -167,63 +169,88 @@ tokensSpec = do
     prop "put/get round-trip"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                ioProperty
-                    $ withTestState
-                    $ \st -> do
-                        putToken (tokens st) tid ts
-                        r <- getToken (tokens st) tid
-                        pure (r === Just ts)
-
-    prop "put/remove/get returns Nothing"
-        $ forAll genTokenId
-        $ \tid ->
-            forAll genTokenState $ \ts ->
-                ioProperty
-                    $ withTestState
-                    $ \st -> do
-                        putToken (tokens st) tid ts
-                        removeToken (tokens st) tid
-                        r <- getToken (tokens st) tid
-                        pure
-                            (isNothing r === True)
-
-    prop "put appears in listTokens"
-        $ forAll genTokenId
-        $ \tid ->
-            forAll genTokenState $ \ts ->
-                ioProperty
-                    $ withTestState
-                    $ \st -> do
-                        putToken (tokens st) tid ts
-                        ids <-
-                            listTokens (tokens st)
-                        pure
-                            ( (tid `elem` ids)
-                                === True
-                            )
-
-    prop "put overwrites previous"
-        $ forAll genTokenId
-        $ \tid ->
-            forAll genTokenState $ \ts1 ->
-                forAll genTokenState $ \ts2 ->
+            forAll genTxIn $ \ref ->
+                forAll genTokenState $ \ts ->
                     ioProperty
                         $ withTestState
                         $ \st -> do
                             putToken
                                 (tokens st)
                                 tid
-                                ts1
-                            putToken
-                                (tokens st)
-                                tid
-                                ts2
+                                (LocatedTokenState ref ts)
                             r <-
                                 getToken
                                     (tokens st)
                                     tid
-                            pure (r === Just ts2)
+                            pure
+                                ( r
+                                    === Just
+                                        (LocatedTokenState ref ts)
+                                )
+
+    prop "put/remove/get returns Nothing"
+        $ forAll genTokenId
+        $ \tid ->
+            forAll genTxIn $ \ref ->
+                forAll genTokenState $ \ts ->
+                    ioProperty
+                        $ withTestState
+                        $ \st -> do
+                            putToken
+                                (tokens st)
+                                tid
+                                (LocatedTokenState ref ts)
+                            removeToken (tokens st) tid
+                            r <- getToken (tokens st) tid
+                            pure
+                                (isNothing r === True)
+
+    prop "put appears in listTokens"
+        $ forAll genTokenId
+        $ \tid ->
+            forAll genTxIn $ \ref ->
+                forAll genTokenState $ \ts ->
+                    ioProperty
+                        $ withTestState
+                        $ \st -> do
+                            putToken
+                                (tokens st)
+                                tid
+                                (LocatedTokenState ref ts)
+                            ids <-
+                                listTokens (tokens st)
+                            pure
+                                ( (tid `elem` ids)
+                                    === True
+                                )
+
+    prop "put overwrites previous"
+        $ forAll genTokenId
+        $ \tid ->
+            forAll genTxIn $ \ref1 ->
+                forAll genTxIn $ \ref2 ->
+                    forAll genTokenState $ \ts1 ->
+                        forAll genTokenState $ \ts2 ->
+                            ioProperty
+                                $ withTestState
+                                $ \st -> do
+                                    putToken
+                                        (tokens st)
+                                        tid
+                                        (LocatedTokenState ref1 ts1)
+                                    putToken
+                                        (tokens st)
+                                        tid
+                                        (LocatedTokenState ref2 ts2)
+                                    r <-
+                                        getToken
+                                            (tokens st)
+                                            tid
+                                    pure
+                                        ( r
+                                            === Just
+                                                (LocatedTokenState ref2 ts2)
+                                        )
 
     prop "remove on empty doesn't crash"
         $ forAll genTokenId
@@ -249,13 +276,16 @@ requestsSpec = do
                         $ \st -> do
                             putRequest
                                 (requests st)
-                                txin
-                                req
+                                (LocatedRequest txin req)
                             r <-
                                 getRequest
                                     (requests st)
                                     txin
-                            pure (r === Just req)
+                            pure
+                                ( r
+                                    === Just
+                                        (LocatedRequest txin req)
+                                )
 
     prop "put/remove/get returns Nothing"
         $ forAll genTxIn
@@ -267,8 +297,7 @@ requestsSpec = do
                         $ \st -> do
                             putRequest
                                 (requests st)
-                                txin
-                                req
+                                (LocatedRequest txin req)
                             removeRequest
                                 (requests st)
                                 txin
@@ -302,19 +331,20 @@ requestsSpec = do
                                                         $ \st -> do
                                                             putRequest
                                                                 (requests st)
-                                                                txin1
-                                                                req1
+                                                                (LocatedRequest txin1 req1)
                                                             putRequest
                                                                 (requests st)
-                                                                txin2
-                                                                req2
+                                                                (LocatedRequest txin2 req2)
                                                             r <-
                                                                 requestsByToken
                                                                     (requests st)
                                                                     tid1
                                                             pure
                                                                 ( r
-                                                                    === [req1]
+                                                                    === [ LocatedRequest
+                                                                            txin1
+                                                                            req1
+                                                                        ]
                                                                 )
 
     prop "requestsByToken on empty returns []"
@@ -395,12 +425,14 @@ tokensSurviveReopen =
                 putToken
                     (tokens st)
                     fixTokenId
-                    fixTokenState
+                    (LocatedTokenState fixTxIn fixTokenState)
             -- Phase 2: reopen and verify
             withTestStateAt dir $ \st -> do
                 r <-
                     getToken (tokens st) fixTokenId
-                r `shouldBe` Just fixTokenState
+                r
+                    `shouldBe` Just
+                        (LocatedTokenState fixTxIn fixTokenState)
 
 -- | Put a request, close DB, reopen, verify it's
 -- there.
@@ -412,13 +444,14 @@ requestsSurviveReopen =
             withTestStateAt dir $ \st ->
                 putRequest
                     (requests st)
-                    fixTxIn
-                    fixRequest
+                    (LocatedRequest fixTxIn fixRequest)
             -- Phase 2: reopen and verify
             withTestStateAt dir $ \st -> do
                 r <-
                     getRequest (requests st) fixTxIn
-                r `shouldBe` Just fixRequest
+                r
+                    `shouldBe` Just
+                        (LocatedRequest fixTxIn fixRequest)
 
 -- | Put a checkpoint, close DB, reopen, verify.
 checkpointSurvivesReopen :: IO ()
@@ -450,7 +483,7 @@ removePersistsAcrossReopen =
                 putToken
                     (tokens st)
                     fixTokenId
-                    fixTokenState
+                    (LocatedTokenState fixTxIn fixTokenState)
                 removeToken (tokens st) fixTokenId
             -- Phase 2: reopen and verify gone
             withTestStateAt dir $ \st -> do

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/RollbackSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/RollbackSpec.hs
@@ -47,6 +47,8 @@ import Cardano.Ledger.TxIn qualified as Ledger
 import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , Coin (..)
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -144,9 +146,10 @@ tokenTests = describe "Token rollback" $ do
         let st = envState env
             tid = tokA
             ts = tokStateA
-        applyAtSlot env 1 (CageBoot tid ts)
+            stRef = stRefA
+        applyAtSlot env 1 (CageBoot tid stRef ts)
         getToken (tokens st) tid
-            `shouldReturn` Just ts
+            `shouldReturn` Just (LocatedTokenState stRef ts)
         rollback env 0
         getToken (tokens st) tid
             `shouldReturn` Nothing
@@ -156,13 +159,14 @@ tokenTests = describe "Token rollback" $ do
         let st = envState env
             tid = tokA
             ts = tokStateA
-        applyAtSlot env 1 (CageBoot tid ts)
+            stRef = stRefA
+        applyAtSlot env 1 (CageBoot tid stRef ts)
         applyAtSlot env 2 (CageBurn tid)
         getToken (tokens st) tid
             `shouldReturn` Nothing
         rollback env 1
         getToken (tokens st) tid
-            `shouldReturn` Just ts
+            `shouldReturn` Just (LocatedTokenState stRef ts)
 
     it
         "can rollback a token removal to before \
@@ -172,7 +176,8 @@ tokenTests = describe "Token rollback" $ do
             let st = envState env
                 tid = tokA
                 ts = tokStateA
-            applyAtSlot env 1 (CageBoot tid ts)
+                stRef = stRefA
+            applyAtSlot env 1 (CageBoot tid stRef ts)
             applyAtSlot env 2 (CageBurn tid)
             rollback env 0
             getToken (tokens st) tid
@@ -189,7 +194,7 @@ requestTests = describe "Request rollback" $ do
         let st = envState env
         applyAtSlot env 1 (CageRequest txInA reqA)
         getRequest (requests st) txInA
-            `shouldReturn` Just reqA
+            `shouldReturn` Just (LocatedRequest txInA reqA)
         rollback env 0
         getRequest (requests st) txInA
             `shouldReturn` Nothing
@@ -203,7 +208,7 @@ requestTests = describe "Request rollback" $ do
             `shouldReturn` Nothing
         rollback env 1
         getRequest (requests st) txInA
-            `shouldReturn` Just reqA
+            `shouldReturn` Just (LocatedRequest txInA reqA)
 
     it
         "can rollback a request removal to before \
@@ -231,17 +236,21 @@ updateTests = describe "Update rollback" $ do
         let st = envState env
             tid = tokA
             ts = tokStateA
+            stRef = stRefA
+            newStRef = stRefB
             newRoot = rootB
-        applyAtSlot env 1 (CageBoot tid ts)
+        applyAtSlot env 1 (CageBoot tid stRef ts)
         applyAtSlot
             env
             2
-            (CageUpdate tid newRoot [])
+            (CageUpdate tid newStRef newRoot [])
         mTs <- getToken (tokens st) tid
-        fmap root mTs `shouldBe` Just newRoot
+        fmap (root . tokenState) mTs
+            `shouldBe` Just newRoot
         rollback env 1
         mTs' <- getToken (tokens st) tid
-        fmap root mTs' `shouldBe` Just (root ts)
+        fmap (root . tokenState) mTs'
+            `shouldBe` Just (root ts)
 
     it
         "can rollback a token update with \
@@ -251,8 +260,10 @@ updateTests = describe "Update rollback" $ do
             let st = envState env
                 tid = tokA
                 ts = tokStateA
+                stRef = stRefA
+                newStRef = stRefB
                 newRoot = rootB
-            applyAtSlot env 1 (CageBoot tid ts)
+            applyAtSlot env 1 (CageBoot tid stRef ts)
             applyAtSlot
                 env
                 1
@@ -262,6 +273,7 @@ updateTests = describe "Update rollback" $ do
                 2
                 ( CageUpdate
                     tid
+                    newStRef
                     newRoot
                     [txInA]
                 )
@@ -271,11 +283,12 @@ updateTests = describe "Update rollback" $ do
             rollback env 1
             -- Token root restored
             mTs <- getToken (tokens st) tid
-            fmap root mTs
+            fmap (root . tokenState) mTs
                 `shouldBe` Just (root ts)
             -- Request restored
             getRequest (requests st) txInA
-                `shouldReturn` Just reqA
+                `shouldReturn` Just
+                    (LocatedRequest txInA reqA)
 
 -- ---------------------------------------------------------
 -- Fixed test data
@@ -302,6 +315,12 @@ rootB = Root "new-root-hash-bytes"
 
 txInA :: TxIn
 txInA = genTestTxIn 0
+
+stRefA :: TxIn
+stRefA = genTestTxIn 1
+
+stRefB :: TxIn
+stRefB = genTestTxIn 2
 
 reqA :: Request
 reqA =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
@@ -109,6 +109,7 @@ import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , BlockId (..)
     , Coin (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -369,7 +370,7 @@ spec = describe "Unified 14-CF" $ do
                     $ applyCageBlockEvents
                         mkTransactionalState
                         mkUnifiedTrieManager
-                        [CageBoot tokA tokStateA]
+                        [CageBoot tokA stRefA tokStateA]
             -- Read it back
             mts <-
                 transact
@@ -377,7 +378,9 @@ spec = describe "Unified 14-CF" $ do
                     $ getToken
                         (tokens mkTransactionalState)
                         tokA
-            mts `shouldBe` Just tokStateA
+            mts
+                `shouldBe` Just
+                    (LocatedTokenState stRefA tokStateA)
 
     it "write/read UTxO KV via InUtxo" $ do
         withUnifiedDB $ \transact -> do
@@ -409,7 +412,7 @@ spec = describe "Unified 14-CF" $ do
                         $ applyCageBlockEvents
                             mkTransactionalState
                             mkUnifiedTrieManager
-                            [CageBoot tokA tokStateA]
+                            [CageBoot tokA stRefA tokStateA]
                 mapColumns InUtxo
                     $ csmtInsert csmtOps "key-pad-32-bytes-xxxxxxxxxx" "val"
             -- Verify both
@@ -419,7 +422,9 @@ spec = describe "Unified 14-CF" $ do
                     $ getToken
                         (tokens mkTransactionalState)
                         tokA
-            mts `shouldBe` Just tokStateA
+            mts
+                `shouldBe` Just
+                    (LocatedTokenState stRefA tokStateA)
             mv <-
                 transact
                     $ mapColumns InUtxo
@@ -437,7 +442,7 @@ spec = describe "Unified 14-CF" $ do
                     $ applyCageBlockEvents
                         mkTransactionalState
                         mkUnifiedTrieManager
-                        [CageBoot tokA tokStateA]
+                        [CageBoot tokA stRefA tokStateA]
             -- Request
             _ <-
                 transact
@@ -455,6 +460,7 @@ spec = describe "Unified 14-CF" $ do
                         mkUnifiedTrieManager
                         [ CageUpdate
                             tokA
+                            newStRefA
                             (Root "new-root")
                             [txInA]
                         ]
@@ -467,7 +473,10 @@ spec = describe "Unified 14-CF" $ do
                         tokA
             mts
                 `shouldBe` Just
-                    tokStateA{root = Root "new-root"}
+                    ( LocatedTokenState
+                        newStRefA
+                        tokStateA{root = Root "new-root"}
+                    )
 
     describe "with persistent trie manager" $ do
         it "tx boot then IO trie read" $ do
@@ -479,7 +488,7 @@ spec = describe "Unified 14-CF" $ do
                         $ applyCageBlockEvents
                             mkTransactionalState
                             mkUnifiedTrieManager
-                            [ CageBoot tokA tokStateA
+                            [ CageBoot tokA stRefA tokStateA
                             , CageRequest txInA reqA
                             ]
                 -- Update via transaction (trie mutation)
@@ -491,6 +500,7 @@ spec = describe "Unified 14-CF" $ do
                             mkUnifiedTrieManager
                             [ CageUpdate
                                 tokA
+                                newStRefA
                                 (Root "new-root")
                                 [txInA]
                             ]
@@ -509,7 +519,7 @@ spec = describe "Unified 14-CF" $ do
                         $ applyCageBlockEvents
                             mkTransactionalState
                             mkUnifiedTrieManager
-                            [CageBoot tokA tokStateA]
+                            [CageBoot tokA stRefA tokStateA]
                 -- IO read after boot
                 withTrie tm tokA $ \trie -> do
                     _ <- getRoot trie
@@ -530,6 +540,7 @@ spec = describe "Unified 14-CF" $ do
                             mkUnifiedTrieManager
                             [ CageUpdate
                                 tokA
+                                newStRefA
                                 (Root "updated")
                                 [txInA]
                             ]
@@ -552,6 +563,7 @@ spec = describe "Unified 14-CF" $ do
                                     mkUnifiedTrieManager
                                     [ CageBoot
                                         tokA
+                                        stRefA
                                         tokStateA
                                     , CageRequest txInA reqA
                                     ]
@@ -570,6 +582,7 @@ spec = describe "Unified 14-CF" $ do
                             mkUnifiedTrieManager
                             [ CageUpdate
                                 tokA
+                                newStRefA
                                 (Root "mixed")
                                 [txInA]
                             ]
@@ -606,7 +619,7 @@ spec = describe "Unified 14-CF" $ do
                         InRollbacks
                         maxBound
                         (1 :: SlotNo)
-                        ( [CageBoot tokA tokStateA]
+                        ( [CageBoot tokA stRefA tokStateA]
                         , [UTxO.Insert "k1-pad-32bytes-xxxxxxxxxxxx" "v1"]
                         )
                         phase0
@@ -621,7 +634,9 @@ spec = describe "Unified 14-CF" $ do
                         $ getToken
                             (tokens mkTransactionalState)
                             tokA
-                mts `shouldBe` Just tokStateA
+                mts
+                    `shouldBe` Just
+                        (LocatedTokenState stRefA tokStateA)
 
         it "full composed lifecycle: restore, follow, rollback" $ do
             withUnifiedDB $ \transact -> do
@@ -640,7 +655,7 @@ spec = describe "Unified 14-CF" $ do
                         maxBound
                         (1 :: SlotNo)
                         (
-                            [ CageBoot tokA tokStateA
+                            [ CageBoot tokA stRefA tokStateA
                             , CageRequest txInA reqA
                             ]
                         , [UTxO.Insert "utxo1-pad-32bytes-xxxxxxxxxx" "out1"]
@@ -669,6 +684,7 @@ spec = describe "Unified 14-CF" $ do
                                 (
                                     [ CageUpdate
                                         tokA
+                                        newStRefA
                                         (Root "root2")
                                         [txInA]
                                     ]
@@ -732,7 +748,7 @@ spec = describe "Unified 14-CF" $ do
                             InRollbacks
                             maxBound
                             (s + 1)
-                            ( [CageBoot tokA tokStateA]
+                            ( [CageBoot tokA stRefA tokStateA]
                             , []
                             )
                             phase0
@@ -777,6 +793,7 @@ spec = describe "Unified 14-CF" $ do
                                     (
                                         [ CageUpdate
                                             tokA
+                                            newStRefA
                                             (Root "r")
                                             [txInA]
                                         ]
@@ -814,7 +831,7 @@ spec = describe "Unified 14-CF" $ do
                         InRollbacks
                         maxBound
                         (1 :: SlotNo)
-                        ( [CageBoot tokA tokStateA, CageRequest txInA reqA]
+                        ( [CageBoot tokA stRefA tokStateA, CageRequest txInA reqA]
                         , [UTxO.Insert "utxo-key-padded-to-32-bytesXX" "val1"]
                         )
                         phase0
@@ -837,7 +854,7 @@ spec = describe "Unified 14-CF" $ do
                                 InRollbacks
                                 maxBound
                                 (2 :: SlotNo)
-                                ( [CageUpdate tokA (Root "r2") [txInA]]
+                                ( [CageUpdate tokA newStRefA (Root "r2") [txInA]]
                                 , [UTxO.Insert "utxo-key2-padded-to-32-byteX" "val2"]
                                 )
                                 phase2
@@ -886,7 +903,7 @@ spec = describe "Unified 14-CF" $ do
                             InRollbacks
                             maxBound
                             (s + 1)
-                            ([CageBoot tokA tokStateA], [])
+                            ([CageBoot tokA stRefA tokStateA], [])
                             phase0
                     case phase1 of
                         InRestoration r -> do
@@ -915,7 +932,7 @@ spec = describe "Unified 14-CF" $ do
                                     InRollbacks
                                     maxBound
                                     (s + 3)
-                                    ( [CageUpdate tokA (Root "r") [txInA]]
+                                    ( [CageUpdate tokA newStRefA (Root "r") [txInA]]
                                     , []
                                     )
                                     phase3
@@ -944,7 +961,7 @@ spec = describe "Unified 14-CF" $ do
                         $ applyCageBlockEvents
                             mkTransactionalState
                             mkUnifiedTrieManager
-                            [CageBoot tokA tokStateA]
+                            [CageBoot tokA stRefA tokStateA]
                 -- Concurrent: tx writes and IO reads
                 concurrently_
                     ( do
@@ -1019,7 +1036,7 @@ spec = describe "Unified 14-CF" $ do
                             InRollbacks
                             maxBound
                             (1 :: SlotNo)
-                            ( [CageBoot tokA tokStateA]
+                            ( [CageBoot tokA stRefA tokStateA]
                             , []
                             )
                             phase0
@@ -1202,6 +1219,12 @@ txInA = genTestTxIn 0
 
 txInB :: TxIn
 txInB = genTestTxIn 1
+
+stRefA :: TxIn
+stRefA = genTestTxIn 10
+
+newStRefA :: TxIn
+newStRefA = genTestTxIn 20
 
 reqA :: Request
 reqA =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/StateSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/StateSpec.hs
@@ -16,6 +16,10 @@ import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (forAll, (==>))
 import Test.QuickCheck.Monadic (assert, monadicIO, run)
 
+import Cardano.MPFS.Core.Types
+    ( LocatedRequest (..)
+    , LocatedTokenState (..)
+    )
 import Cardano.MPFS.Generators
     ( genBlockId
     , genRequest
@@ -58,45 +62,64 @@ tokensSpec newTokens = do
     prop "put/get round-trip"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                monadicIO $ do
-                    tok <- run newTokens
-                    run $ putToken tok tid ts
-                    r <- run $ getToken tok tid
-                    assert (r == Just ts)
+            forAll genTxIn $ \ref ->
+                forAll genTokenState $ \ts ->
+                    let lts = LocatedTokenState ref ts
+                    in  monadicIO $ do
+                            tok <- run newTokens
+                            run $ putToken tok tid lts
+                            r <- run $ getToken tok tid
+                            assert (r == Just lts)
 
     prop "put/remove/get returns Nothing"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                monadicIO $ do
-                    tok <- run newTokens
-                    run $ putToken tok tid ts
-                    run $ removeToken tok tid
-                    r <- run $ getToken tok tid
-                    assert (isNothing r)
+            forAll genTxIn $ \ref ->
+                forAll genTokenState $ \ts ->
+                    monadicIO $ do
+                        tok <- run newTokens
+                        run
+                            $ putToken
+                                tok
+                                tid
+                                (LocatedTokenState ref ts)
+                        run $ removeToken tok tid
+                        r <- run $ getToken tok tid
+                        assert (isNothing r)
 
     prop "put appears in listTokens"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts ->
-                monadicIO $ do
-                    tok <- run newTokens
-                    run $ putToken tok tid ts
-                    ids <- run $ listTokens tok
-                    assert (tid `elem` ids)
+            forAll genTxIn $ \ref ->
+                forAll genTokenState $ \ts ->
+                    monadicIO $ do
+                        tok <- run newTokens
+                        run
+                            $ putToken
+                                tok
+                                tid
+                                (LocatedTokenState ref ts)
+                        ids <- run $ listTokens tok
+                        assert (tid `elem` ids)
 
     prop "put overwrites previous"
         $ forAll genTokenId
         $ \tid ->
-            forAll genTokenState $ \ts1 ->
-                forAll genTokenState $ \ts2 ->
-                    monadicIO $ do
-                        tok <- run newTokens
-                        run $ putToken tok tid ts1
-                        run $ putToken tok tid ts2
-                        r <- run $ getToken tok tid
-                        assert (r == Just ts2)
+            forAll genTxIn $ \ref1 ->
+                forAll genTxIn $ \ref2 ->
+                    forAll genTokenState $ \ts1 ->
+                        forAll genTokenState $ \ts2 ->
+                            let lts2 = LocatedTokenState ref2 ts2
+                            in  monadicIO $ do
+                                    tok <- run newTokens
+                                    run
+                                        $ putToken
+                                            tok
+                                            tid
+                                            (LocatedTokenState ref1 ts1)
+                                    run $ putToken tok tid lts2
+                                    r <- run $ getToken tok tid
+                                    assert (r == Just lts2)
 
     prop "remove on empty doesn't crash"
         $ forAll genTokenId
@@ -113,11 +136,12 @@ requestsSpec newRequests = do
         $ \txin ->
             forAll genTokenId $ \tid ->
                 forAll (genRequest tid) $ \req ->
-                    monadicIO $ do
-                        rs <- run newRequests
-                        run $ putRequest rs txin req
-                        r <- run $ getRequest rs txin
-                        assert (r == Just req)
+                    let lr = LocatedRequest txin req
+                    in  monadicIO $ do
+                            rs <- run newRequests
+                            run $ putRequest rs lr
+                            r <- run $ getRequest rs txin
+                            assert (r == Just lr)
 
     prop "put/remove/get returns Nothing"
         $ forAll genTxIn
@@ -126,7 +150,10 @@ requestsSpec newRequests = do
                 forAll (genRequest tid) $ \req ->
                     monadicIO $ do
                         rs <- run newRequests
-                        run $ putRequest rs txin req
+                        run
+                            $ putRequest
+                                rs
+                                (LocatedRequest txin req)
                         run $ removeRequest rs txin
                         r <- run $ getRequest rs txin
                         assert (isNothing r)
@@ -141,12 +168,14 @@ requestsSpec newRequests = do
                             txin1 /= txin2 ==>
                                 forAll (genRequest tid1) $ \req1 ->
                                     forAll (genRequest tid2) $ \req2 ->
-                                        monadicIO $ do
-                                            rs <- run newRequests
-                                            run $ putRequest rs txin1 req1
-                                            run $ putRequest rs txin2 req2
-                                            r <- run $ requestsByToken rs tid1
-                                            assert (r == [req1])
+                                        let lr1 = LocatedRequest txin1 req1
+                                            lr2 = LocatedRequest txin2 req2
+                                        in  monadicIO $ do
+                                                rs <- run newRequests
+                                                run $ putRequest rs lr1
+                                                run $ putRequest rs lr2
+                                                r <- run $ requestsByToken rs tid1
+                                                assert (r == [lr1])
 
     prop "requestsByToken on empty returns []"
         $ forAll genTokenId

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -115,6 +115,8 @@ import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , Coin (..)
     , ConwayEra
+    , LocatedRequest (..)
+    , LocatedTokenState (..)
     , Operation (..)
     , PParams
     , Request (..)
@@ -1705,7 +1707,8 @@ runRetractRequestWith = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     -- Generate TxIns
     reqIn <- generate genTxIn
     stateIn <- generate genTxIn
@@ -1720,7 +1723,7 @@ runRetractRequestWith = do
                 , requestFee = Coin 1_000_000
                 , requestSubmittedAt = 0
                 }
-    putRequest (requests st) reqIn req
+    putRequest (requests st) (LocatedRequest reqIn req)
     -- Build cage UTxOs
     let scriptAddr = cageAddr Testnet
         feeAddr = testAddr testKh
@@ -1770,7 +1773,8 @@ runUpdateTokenWith = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     -- Generate TxIns
     stateIn <- generate genTxIn
     reqIn <- generate genTxIn
@@ -1828,7 +1832,8 @@ runEndTokenWith = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     stateIn <- generate genTxIn
     feeIn <- generate genTxIn
     let scriptAddr = cageAddr Testnet
@@ -1901,7 +1906,8 @@ mkTestFixture = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     txIn <- generate genTxIn
     let feeAddr = testAddr testKh
         utxo =
@@ -1939,7 +1945,8 @@ mkRealisticFixture = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     txIn <- generate genTxIn
     let feeAddr = testAddr testKh
         utxo =
@@ -1999,7 +2006,8 @@ runRealisticUpdateWith = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     stateIn <- generate genTxIn
     reqIn <- generate genTxIn
     feeIn <- generate genTxIn
@@ -2052,7 +2060,8 @@ runTightUpdate = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     stateIn <- generate genTxIn
     reqIn <- generate genTxIn
     feeIn <- generate genTxIn
@@ -2105,7 +2114,8 @@ runRealisticRetractWith = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     reqIn <- generate genTxIn
     stateIn <- generate genTxIn
     feeIn <- generate genTxIn
@@ -2118,7 +2128,7 @@ runRealisticRetractWith = do
                 , requestFee = Coin 1_000_000
                 , requestSubmittedAt = 0
                 }
-    putRequest (requests st) reqIn req
+    putRequest (requests st) (LocatedRequest reqIn req)
     let scriptAddr = cageAddr Testnet
         feeAddr = testAddr testKh
         cageUtxos =
@@ -2166,7 +2176,8 @@ runRealisticEndWith = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     stateIn <- generate genTxIn
     feeIn <- generate genTxIn
     let scriptAddr = cageAddr Testnet
@@ -2236,7 +2247,8 @@ runRejectRequests = do
                 , processTime = 300_000
                 , retractTime = 600_000
                 }
-    putToken (tokens st) testTid ts
+    stRef <- generate genTxIn
+    putToken (tokens st) testTid (LocatedTokenState stRef ts)
     stateIn <- generate genTxIn
     reqIn <- generate genTxIn
     feeIn <- generate genTxIn

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -12,6 +12,25 @@
             ],
             "type": "object"
         },
+        "ChainPointJSON": {
+            "description": "Indexed chain point baked into proof-bearing responses",
+            "properties": {
+                "block_id": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "slot": {
+                    "format": "int64",
+                    "maximum": 1.8446744073709551615e19,
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "slot",
+                "block_id"
+            ],
+            "type": "object"
+        },
         "DeleteRequest": {
             "description": "Delete a key (value is the current stored value)",
             "properties": {
@@ -49,6 +68,42 @@
             "required": [
                 "token",
                 "address"
+            ],
+            "type": "object"
+        },
+        "FactResponse": {
+            "description": "Proof-bearing fact value response",
+            "properties": {
+                "fact": {
+                    "$ref": "#/definitions/FactWitness"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "value": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "snapshot",
+                "value",
+                "fact"
+            ],
+            "type": "object"
+        },
+        "FactWitness": {
+            "description": "State witness plus MPF inclusion proof",
+            "properties": {
+                "mpf_proof": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "state": {
+                    "$ref": "#/definitions/WitnessedTokenState"
+                }
+            },
+            "required": [
+                "state",
+                "mpf_proof"
             ],
             "type": "object"
         },
@@ -223,6 +278,22 @@
             ],
             "type": "object"
         },
+        "ProofResponse": {
+            "description": "Proof-bearing MPF proof response",
+            "properties": {
+                "fact": {
+                    "$ref": "#/definitions/FactWitness"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                }
+            },
+            "required": [
+                "snapshot",
+                "fact"
+            ],
+            "type": "object"
+        },
         "RejectRequest": {
             "description": "Reject Phase 3 expired requests for a token",
             "properties": {
@@ -271,6 +342,25 @@
                 "operation",
                 "fee",
                 "submitted_at"
+            ],
+            "type": "object"
+        },
+        "RequestsResponse": {
+            "description": "Proof-bearing pending requests response",
+            "properties": {
+                "requests": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedRequest"
+                    },
+                    "type": "array"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                }
+            },
+            "required": [
+                "snapshot",
+                "requests"
             ],
             "type": "object"
         },
@@ -350,6 +440,22 @@
             "description": "Hex-encoded token identifier",
             "type": "string"
         },
+        "TokenResponse": {
+            "description": "Proof-bearing token state response",
+            "properties": {
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "state": {
+                    "$ref": "#/definitions/WitnessedTokenState"
+                }
+            },
+            "required": [
+                "snapshot",
+                "state"
+            ],
+            "type": "object"
+        },
         "TokenStateJSON": {
             "description": "On-chain token state",
             "properties": {
@@ -375,6 +481,25 @@
                 "tip",
                 "process_time",
                 "retract_time"
+            ],
+            "type": "object"
+        },
+        "TxInJSON": {
+            "description": "UTxO reference",
+            "properties": {
+                "tx_id": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "tx_ix": {
+                    "format": "int64",
+                    "maximum": 1.8446744073709551615e19,
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "tx_id",
+                "tx_ix"
             ],
             "type": "object"
         },
@@ -419,6 +544,74 @@
                 "old_value",
                 "new_value",
                 "address"
+            ],
+            "type": "object"
+        },
+        "VerificationSnapshot": {
+            "description": "UTxO-CSMT root and indexed chain point against which bundled proofs are valid",
+            "properties": {
+                "chainpoint": {
+                    "$ref": "#/definitions/ChainPointJSON"
+                },
+                "utxo_root": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "utxo_root",
+                "chainpoint"
+            ],
+            "type": "object"
+        },
+        "WitnessedRequest": {
+            "description": "Pending request plus UTxO witness",
+            "properties": {
+                "request": {
+                    "$ref": "#/definitions/RequestJSON"
+                },
+                "utxo": {
+                    "$ref": "#/definitions/WitnessedUtxo"
+                }
+            },
+            "required": [
+                "utxo",
+                "request"
+            ],
+            "type": "object"
+        },
+        "WitnessedTokenState": {
+            "description": "Token state plus UTxO witness",
+            "properties": {
+                "state": {
+                    "$ref": "#/definitions/TokenStateJSON"
+                },
+                "utxo": {
+                    "$ref": "#/definitions/WitnessedUtxo"
+                }
+            },
+            "required": [
+                "utxo",
+                "state"
+            ],
+            "type": "object"
+        },
+        "WitnessedUtxo": {
+            "description": "UTxO reference, CBOR body, and UTxO-CSMT inclusion proof",
+            "properties": {
+                "tx_in": {
+                    "$ref": "#/definitions/TxInJSON"
+                },
+                "tx_out": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "utxo_proof": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "tx_in",
+                "tx_out",
+                "utxo_proof"
             ],
             "type": "object"
         }
@@ -512,7 +705,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/TokenStateJSON"
+                            "$ref": "#/definitions/TokenResponse"
                         }
                     },
                     "400": {
@@ -544,7 +737,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/FactResponse"
                         }
                     },
                     "400": {
@@ -576,7 +769,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/ProofResponse"
                         }
                     },
                     "400": {
@@ -602,10 +795,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "items": {
-                                "$ref": "#/definitions/RequestJSON"
-                            },
-                            "type": "array"
+                            "$ref": "#/definitions/RequestsResponse"
                         }
                     },
                     "400": {

--- a/flake.lock
+++ b/flake.lock
@@ -3299,10 +3299,6 @@
       "inputs": {
         "CHaP": "CHaP",
         "asciinema": "asciinema",
-        "cardano-mpfs-cage": [
-          "cardano-mpfs-onchain",
-          "cardano-mpfs-cage"
-        ],
         "cardano-mpfs-onchain": "cardano-mpfs-onchain",
         "cardano-node": [
           "cardano-node-clients",

--- a/specs/177-proof-carrying-api/plan.md
+++ b/specs/177-proof-carrying-api/plan.md
@@ -224,6 +224,167 @@ contains the root and chain point needed for external matching.
 `HTTP/Types.hs`, `HTTP/Swagger.hs`,
 `e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs`
 
+## Architectural Principles
+
+These principles are normative for the whole umbrella (#208) and
+codified in the project [constitution](../../.specify/memory/constitution.md)
+v1.1.0 (Principles VIII, IX, X). They are repeated here because they
+shape every slice from #211 forward and explain *why* the response
+shapes were chosen the way they were.
+
+### Pure offline verification (Constitution VIII)
+
+The whole point of proof-bearing responses is that the server is
+*untrusted infrastructure*. Trust collapses to a single `utxo_root`
+that the client obtains from a trusted external source — for example,
+the same root attested by the on-chain UTxO-CSMT — and from there every
+further check MUST be a pure fold over the proof data. No network, no
+disk, no `IO`, no timeouts, no clocks.
+
+Concretely, every verifier shipped in `cardano-mpfs-client` MUST have a
+shape compatible with:
+
+```haskell
+verify :: TrustedRoot -> Bundle -> Either VerifyError a
+```
+
+and verifiers MUST compose as `Kleisli (Either VerifyError)` arrows.
+Any verifier that needs `IO` is the wrong shape and MUST be redesigned;
+any dependency that forces `IO` into the verifier MUST be swapped or
+vendored.
+
+### ProofGraph recursion: two levels of Merkle-ness
+
+The data model has two stacked Merkle structures:
+
+1. **UTxO-CSMT** — the global UTxO set as a Compact Sparse Merkle Tree.
+   Its root is the `utxo_root` baked into every snapshot.
+2. **Per-token MPF** — each MPFS token's datum carries a Merkle
+   Patricia Forestry root over the facts it owns.
+
+Verifying a proof-bearing response is therefore not a flat check but a
+*recursion over a directed acyclic proof graph*. For a fact lookup the
+chain is:
+
+```
+utxo_root  ─CSMT proof→  TxOut (datum)
+                          │
+                          └── mpfRoot  ─MPF proof→  fact value
+```
+
+For an unsigned-tx response the same shape extends to consumed inputs
+and to MPF proofs for every key the builder relied on. When a datum
+itself contains a sub-trie root (e.g. nested namespaces), the verifier
+recurses again: the sub-trie root becomes the next `TrustedRoot` and
+the next layer of the bundle is checked against it.
+
+Implementation shape:
+
+```haskell
+data ProofGraph
+    = CsmtLeaf  CsmtInclusionProof TxOut
+    | MpfLeaf   MpfInclusionProof  Value
+    | MpfUpdate MpfInclusionProof  ProofGraph
+    -- … extended as new datum shapes appear
+
+verifyNode
+    :: TrustedRoot
+    -> ProofGraph
+    -> Either VerifyError TrustedRoot
+```
+
+`verifyNode` returns the *next* trusted root (the datum's `mpfRoot`,
+or a nested sub-trie root) so the caller can keep folding. The
+top-level verifier is a fold of `verifyNode` calls anchored at the
+snapshot's `utxo_root`.
+
+This is why the response types in slice 2 carry full `WitnessedUtxo` +
+`MpfInclusionProof` values rather than scalars: the JSON shape mirrors
+the recursion structure of `ProofGraph`, and adding a new on-chain
+nesting level is a change to one verifier instead of every client.
+
+### Unsigned-tx bundles as proof graphs (slices 3–5)
+
+For tx-building endpoints the same `ProofGraph` machinery covers both
+*input* witnesses (consumed UTxOs proven against `utxo_root`) and any
+MPF facts the builder consulted. The unsigned tx itself is *not* what
+the client trusts; the client trusts the proof graph that justifies
+each input and each fact, and then re-derives that the tx body is the
+unique transaction implied by those witnesses.
+
+The slice-3 `UnsignedTxBundle` type therefore carries:
+
+- the unsigned tx CBOR
+- a `ProofGraph` rooted at the snapshot covering every consumed input
+- per-request sub-graphs for batched flows (`update`, `reject`)
+
+with explicit, deterministic association between request items and
+their proof sub-graphs so a client can verify each one independently
+before signing.
+
+### One verifier, many targets (Constitution IX)
+
+The verifier MUST exist exactly once, in Haskell, in the
+`cardano-mpfs-client` package, and MUST be cross-compiled to every
+runtime a client might live in:
+
+- GHC native — server, CLI, Haskell tests
+- GHC-WASM — browsers, Node, embedded wallets, hardware signers
+- GHC-JS backend — environments that cannot load WASM
+
+Re-implementing the verifier in TypeScript, JavaScript, Rust, or any
+other language is forbidden. The whole trust model collapses if every
+wallet vendor ships a different implementation; security fixes lag,
+encodings drift silently, and "we have a proof-bearing API" stops
+meaning anything.
+
+Consequences for `cardano-mpfs-client`:
+
+- No `IO`, no `unix`, no `process`, no native C FFI beyond pure
+  hashing primitives.
+- Every new dependency MUST clear the GHC-WASM and GHC-JS cross-compile
+  matrix before landing.
+- CI MUST build WASM and JS artifacts and run a cross-target QuickCheck
+  suite asserting byte-identical `Either VerifyError a` outputs across
+  GHC-native / GHC-WASM / GHC-JS for the same input.
+- Releases MUST publish the npm package alongside Hackage; a release
+  that ships Haskell but not WASM/JS is incomplete.
+
+### Lean as source of truth (Constitution X)
+
+The verifier's state machine MUST be formalized in Lean before it is
+implemented in Haskell. The Lean predicates and preservation theorems
+are the authoritative specification; the Haskell implementation exists
+to match them. A QuickCheck property `prop_matchesLeanReference`
+generates random inputs and asserts the Haskell implementation agrees
+with the Lean-extracted reference, and the cross-target suite (above)
+extends that property to the compiled WASM/JS artifacts.
+
+For this umbrella the Lean artifacts to land before slice 4 are:
+
+1. `ProofGraph` data type and `verifyNode` reference function.
+2. Preservation theorems: a verified node returns a root that closes
+   over the same fact / UTxO the Haskell verifier closes over.
+3. The fold theorem: `verify = foldM verifyNode utxoRoot bundle`
+   accepts iff every nested check accepts.
+
+### Follow-up: cross-compile spike for `cardano-mpfs-client`
+
+Principle IX is currently aspirational for this repo — slice 2 ships a
+GHC-native verifier, but no WASM/JS build has been proven. Before
+slice 4 lands we MUST run a half-day spike that:
+
+- attempts a GHC-WASM build of `cardano-mpfs-client` end-to-end,
+- attempts the GHC-JS backend build of the same package,
+- pins or swaps any transitive dependency that fails to cross-compile,
+- adds the `nix build` outputs and a minimal cross-target QuickCheck
+  invocation to CI.
+
+This spike is a hard prerequisite for slices 4–6: if the verifier
+cannot be compiled to a wallet runtime, the proof-bearing tx
+endpoints have no client. Tracking issue to be filed under the #208
+umbrella.
+
 ## Risks
 
 - **Snapshot drift during response assembly**: If the indexer advances


### PR DESCRIPTION
## Summary

Slice 2 of the proof-carrying API umbrella (#208). Converts the four
read-side token endpoints to return proof-bearing JSON objects that
clients can verify offline against a single trusted `utxo_root`.

Closes #211.

## Scope

- `GET /tokens/:id` → `TokenResponse` with `WitnessedTokenState`
- `GET /tokens/:id/facts/:key` → `FactResponse` with `FactWitness` + MPF inclusion proof
- `GET /tokens/:id/proofs/:key` → `ProofResponse` with MPF inclusion/non-inclusion proof
- `GET /tokens/:id/requests` → `RequestsResponse` with `WitnessedRequest` array

Every response embeds its own `VerificationSnapshot` = `{ utxo_root, chainpoint }`.

## Stack

Eight stgit patches on `feat/211-proof-bearing-reads`:

1. `refactor: propagate UTxO refs through indexer interfaces` — threading `TxIn`/`TxOut` witnesses through `State`/`Tokens`/`Requests`
2. `feat: add proof-bearing read response types` — `WitnessedUtxo`, `WitnessedTokenState`, `WitnessedRequest`, `FactWitness`, response envelopes
3. `feat: proof-bearing GET /tokens/:id`
4. `feat: proof-bearing GET /tokens/:id/facts/:key and /proofs/:key`
5. `feat: proof-bearing GET /tokens/:id/requests`
6. `docs: regenerate swagger for proof-bearing reads` — `just update-swagger` output
7. `test: e2e ProofsSpec — verify proof-bearing reads via cardano-mpfs-client` — end-to-end round-trip: boot token, insert fact, process update, call all four endpoints, `verifyVerificationSnapshot` on each
8. `docs: capture proving-centric architecture in constitution and plan` — constitution v1.0.0 → v1.1.0 (Principles VIII/IX/X), plan section on `ProofGraph` recursion and client portability

## Architectural context

Patch 8 bumps the project [constitution](.specify/memory/constitution.md) to v1.1.0, adding three normative principles that shape every slice from here forward:

- **VIII. Pure Offline Verification** — verifiers MUST be `Hex -> Bundle -> Either VerifyError a`, no IO, no network.
- **IX. One Verifier, Many Targets** — single Haskell verifier in `cardano-mpfs-client`, cross-compiled to GHC-native, GHC-WASM, GHC-JS. Re-implementations in TS/JS/Rust forbidden.
- **X. Lean as Source of Truth** — verifier state machine formalized in Lean 4 before Haskell implementation; QuickCheck bridges the two.

The [plan](specs/177-proof-carrying-api/plan.md) now has an Architectural Principles section documenting the `ProofGraph` recursion model (two levels of Merkle-ness: UTxO-CSMT global + per-token MPF, with recursion into sub-trie roots) and flags a half-day WASM/JS spike on `cardano-mpfs-client` as a hard gate before slice 4.

## Test plan

- [x] `just ci` — 369 unit examples passing, fourmolu clean, hlint clean
- [x] E2E `ProofsSpec` with `MPFS_BLUEPRINT` set — 1 example, 0 failures in 15.45s; verifies snapshot + witnesses end-to-end via released `cardano-mpfs-client`
- [x] Swagger freshness check passes

## Follow-ups

- File WASM/JS cross-compile spike issue (hard gate before slice 4).
- Slices 3–5 (transaction bundles) land on the `ProofGraph` shape documented here.