### PR TITLE
feat: proof-bearing UnsignedTxBundle from TxBuilder

### DIFF
--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -64,14 +64,18 @@ import Cardano.MPFS.Core.Blueprint
     , loadBlueprint
     )
 import Cardano.MPFS.Core.Types
-    ( Coin (..)
+    ( BlockId (..)
+    , Coin (..)
     , ConwayEra
     , LocatedTokenState (..)
     , Root (..)
     , TokenId (..)
     , TokenState (..)
     )
-import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.Provider
+    ( Provider (..)
+    , SlotNo (..)
+    )
 import Cardano.MPFS.State
     ( Requests (..)
     , State (..)
@@ -82,7 +86,9 @@ import Cardano.MPFS.Submitter
     , Submitter (..)
     )
 import Cardano.MPFS.TxBuilder
-    ( TxBuilder (..)
+    ( BundleSnapshot (..)
+    , TxBuilder (..)
+    , UnsignedTxBundle (..)
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -158,6 +164,7 @@ cageFlowSpec scriptBytes =
                 buildAndSubmit ctx
                     $ bootToken
                         (txBuilder ctx)
+                        emptySnap
                         genesisAddr
             let tokenId =
                     extractTokenId cfg signedBoot
@@ -180,6 +187,7 @@ cageFlowSpec scriptBytes =
                 buildAndSubmit ctx
                     $ requestInsert
                         (txBuilder ctx)
+                        emptySnap
                         tokenId
                         "hello"
                         "world"
@@ -205,6 +213,7 @@ cageFlowSpec scriptBytes =
                 buildAndSubmit ctx
                     $ updateToken
                         (txBuilder ctx)
+                        emptySnap
                         tokenId
                         genesisAddr
 
@@ -228,6 +237,7 @@ cageFlowSpec scriptBytes =
                 buildAndSubmit ctx
                     $ requestInsert
                         (txBuilder ctx)
+                        emptySnap
                         tokenId
                         "bye"
                         "moon"
@@ -258,6 +268,7 @@ cageFlowSpec scriptBytes =
                 buildAndSubmit ctx
                     $ retractRequest
                         (txBuilder ctx)
+                        emptySnap
                         req2TxIn
                         genesisAddr
 
@@ -283,6 +294,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ bootToken
                             (txBuilder ctx)
+                            emptySnap
                             genesisAddr
                 let tokenId =
                         extractTokenId cfg signedBoot
@@ -297,6 +309,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ requestInsert
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             "aaa"
                             "val1"
@@ -318,6 +331,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ updateToken
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             genesisAddr
                 -- Wait for trie root to update
@@ -345,6 +359,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ requestDelete
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             "aaa"
                             "val1"
@@ -372,6 +387,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ updateToken
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             genesisAddr
                 _ <-
@@ -394,6 +410,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ requestInsert
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             "bbb"
                             "val2"
@@ -413,6 +430,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ requestInsert
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             "ccc"
                             "val3"
@@ -440,6 +458,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ updateToken
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             genesisAddr
                 _ <-
@@ -461,6 +480,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ requestDelete
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             "bbb"
                             "val2"
@@ -480,6 +500,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ requestInsert
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             "ddd"
                             "val4"
@@ -508,6 +529,7 @@ deleteFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ updateToken
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             genesisAddr
                 pollOrFail 60 "update-mixed" $ do
@@ -535,6 +557,7 @@ rejectFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ bootToken
                             (txBuilder ctx)
+                            emptySnap
                             genesisAddr
                 let tokenId =
                         extractTokenId cfg signedBoot
@@ -549,6 +572,7 @@ rejectFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ requestInsert
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             "reject-me"
                             "val"
@@ -582,6 +606,7 @@ rejectFlowSpec scriptBytes =
                     buildAndSubmit ctx
                         $ rejectRequests
                             (txBuilder ctx)
+                            emptySnap
                             tokenId
                             genesisAddr
 
@@ -700,11 +725,12 @@ pollUntilJust timeoutSec action = go attempts
 -- | Build, sign, submit, and wait for a tx.
 buildAndSubmit
     :: Context IO
+    -> IO UnsignedTxBundle
     -> IO (Tx ConwayEra)
-    -> IO (Tx ConwayEra)
-buildAndSubmit ctx buildTx = do
-    unsigned <- buildTx
-    let signed =
+buildAndSubmit ctx buildBundle = do
+    bundle <- buildBundle
+    let unsigned = bundleTx bundle
+        signed =
             addKeyWitness
                 genesisSignKey
                 unsigned
@@ -712,6 +738,17 @@ buildAndSubmit ctx buildTx = do
     assertSubmitted result
     awaitTx
     pure signed
+
+-- | Placeholder snapshot used by e2e tests. The
+-- builder embeds it verbatim but does not yet use
+-- it to drive tx construction.
+emptySnap :: BundleSnapshot
+emptySnap =
+    BundleSnapshot
+        { snapshotUtxoRoot = BS.replicate 32 0
+        , snapshotSlot = SlotNo 0
+        , snapshotBlockId = BlockId (BS.replicate 32 0)
+        }
 
 -- | Assert that a submit result is 'Submitted'.
 assertSubmitted :: SubmitResult -> IO ()

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -76,7 +76,8 @@ import Cardano.MPFS.Core.Blueprint
     , loadBlueprint
     )
 import Cardano.MPFS.Core.Types
-    ( Coin (..)
+    ( BlockId (..)
+    , Coin (..)
     , ConwayEra
     , LocatedRequest (..)
     , LocatedTokenState (..)
@@ -86,7 +87,10 @@ import Cardano.MPFS.Core.Types
     , TokenId (..)
     , TokenState (..)
     )
-import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.Provider
+    ( Provider (..)
+    , SlotNo (..)
+    )
 import Cardano.MPFS.State
     ( Requests (..)
     , State (..)
@@ -97,7 +101,11 @@ import Cardano.MPFS.Submitter
     , Submitter (..)
     )
 import Cardano.MPFS.Trie (TrieManager (..))
-import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot (..)
+    , TxBuilder (..)
+    , UnsignedTxBundle (..)
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -171,11 +179,13 @@ cageFlowSpec bpPath scriptBytes =
                     cageAddrFromCfg cfg Testnet
 
             -- Step 1: Boot token
-            unsignedBoot <-
+            bundleBoot <-
                 bootToken
                     (txBuilder ctx)
+                    emptySnap
                     genesisAddr
-            let signedBoot =
+            let unsignedBoot = bundleTx bundleBoot
+                signedBoot =
                     addKeyWitness
                         genesisSignKey
                         unsignedBoot
@@ -231,14 +241,16 @@ cageFlowSpec bpPath scriptBytes =
                 `shouldSatisfy` (not . null)
 
             -- Step 2: Request insert
-            unsignedReq <-
+            bundleReq <-
                 requestInsert
                     (txBuilder ctx)
+                    emptySnap
                     tokenId
                     "hello"
                     "world"
                     genesisAddr
-            let signedReq =
+            let unsignedReq = bundleTx bundleReq
+                signedReq =
                     addKeyWitness
                         genesisSignKey
                         unsignedReq
@@ -258,12 +270,14 @@ cageFlowSpec bpPath scriptBytes =
                 `shouldSatisfy` (> length cageUtxos)
 
             -- Step 3: Update token
-            unsignedUpdate <-
+            bundleUpdate <-
                 updateToken
                     (txBuilder ctx)
+                    emptySnap
                     tokenId
                     genesisAddr
-            let signedUpdate =
+            let unsignedUpdate = bundleTx bundleUpdate
+                signedUpdate =
                     addKeyWitness
                         genesisSignKey
                         unsignedUpdate
@@ -319,14 +333,16 @@ cageFlowSpec bpPath scriptBytes =
 
             -- Step 4: Request + retract
             -- Submit a second request
-            unsignedReq2 <-
+            bundleReq2 <-
                 requestInsert
                     (txBuilder ctx)
+                    emptySnap
                     tokenId
                     "bye"
                     "moon"
                     genesisAddr
-            let signedReq2 =
+            let unsignedReq2 = bundleTx bundleReq2
+                signedReq2 =
                     addKeyWitness
                         genesisSignKey
                         unsignedReq2
@@ -374,12 +390,14 @@ cageFlowSpec bpPath scriptBytes =
             threadDelay 32_000_000
 
             -- Retract the second request
-            unsignedRetract <-
+            bundleRetract <-
                 retractRequest
                     (txBuilder ctx)
+                    emptySnap
                     req2TxIn
                     genesisAddr
-            let signedRetract =
+            let unsignedRetract = bundleTx bundleRetract
+                signedRetract =
                     addKeyWitness
                         genesisSignKey
                         unsignedRetract
@@ -454,6 +472,17 @@ withE2E scriptBytes action = do
 -- ---------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------
+
+-- | Placeholder snapshot used by e2e tests. The
+-- builder embeds it verbatim but does not yet use
+-- it to drive tx construction.
+emptySnap :: BundleSnapshot
+emptySnap =
+    BundleSnapshot
+        { snapshotUtxoRoot = BS.replicate 32 0
+        , snapshotSlot = SlotNo 0
+        , snapshotBlockId = BlockId (BS.replicate 32 0)
+        }
 
 -- | Assert that a submit result is 'Submitted'.
 assertSubmitted :: SubmitResult -> IO ()

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -53,7 +53,8 @@ import Cardano.MPFS.Core.Blueprint
     , loadBlueprint
     )
 import Cardano.MPFS.Core.Types
-    ( Coin (..)
+    ( BlockId (..)
+    , Coin (..)
     , ConwayEra
     , LocatedRequest (..)
     , LocatedTokenState (..)
@@ -75,7 +76,11 @@ import Cardano.MPFS.Submitter
     ( SubmitResult (..)
     , Submitter (..)
     )
-import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot (..)
+    , TxBuilder (..)
+    , UnsignedTxBundle (..)
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -145,6 +150,7 @@ chainsyncSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ bootToken
                         (txBuilder ctx)
+                        emptySnap
                         genesisAddr
             let tokenId =
                     extractTokenId cfg signedBoot
@@ -176,6 +182,7 @@ chainsyncSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ bootToken
                         (txBuilder ctx)
+                        emptySnap
                         genesisAddr
             let tokenId =
                     extractTokenId cfg signedBoot
@@ -197,6 +204,7 @@ chainsyncSpecs scriptBytes = do
                         buildAndSubmit ctx
                             $ requestInsert
                                 (txBuilder ctx)
+                                emptySnap
                                 tokenId
                                 "hello"
                                 "world"
@@ -242,6 +250,7 @@ chainsyncSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ bootToken
                         (txBuilder ctx)
+                        emptySnap
                         genesisAddr
             let tokenId =
                     extractTokenId cfg signedBoot
@@ -330,11 +339,12 @@ withE2E scriptBytes action = do
 -- | Build, sign, submit, and wait for a tx.
 buildAndSubmit
     :: Context IO
+    -> IO UnsignedTxBundle
     -> IO (Tx ConwayEra)
-    -> IO (Tx ConwayEra)
-buildAndSubmit ctx buildTx = do
-    unsigned <- buildTx
-    let signed =
+buildAndSubmit ctx buildBundle = do
+    bundle <- buildBundle
+    let unsigned = bundleTx bundle
+        signed =
             addKeyWitness
                 genesisSignKey
                 unsigned
@@ -342,6 +352,17 @@ buildAndSubmit ctx buildTx = do
     assertSubmitted result
     awaitTx
     pure signed
+
+-- | Placeholder snapshot used by e2e tests. The
+-- builder embeds it verbatim but does not yet use
+-- it to drive tx construction.
+emptySnap :: BundleSnapshot
+emptySnap =
+    BundleSnapshot
+        { snapshotUtxoRoot = BS.replicate 32 0
+        , snapshotSlot = SlotNo 0
+        , snapshotBlockId = BlockId (BS.replicate 32 0)
+        }
 
 -- | Assert that a submit result is 'Submitted'.
 assertSubmitted :: SubmitResult -> IO ()

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
@@ -28,7 +28,9 @@ import Cardano.MPFS.Core.Blueprint
     , loadBlueprint
     )
 import Cardano.MPFS.Core.Types
-    ( TokenId
+    ( BlockId (..)
+    , SlotNo (..)
+    , TokenId
     )
 import Cardano.MPFS.State
     ( State (..)
@@ -39,7 +41,11 @@ import Cardano.MPFS.Submitter
     , Submitter (..)
     )
 import Cardano.MPFS.Trace (AppTrace (..))
-import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot (..)
+    , TxBuilder (..)
+    , UnsignedTxBundle (..)
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -74,6 +80,7 @@ import Control.Tracer
     ( Tracer (..)
     , traceWith
     )
+import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
 import Data.Foldable (for_)
 import System.Environment (lookupEnv)
@@ -321,9 +328,10 @@ mkAppConfig socketPath cfg tracer dbPath = do
 -- index it.
 bootAndAwait :: Context IO -> IO TokenId
 bootAndAwait ctx = do
-    unsignedBoot <-
-        bootToken (txBuilder ctx) genesisAddr
-    let signed =
+    bundle <-
+        bootToken (txBuilder ctx) emptySnap genesisAddr
+    let unsignedBoot = bundleTx bundle
+        signed =
             addKeyWitness genesisSignKey unsignedBoot
     result <- submitTx (submitter ctx) signed
     case result of
@@ -342,6 +350,17 @@ bootAndAwait ctx = do
             error
                 $ "boot rejected: "
                     ++ show reason
+
+-- | Placeholder snapshot used by e2e tests. The
+-- builder embeds it verbatim but does not yet use
+-- it to drive tx construction.
+emptySnap :: BundleSnapshot
+emptySnap =
+    BundleSnapshot
+        { snapshotUtxoRoot = BS.replicate 32 0
+        , snapshotSlot = SlotNo 0
+        , snapshotBlockId = BlockId (BS.replicate 32 0)
+        }
 
 -- * Config
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -83,17 +83,25 @@ import Cardano.MPFS.Core.Blueprint
     , loadBlueprint
     )
 import Cardano.MPFS.Core.Types
-    ( Coin (..)
+    ( BlockId (..)
+    , Coin (..)
     , ConwayEra
     , TokenId (..)
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
-import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.Provider
+    ( Provider (..)
+    , SlotNo (..)
+    )
 import Cardano.MPFS.Submitter
     ( SubmitResult (..)
     , Submitter (..)
     )
-import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot (..)
+    , TxBuilder (..)
+    , UnsignedTxBundle (..)
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -169,7 +177,7 @@ lifecycleSpec scriptBytes =
             -- Boot
             bootTx <-
                 submit
-                    $ bootToken tb genesisAddr
+                    $ bootToken tb emptySnap genesisAddr
             let tid =
                     extractTokenId cfg bootTx
 
@@ -181,6 +189,7 @@ lifecycleSpec scriptBytes =
                 submit
                     $ requestInsert
                         tb
+                        emptySnap
                         tid
                         "hello"
                         "world"
@@ -194,6 +203,7 @@ lifecycleSpec scriptBytes =
                 submit
                     $ updateToken
                         tb
+                        emptySnap
                         tid
                         genesisAddr
 
@@ -205,6 +215,7 @@ lifecycleSpec scriptBytes =
                 submit
                     $ requestInsert
                         tb
+                        emptySnap
                         tid
                         "bye"
                         "moon"
@@ -223,6 +234,7 @@ lifecycleSpec scriptBytes =
                 submit
                     $ retractRequest
                         tb
+                        emptySnap
                         reqTxIn
                         genesisAddr
 
@@ -234,6 +246,7 @@ lifecycleSpec scriptBytes =
                 submit
                     $ endToken
                         tb
+                        emptySnap
                         tid
                         genesisAddr
 
@@ -251,11 +264,12 @@ signSubmitAwait
     -- ^ Timeout in seconds
     -> Application
     -> Context IO
+    -> IO UnsignedTxBundle
     -> IO (Tx ConwayEra)
-    -> IO (Tx ConwayEra)
-signSubmitAwait timeout app ctx buildTx = do
-    unsigned <- buildTx
-    let signed =
+signSubmitAwait timeout app ctx buildBundle = do
+    bundle <- buildBundle
+    let unsigned = bundleTx bundle
+        signed =
             addKeyWitness
                 genesisSignKey
                 unsigned
@@ -264,6 +278,17 @@ signSubmitAwait timeout app ctx buildTx = do
     assertSubmitted result
     awaitTx timeout app (txIdTx signed)
     pure signed
+
+-- | Placeholder snapshot used by e2e tests. The
+-- builder embeds it verbatim but does not yet use
+-- it to drive tx construction.
+emptySnap :: BundleSnapshot
+emptySnap =
+    BundleSnapshot
+        { snapshotUtxoRoot = BS.replicate 32 0
+        , snapshotSlot = SlotNo 0
+        , snapshotBlockId = BlockId (BS.replicate 32 0)
+        }
 
 -- | @GET \/tx\/:txId?timeout=N@ — block until
 -- the indexer has seen this transaction.

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -52,6 +52,7 @@ import Cardano.MPFS.Core.Blueprint
     )
 import Cardano.MPFS.Core.Types
     ( Addr
+    , BlockId (..)
     , Coin (..)
     , ConwayEra
     , LocatedRequest (..)
@@ -71,7 +72,10 @@ import Cardano.MPFS.Indexer.Follower
     , computeInverse
     , detectFromTx
     )
-import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.Provider
+    ( Provider (..)
+    , SlotNo (..)
+    )
 import Cardano.MPFS.State
     ( Requests (..)
     , State (..)
@@ -85,7 +89,11 @@ import Cardano.MPFS.Trie
     ( Trie (..)
     , TrieManager (..)
     )
-import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot (..)
+    , TxBuilder (..)
+    , UnsignedTxBundle (..)
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -162,7 +170,7 @@ indexerSpecs scriptBytes = do
             -- Submit boot tx
             signedBoot <-
                 buildAndSubmit ctx
-                    $ bootToken (txBuilder ctx) genesisAddr
+                    $ bootToken (txBuilder ctx) emptySnap genesisAddr
             let resolver =
                     mkResolver preUtxos []
 
@@ -229,6 +237,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ requestInsert
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         "hello"
                         "world"
@@ -288,6 +297,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ requestInsert
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         "hello"
                         "world"
@@ -329,6 +339,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ updateToken
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         genesisAddr
             let resolver =
@@ -434,6 +445,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ requestInsert
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         "bye"
                         "moon"
@@ -477,6 +489,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ retractRequest
                         (txBuilder ctx)
+                        emptySnap
                         reqTxIn
                         genesisAddr
             let resolver =
@@ -546,6 +559,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ endToken
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         genesisAddr
             let resolver =
@@ -616,6 +630,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ endToken
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         genesisAddr
             let resolver =
@@ -685,6 +700,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ bootToken
                         (txBuilder ctx)
+                        emptySnap
                         genesisAddr
             let resolver =
                     mkResolver preUtxos []
@@ -755,6 +771,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ requestInsert
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         "key1"
                         "val1"
@@ -785,6 +802,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ requestInsert
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         "key2"
                         "val2"
@@ -826,6 +844,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ updateToken
                         (txBuilder ctx)
+                        emptySnap
                         tid
                         genesisAddr
             let resolver =
@@ -862,6 +881,7 @@ indexerSpecs scriptBytes = do
                 buildAndSubmit ctx
                     $ bootToken
                         (txBuilder ctx)
+                        emptySnap
                         genesisAddr
             let resolver =
                     mkResolver preUtxos []
@@ -953,11 +973,12 @@ withE2E scriptBytes action = do
 -- | Build, sign, submit, and wait for a tx.
 buildAndSubmit
     :: Context IO
+    -> IO UnsignedTxBundle
     -> IO (Tx ConwayEra)
-    -> IO (Tx ConwayEra)
-buildAndSubmit ctx buildTx = do
-    unsigned <- buildTx
-    let signed =
+buildAndSubmit ctx buildBundle = do
+    bundle <- buildBundle
+    let unsigned = bundleTx bundle
+        signed =
             addKeyWitness
                 genesisSignKey
                 unsigned
@@ -965,6 +986,17 @@ buildAndSubmit ctx buildTx = do
     assertSubmitted result
     awaitTx
     pure signed
+
+-- | Placeholder snapshot used by e2e tests. The
+-- builder embeds it verbatim but does not yet use
+-- it to drive tx construction.
+emptySnap :: BundleSnapshot
+emptySnap =
+    BundleSnapshot
+        { snapshotUtxoRoot = BS.replicate 32 0
+        , snapshotSlot = SlotNo 0
+        , snapshotBlockId = BlockId (BS.replicate 32 0)
+        }
 
 -- | Assert that a submit result is 'Submitted'.
 assertSubmitted :: SubmitResult -> IO ()
@@ -1016,7 +1048,7 @@ bootAndRegister cfg ctx = do
     -- Build + submit boot tx
     signedBoot <-
         buildAndSubmit ctx
-            $ bootToken (txBuilder ctx) genesisAddr
+            $ bootToken (txBuilder ctx) emptySnap genesisAddr
 
     -- Detect and apply
     let resolver =

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -92,17 +92,25 @@ import Cardano.MPFS.Core.Blueprint
     , loadBlueprint
     )
 import Cardano.MPFS.Core.Types
-    ( Coin (..)
+    ( BlockId (..)
+    , Coin (..)
     , ConwayEra
     , TokenId (..)
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
-import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.Provider
+    ( Provider (..)
+    , SlotNo (..)
+    )
 import Cardano.MPFS.Submitter
     ( SubmitResult (..)
     , Submitter (..)
     )
-import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot (..)
+    , TxBuilder (..)
+    , UnsignedTxBundle (..)
+    )
 import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
 import Cardano.MPFS.TxBuilder.Real.Internal
     ( cagePolicyIdFromCfg
@@ -179,7 +187,7 @@ proofsSpec scriptBytes =
 
             -- Boot → insert → update to land the fact
             bootTx <-
-                submit $ bootToken tb genesisAddr
+                submit $ bootToken tb emptySnap genesisAddr
             let tid = extractTokenId cfg bootTx
                 tidHex = tokenIdHex tid
                 keyHex = B16.encode factKey
@@ -188,6 +196,7 @@ proofsSpec scriptBytes =
                 submit
                     $ requestInsert
                         tb
+                        emptySnap
                         tid
                         factKey
                         factValue
@@ -196,6 +205,7 @@ proofsSpec scriptBytes =
                 submit
                     $ updateToken
                         tb
+                        emptySnap
                         tid
                         genesisAddr
 
@@ -206,6 +216,7 @@ proofsSpec scriptBytes =
                 submit
                     $ requestInsert
                         tb
+                        emptySnap
                         tid
                         "bye"
                         "moon"
@@ -372,16 +383,28 @@ signSubmitAwait
     :: Int
     -> Application
     -> Context IO
+    -> IO UnsignedTxBundle
     -> IO (Tx ConwayEra)
-    -> IO (Tx ConwayEra)
-signSubmitAwait timeout app ctx buildTx = do
-    unsigned <- buildTx
-    let signed =
+signSubmitAwait timeout app ctx buildBundle = do
+    bundle <- buildBundle
+    let unsigned = bundleTx bundle
+        signed =
             addKeyWitness genesisSignKey unsigned
     result <- submitTx (submitter ctx) signed
     assertSubmitted result
     awaitTx timeout app (txIdTx signed)
     pure signed
+
+-- | Placeholder snapshot used by e2e tests. The
+-- builder embeds it verbatim but does not yet use
+-- it to drive tx construction.
+emptySnap :: BundleSnapshot
+emptySnap =
+    BundleSnapshot
+        { snapshotUtxoRoot = BS.replicate 32 0
+        , snapshotSlot = SlotNo 0
+        , snapshotBlockId = BlockId (BS.replicate 32 0)
+        }
 
 awaitTx :: Int -> Application -> TxId -> IO ()
 awaitTx timeout app tid = do

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -112,6 +112,10 @@ import Cardano.UTxOCSMT.Application.Metrics
 import Cardano.MPFS.State qualified as St
 import Cardano.MPFS.Submitter qualified as Sub
 import Cardano.MPFS.Trie qualified as Trie
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot (..)
+    , UnsignedTxBundle (..)
+    )
 import Cardano.MPFS.TxBuilder qualified as Tx
 
 -- | Combined API with Swagger UI.
@@ -270,6 +274,33 @@ requireSnapshot ctx = do
                             { cpSlot = s
                             , cpBlockId = Hex b
                             }
+                    }
+        _ ->
+            throwError
+                err503
+                    { errBody =
+                        "Verification snapshot \
+                        \not yet available"
+                    }
+
+-- | Read the current ledger-native 'BundleSnapshot'
+-- from context, or 503 if the indexer has not yet
+-- produced a UTxO-CSMT root or a checkpoint.
+requireBundleSnapshot
+    :: Context IO -> Handler BundleSnapshot
+requireBundleSnapshot ctx = do
+    mRoot <- liftIO $ utxoRoot ctx
+    mCp <-
+        liftIO
+            $ St.getCheckpoint
+                (St.checkpoints (state ctx))
+    case (mRoot, mCp) of
+        (Just r, Just (slot, blk)) ->
+            pure
+                BundleSnapshot
+                    { snapshotUtxoRoot = r
+                    , snapshotSlot = slot
+                    , snapshotBlockId = blk
                     }
         _ ->
             throwError
@@ -549,9 +580,11 @@ txBootHandler
     :: Context IO -> BootRequest -> Handler Hex
 txBootHandler ctx (BootRequest addrHex) = do
     addr <- requireAddr addrHex
-    tx <-
-        liftIO $ Tx.bootToken (txBuilder ctx) addr
-    pure (serializeTx tx)
+    snap <- requireBundleSnapshot ctx
+    bundle <-
+        liftIO
+            $ Tx.bootToken (txBuilder ctx) snap addr
+    pure (serializeTx (bundleTx bundle))
 
 txInsertHandler
     :: Context IO -> InsertRequest -> Handler Hex
@@ -564,15 +597,17 @@ txInsertHandler
         , irAddr = addrHex
         } = do
         addr <- requireAddr addrHex
-        tx <-
+        snap <- requireBundleSnapshot ctx
+        bundle <-
             liftIO
                 $ Tx.requestInsert
                     (txBuilder ctx)
+                    snap
                     tid
                     k
                     v
                     addr
-        pure (serializeTx tx)
+        pure (serializeTx (bundleTx bundle))
 
 txDeleteHandler
     :: Context IO -> DeleteRequest -> Handler Hex
@@ -585,15 +620,17 @@ txDeleteHandler
         , drAddr = addrHex
         } = do
         addr <- requireAddr addrHex
-        tx <-
+        snap <- requireBundleSnapshot ctx
+        bundle <-
             liftIO
                 $ Tx.requestDelete
                     (txBuilder ctx)
+                    snap
                     tid
                     k
                     v
                     addr
-        pure (serializeTx tx)
+        pure (serializeTx (bundleTx bundle))
 
 txUpdateValueHandler
     :: Context IO
@@ -609,16 +646,18 @@ txUpdateValueHandler
         , uvrAddr = addrHex
         } = do
         addr <- requireAddr addrHex
-        tx <-
+        snap <- requireBundleSnapshot ctx
+        bundle <-
             liftIO
                 $ Tx.requestUpdate
                     (txBuilder ctx)
+                    snap
                     tid
                     k
                     oldV
                     newV
                     addr
-        pure (serializeTx tx)
+        pure (serializeTx (bundleTx bundle))
 
 txRejectHandler
     :: Context IO
@@ -631,13 +670,15 @@ txRejectHandler
         , rejAddr = addrHex
         } = do
         addr <- requireAddr addrHex
-        tx <-
+        snap <- requireBundleSnapshot ctx
+        bundle <-
             liftIO
                 $ Tx.rejectRequests
                     (txBuilder ctx)
+                    snap
                     tid
                     addr
-        pure (serializeTx tx)
+        pure (serializeTx (bundleTx bundle))
 
 txUpdateHandler
     :: Context IO -> UpdateRequest -> Handler Hex
@@ -648,13 +689,15 @@ txUpdateHandler
         , urAddr = addrHex
         } = do
         addr <- requireAddr addrHex
-        tx <-
+        snap <- requireBundleSnapshot ctx
+        bundle <-
             liftIO
                 $ Tx.updateToken
                     (txBuilder ctx)
+                    snap
                     tid
                     addr
-        pure (serializeTx tx)
+        pure (serializeTx (bundleTx bundle))
 
 txRetractHandler
     :: Context IO -> RetractRequest -> Handler Hex
@@ -666,13 +709,15 @@ txRetractHandler
         } = do
         addr <- requireAddr addrHex
         txIn <- parseUtxoRef utxoRef
-        tx <-
+        snap <- requireBundleSnapshot ctx
+        bundle <-
             liftIO
                 $ Tx.retractRequest
                     (txBuilder ctx)
+                    snap
                     txIn
                     addr
-        pure (serializeTx tx)
+        pure (serializeTx (bundleTx bundle))
 
 txEndHandler
     :: Context IO -> EndRequest -> Handler Hex
@@ -683,13 +728,15 @@ txEndHandler
         , erAddr = addrHex
         } = do
         addr <- requireAddr addrHex
-        tx <-
+        snap <- requireBundleSnapshot ctx
+        bundle <-
             liftIO
                 $ Tx.endToken
                     (txBuilder ctx)
+                    snap
                     tid
                     addr
-        pure (serializeTx tx)
+        pure (serializeTx (bundleTx bundle))
 
 txSubmitHandler
     :: Context IO -> SubmitRequest -> Handler Hex

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
@@ -22,35 +22,35 @@ import Cardano.MPFS.TxBuilder (TxBuilder (..))
 mkMockTxBuilder :: TxBuilder IO
 mkMockTxBuilder =
     TxBuilder
-        { bootToken = \_ ->
+        { bootToken = \_ _ ->
             error
                 "mkMockTxBuilder: bootToken \
                 \not implemented"
-        , requestInsert = \_ _ _ _ ->
+        , requestInsert = \_ _ _ _ _ ->
             error
                 "mkMockTxBuilder: requestInsert \
                 \not implemented"
-        , requestDelete = \_ _ _ _ ->
+        , requestDelete = \_ _ _ _ _ ->
             error
                 "mkMockTxBuilder: requestDelete \
                 \not implemented"
-        , requestUpdate = \_ _ _ _ _ ->
+        , requestUpdate = \_ _ _ _ _ _ ->
             error
                 "mkMockTxBuilder: requestUpdate \
                 \not implemented"
-        , updateToken = \_ _ ->
+        , updateToken = \_ _ _ ->
             error
                 "mkMockTxBuilder: updateToken \
                 \not implemented"
-        , retractRequest = \_ _ ->
+        , retractRequest = \_ _ _ ->
             error
                 "mkMockTxBuilder: retractRequest \
                 \not implemented"
-        , rejectRequests = \_ _ ->
+        , rejectRequests = \_ _ _ ->
             error
                 "mkMockTxBuilder: rejectRequests \
                 \not implemented"
-        , endToken = \_ _ ->
+        , endToken = \_ _ _ ->
             error
                 "mkMockTxBuilder: endToken \
                 \not implemented"

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
@@ -14,6 +14,13 @@
 module Cardano.MPFS.TxBuilder
     ( -- * Transaction builder interface
       TxBuilder (..)
+
+      -- * Proof-bearing unsigned-transaction bundles
+    , UnsignedTxBundle (..)
+    , BundleSnapshot (..)
+    , WitnessedInput (..)
+    , TrieFact (..)
+    , bareTxBundle
     ) where
 
 import Data.ByteString (ByteString)
@@ -22,58 +29,156 @@ import Cardano.Ledger.Api.Tx (Tx)
 
 import Cardano.MPFS.Core.Types
     ( Addr
+    , BlockId
     , ConwayEra
+    , SlotNo
     , TokenId
     , TxIn
     )
 
--- | Interface for constructing transactions for
--- all MPFS protocol operations. Returns full
--- ledger 'Tx' values ready for signing.
+-- | Interface for constructing proof-bearing
+-- transactions for all MPFS protocol operations.
+-- Every method takes the 'BundleSnapshot' that the
+-- caller has already resolved so the returned
+-- 'UnsignedTxBundle' bakes in a verified root and
+-- indexed chain point.
 data TxBuilder m = TxBuilder
     { bootToken
-        :: Addr -> m (Tx ConwayEra)
+        :: BundleSnapshot
+        -> Addr
+        -> m UnsignedTxBundle
     -- ^ Create a new MPFS token
     , requestInsert
-        :: TokenId
+        :: BundleSnapshot
+        -> TokenId
         -> ByteString
         -> ByteString
         -> Addr
-        -> m (Tx ConwayEra)
+        -> m UnsignedTxBundle
     -- ^ Request inserting a key-value pair
     , requestDelete
-        :: TokenId
+        :: BundleSnapshot
+        -> TokenId
         -> ByteString
         -> ByteString
         -> Addr
-        -> m (Tx ConwayEra)
+        -> m UnsignedTxBundle
     -- ^ Request deleting a key (key, old value)
     , requestUpdate
-        :: TokenId
+        :: BundleSnapshot
+        -> TokenId
         -> ByteString
         -> ByteString
         -> ByteString
         -> Addr
-        -> m (Tx ConwayEra)
+        -> m UnsignedTxBundle
     -- ^ Request updating a key (key, old val, new val)
     , updateToken
-        :: TokenId
+        :: BundleSnapshot
+        -> TokenId
         -> Addr
-        -> m (Tx ConwayEra)
+        -> m UnsignedTxBundle
     -- ^ Process pending requests for a token
     , retractRequest
-        :: TxIn
+        :: BundleSnapshot
+        -> TxIn
         -> Addr
-        -> m (Tx ConwayEra)
+        -> m UnsignedTxBundle
     -- ^ Cancel a pending request
     , rejectRequests
-        :: TokenId
+        :: BundleSnapshot
+        -> TokenId
         -> Addr
-        -> m (Tx ConwayEra)
+        -> m UnsignedTxBundle
     -- ^ Reject Phase 3 requests for a token
     , endToken
-        :: TokenId
+        :: BundleSnapshot
+        -> TokenId
         -> Addr
-        -> m (Tx ConwayEra)
+        -> m UnsignedTxBundle
     -- ^ Retire an MPFS token
     }
+
+-- | Proof-bearing unsigned-transaction bundle.
+--
+-- The output of a proof-carrying tx builder. A client
+-- verifies the bundle offline by checking that every
+-- consumed input's 'WitnessedInput' and every
+-- 'TrieFact' resolves against the bundle's
+-- 'BundleSnapshot' root, then re-derives that
+-- 'bundleTx' is the unique transaction implied by
+-- those witnesses.
+--
+-- Ledger-native: 'bundleTx' is a full Conway-era
+-- 'Tx' and 'WitnessedInput' references ledger 'TxIn'
+-- and serialized 'TxOut' CBOR. Serialization for the
+-- HTTP boundary lives in "Cardano.MPFS.HTTP.Types".
+data UnsignedTxBundle = UnsignedTxBundle
+    { bundleTx :: Tx ConwayEra
+    -- ^ Unsigned transaction ready for key witnesses
+    , bundleSnapshot :: BundleSnapshot
+    -- ^ UTxO-CSMT root and chain point the bundle
+    -- was built against
+    , bundleInputs :: [WitnessedInput]
+    -- ^ Every consumed input with its UTxO-CSMT
+    -- inclusion proof against 'bundleSnapshot'
+    , bundleFacts :: [TrieFact]
+    -- ^ Trie facts the builder relied on; empty for
+    -- endpoints that consume no trie state
+    }
+
+-- | Indexed snapshot a bundle's proofs verify
+-- against. Matches the shape of the HTTP-level
+-- @VerificationSnapshot@ but carries raw bytes rather
+-- than hex-wrapped JSON values.
+data BundleSnapshot = BundleSnapshot
+    { snapshotUtxoRoot :: ByteString
+    -- ^ UTxO-CSMT Merkle root (raw bytes)
+    , snapshotSlot :: SlotNo
+    -- ^ Indexed chain point slot
+    , snapshotBlockId :: BlockId
+    -- ^ Indexed chain point block id
+    }
+    deriving (Eq, Show)
+
+-- | A consumed input with its UTxO-CSMT inclusion
+-- proof against 'snapshotUtxoRoot'.
+data WitnessedInput = WitnessedInput
+    { witnessedRef :: TxIn
+    -- ^ The spent input's reference
+    , witnessedTxOut :: ByteString
+    -- ^ Serialized ledger CBOR of the consumed 'TxOut'
+    , witnessedCsmtProof :: ByteString
+    -- ^ CSMT inclusion proof against the root
+    }
+    deriving (Eq, Show)
+
+-- | A trie fact the builder depended on. Surfaces
+-- for trie-dependent endpoints so clients can verify
+-- the MPF claim alongside the consumed UTxOs.
+data TrieFact = TrieFact
+    { factKey :: ByteString
+    -- ^ Trie key the builder looked up
+    , factValue :: Maybe ByteString
+    -- ^ Value bound to 'factKey', or 'Nothing' for
+    -- membership-of-absence facts
+    , factMpfProof :: ByteString
+    -- ^ MPF inclusion\/exclusion proof against the
+    -- relevant trie root
+    }
+    deriving (Eq, Show)
+
+-- | Wrap a bare unsigned 'Tx' as a proof-bearing
+-- bundle with no bundled inputs or facts. Used by
+-- migration steps that have not yet produced
+-- witnesses, and by tests that only care about the
+-- tx body.
+bareTxBundle
+    :: BundleSnapshot -> Tx ConwayEra -> UnsignedTxBundle
+bareTxBundle snap tx =
+    UnsignedTxBundle
+        { bundleTx = tx
+        , bundleSnapshot = snap
+        , bundleInputs = []
+        , bundleFacts = []
+        }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
@@ -26,8 +26,7 @@ import Cardano.Ledger.Alonzo.TxBody
     ( scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , mkBasicTx
+    ( mkBasicTx
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -69,9 +68,13 @@ import Cardano.MPFS.Core.OnChain
 import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , Coin (..)
-    , ConwayEra
     )
 import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot
+    , UnsignedTxBundle
+    , bareTxBundle
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -87,10 +90,12 @@ bootTokenImpl
     -- ^ Cage script config
     -> Provider IO
     -- ^ Blockchain query interface
+    -> BundleSnapshot
+    -- ^ Snapshot this bundle will be anchored to
     -> Addr
     -- ^ Owner address (receives change, owns the token)
-    -> IO (Tx ConwayEra)
-bootTokenImpl cfg prov addr = do
+    -> IO UnsignedTxBundle
+bootTokenImpl cfg prov snap addr = do
     pp <- queryProtocolParams prov
     utxos <- queryUTxOs prov addr
     case utxos of
@@ -196,9 +201,11 @@ bootTokenImpl cfg prov addr = do
                         & witsTxL . rdmrsTxWitsL
                             .~ redeemers
             -- 7. Evaluate and balance
-            evaluateAndBalance
-                prov
-                pp
-                allInputUtxos
-                addr
-                tx
+            balanced <-
+                evaluateAndBalance
+                    prov
+                    pp
+                    allInputUtxos
+                    addr
+                    tx
+            pure (bareTxBundle snap balanced)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
@@ -22,8 +22,7 @@ import Cardano.Ledger.Alonzo.TxBody
     , scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , mkBasicTx
+    ( mkBasicTx
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -55,10 +54,14 @@ import Cardano.MPFS.Core.OnChain
     , UpdateRedeemer (..)
     )
 import Cardano.MPFS.Core.Types
-    ( ConwayEra
-    , TokenId (..)
+    ( TokenId (..)
     )
 import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot
+    , UnsignedTxBundle
+    , bareTxBundle
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -81,12 +84,14 @@ endTokenImpl
     -- ^ Cage script config
     -> Provider IO
     -- ^ Blockchain query interface
+    -> BundleSnapshot
+    -- ^ Snapshot this bundle will be anchored to
     -> TokenId
     -- ^ Token to retire
     -> Addr
     -- ^ Fee-paying address (receives remaining ADA)
-    -> IO (Tx ConwayEra)
-endTokenImpl cfg prov tid addr = do
+    -> IO UnsignedTxBundle
+endTokenImpl cfg prov snap tid addr = do
     -- 1. Query cage UTxOs
     let scriptAddr =
             cageAddrFromCfg cfg (network cfg)
@@ -175,9 +180,11 @@ endTokenImpl cfg prov tid addr = do
                         script
                 & witsTxL . rdmrsTxWitsL
                     .~ redeemers
-    evaluateAndBalance
-        prov
-        pp
-        [feeUtxo, stateUtxo]
-        addr
-        tx
+    balanced <-
+        evaluateAndBalance
+            prov
+            pp
+            [feeUtxo, stateUtxo]
+            addr
+            tx
+    pure (bareTxBundle snap balanced)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
@@ -82,6 +82,11 @@ import Cardano.MPFS.Provider
     ( Provider (..)
     )
 import Cardano.MPFS.State (State (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot
+    , UnsignedTxBundle
+    , bareTxBundle
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -104,10 +109,11 @@ rejectRequestsImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> BundleSnapshot
     -> TokenId
     -> Addr
-    -> IO (Tx ConwayEra)
-rejectRequestsImpl cfg prov _st tid addr = do
+    -> IO UnsignedTxBundle
+rejectRequestsImpl cfg prov _st snap tid addr = do
     -- 1. Query on-chain context
     (stateUtxo, reqUtxos, feeUtxo, pp) <-
         queryRejectContext cfg prov tid addr
@@ -141,7 +147,7 @@ rejectRequestsImpl cfg prov _st tid addr = do
             addr
             (prog :: Tx.TxBuild NoCtx Void ())
     case result of
-        Right tx -> pure tx
+        Right tx -> pure (bareTxBundle snap tx)
         Left err ->
             error
                 $ "rejectRequests: build failed: "

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -24,8 +24,7 @@ import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , mkBasicTx
+    ( mkBasicTx
     )
 import Cardano.Ledger.Api.Tx.Body
     ( mkBasicTxBody
@@ -54,6 +53,11 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.State (State (..), Tokens (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot
+    , UnsignedTxBundle
+    , bareTxBundle
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -68,18 +72,20 @@ requestInsertImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> BundleSnapshot
     -> TokenId
     -> ByteString
     -- ^ Key to insert
     -> ByteString
     -- ^ Value to insert
     -> Addr
-    -> IO (Tx ConwayEra)
-requestInsertImpl cfg prov st tid key value =
+    -> IO UnsignedTxBundle
+requestInsertImpl cfg prov st snap tid key value =
     requestImpl
         cfg
         prov
         st
+        snap
         tid
         key
         (OpInsert value)
@@ -89,18 +95,20 @@ requestDeleteImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> BundleSnapshot
     -> TokenId
     -> ByteString
     -- ^ Key to delete
     -> ByteString
     -- ^ Old value (for on-chain proof)
     -> Addr
-    -> IO (Tx ConwayEra)
-requestDeleteImpl cfg prov st tid key val =
+    -> IO UnsignedTxBundle
+requestDeleteImpl cfg prov st snap tid key val =
     requestImpl
         cfg
         prov
         st
+        snap
         tid
         key
         (OpDelete val)
@@ -110,6 +118,7 @@ requestUpdateImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> BundleSnapshot
     -> TokenId
     -> ByteString
     -- ^ Key to update
@@ -118,15 +127,24 @@ requestUpdateImpl
     -> ByteString
     -- ^ New value
     -> Addr
-    -> IO (Tx ConwayEra)
-requestUpdateImpl cfg prov st tid key oldVal newVal =
-    requestImpl
-        cfg
-        prov
-        st
-        tid
-        key
-        (OpUpdate oldVal newVal)
+    -> IO UnsignedTxBundle
+requestUpdateImpl
+    cfg
+    prov
+    st
+    snap
+    tid
+    key
+    oldVal
+    newVal =
+        requestImpl
+            cfg
+            prov
+            st
+            snap
+            tid
+            key
+            (OpUpdate oldVal newVal)
 
 -- | Generic request transaction builder.
 --
@@ -141,6 +159,7 @@ requestImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> BundleSnapshot
     -> TokenId
     -> ByteString
     -- ^ Trie key
@@ -148,8 +167,8 @@ requestImpl
     -- ^ Insert, Delete, or Update
     -> Addr
     -- ^ Requester's address
-    -> IO (Tx ConwayEra)
-requestImpl cfg prov st tid key op addr = do
+    -> IO UnsignedTxBundle
+requestImpl cfg prov st snap tid key op addr = do
     mTs <- getToken (tokens st) tid
     LocatedTokenState
         { tokenState = TokenState{tip = Coin mf}
@@ -199,7 +218,8 @@ requestImpl cfg prov st tid key op addr = do
         Left err ->
             error
                 $ "requestImpl: " <> show err
-        Right br -> pure (balancedTx br)
+        Right br ->
+            pure (bareTxBundle snap (balancedTx br))
 
 -- | Compute the ADA to lock in a request output.
 --

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
@@ -29,8 +29,7 @@ import Cardano.Ledger.Alonzo.TxBody
     , scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , mkBasicTx
+    ( mkBasicTx
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -65,14 +64,18 @@ import Cardano.MPFS.Core.OnChain
     , UpdateRedeemer (..)
     )
 import Cardano.MPFS.Core.Types
-    ( ConwayEra
-    , LocatedRequest (..)
+    ( LocatedRequest (..)
     , Request (..)
     )
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.State
     ( Requests (..)
     , State (..)
+    )
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot
+    , UnsignedTxBundle
+    , bareTxBundle
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -94,12 +97,14 @@ retractRequestImpl
     -- ^ Blockchain query interface
     -> State IO
     -- ^ Request state (to look up the request)
+    -> BundleSnapshot
+    -- ^ Snapshot this bundle will be anchored to
     -> TxIn
     -- ^ UTxO reference of the request to retract
     -> Addr
     -- ^ Requester's address (receives refund)
-    -> IO (Tx ConwayEra)
-retractRequestImpl cfg prov st reqTxIn addr = do
+    -> IO UnsignedTxBundle
+retractRequestImpl cfg prov st snap reqTxIn addr = do
     -- 1. Look up the request to find its token
     mReq <- getRequest (requests st) reqTxIn
     req <- case mReq of
@@ -223,9 +228,11 @@ retractRequestImpl cfg prov st reqTxIn addr = do
                         script
                 & witsTxL . rdmrsTxWitsL
                     .~ redeemers
-    evaluateAndBalance
-        prov
-        pp
-        [feeUtxo, reqUtxoPair]
-        addr
-        tx
+    balanced <-
+        evaluateAndBalance
+            prov
+            pp
+            [feeUtxo, reqUtxoPair]
+            addr
+            tx
+    pure (bareTxBundle snap balanced)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -101,6 +101,11 @@ import Cardano.MPFS.Trie
     ( Trie (..)
     , TrieManager (..)
     )
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot
+    , UnsignedTxBundle
+    , bareTxBundle
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -121,10 +126,11 @@ updateTokenImpl
     -> Provider IO
     -> State IO
     -> TrieManager IO
+    -> BundleSnapshot
     -> TokenId
     -> Addr
-    -> IO (Tx ConwayEra)
-updateTokenImpl cfg prov _st tm tid addr = do
+    -> IO UnsignedTxBundle
+updateTokenImpl cfg prov _st tm snap tid addr = do
     -- 1. Query on-chain context
     (stateUtxo, reqUtxos, feeUtxo, pp) <-
         queryContext cfg prov tid addr
@@ -210,7 +216,7 @@ updateTokenImpl cfg prov _st tm tid addr = do
                     <> " getMinFee(0)="
                     <> show getMin
                     <> "\n"
-            pure tx
+            pure (bareTxBundle snap tx)
         Left err ->
             error
                 $ "updateToken: build failed: "

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -113,6 +113,7 @@ import Cardano.MPFS.Core.OnChain
     )
 import Cardano.MPFS.Core.Types
     ( AssetName (..)
+    , BlockId (..)
     , Coin (..)
     , ConwayEra
     , LocatedRequest (..)
@@ -146,7 +147,12 @@ import Cardano.MPFS.Trie
 import Cardano.MPFS.Trie.PureManager
     ( mkPureTrieManager
     )
-import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot (..)
+    , TxBuilder (..)
+    , UnsignedTxBundle (..)
+    , bareTxBundle
+    )
 import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
 import Cardano.MPFS.TxBuilder.Real
     ( computeRefund
@@ -180,6 +186,17 @@ testKh =
         $ hashFromStringAsHex @Blake2b_224
             "00000000000000000000000000\
             \00000000000000000000000000000a"
+
+-- | A fixed 'BundleSnapshot' used by every test
+-- runner. Tests do not yet assert on the snapshot
+-- so any stable value works.
+testSnap :: BundleSnapshot
+testSnap =
+    BundleSnapshot
+        { snapshotUtxoRoot = BS.replicate 32 0
+        , snapshotSlot = SlotNo 0
+        , snapshotBlockId = BlockId (BS.replicate 32 0)
+        }
 
 -- | Zero-fee PParams for deterministic balancing.
 zeroPP :: PParams ConwayEra
@@ -411,6 +428,7 @@ mkRequestTxOut =
 spec :: Spec
 spec = describe "Cardano.MPFS.TxBuilder.Real" $ do
     cageIdentitySpec
+    bundleShapeSpec
     requestInsertSpec
     requestDeleteSpec
     retractRequestSpec
@@ -461,6 +479,65 @@ cageIdentitySpec =
                 _ ->
                     error
                         "expected Addr, got Bootstrap"
+
+-- ---------------------------------------------------------
+-- UnsignedTxBundle shape
+-- ---------------------------------------------------------
+
+-- | Shape tests for the proof-bearing bundle plumbing.
+-- Builders currently return 'bareTxBundle'-wrapped
+-- transactions; the dedicated input\/fact witnesses
+-- will be populated in later slices.
+bundleShapeSpec :: Spec
+bundleShapeSpec =
+    describe "UnsignedTxBundle" $ do
+        it "bareTxBundle preserves the wrapped tx" $ do
+            (_, _, builder, _) <- mkTestFixture
+            let feeAddr = testAddr testKh
+            bundle <-
+                requestInsert
+                    builder
+                    testSnap
+                    testTid
+                    "mykey"
+                    "myvalue"
+                    feeAddr
+            let bare =
+                    bareTxBundle
+                        (bundleSnapshot bundle)
+                        (bundleTx bundle)
+            bundleTx bare
+                `shouldBe` bundleTx bundle
+
+        it "builder bundle carries the snapshot" $ do
+            (_, _, builder, _) <- mkTestFixture
+            let feeAddr = testAddr testKh
+            bundle <-
+                requestInsert
+                    builder
+                    testSnap
+                    testTid
+                    "mykey"
+                    "myvalue"
+                    feeAddr
+            snapshotUtxoRoot (bundleSnapshot bundle)
+                `shouldBe` snapshotUtxoRoot testSnap
+            snapshotSlot (bundleSnapshot bundle)
+                `shouldBe` snapshotSlot testSnap
+
+        it "builder bundle has no witnesses yet" $ do
+            (_, _, builder, _) <- mkTestFixture
+            let feeAddr = testAddr testKh
+            bundle <-
+                requestInsert
+                    builder
+                    testSnap
+                    testTid
+                    "mykey"
+                    "myvalue"
+                    feeAddr
+            bundleInputs bundle `shouldSatisfy` null
+            bundleFacts bundle `shouldSatisfy` null
 
 -- ---------------------------------------------------------
 -- requestInsert
@@ -1672,21 +1749,29 @@ runRequestInsertWith
 runRequestInsertWith = do
     (_st, _prov, builder, txIn) <- mkTestFixture
     let feeAddr = testAddr testKh
-    tx <-
+    bundle <-
         requestInsert
             builder
+            testSnap
             testTid
             "mykey"
             "myvalue"
             feeAddr
-    pure (tx, txIn)
+    pure (bundleTx bundle, txIn)
 
 -- | Set up state + provider, run requestDelete.
 runRequestDelete :: IO (Tx ConwayEra)
 runRequestDelete = do
     (_st, _prov, builder, _txIn) <- mkTestFixture
     let feeAddr = testAddr testKh
-    requestDelete builder testTid "mykey" "myval" feeAddr
+    bundleTx
+        <$> requestDelete
+            builder
+            testSnap
+            testTid
+            "mykey"
+            "myval"
+            feeAddr
 
 -- | Run retractRequest.
 runRetractRequest :: IO (Tx ConwayEra)
@@ -1750,9 +1835,9 @@ runRetractRequestWith = do
                 prov
                 st
                 dummyTrieManager
-    tx <-
-        retractRequest builder reqIn feeAddr
-    pure (tx, reqIn, stateIn)
+    bundle <-
+        retractRequest builder testSnap reqIn feeAddr
+    pure (bundleTx bundle, reqIn, stateIn)
 
 -- | Run updateToken.
 runUpdateToken :: IO (Tx ConwayEra)
@@ -1812,9 +1897,9 @@ runUpdateTokenWith = do
                 prov
                 st
                 trieManager
-    tx <-
-        updateToken builder testTid feeAddr
-    pure (tx, stateIn, reqIn)
+    bundle <-
+        updateToken builder testSnap testTid feeAddr
+    pure (bundleTx bundle, stateIn, reqIn)
 
 -- | Run endToken.
 runEndToken :: IO (Tx ConwayEra)
@@ -1859,8 +1944,8 @@ runEndTokenWith = do
                 prov
                 st
                 dummyTrieManager
-    tx <- endToken builder testTid feeAddr
-    pure (tx, stateIn)
+    bundle <- endToken builder testSnap testTid feeAddr
+    pure (bundleTx bundle, stateIn)
 
 -- | Run bootToken with a given CageConfig.
 runBootToken :: CageConfig -> IO (Tx ConwayEra)
@@ -1886,7 +1971,7 @@ runBootToken cfg = do
                 prov
                 st
                 dummyTrieManager
-    bootToken builder feeAddr
+    bundleTx <$> bootToken builder testSnap feeAddr
 
 -- | Token ID used across tests.
 testTid :: TokenId
@@ -1977,14 +2062,15 @@ runRealisticRequestInsertWith = do
     (_st, _prov, builder, txIn) <-
         mkRealisticFixture
     let feeAddr = testAddr testKh
-    tx <-
+    bundle <-
         requestInsert
             builder
+            testSnap
             testTid
             "mykey"
             "myvalue"
             feeAddr
-    pure (tx, txIn)
+    pure (bundleTx bundle, txIn)
 
 -- | Run updateToken with realistic PParams.
 runRealisticUpdate :: IO (Tx ConwayEra)
@@ -2041,9 +2127,9 @@ runRealisticUpdateWith = do
                 prov
                 st
                 trieManager
-    tx <-
-        updateToken builder testTid feeAddr
-    pure (tx, stateIn, reqIn)
+    bundle <-
+        updateToken builder testSnap testTid feeAddr
+    pure (bundleTx bundle, stateIn, reqIn)
 
 -- | Run updateToken with tight request locked ADA.
 -- The request UTxO has the minimum locked ADA
@@ -2098,7 +2184,8 @@ runTightUpdate = do
                 prov
                 st
                 trieManager
-    updateToken builder testTid feeAddr
+    bundleTx
+        <$> updateToken builder testSnap testTid feeAddr
 
 -- | Run retractRequest with realistic PParams
 -- and return details.
@@ -2154,9 +2241,9 @@ runRealisticRetractWith = do
                 prov
                 st
                 dummyTrieManager
-    tx <-
-        retractRequest builder reqIn feeAddr
-    pure (tx, reqIn, stateIn)
+    bundle <-
+        retractRequest builder testSnap reqIn feeAddr
+    pure (bundleTx bundle, reqIn, stateIn)
 
 -- | Run endToken with realistic PParams.
 runRealisticEnd :: IO (Tx ConwayEra)
@@ -2203,8 +2290,8 @@ runRealisticEndWith = do
                 prov
                 st
                 dummyTrieManager
-    tx <- endToken builder testTid feeAddr
-    pure (tx, stateIn)
+    bundle <- endToken builder testSnap testTid feeAddr
+    pure (bundleTx bundle, stateIn)
 
 -- | Run bootToken with realistic PParams.
 runRealisticBootToken
@@ -2231,7 +2318,7 @@ runRealisticBootToken cfg = do
                 prov
                 st
                 dummyTrieManager
-    bootToken builder feeAddr
+    bundleTx <$> bootToken builder testSnap feeAddr
 
 -- | Run rejectRequests with mock expired request.
 -- The request has submittedAt=0, processTime=300s,
@@ -2277,4 +2364,5 @@ runRejectRequests = do
                 prov
                 st
                 trieManager
-    rejectRequests builder testTid feeAddr
+    bundleTx
+        <$> rejectRequests builder testSnap testTid feeAddr


### PR DESCRIPTION
## Summary

Introduces `UnsignedTxBundle` as the uniform return type for every
`TxBuilder` method. Each method now takes a `BundleSnapshot`
(UTxO-CSMT root + indexed chain point) as its first argument and
returns a bundle that carries:

- `bundleTx :: Tx ConwayEra` — the unsigned transaction
- `bundleSnapshot` — the snapshot the bundle was built against
- `bundleInputs :: [WitnessedInput]` — CSMT proofs for consumed inputs
- `bundleFacts :: [TrieFact]` — MPF claims the builder relied on

For slice 3, builders wrap their output via `bareTxBundle` (empty
`bundleInputs` / `bundleFacts`). Later slices populate the witness
and fact lists and teach the HTTP layer to surface them.

## Changes

- New types + `bareTxBundle` in `Cardano.MPFS.TxBuilder`
- All six Real impls (Boot/End/Reject/Request/Retract/Update) thread
  `BundleSnapshot` through and return bundles
- Mock updated for the new arity
- `HTTP/Server.hs` resolves the snapshot via a new
  `requireBundleSnapshot` helper, then unwraps `bundleTx` before
  serializing
- Unit + e2e tests adapted; three bundle-shape tests added

## Test plan

- [x] `just ci` (build, 372 unit tests, format-check, hlint) — green
- [ ] Manual: e2e suite (requires local cardano-node) on reviewer side
- [x] Three new `UnsignedTxBundle` shape tests in `TxBuilderSpec`

Refs #212 — https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/212