### PR TITLE
feat: proof-carrying tx responses + client verify DSL

### DIFF
--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -42,6 +42,7 @@ library
 
   exposed-modules:
     Cardano.MPFS.Client
+    Cardano.MPFS.Client.Bundle
     Cardano.MPFS.Client.Snapshot
     Cardano.MPFS.Client.Verify
 
@@ -73,5 +74,8 @@ test-suite unit-tests
     , hspec                >=2.11 && <2.12
     , text
 
-  other-modules:    Cardano.MPFS.Client.SnapshotSpec
+  other-modules:
+    Cardano.MPFS.Client.BundleSpec
+    Cardano.MPFS.Client.SnapshotSpec
+
   ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
@@ -2,8 +2,9 @@
 -- Module      : Cardano.MPFS.Client
 -- Description : Public surface of the MPFS verification client.
 --
--- Re-exports the snapshot JSON contract and offline verifiers for
--- consumers that want one import.
+-- Re-exports the snapshot JSON contract, the per-endpoint response
+-- envelopes, and the offline verifiers for consumers that want one
+-- import.
 module Cardano.MPFS.Client
     ( -- * Snapshot
       VerificationSnapshot (..)
@@ -11,11 +12,51 @@ module Cardano.MPFS.Client
     , Hex (..)
     , statusSnapshot
 
+      -- * Response envelopes
+    , TxIn (..)
+    , WitnessedUtxo (..)
+    , TrieFact (..)
+    , BootProof (..)
+    , RequestProof (..)
+    , RetractProof (..)
+    , RejectProof (..)
+    , EndProof (..)
+    , UpdateProof (..)
+    , BootTxResponse (..)
+    , RequestTxResponse (..)
+    , RetractTxResponse (..)
+    , RejectTxResponse (..)
+    , EndTxResponse (..)
+    , UpdateTxResponse (..)
+
       -- * Verification
     , VerifyError (..)
     , verifyVerificationSnapshot
+    , verifyBootTxResponse
+    , verifyRequestTxResponse
+    , verifyRetractTxResponse
+    , verifyRejectTxResponse
+    , verifyEndTxResponse
+    , verifyUpdateTxResponse
     ) where
 
+import Cardano.MPFS.Client.Bundle
+    ( BootProof (..)
+    , BootTxResponse (..)
+    , EndProof (..)
+    , EndTxResponse (..)
+    , RejectProof (..)
+    , RejectTxResponse (..)
+    , RequestProof (..)
+    , RequestTxResponse (..)
+    , RetractProof (..)
+    , RetractTxResponse (..)
+    , TrieFact (..)
+    , TxIn (..)
+    , UpdateProof (..)
+    , UpdateTxResponse (..)
+    , WitnessedUtxo (..)
+    )
 import Cardano.MPFS.Client.Snapshot
     ( ChainPoint (..)
     , Hex (..)
@@ -24,5 +65,11 @@ import Cardano.MPFS.Client.Snapshot
     )
 import Cardano.MPFS.Client.Verify
     ( VerifyError (..)
+    , verifyBootTxResponse
+    , verifyEndTxResponse
+    , verifyRejectTxResponse
+    , verifyRequestTxResponse
+    , verifyRetractTxResponse
+    , verifyUpdateTxResponse
     , verifyVerificationSnapshot
     )

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Bundle.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Bundle.hs
@@ -1,0 +1,359 @@
+-- |
+-- Module      : Cardano.MPFS.Client.Bundle
+-- Description : Per-endpoint proof-bearing response contracts.
+--
+-- Haskell mirrors of the per-endpoint response envelopes that
+-- cardano-mpfs-offchain's @POST \/tx\/…@ routes return. Each
+-- response carries the unsigned transaction CBOR (hex), the
+-- 'VerificationSnapshot' the bundled proofs target, and an
+-- endpoint-specific proof payload whose named fields enumerate
+-- the roles its inputs play (state, funding, pending request, …).
+--
+-- The module is pure-Haskell and imports only @aeson@,
+-- @bytestring@, and @text@. No @cardano-ledger-*@ dependency and
+-- no C FFI: the client verifier must build on GHC-native,
+-- GHC-WASM, and GHC-JS.
+module Cardano.MPFS.Client.Bundle
+    ( -- * Witnesses
+      TxIn (..)
+    , WitnessedUtxo (..)
+    , TrieFact (..)
+
+      -- * Per-endpoint proof payloads
+    , BootProof (..)
+    , RequestProof (..)
+    , RetractProof (..)
+    , RejectProof (..)
+    , EndProof (..)
+    , UpdateProof (..)
+
+      -- * Response envelopes
+    , BootTxResponse (..)
+    , RequestTxResponse (..)
+    , RetractTxResponse (..)
+    , RejectTxResponse (..)
+    , EndTxResponse (..)
+    , UpdateTxResponse (..)
+    ) where
+
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , object
+    , withObject
+    , (.:)
+    , (.=)
+    )
+import Data.Word (Word64)
+
+import Cardano.MPFS.Client.Snapshot
+    ( Hex (..)
+    , VerificationSnapshot (..)
+    )
+
+-- | UTxO reference: a transaction id (hex) and the output
+-- index within that transaction.
+data TxIn = TxIn
+    { txId :: Hex
+    , txIx :: Word64
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON TxIn where
+    parseJSON = withObject "TxIn" $ \o ->
+        TxIn <$> o .: "tx_id" <*> o .: "tx_ix"
+
+instance ToJSON TxIn where
+    toJSON TxIn{..} =
+        object ["tx_id" .= txId, "tx_ix" .= txIx]
+
+-- | A witnessed UTxO: the reference, the CBOR-encoded
+-- @TxOut@ body (hex), and the UTxO-CSMT inclusion proof
+-- binding the pair into the snapshot's @utxo_root@.
+--
+-- A 'WitnessedUtxo' covers both consumed inputs and
+-- reference inputs: verifiers treat the two cases
+-- identically.
+data WitnessedUtxo = WitnessedUtxo
+    { txIn :: TxIn
+    , txOut :: Hex
+    , utxoProof :: Hex
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON WitnessedUtxo where
+    parseJSON = withObject "WitnessedUtxo" $ \o ->
+        WitnessedUtxo
+            <$> o .: "tx_in"
+            <*> o .: "tx_out"
+            <*> o .: "utxo_proof"
+
+instance ToJSON WitnessedUtxo where
+    toJSON WitnessedUtxo{..} =
+        object
+            [ "tx_in" .= txIn
+            , "tx_out" .= txOut
+            , "utxo_proof" .= utxoProof
+            ]
+
+-- | A single trie read: a key, its optional value, and
+-- an MPF inclusion\/absence proof against a trie root.
+data TrieFact = TrieFact
+    { key :: Hex
+    , value :: Maybe Hex
+    , mpfProof :: Hex
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON TrieFact where
+    parseJSON = withObject "TrieFact" $ \o ->
+        TrieFact
+            <$> o .: "key"
+            <*> o .: "value"
+            <*> o .: "mpf_proof"
+
+instance ToJSON TrieFact where
+    toJSON TrieFact{..} =
+        object
+            [ "key" .= key
+            , "value" .= value
+            , "mpf_proof" .= mpfProof
+            ]
+
+-- | Proof payload for @POST \/tx\/boot@.
+newtype BootProof = BootProof
+    { funding :: [WitnessedUtxo]
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON BootProof where
+    parseJSON = withObject "BootProof" $ \o ->
+        BootProof <$> o .: "funding"
+
+instance ToJSON BootProof where
+    toJSON BootProof{funding = f} =
+        object ["funding" .= f]
+
+-- | Proof payload for
+-- @POST \/tx\/request\/{insert,delete,update}@.
+newtype RequestProof = RequestProof
+    { funding :: [WitnessedUtxo]
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON RequestProof where
+    parseJSON = withObject "RequestProof" $ \o ->
+        RequestProof <$> o .: "funding"
+
+instance ToJSON RequestProof where
+    toJSON RequestProof{funding = f} =
+        object ["funding" .= f]
+
+-- | Proof payload for @POST \/tx\/retract@.
+data RetractProof = RetractProof
+    { requestIn :: WitnessedUtxo
+    , stateRef :: WitnessedUtxo
+    , funding :: [WitnessedUtxo]
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON RetractProof where
+    parseJSON = withObject "RetractProof" $ \o ->
+        RetractProof
+            <$> o .: "request_in"
+            <*> o .: "state_ref"
+            <*> o .: "funding"
+
+instance ToJSON RetractProof where
+    toJSON (RetractProof ri sr fs) =
+        object
+            [ "request_in" .= ri
+            , "state_ref" .= sr
+            , "funding" .= fs
+            ]
+
+-- | Proof payload for @POST \/tx\/reject@.
+data RejectProof = RejectProof
+    { state :: WitnessedUtxo
+    , requestIns :: [WitnessedUtxo]
+    , funding :: [WitnessedUtxo]
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON RejectProof where
+    parseJSON = withObject "RejectProof" $ \o ->
+        RejectProof
+            <$> o .: "state"
+            <*> o .: "request_ins"
+            <*> o .: "funding"
+
+instance ToJSON RejectProof where
+    toJSON (RejectProof st ris fs) =
+        object
+            [ "state" .= st
+            , "request_ins" .= ris
+            , "funding" .= fs
+            ]
+
+-- | Proof payload for @POST \/tx\/end@.
+data EndProof = EndProof
+    { state :: WitnessedUtxo
+    , funding :: [WitnessedUtxo]
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON EndProof where
+    parseJSON = withObject "EndProof" $ \o ->
+        EndProof <$> o .: "state" <*> o .: "funding"
+
+instance ToJSON EndProof where
+    toJSON (EndProof st fs) =
+        object ["state" .= st, "funding" .= fs]
+
+-- | Proof payload for @POST \/tx\/update@.
+data UpdateProof = UpdateProof
+    { state :: WitnessedUtxo
+    , requests :: [WitnessedUtxo]
+    , funding :: [WitnessedUtxo]
+    , trieRoot :: Hex
+    , trieRead :: [TrieFact]
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON UpdateProof where
+    parseJSON = withObject "UpdateProof" $ \o ->
+        UpdateProof
+            <$> o .: "state"
+            <*> o .: "requests"
+            <*> o .: "funding"
+            <*> o .: "trie_root"
+            <*> o .: "trie_read"
+
+instance ToJSON UpdateProof where
+    toJSON (UpdateProof st rs fs tr tread) =
+        object
+            [ "state" .= st
+            , "requests" .= rs
+            , "funding" .= fs
+            , "trie_root" .= tr
+            , "trie_read" .= tread
+            ]
+
+-- | Response envelope for @POST \/tx\/boot@.
+data BootTxResponse = BootTxResponse
+    { tx :: Hex
+    , snapshot :: VerificationSnapshot
+    , proof :: BootProof
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON BootTxResponse where
+    parseJSON = withObject "BootTxResponse" $ \o ->
+        BootTxResponse
+            <$> o .: "tx"
+            <*> o .: "snapshot"
+            <*> o .: "proof"
+
+instance ToJSON BootTxResponse where
+    toJSON (BootTxResponse t s p) =
+        object ["tx" .= t, "snapshot" .= s, "proof" .= p]
+
+-- | Response envelope for
+-- @POST \/tx\/request\/{insert,delete,update}@.
+data RequestTxResponse = RequestTxResponse
+    { tx :: Hex
+    , snapshot :: VerificationSnapshot
+    , proof :: RequestProof
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON RequestTxResponse where
+    parseJSON =
+        withObject "RequestTxResponse" $ \o ->
+            RequestTxResponse
+                <$> o .: "tx"
+                <*> o .: "snapshot"
+                <*> o .: "proof"
+
+instance ToJSON RequestTxResponse where
+    toJSON (RequestTxResponse t s p) =
+        object ["tx" .= t, "snapshot" .= s, "proof" .= p]
+
+-- | Response envelope for @POST \/tx\/retract@.
+data RetractTxResponse = RetractTxResponse
+    { tx :: Hex
+    , snapshot :: VerificationSnapshot
+    , proof :: RetractProof
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON RetractTxResponse where
+    parseJSON =
+        withObject "RetractTxResponse" $ \o ->
+            RetractTxResponse
+                <$> o .: "tx"
+                <*> o .: "snapshot"
+                <*> o .: "proof"
+
+instance ToJSON RetractTxResponse where
+    toJSON (RetractTxResponse t s p) =
+        object ["tx" .= t, "snapshot" .= s, "proof" .= p]
+
+-- | Response envelope for @POST \/tx\/reject@.
+data RejectTxResponse = RejectTxResponse
+    { tx :: Hex
+    , snapshot :: VerificationSnapshot
+    , proof :: RejectProof
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON RejectTxResponse where
+    parseJSON =
+        withObject "RejectTxResponse" $ \o ->
+            RejectTxResponse
+                <$> o .: "tx"
+                <*> o .: "snapshot"
+                <*> o .: "proof"
+
+instance ToJSON RejectTxResponse where
+    toJSON (RejectTxResponse t s p) =
+        object ["tx" .= t, "snapshot" .= s, "proof" .= p]
+
+-- | Response envelope for @POST \/tx\/end@.
+data EndTxResponse = EndTxResponse
+    { tx :: Hex
+    , snapshot :: VerificationSnapshot
+    , proof :: EndProof
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON EndTxResponse where
+    parseJSON = withObject "EndTxResponse" $ \o ->
+        EndTxResponse
+            <$> o .: "tx"
+            <*> o .: "snapshot"
+            <*> o .: "proof"
+
+instance ToJSON EndTxResponse where
+    toJSON (EndTxResponse t s p) =
+        object ["tx" .= t, "snapshot" .= s, "proof" .= p]
+
+-- | Response envelope for @POST \/tx\/update@.
+data UpdateTxResponse = UpdateTxResponse
+    { tx :: Hex
+    , snapshot :: VerificationSnapshot
+    , proof :: UpdateProof
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON UpdateTxResponse where
+    parseJSON =
+        withObject "UpdateTxResponse" $ \o ->
+            UpdateTxResponse
+                <$> o .: "tx"
+                <*> o .: "snapshot"
+                <*> o .: "proof"
+
+instance ToJSON UpdateTxResponse where
+    toJSON (UpdateTxResponse t s p) =
+        object ["tx" .= t, "snapshot" .= s, "proof" .= p]

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
@@ -2,34 +2,69 @@
 -- Module      : Cardano.MPFS.Client.Verify
 -- Description : Offline verifiers for MPFS proof-bearing responses.
 --
--- This slice ships the snapshot-level verifier. Verifiers for
--- 'WitnessedUtxo', 'FactWitness', and 'UnsignedTxWitnessBundle' are
--- added by later slices alongside the server-side response types they
--- consume.
+-- Snapshot well-formedness plus structural traversers for every
+-- per-endpoint response envelope. Each traverser walks the named
+-- 'WitnessedUtxo' roles its proof carries, confirms the inline hex
+-- fields decode, and invokes 'verifyVerificationSnapshot' on the
+-- bundled snapshot. Semantic checks that require decoding a
+-- @TxOut@ CBOR or replaying a CSMT\/MPF proof arrive in later
+-- slices.
 module Cardano.MPFS.Client.Verify
     ( VerifyError (..)
     , verifyVerificationSnapshot
+
+      -- * Per-endpoint verifiers
+    , verifyBootTxResponse
+    , verifyRequestTxResponse
+    , verifyRetractTxResponse
+    , verifyRejectTxResponse
+    , verifyEndTxResponse
+    , verifyUpdateTxResponse
     ) where
 
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+
+import Cardano.MPFS.Client.Bundle
+    ( BootProof (..)
+    , BootTxResponse (..)
+    , EndProof (..)
+    , EndTxResponse (..)
+    , RejectProof (..)
+    , RejectTxResponse (..)
+    , RequestProof (..)
+    , RequestTxResponse (..)
+    , RetractProof (..)
+    , RetractTxResponse (..)
+    , TrieFact (..)
+    , TxIn (..)
+    , UpdateProof (..)
+    , UpdateTxResponse (..)
+    , WitnessedUtxo (..)
+    )
 import Cardano.MPFS.Client.Snapshot
     ( ChainPoint (..)
     , Hex (..)
     , VerificationSnapshot (..)
     )
-import Data.ByteString qualified as BS
-import Data.ByteString.Base16 qualified as Base16
-import Data.Text (Text)
-import Data.Text.Encoding qualified as T
 
 -- | Structured error returned when a proof-bearing bundle fails
--- verification. Each case is tagged so the CLI and future verifiers can
--- render consistent pass/fail messages.
+-- verification. The @field@ text of each case is a dotted path
+-- rooted at the endpoint name (e.g. @"boot.funding[0].utxo_proof"@)
+-- so the CLI can render which named role of which endpoint
+-- tripped the check.
 data VerifyError
-    = -- | Field name and the offending value that failed hex decoding.
+    = -- | Field path and the offending value that failed hex decoding.
       MalformedHex Text Text
-    | -- | Field name, expected byte length, actual byte length.
+    | -- | Field path, expected byte length, actual byte length.
       WrongHexLength Text Int Int
-    | EmptyBlockId
+    | -- | The snapshot's chainpoint block id decoded to zero bytes.
+      EmptyBlockId
+    | -- | The top-level transaction CBOR failed to hex-decode.
+      MalformedTxCbor Text
     deriving stock (Eq, Show)
 
 -- | Structural check for the snapshot that every proof-bearing response
@@ -42,6 +77,121 @@ verifyVerificationSnapshot VerificationSnapshot{..} = do
     checkHash32 "utxo_root" utxoRoot
     let ChainPoint{blockId} = chainpoint
     checkNonEmptyHash "chainpoint.block_id" blockId
+
+-- | Verify the structural well-formedness of a @POST \/tx\/boot@
+-- response: the unsigned tx CBOR decodes, the snapshot is
+-- well-formed, and every funding witness has decodable
+-- @tx_in@\/@tx_out@\/@utxo_proof@ bytes.
+verifyBootTxResponse :: BootTxResponse -> Either VerifyError ()
+verifyBootTxResponse (BootTxResponse t s (BootProof fs)) = do
+    checkTxCbor "boot.tx" t
+    verifyVerificationSnapshot s
+    checkFunding "boot" fs
+
+-- | Verify a @POST \/tx\/request\/{insert,delete,update}@ response.
+verifyRequestTxResponse :: RequestTxResponse -> Either VerifyError ()
+verifyRequestTxResponse (RequestTxResponse t s (RequestProof fs)) = do
+    checkTxCbor "request.tx" t
+    verifyVerificationSnapshot s
+    checkFunding "request" fs
+
+-- | Verify a @POST \/tx\/retract@ response.
+verifyRetractTxResponse :: RetractTxResponse -> Either VerifyError ()
+verifyRetractTxResponse
+    (RetractTxResponse t s (RetractProof ri sr fs)) = do
+        checkTxCbor "retract.tx" t
+        verifyVerificationSnapshot s
+        checkWitnessedUtxo "retract.request_in" ri
+        checkWitnessedUtxo "retract.state_ref" sr
+        checkFunding "retract" fs
+
+-- | Verify a @POST \/tx\/reject@ response.
+verifyRejectTxResponse :: RejectTxResponse -> Either VerifyError ()
+verifyRejectTxResponse
+    (RejectTxResponse t s (RejectProof st ris fs)) = do
+        checkTxCbor "reject.tx" t
+        verifyVerificationSnapshot s
+        checkWitnessedUtxo "reject.state" st
+        checkWitnessedUtxos "reject.request_ins" ris
+        checkFunding "reject" fs
+
+-- | Verify a @POST \/tx\/end@ response.
+verifyEndTxResponse :: EndTxResponse -> Either VerifyError ()
+verifyEndTxResponse (EndTxResponse t s (EndProof st fs)) = do
+    checkTxCbor "end.tx" t
+    verifyVerificationSnapshot s
+    checkWitnessedUtxo "end.state" st
+    checkFunding "end" fs
+
+-- | Verify a @POST \/tx\/update@ response.
+verifyUpdateTxResponse :: UpdateTxResponse -> Either VerifyError ()
+verifyUpdateTxResponse
+    (UpdateTxResponse t s (UpdateProof st rs fs tr tread)) = do
+        checkTxCbor "update.tx" t
+        verifyVerificationSnapshot s
+        checkWitnessedUtxo "update.state" st
+        checkWitnessedUtxos "update.requests" rs
+        checkFunding "update" fs
+        checkHash32 "update.trie_root" tr
+        checkTrieFacts "update.trie_read" tread
+
+checkFunding :: Text -> [WitnessedUtxo] -> Either VerifyError ()
+checkFunding endpoint =
+    checkWitnessedUtxos (endpoint <> ".funding")
+
+checkWitnessedUtxos
+    :: Text -> [WitnessedUtxo] -> Either VerifyError ()
+checkWitnessedUtxos prefix =
+    traverseIndexed prefix checkWitnessedUtxo
+
+checkWitnessedUtxo :: Text -> WitnessedUtxo -> Either VerifyError ()
+checkWitnessedUtxo prefix WitnessedUtxo{..} = do
+    checkTxIn (prefix <> ".tx_in") txIn
+    checkNonEmpty (prefix <> ".tx_out") txOut
+    checkNonEmpty (prefix <> ".utxo_proof") utxoProof
+
+checkTxIn :: Text -> TxIn -> Either VerifyError ()
+checkTxIn prefix TxIn{..} =
+    checkHash32 (prefix <> ".tx_id") txId
+
+checkTrieFacts :: Text -> [TrieFact] -> Either VerifyError ()
+checkTrieFacts prefix =
+    traverseIndexed prefix checkTrieFact
+
+checkTrieFact :: Text -> TrieFact -> Either VerifyError ()
+checkTrieFact prefix TrieFact{..} = do
+    checkNonEmpty (prefix <> ".key") key
+    case value of
+        Nothing -> Right ()
+        Just v -> checkNonEmpty (prefix <> ".value") v
+    checkNonEmpty (prefix <> ".mpf_proof") mpfProof
+
+traverseIndexed
+    :: Text
+    -> (Text -> a -> Either VerifyError ())
+    -> [a]
+    -> Either VerifyError ()
+traverseIndexed prefix f = go (0 :: Int)
+  where
+    go _ [] = Right ()
+    go i (x : xs) = do
+        f (prefix <> "[" <> T.pack (show i) <> "]") x
+        go (i + 1) xs
+
+checkTxCbor :: Text -> Hex -> Either VerifyError ()
+checkTxCbor field (Hex txt) =
+    case Base16.decode (T.encodeUtf8 txt) of
+        Right bs
+            | BS.null bs -> Left (MalformedTxCbor field)
+            | otherwise -> Right ()
+        Left _ -> Left (MalformedTxCbor field)
+
+checkNonEmpty :: Text -> Hex -> Either VerifyError ()
+checkNonEmpty field h = do
+    bs <- decodeHex field h
+    if BS.null bs
+        then Left (WrongHexLength field 1 0)
+        else Right ()
 
 checkHash32 :: Text -> Hex -> Either VerifyError ()
 checkHash32 field h = do

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/BundleSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/BundleSpec.hs
@@ -1,0 +1,219 @@
+module Cardano.MPFS.Client.BundleSpec (spec) where
+
+import Data.Aeson qualified as Aeson
+import Data.Text qualified as T
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+import Cardano.MPFS.Client
+    ( BootProof (..)
+    , BootTxResponse (..)
+    , ChainPoint (..)
+    , EndProof (..)
+    , EndTxResponse (..)
+    , Hex (..)
+    , RejectProof (..)
+    , RejectTxResponse (..)
+    , RequestProof (..)
+    , RequestTxResponse (..)
+    , RetractProof (..)
+    , RetractTxResponse (..)
+    , TrieFact (..)
+    , TxIn (..)
+    , UpdateProof (..)
+    , UpdateTxResponse (..)
+    , VerificationSnapshot (..)
+    , VerifyError (..)
+    , WitnessedUtxo (..)
+    , verifyBootTxResponse
+    , verifyEndTxResponse
+    , verifyRejectTxResponse
+    , verifyRequestTxResponse
+    , verifyRetractTxResponse
+    , verifyUpdateTxResponse
+    )
+
+spec :: Spec
+spec = do
+    describe "BootTxResponse" $ do
+        it "round-trips via aeson" $ do
+            let r = bootResponse [okUtxo]
+            Aeson.eitherDecode (Aeson.encode r) `shouldBe` Right r
+
+        it "verifies a well-formed payload"
+            $ verifyBootTxResponse (bootResponse [okUtxo])
+            `shouldBe` Right ()
+
+        it "rejects a funding witness with malformed tx_id"
+            $ verifyBootTxResponse (bootResponse [badTxIdUtxo])
+            `shouldSatisfy` isMalformed "boot.funding[0].tx_in.tx_id"
+
+        it "rejects a malformed tx CBOR"
+            $ verifyBootTxResponse
+                (BootTxResponse (Hex "zz") snapshot32 (BootProof []))
+            `shouldBe` Left (MalformedTxCbor "boot.tx")
+
+    describe "RequestTxResponse" $ do
+        it "round-trips via aeson" $ do
+            let r = requestResponse
+            Aeson.eitherDecode (Aeson.encode r) `shouldBe` Right r
+
+        it "verifies a well-formed payload"
+            $ verifyRequestTxResponse requestResponse
+            `shouldBe` Right ()
+
+    describe "RetractTxResponse" $ do
+        it "round-trips via aeson" $ do
+            let r = retractResponse
+            Aeson.eitherDecode (Aeson.encode r) `shouldBe` Right r
+
+        it "verifies a well-formed payload"
+            $ verifyRetractTxResponse retractResponse
+            `shouldBe` Right ()
+
+        it "rejects an empty tx_out on state_ref"
+            $ verifyRetractTxResponse
+                ( RetractTxResponse
+                    txCbor
+                    snapshot32
+                    (RetractProof okUtxo badTxOutUtxo [])
+                )
+            `shouldSatisfy` isWrongLength "retract.state_ref.tx_out"
+
+    describe "RejectTxResponse" $ do
+        it "round-trips via aeson" $ do
+            let r = rejectResponse
+            Aeson.eitherDecode (Aeson.encode r) `shouldBe` Right r
+
+        it "verifies a well-formed payload"
+            $ verifyRejectTxResponse rejectResponse
+            `shouldBe` Right ()
+
+    describe "EndTxResponse" $ do
+        it "round-trips via aeson" $ do
+            let r = endResponse
+            Aeson.eitherDecode (Aeson.encode r) `shouldBe` Right r
+
+        it "verifies a well-formed payload"
+            $ verifyEndTxResponse endResponse
+            `shouldBe` Right ()
+
+    describe "UpdateTxResponse" $ do
+        it "round-trips via aeson" $ do
+            let r = updateResponse
+            Aeson.eitherDecode (Aeson.encode r) `shouldBe` Right r
+
+        it "verifies a well-formed payload"
+            $ verifyUpdateTxResponse updateResponse
+            `shouldBe` Right ()
+
+        it "rejects a non-32-byte trie_root"
+            $ verifyUpdateTxResponse (mkUpdate (Hex shortHex) [okTrie])
+            `shouldSatisfy` isWrongLength "update.trie_root"
+
+        it "rejects an empty mpf_proof on a trie fact"
+            $ verifyUpdateTxResponse
+                (mkUpdate validRoot [emptyProofTrie])
+            `shouldSatisfy` isWrongLength
+                "update.trie_read[0].mpf_proof"
+
+txCbor :: Hex
+txCbor = Hex "deadbeef"
+
+validRoot :: Hex
+validRoot = Hex (T.replicate 64 "d")
+
+shortHex :: T.Text
+shortHex = T.replicate 10 "a"
+
+snapshot32 :: VerificationSnapshot
+snapshot32 =
+    VerificationSnapshot
+        { utxoRoot = Hex (T.replicate 64 "a")
+        , chainpoint =
+            ChainPoint
+                { slot = 42
+                , blockId = Hex (T.replicate 64 "b")
+                }
+        }
+
+okTxIn :: TxIn
+okTxIn = TxIn{txId = Hex (T.replicate 64 "c"), txIx = 0}
+
+okUtxo :: WitnessedUtxo
+okUtxo =
+    WitnessedUtxo
+        { txIn = okTxIn
+        , txOut = Hex "aa"
+        , utxoProof = Hex "bb"
+        }
+
+badTxIdUtxo :: WitnessedUtxo
+badTxIdUtxo =
+    WitnessedUtxo
+        { txIn = TxIn{txId = Hex "zz", txIx = 0}
+        , txOut = Hex "aa"
+        , utxoProof = Hex "bb"
+        }
+
+badTxOutUtxo :: WitnessedUtxo
+badTxOutUtxo =
+    WitnessedUtxo
+        { txIn = okTxIn
+        , txOut = Hex ""
+        , utxoProof = Hex "bb"
+        }
+
+okTrie :: TrieFact
+okTrie = TrieFact (Hex "ab") (Just (Hex "cd")) (Hex "ef")
+
+emptyProofTrie :: TrieFact
+emptyProofTrie = TrieFact (Hex "ab") Nothing (Hex "")
+
+bootResponse :: [WitnessedUtxo] -> BootTxResponse
+bootResponse fs = BootTxResponse txCbor snapshot32 (BootProof fs)
+
+requestResponse :: RequestTxResponse
+requestResponse =
+    RequestTxResponse txCbor snapshot32 (RequestProof [okUtxo])
+
+retractResponse :: RetractTxResponse
+retractResponse =
+    RetractTxResponse
+        txCbor
+        snapshot32
+        (RetractProof okUtxo okUtxo [okUtxo])
+
+rejectResponse :: RejectTxResponse
+rejectResponse =
+    RejectTxResponse
+        txCbor
+        snapshot32
+        (RejectProof okUtxo [okUtxo] [okUtxo])
+
+endResponse :: EndTxResponse
+endResponse =
+    EndTxResponse txCbor snapshot32 (EndProof okUtxo [okUtxo])
+
+updateResponse :: UpdateTxResponse
+updateResponse = mkUpdate validRoot [okTrie]
+
+mkUpdate :: Hex -> [TrieFact] -> UpdateTxResponse
+mkUpdate tr facts =
+    UpdateTxResponse
+        txCbor
+        snapshot32
+        ( UpdateProof
+            okUtxo
+            [okUtxo]
+            [okUtxo]
+            tr
+            facts
+        )
+
+isMalformed :: T.Text -> Either VerifyError () -> Bool
+isMalformed fld (Left (MalformedHex f _)) = f == fld
+isMalformed _ _ = False
+
+isWrongLength :: T.Text -> Either VerifyError () -> Bool
+isWrongLength fld (Left (WrongHexLength f _ _)) = f == fld
+isWrongLength _ _ = False

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -1,7 +1,10 @@
 module Main (main) where
 
+import Cardano.MPFS.Client.BundleSpec qualified as BundleSpec
 import Cardano.MPFS.Client.SnapshotSpec qualified as SnapshotSpec
 import Test.Hspec (hspec)
 
 main :: IO ()
-main = hspec SnapshotSpec.spec
+main = hspec $ do
+    SnapshotSpec.spec
+    BundleSpec.spec

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -87,8 +87,8 @@ import Cardano.MPFS.Submitter
     )
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
+    , ProofEnvelope (..)
     , TxBuilder (..)
-    , UnsignedTxBundle (..)
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -725,11 +725,11 @@ pollUntilJust timeoutSec action = go attempts
 -- | Build, sign, submit, and wait for a tx.
 buildAndSubmit
     :: Context IO
-    -> IO UnsignedTxBundle
+    -> IO (ProofEnvelope p)
     -> IO (Tx ConwayEra)
 buildAndSubmit ctx buildBundle = do
     bundle <- buildBundle
-    let unsigned = bundleTx bundle
+    let unsigned = envTx bundle
         signed =
             addKeyWitness
                 genesisSignKey

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -103,8 +103,8 @@ import Cardano.MPFS.Submitter
 import Cardano.MPFS.Trie (TrieManager (..))
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
+    , ProofEnvelope (..)
     , TxBuilder (..)
-    , UnsignedTxBundle (..)
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -184,7 +184,7 @@ cageFlowSpec bpPath scriptBytes =
                     (txBuilder ctx)
                     emptySnap
                     genesisAddr
-            let unsignedBoot = bundleTx bundleBoot
+            let unsignedBoot = envTx bundleBoot
                 signedBoot =
                     addKeyWitness
                         genesisSignKey
@@ -249,7 +249,7 @@ cageFlowSpec bpPath scriptBytes =
                     "hello"
                     "world"
                     genesisAddr
-            let unsignedReq = bundleTx bundleReq
+            let unsignedReq = envTx bundleReq
                 signedReq =
                     addKeyWitness
                         genesisSignKey
@@ -276,7 +276,7 @@ cageFlowSpec bpPath scriptBytes =
                     emptySnap
                     tokenId
                     genesisAddr
-            let unsignedUpdate = bundleTx bundleUpdate
+            let unsignedUpdate = envTx bundleUpdate
                 signedUpdate =
                     addKeyWitness
                         genesisSignKey
@@ -341,7 +341,7 @@ cageFlowSpec bpPath scriptBytes =
                     "bye"
                     "moon"
                     genesisAddr
-            let unsignedReq2 = bundleTx bundleReq2
+            let unsignedReq2 = envTx bundleReq2
                 signedReq2 =
                     addKeyWitness
                         genesisSignKey
@@ -396,7 +396,7 @@ cageFlowSpec bpPath scriptBytes =
                     emptySnap
                     req2TxIn
                     genesisAddr
-            let unsignedRetract = bundleTx bundleRetract
+            let unsignedRetract = envTx bundleRetract
                 signedRetract =
                     addKeyWitness
                         genesisSignKey

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -78,8 +78,8 @@ import Cardano.MPFS.Submitter
     )
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
+    , ProofEnvelope (..)
     , TxBuilder (..)
-    , UnsignedTxBundle (..)
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -339,11 +339,11 @@ withE2E scriptBytes action = do
 -- | Build, sign, submit, and wait for a tx.
 buildAndSubmit
     :: Context IO
-    -> IO UnsignedTxBundle
+    -> IO (ProofEnvelope p)
     -> IO (Tx ConwayEra)
 buildAndSubmit ctx buildBundle = do
     bundle <- buildBundle
-    let unsigned = bundleTx bundle
+    let unsigned = envTx bundle
         signed =
             addKeyWitness
                 genesisSignKey

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
@@ -43,8 +43,8 @@ import Cardano.MPFS.Submitter
 import Cardano.MPFS.Trace (AppTrace (..))
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
+    , ProofEnvelope (..)
     , TxBuilder (..)
-    , UnsignedTxBundle (..)
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -330,7 +330,7 @@ bootAndAwait :: Context IO -> IO TokenId
 bootAndAwait ctx = do
     bundle <-
         bootToken (txBuilder ctx) emptySnap genesisAddr
-    let unsignedBoot = bundleTx bundle
+    let unsignedBoot = envTx bundle
         signed =
             addKeyWitness genesisSignKey unsignedBoot
     result <- submitTx (submitter ctx) signed

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -99,8 +99,8 @@ import Cardano.MPFS.Submitter
     )
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
+    , ProofEnvelope (..)
     , TxBuilder (..)
-    , UnsignedTxBundle (..)
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -264,11 +264,11 @@ signSubmitAwait
     -- ^ Timeout in seconds
     -> Application
     -> Context IO
-    -> IO UnsignedTxBundle
+    -> IO (ProofEnvelope p)
     -> IO (Tx ConwayEra)
 signSubmitAwait timeout app ctx buildBundle = do
     bundle <- buildBundle
-    let unsigned = bundleTx bundle
+    let unsigned = envTx bundle
         signed =
             addKeyWitness
                 genesisSignKey

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -91,8 +91,8 @@ import Cardano.MPFS.Trie
     )
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
+    , ProofEnvelope (..)
     , TxBuilder (..)
-    , UnsignedTxBundle (..)
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -973,11 +973,11 @@ withE2E scriptBytes action = do
 -- | Build, sign, submit, and wait for a tx.
 buildAndSubmit
     :: Context IO
-    -> IO UnsignedTxBundle
+    -> IO (ProofEnvelope p)
     -> IO (Tx ConwayEra)
 buildAndSubmit ctx buildBundle = do
     bundle <- buildBundle
-    let unsigned = bundleTx bundle
+    let unsigned = envTx bundle
         signed =
             addKeyWitness
                 genesisSignKey

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -31,8 +31,11 @@ import Data.Aeson
     ( FromJSON (..)
     , Value
     , decode
+    , encode
+    , object
     , withObject
     , (.:)
+    , (.=)
     )
 import Data.Aeson.Key (Key)
 import Data.Aeson.Key qualified as Key
@@ -44,15 +47,25 @@ import Data.ByteString.Short qualified as SBS
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Lens.Micro ((^.))
-import Network.HTTP.Types (status200)
-import Network.Wai (Application)
+import Network.HTTP.Types
+    ( hContentType
+    , methodPost
+    , status200
+    )
+import Network.Wai
+    ( Application
+    , Request (..)
+    )
 import Network.Wai.Test
-    ( SResponse (..)
+    ( SRequest (..)
+    , SResponse (..)
     , defaultRequest
     , request
     , runSession
     , setPath
+    , srequest
     )
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
@@ -68,15 +81,16 @@ import Test.Hspec
     )
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
+import Cardano.Ledger.Address (Addr, serialiseAddr)
 import Cardano.Ledger.Api.Tx (Tx, bodyTxL, txIdTx)
 import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
-import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.BaseTypes (Network (..), TxIx (..))
 import Cardano.Ledger.Hashes (extractHash)
 import Cardano.Ledger.Mary.Value
     ( AssetName (..)
     , MultiAsset (..)
     )
-import Cardano.Ledger.TxIn (TxId (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -125,8 +139,19 @@ import Cardano.Node.Client.E2E.Setup
     )
 
 import Cardano.MPFS.Client
-    ( Hex (..)
+    ( BootTxResponse
+    , EndTxResponse
+    , Hex (..)
+    , RequestTxResponse
+    , RetractTxResponse
+    , UpdateTxResponse
     , VerificationSnapshot
+    , VerifyError
+    , verifyBootTxResponse
+    , verifyEndTxResponse
+    , verifyRequestTxResponse
+    , verifyRetractTxResponse
+    , verifyUpdateTxResponse
     , verifyVerificationSnapshot
     )
 
@@ -212,7 +237,7 @@ proofsSpec scriptBytes =
             -- Add a second pending request so the
             -- /requests endpoint returns a non-empty
             -- witnessed list.
-            _ <-
+            reqTx <-
                 submit
                     $ requestInsert
                         tb
@@ -221,6 +246,8 @@ proofsSpec scriptBytes =
                         "bye"
                         "moon"
                         genesisAddr
+            let reqTxIn =
+                    TxIn (txIdTx reqTx) (TxIx 0)
 
             -- Pull every proof-bearing read.
             tokenObj <- getJSON app ("/tokens/" <> tidHex)
@@ -263,6 +290,79 @@ proofsSpec scriptBytes =
             assertProofEnvelope proofObj
 
             assertRequestsEnvelope requestsObj
+
+            -- Drive every write endpoint over HTTP and
+            -- verify its response with the offline
+            -- Client.Verify DSL. We do not submit the
+            -- returned unsigned txs — the goal is to
+            -- confirm the server emits well-formed
+            -- proof envelopes at the current state.
+            let addrHex = hexAddr genesisAddr
+                retractUtxoRef =
+                    txInUrlRef reqTxIn
+
+            bootResp <-
+                postJSON app "/tx/boot"
+                    $ object ["address" .= addrHex]
+            assertVerify
+                "boot"
+                verifyBootTxResponse
+                (bootResp :: BootTxResponse)
+
+            insertResp <-
+                postJSON
+                    app
+                    "/tx/request/insert"
+                    $ object
+                        [ "token" .= Hex (TE.decodeUtf8 tidHex)
+                        , "key" .= Hex (TE.decodeUtf8 (B16.encode "baz"))
+                        , "value"
+                            .= Hex (TE.decodeUtf8 (B16.encode "qux"))
+                        , "address" .= addrHex
+                        ]
+            assertVerify
+                "request/insert"
+                verifyRequestTxResponse
+                (insertResp :: RequestTxResponse)
+
+            updateResp <-
+                postJSON app "/tx/update"
+                    $ object
+                        [ "token" .= Hex (TE.decodeUtf8 tidHex)
+                        , "address" .= addrHex
+                        ]
+            assertVerify
+                "update"
+                verifyUpdateTxResponse
+                (updateResp :: UpdateTxResponse)
+
+            retractResp <-
+                postJSON app "/tx/retract"
+                    $ object
+                        [ "utxo" .= retractUtxoRef
+                        , "address" .= addrHex
+                        ]
+            assertVerify
+                "retract"
+                verifyRetractTxResponse
+                (retractResp :: RetractTxResponse)
+
+            -- /tx/reject requires a request whose
+            -- processing deadline has already elapsed;
+            -- the fresh insert above does not qualify.
+            -- Reject coverage lives in the client
+            -- structural unit tests — skip it here.
+
+            endResp <-
+                postJSON app "/tx/end"
+                    $ object
+                        [ "token" .= Hex (TE.decodeUtf8 tidHex)
+                        , "address" .= addrHex
+                        ]
+            assertVerify
+                "end"
+                verifyEndTxResponse
+                (endResp :: EndTxResponse)
 
 -- -------------------------------------------------
 -- Assertions on response shape
@@ -433,6 +533,67 @@ getJSON app path = do
                     $ "non-JSON response: "
                         <> show (simpleBody resp)
                 error "unreachable"
+
+-- | POST a JSON body and decode the response.
+postJSON
+    :: FromJSON a
+    => Application
+    -> ByteString
+    -> Value
+    -> IO a
+postJSON app path body = do
+    let req =
+            (setPath defaultRequest path)
+                { requestMethod = methodPost
+                , requestHeaders =
+                    [ (hContentType, "application/json")
+                    ]
+                }
+    resp <-
+        runSession
+            (srequest (SRequest req (encode body)))
+            app
+    simpleStatus resp `shouldBe` status200
+    case decode (simpleBody resp) of
+        Just v -> pure v
+        Nothing ->
+            do
+                expectationFailure
+                    $ "POST "
+                        <> show path
+                        <> " returned non-JSON: "
+                        <> show (simpleBody resp)
+                error "unreachable"
+
+-- | Invoke a 'Client.Verify' function on a decoded
+-- response and fail the test with a labeled error if
+-- structural verification rejects the bundle.
+assertVerify
+    :: String
+    -> (a -> Either VerifyError ())
+    -> a
+    -> IO ()
+assertVerify label f x = case f x of
+    Right () -> pure ()
+    Left err ->
+        expectationFailure
+            $ label
+                <> ": verifier rejected bundle: "
+                <> show err
+
+-- | Hex-encode a bech32-serialisable address for
+-- JSON transport.
+hexAddr :: Addr -> Hex
+hexAddr =
+    Hex . TE.decodeUtf8 . B16.encode . serialiseAddr
+
+-- | Render a TxIn as the @txhash#ix@ string expected
+-- by the /tx/retract request body.
+txInUrlRef :: TxIn -> Text
+txInUrlRef (TxIn txI (TxIx ix)) =
+    TE.decodeUtf8 (txIdHex txI)
+        <> "#"
+        <> T.pack (show ix)
 
 getRaw :: Application -> ByteString -> IO SResponse
 getRaw app path =

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -108,8 +108,8 @@ import Cardano.MPFS.Submitter
     )
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
+    , ProofEnvelope (..)
     , TxBuilder (..)
-    , UnsignedTxBundle (..)
     )
 import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
 import Cardano.MPFS.TxBuilder.Real.Internal
@@ -383,11 +383,11 @@ signSubmitAwait
     :: Int
     -> Application
     -> Context IO
-    -> IO UnsignedTxBundle
+    -> IO (ProofEnvelope p)
     -> IO (Tx ConwayEra)
 signSubmitAwait timeout app ctx buildBundle = do
     bundle <- buildBundle
-    let unsigned = bundleTx bundle
+    let unsigned = envTx bundle
         signed =
             addKeyWitness genesisSignKey unsigned
     result <- submitTx (submitter ctx) signed

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -619,6 +619,7 @@ withApplication cfg action = do
                                         prov
                                         st
                                         tm
+                                        proof
                                 , utxoExists = exists
                                 , resolveUtxo = resolve
                                 , awaitUtxo =

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
@@ -68,19 +68,25 @@ import Servant.API
 import Cardano.MPFS.HTTP.Encoding (Hex)
 import Cardano.MPFS.HTTP.Types
     ( BootRequest
+    , BootTxResponse
     , DeleteRequest
     , EndRequest
+    , EndTxResponse
     , FactResponse
     , InsertRequest
     , ProofResponse
     , RejectRequest
+    , RejectTxResponse
+    , RequestTxResponse
     , RequestsResponse
     , RetractRequest
+    , RetractTxResponse
     , StatusResponse
     , SubmitRequest
     , TokenIdJSON
     , TokenResponse
     , UpdateRequest
+    , UpdateTxResponse
     , UpdateValueRequest
     )
 import Cardano.UTxOCSMT.Application.Metrics (Metrics)
@@ -182,12 +188,14 @@ type TxAwaitAPI =
         :> QueryParam "timeout" Word64
         :> Get '[JSON] NoContent
 
--- | @POST \/tx\/boot@ — build a boot transaction.
+-- | @POST \/tx\/boot@ — build a boot transaction,
+-- returning the unsigned CBOR together with the
+-- verification snapshot and boot proof payload.
 type TxBootAPI =
     "tx"
         :> "boot"
         :> ReqBody '[JSON] BootRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] BootTxResponse
 
 -- | @POST \/tx\/request\/insert@ — build an insert
 -- request transaction.
@@ -196,7 +204,7 @@ type TxInsertAPI =
         :> "request"
         :> "insert"
         :> ReqBody '[JSON] InsertRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] RequestTxResponse
 
 -- | @POST \/tx\/request\/delete@ — build a delete
 -- request transaction.
@@ -205,7 +213,7 @@ type TxDeleteAPI =
         :> "request"
         :> "delete"
         :> ReqBody '[JSON] DeleteRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] RequestTxResponse
 
 -- | @POST \/tx\/request\/update@ — build an
 -- update-value request transaction.
@@ -214,7 +222,7 @@ type TxRequestUpdateAPI =
         :> "request"
         :> "update"
         :> ReqBody '[JSON] UpdateValueRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] RequestTxResponse
 
 -- | @POST \/tx\/reject@ — build a reject
 -- transaction for Phase 3 requests.
@@ -222,7 +230,7 @@ type TxRejectAPI =
     "tx"
         :> "reject"
         :> ReqBody '[JSON] RejectRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] RejectTxResponse
 
 -- | @POST \/tx\/update@ — build an update
 -- transaction.
@@ -230,7 +238,7 @@ type TxUpdateAPI =
     "tx"
         :> "update"
         :> ReqBody '[JSON] UpdateRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] UpdateTxResponse
 
 -- | @POST \/tx\/retract@ — build a retract
 -- transaction.
@@ -238,14 +246,14 @@ type TxRetractAPI =
     "tx"
         :> "retract"
         :> ReqBody '[JSON] RetractRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] RetractTxResponse
 
 -- | @POST \/tx\/end@ — build an end transaction.
 type TxEndAPI =
     "tx"
         :> "end"
         :> ReqBody '[JSON] EndRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] EndTxResponse
 
 -- | @POST \/tx\/submit@ — submit a signed
 -- transaction.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -48,7 +48,6 @@ import Cardano.Ledger.Binary
     ( DecoderError
     , decodeFull'
     , natVersion
-    , serialize'
     )
 import Cardano.Ledger.Hashes
     ( extractHash
@@ -79,26 +78,38 @@ import Cardano.MPFS.HTTP.Swagger
     )
 import Cardano.MPFS.HTTP.Types
     ( BootRequest (..)
+    , BootTxResponse
     , ChainPointJSON (..)
     , DeleteRequest (..)
     , EndRequest (..)
+    , EndTxResponse
     , FactResponse (..)
     , FactWitness (..)
     , InsertRequest (..)
     , ProofResponse (..)
     , RejectRequest (..)
+    , RejectTxResponse
+    , RequestTxResponse
     , RequestsResponse (..)
     , RetractRequest (..)
+    , RetractTxResponse
     , StatusResponse (..)
     , SubmitRequest (..)
     , TokenIdJSON (..)
     , TokenResponse (..)
     , UpdateRequest (..)
+    , UpdateTxResponse
     , UpdateValueRequest (..)
     , VerificationSnapshot (..)
     , WitnessedRequest (..)
     , WitnessedTokenState (..)
     , WitnessedUtxo (..)
+    , mkBootTxResponse
+    , mkEndTxResponse
+    , mkRejectTxResponse
+    , mkRequestTxResponse
+    , mkRetractTxResponse
+    , mkUpdateTxResponse
     , parseAddr
     , requestToJSON
     , tokenStateToJSON
@@ -112,10 +123,7 @@ import Cardano.UTxOCSMT.Application.Metrics
 import Cardano.MPFS.State qualified as St
 import Cardano.MPFS.Submitter qualified as Sub
 import Cardano.MPFS.Trie qualified as Trie
-import Cardano.MPFS.TxBuilder
-    ( BundleSnapshot (..)
-    , UnsignedTxBundle (..)
-    )
+import Cardano.MPFS.TxBuilder (BundleSnapshot (..))
 import Cardano.MPFS.TxBuilder qualified as Tx
 
 -- | Combined API with Swagger UI.
@@ -560,10 +568,6 @@ parseTxIdRaw bs =
 -- Transaction handlers
 -- ---------------------------------------------------------
 
--- | Serialize a 'Tx ConwayEra' to hex CBOR.
-serializeTx :: Tx ConwayEra -> Hex
-serializeTx = Hex . serialize' (natVersion @11)
-
 -- | Parse an address from hex or throw 400.
 requireAddr :: Hex -> Handler Addr
 requireAddr h =
@@ -577,17 +581,21 @@ requireAddr h =
                     }
 
 txBootHandler
-    :: Context IO -> BootRequest -> Handler Hex
+    :: Context IO
+    -> BootRequest
+    -> Handler BootTxResponse
 txBootHandler ctx (BootRequest addrHex) = do
     addr <- requireAddr addrHex
     snap <- requireBundleSnapshot ctx
     bundle <-
         liftIO
             $ Tx.bootToken (txBuilder ctx) snap addr
-    pure (serializeTx (bundleTx bundle))
+    pure (mkBootTxResponse bundle)
 
 txInsertHandler
-    :: Context IO -> InsertRequest -> Handler Hex
+    :: Context IO
+    -> InsertRequest
+    -> Handler RequestTxResponse
 txInsertHandler
     ctx
     InsertRequest
@@ -607,10 +615,12 @@ txInsertHandler
                     k
                     v
                     addr
-        pure (serializeTx (bundleTx bundle))
+        pure (mkRequestTxResponse bundle)
 
 txDeleteHandler
-    :: Context IO -> DeleteRequest -> Handler Hex
+    :: Context IO
+    -> DeleteRequest
+    -> Handler RequestTxResponse
 txDeleteHandler
     ctx
     DeleteRequest
@@ -630,12 +640,12 @@ txDeleteHandler
                     k
                     v
                     addr
-        pure (serializeTx (bundleTx bundle))
+        pure (mkRequestTxResponse bundle)
 
 txUpdateValueHandler
     :: Context IO
     -> UpdateValueRequest
-    -> Handler Hex
+    -> Handler RequestTxResponse
 txUpdateValueHandler
     ctx
     UpdateValueRequest
@@ -657,12 +667,12 @@ txUpdateValueHandler
                     oldV
                     newV
                     addr
-        pure (serializeTx (bundleTx bundle))
+        pure (mkRequestTxResponse bundle)
 
 txRejectHandler
     :: Context IO
     -> RejectRequest
-    -> Handler Hex
+    -> Handler RejectTxResponse
 txRejectHandler
     ctx
     RejectRequest
@@ -678,10 +688,12 @@ txRejectHandler
                     snap
                     tid
                     addr
-        pure (serializeTx (bundleTx bundle))
+        pure (mkRejectTxResponse bundle)
 
 txUpdateHandler
-    :: Context IO -> UpdateRequest -> Handler Hex
+    :: Context IO
+    -> UpdateRequest
+    -> Handler UpdateTxResponse
 txUpdateHandler
     ctx
     UpdateRequest
@@ -697,10 +709,12 @@ txUpdateHandler
                     snap
                     tid
                     addr
-        pure (serializeTx (bundleTx bundle))
+        pure (mkUpdateTxResponse bundle)
 
 txRetractHandler
-    :: Context IO -> RetractRequest -> Handler Hex
+    :: Context IO
+    -> RetractRequest
+    -> Handler RetractTxResponse
 txRetractHandler
     ctx
     RetractRequest
@@ -717,10 +731,12 @@ txRetractHandler
                     snap
                     txIn
                     addr
-        pure (serializeTx (bundleTx bundle))
+        pure (mkRetractTxResponse bundle)
 
 txEndHandler
-    :: Context IO -> EndRequest -> Handler Hex
+    :: Context IO
+    -> EndRequest
+    -> Handler EndTxResponse
 txEndHandler
     ctx
     EndRequest
@@ -736,7 +752,7 @@ txEndHandler
                     snap
                     tid
                     addr
-        pure (serializeTx (bundleTx bundle))
+        pure (mkEndTxResponse bundle)
 
 txSubmitHandler
     :: Context IO -> SubmitRequest -> Handler Hex

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -52,6 +52,30 @@ module Cardano.MPFS.HTTP.Types
     , EndRequest (..)
     , SubmitRequest (..)
 
+      -- * Proof-bearing tx responses
+    , TrieFactJSON (..)
+    , trieFactToJSON
+    , witnessedInputToJSON
+    , bundleSnapshotToJSON
+    , BootProofJSON (..)
+    , RequestProofJSON (..)
+    , RetractProofJSON (..)
+    , RejectProofJSON (..)
+    , EndProofJSON (..)
+    , UpdateProofJSON (..)
+    , BootTxResponse (..)
+    , RequestTxResponse (..)
+    , RetractTxResponse (..)
+    , RejectTxResponse (..)
+    , EndTxResponse (..)
+    , UpdateTxResponse (..)
+    , mkBootTxResponse
+    , mkRequestTxResponse
+    , mkRetractTxResponse
+    , mkRejectTxResponse
+    , mkEndTxResponse
+    , mkUpdateTxResponse
+
       -- * Address parsing
     , parseAddr
     ) where
@@ -78,6 +102,7 @@ import Data.Swagger
     , required
     )
 import Data.Swagger qualified as Swagger
+import Data.Swagger.Declare (Declare)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
@@ -86,7 +111,9 @@ import GHC.IsList (IsList (..))
 import Servant.API (FromHttpApiData (..))
 
 import Cardano.Ledger.Address (decodeAddrEither)
+import Cardano.Ledger.Api.Tx (Tx)
 import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Binary (natVersion, serialize')
 import Cardano.Ledger.Hashes (extractHash)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (AssetName (..))
@@ -96,14 +123,29 @@ import Cardano.Crypto.Hash.Class qualified as Crypto
 
 import Cardano.MPFS.Core.Types
     ( Addr
+    , BlockId (..)
     , Coin (..)
+    , ConwayEra
     , Operation (..)
     , Request (..)
     , Root (..)
+    , SlotNo (..)
     , TokenId (..)
     , TokenState (..)
     )
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
+import Cardano.MPFS.TxBuilder
+    ( BootProof (..)
+    , BundleSnapshot (..)
+    , EndProof (..)
+    , ProofEnvelope (..)
+    , RejectProof (..)
+    , RequestProof (..)
+    , RetractProof (..)
+    , TrieFact (..)
+    , UpdateProof (..)
+    , WitnessedInput (..)
+    )
 
 -- | Response for @GET \/status@.
 data StatusResponse = StatusResponse
@@ -711,6 +753,549 @@ instance FromJSON SubmitRequest where
         SubmitRequest <$> o .: "tx"
 
 -- ---------------------------------------------------------
+-- Proof-bearing tx envelope responses
+-- ---------------------------------------------------------
+
+-- | Convert a 'WitnessedInput' to its JSON wire form.
+-- Reuses 'WitnessedUtxo' because an input witness and a
+-- reference-UTxO witness carry the same triple: a 'TxIn',
+-- the CBOR-encoded 'TxOut', and a UTxO-CSMT inclusion
+-- proof. Verifiers treat the two cases identically.
+witnessedInputToJSON :: WitnessedInput -> WitnessedUtxo
+witnessedInputToJSON
+    WitnessedInput
+        { witnessedRef = tin
+        , witnessedTxOut = out
+        , witnessedCsmtProof = prf
+        } =
+        WitnessedUtxo
+            { wuTxIn = txInToJSON tin
+            , wuTxOut = Hex out
+            , wuProof = Hex prf
+            }
+
+-- | JSON representation of a 'TrieFact'.
+data TrieFactJSON = TrieFactJSON
+    { tfKey :: Hex
+    -- ^ Trie key the builder looked up
+    , tfValue :: Maybe Hex
+    -- ^ Value bound to 'tfKey', or 'Nothing' for an
+    -- absence fact
+    , tfMpfProof :: Hex
+    -- ^ MPF inclusion\/exclusion proof (hex)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON TrieFactJSON where
+    toJSON TrieFactJSON{..} =
+        object
+            [ "key" .= tfKey
+            , "value" .= tfValue
+            , "mpf_proof" .= tfMpfProof
+            ]
+
+instance FromJSON TrieFactJSON where
+    parseJSON = withObject "TrieFactJSON" $ \o ->
+        TrieFactJSON
+            <$> o .: "key"
+            <*> o .: "value"
+            <*> o .: "mpf_proof"
+
+-- | Convert an internal 'TrieFact' to JSON.
+trieFactToJSON :: TrieFact -> TrieFactJSON
+trieFactToJSON
+    TrieFact
+        { factKey = k
+        , factValue = mv
+        , factMpfProof = p
+        } =
+        TrieFactJSON
+            { tfKey = Hex k
+            , tfValue = fmap Hex mv
+            , tfMpfProof = Hex p
+            }
+
+-- | Convert a 'BundleSnapshot' to the HTTP-level
+-- 'VerificationSnapshot'. They carry the same
+-- information — only the encoding differs (raw bytes
+-- vs. hex-wrapped JSON).
+bundleSnapshotToJSON
+    :: BundleSnapshot -> VerificationSnapshot
+bundleSnapshotToJSON
+    BundleSnapshot
+        { snapshotUtxoRoot = r
+        , snapshotSlot = SlotNo s
+        , snapshotBlockId = BlockId b
+        } =
+        VerificationSnapshot
+            { vsUtxoRoot = Hex r
+            , vsChainPoint =
+                ChainPointJSON
+                    { cpSlot = s
+                    , cpBlockId = Hex b
+                    }
+            }
+
+-- | Serialize a Conway-era 'Tx' to hex CBOR.
+serializeTxHex :: Tx ConwayEra -> Hex
+serializeTxHex = Hex . serialize' (natVersion @11)
+
+-- | Proof payload for @POST \/tx\/boot@ responses.
+newtype BootProofJSON = BootProofJSON
+    { bpFunding :: [WitnessedUtxo]
+    -- ^ Witnessed wallet inputs funding the boot tx
+    }
+    deriving (Eq, Show)
+
+instance ToJSON BootProofJSON where
+    toJSON BootProofJSON{..} =
+        object ["funding" .= bpFunding]
+
+instance FromJSON BootProofJSON where
+    parseJSON = withObject "BootProofJSON" $ \o ->
+        BootProofJSON <$> o .: "funding"
+
+-- | Proof payload for
+-- @POST \/tx\/request\/{insert,delete,update}@
+-- responses. All three request endpoints share the
+-- same shape: they only spend wallet inputs and create
+-- a fresh pending-request output.
+newtype RequestProofJSON = RequestProofJSON
+    { rqpFunding :: [WitnessedUtxo]
+    -- ^ Witnessed wallet inputs funding the request tx
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RequestProofJSON where
+    toJSON RequestProofJSON{..} =
+        object ["funding" .= rqpFunding]
+
+instance FromJSON RequestProofJSON where
+    parseJSON =
+        withObject "RequestProofJSON" $ \o ->
+            RequestProofJSON <$> o .: "funding"
+
+-- | Proof payload for @POST \/tx\/retract@ responses.
+data RetractProofJSON = RetractProofJSON
+    { rtpRequestIn :: WitnessedUtxo
+    -- ^ The pending-request UTxO being retracted
+    , rtpStateRef :: WitnessedUtxo
+    -- ^ The state UTxO referenced for its timing
+    -- parameters
+    , rtpFunding :: [WitnessedUtxo]
+    -- ^ Wallet inputs covering fees
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RetractProofJSON where
+    toJSON RetractProofJSON{..} =
+        object
+            [ "request_in" .= rtpRequestIn
+            , "state_ref" .= rtpStateRef
+            , "funding" .= rtpFunding
+            ]
+
+instance FromJSON RetractProofJSON where
+    parseJSON =
+        withObject "RetractProofJSON" $ \o ->
+            RetractProofJSON
+                <$> o .: "request_in"
+                <*> o .: "state_ref"
+                <*> o .: "funding"
+
+-- | Proof payload for @POST \/tx\/reject@ responses.
+data RejectProofJSON = RejectProofJSON
+    { rjpState :: WitnessedUtxo
+    -- ^ The consumed state UTxO
+    , rjpRequestIns :: [WitnessedUtxo]
+    -- ^ The pending-request UTxOs being rejected
+    , rjpFunding :: [WitnessedUtxo]
+    -- ^ Wallet inputs covering fees
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RejectProofJSON where
+    toJSON RejectProofJSON{..} =
+        object
+            [ "state" .= rjpState
+            , "request_ins" .= rjpRequestIns
+            , "funding" .= rjpFunding
+            ]
+
+instance FromJSON RejectProofJSON where
+    parseJSON = withObject "RejectProofJSON" $ \o ->
+        RejectProofJSON
+            <$> o .: "state"
+            <*> o .: "request_ins"
+            <*> o .: "funding"
+
+-- | Proof payload for @POST \/tx\/end@ responses.
+data EndProofJSON = EndProofJSON
+    { epState :: WitnessedUtxo
+    -- ^ The consumed state UTxO
+    , epFunding :: [WitnessedUtxo]
+    -- ^ Wallet inputs covering fees
+    }
+    deriving (Eq, Show)
+
+instance ToJSON EndProofJSON where
+    toJSON EndProofJSON{..} =
+        object
+            [ "state" .= epState
+            , "funding" .= epFunding
+            ]
+
+instance FromJSON EndProofJSON where
+    parseJSON = withObject "EndProofJSON" $ \o ->
+        EndProofJSON
+            <$> o .: "state"
+            <*> o .: "funding"
+
+-- | Proof payload for @POST \/tx\/update@ responses.
+-- Includes the trie-level MPF reads performed during
+-- batch application, rooted at the trie root encoded in
+-- the consumed state datum.
+data UpdateProofJSON = UpdateProofJSON
+    { upState :: WitnessedUtxo
+    -- ^ The consumed state UTxO
+    , upRequests :: [WitnessedUtxo]
+    -- ^ Pending-request UTxOs batched into this update
+    , upFunding :: [WitnessedUtxo]
+    -- ^ Wallet inputs covering fees
+    , upTrieRoot :: Hex
+    -- ^ Trie root from the consumed state datum
+    , upTrieRead :: [TrieFactJSON]
+    -- ^ MPF reads against 'upTrieRoot'
+    }
+    deriving (Eq, Show)
+
+instance ToJSON UpdateProofJSON where
+    toJSON UpdateProofJSON{..} =
+        object
+            [ "state" .= upState
+            , "requests" .= upRequests
+            , "funding" .= upFunding
+            , "trie_root" .= upTrieRoot
+            , "trie_read" .= upTrieRead
+            ]
+
+instance FromJSON UpdateProofJSON where
+    parseJSON = withObject "UpdateProofJSON" $ \o ->
+        UpdateProofJSON
+            <$> o .: "state"
+            <*> o .: "requests"
+            <*> o .: "funding"
+            <*> o .: "trie_root"
+            <*> o .: "trie_read"
+
+-- | Response envelope for @POST \/tx\/boot@.
+data BootTxResponse = BootTxResponse
+    { btrTx :: Hex
+    -- ^ Unsigned transaction CBOR (hex)
+    , btrSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target
+    , btrProof :: BootProofJSON
+    -- ^ Per-endpoint proof payload
+    }
+    deriving (Eq, Show)
+
+instance ToJSON BootTxResponse where
+    toJSON BootTxResponse{..} =
+        object
+            [ "tx" .= btrTx
+            , "snapshot" .= btrSnapshot
+            , "proof" .= btrProof
+            ]
+
+instance FromJSON BootTxResponse where
+    parseJSON = withObject "BootTxResponse" $ \o ->
+        BootTxResponse
+            <$> o .: "tx"
+            <*> o .: "snapshot"
+            <*> o .: "proof"
+
+-- | Response envelope for
+-- @POST \/tx\/request\/{insert,delete,update}@.
+data RequestTxResponse = RequestTxResponse
+    { rqtTx :: Hex
+    , rqtSnapshot :: VerificationSnapshot
+    , rqtProof :: RequestProofJSON
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RequestTxResponse where
+    toJSON RequestTxResponse{..} =
+        object
+            [ "tx" .= rqtTx
+            , "snapshot" .= rqtSnapshot
+            , "proof" .= rqtProof
+            ]
+
+instance FromJSON RequestTxResponse where
+    parseJSON =
+        withObject "RequestTxResponse" $ \o ->
+            RequestTxResponse
+                <$> o .: "tx"
+                <*> o .: "snapshot"
+                <*> o .: "proof"
+
+-- | Response envelope for @POST \/tx\/retract@.
+data RetractTxResponse = RetractTxResponse
+    { rttTx :: Hex
+    , rttSnapshot :: VerificationSnapshot
+    , rttProof :: RetractProofJSON
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RetractTxResponse where
+    toJSON RetractTxResponse{..} =
+        object
+            [ "tx" .= rttTx
+            , "snapshot" .= rttSnapshot
+            , "proof" .= rttProof
+            ]
+
+instance FromJSON RetractTxResponse where
+    parseJSON =
+        withObject "RetractTxResponse" $ \o ->
+            RetractTxResponse
+                <$> o .: "tx"
+                <*> o .: "snapshot"
+                <*> o .: "proof"
+
+-- | Response envelope for @POST \/tx\/reject@.
+data RejectTxResponse = RejectTxResponse
+    { rjtTx :: Hex
+    , rjtSnapshot :: VerificationSnapshot
+    , rjtProof :: RejectProofJSON
+    }
+    deriving (Eq, Show)
+
+instance ToJSON RejectTxResponse where
+    toJSON RejectTxResponse{..} =
+        object
+            [ "tx" .= rjtTx
+            , "snapshot" .= rjtSnapshot
+            , "proof" .= rjtProof
+            ]
+
+instance FromJSON RejectTxResponse where
+    parseJSON =
+        withObject "RejectTxResponse" $ \o ->
+            RejectTxResponse
+                <$> o .: "tx"
+                <*> o .: "snapshot"
+                <*> o .: "proof"
+
+-- | Response envelope for @POST \/tx\/end@.
+data EndTxResponse = EndTxResponse
+    { etTx :: Hex
+    , etSnapshot :: VerificationSnapshot
+    , etProof :: EndProofJSON
+    }
+    deriving (Eq, Show)
+
+instance ToJSON EndTxResponse where
+    toJSON EndTxResponse{..} =
+        object
+            [ "tx" .= etTx
+            , "snapshot" .= etSnapshot
+            , "proof" .= etProof
+            ]
+
+instance FromJSON EndTxResponse where
+    parseJSON = withObject "EndTxResponse" $ \o ->
+        EndTxResponse
+            <$> o .: "tx"
+            <*> o .: "snapshot"
+            <*> o .: "proof"
+
+-- | Response envelope for @POST \/tx\/update@.
+data UpdateTxResponse = UpdateTxResponse
+    { uptTx :: Hex
+    , uptSnapshot :: VerificationSnapshot
+    , uptProof :: UpdateProofJSON
+    }
+    deriving (Eq, Show)
+
+instance ToJSON UpdateTxResponse where
+    toJSON UpdateTxResponse{..} =
+        object
+            [ "tx" .= uptTx
+            , "snapshot" .= uptSnapshot
+            , "proof" .= uptProof
+            ]
+
+instance FromJSON UpdateTxResponse where
+    parseJSON =
+        withObject "UpdateTxResponse" $ \o ->
+            UpdateTxResponse
+                <$> o .: "tx"
+                <*> o .: "snapshot"
+                <*> o .: "proof"
+
+-- | Package a 'ProofEnvelope BootProof' as the JSON
+-- response for @POST \/tx\/boot@.
+mkBootTxResponse
+    :: ProofEnvelope BootProof -> BootTxResponse
+mkBootTxResponse
+    ProofEnvelope
+        { envTx = tx
+        , envSnapshot = snap
+        , envProof = BootProof{bootFunding = funding}
+        } =
+        BootTxResponse
+            { btrTx = serializeTxHex tx
+            , btrSnapshot = bundleSnapshotToJSON snap
+            , btrProof =
+                BootProofJSON
+                    { bpFunding =
+                        map witnessedInputToJSON funding
+                    }
+            }
+
+-- | Package a 'ProofEnvelope RequestProof' as the JSON
+-- response shared by the three request endpoints.
+mkRequestTxResponse
+    :: ProofEnvelope RequestProof
+    -> RequestTxResponse
+mkRequestTxResponse
+    ProofEnvelope
+        { envTx = tx
+        , envSnapshot = snap
+        , envProof =
+            RequestProof{requestFunding = funding}
+        } =
+        RequestTxResponse
+            { rqtTx = serializeTxHex tx
+            , rqtSnapshot = bundleSnapshotToJSON snap
+            , rqtProof =
+                RequestProofJSON
+                    { rqpFunding =
+                        map witnessedInputToJSON funding
+                    }
+            }
+
+-- | Package a 'ProofEnvelope RetractProof' as the JSON
+-- response for @POST \/tx\/retract@.
+mkRetractTxResponse
+    :: ProofEnvelope RetractProof
+    -> RetractTxResponse
+mkRetractTxResponse
+    ProofEnvelope
+        { envTx = tx
+        , envSnapshot = snap
+        , envProof =
+            RetractProof
+                { retractRequestIn = reqIn
+                , retractStateRef = stRef
+                , retractFunding = funding
+                }
+        } =
+        RetractTxResponse
+            { rttTx = serializeTxHex tx
+            , rttSnapshot = bundleSnapshotToJSON snap
+            , rttProof =
+                RetractProofJSON
+                    { rtpRequestIn =
+                        witnessedInputToJSON reqIn
+                    , rtpStateRef =
+                        witnessedInputToJSON stRef
+                    , rtpFunding =
+                        map witnessedInputToJSON funding
+                    }
+            }
+
+-- | Package a 'ProofEnvelope RejectProof' as the JSON
+-- response for @POST \/tx\/reject@.
+mkRejectTxResponse
+    :: ProofEnvelope RejectProof -> RejectTxResponse
+mkRejectTxResponse
+    ProofEnvelope
+        { envTx = tx
+        , envSnapshot = snap
+        , envProof =
+            RejectProof
+                { rejectState = st
+                , rejectRequestIns = reqs
+                , rejectFunding = funding
+                }
+        } =
+        RejectTxResponse
+            { rjtTx = serializeTxHex tx
+            , rjtSnapshot = bundleSnapshotToJSON snap
+            , rjtProof =
+                RejectProofJSON
+                    { rjpState =
+                        witnessedInputToJSON st
+                    , rjpRequestIns =
+                        map witnessedInputToJSON reqs
+                    , rjpFunding =
+                        map witnessedInputToJSON funding
+                    }
+            }
+
+-- | Package a 'ProofEnvelope EndProof' as the JSON
+-- response for @POST \/tx\/end@.
+mkEndTxResponse
+    :: ProofEnvelope EndProof -> EndTxResponse
+mkEndTxResponse
+    ProofEnvelope
+        { envTx = tx
+        , envSnapshot = snap
+        , envProof =
+            EndProof
+                { endState = st
+                , endFunding = funding
+                }
+        } =
+        EndTxResponse
+            { etTx = serializeTxHex tx
+            , etSnapshot = bundleSnapshotToJSON snap
+            , etProof =
+                EndProofJSON
+                    { epState =
+                        witnessedInputToJSON st
+                    , epFunding =
+                        map witnessedInputToJSON funding
+                    }
+            }
+
+-- | Package a 'ProofEnvelope UpdateProof' as the JSON
+-- response for @POST \/tx\/update@.
+mkUpdateTxResponse
+    :: ProofEnvelope UpdateProof -> UpdateTxResponse
+mkUpdateTxResponse
+    ProofEnvelope
+        { envTx = tx
+        , envSnapshot = snap
+        , envProof =
+            UpdateProof
+                { updateState = st
+                , updateRequests = reqs
+                , updateFunding = funding
+                , updateTrieRoot = trieRoot
+                , updateTrieRead = facts
+                }
+        } =
+        UpdateTxResponse
+            { uptTx = serializeTxHex tx
+            , uptSnapshot = bundleSnapshotToJSON snap
+            , uptProof =
+                UpdateProofJSON
+                    { upState =
+                        witnessedInputToJSON st
+                    , upRequests =
+                        map witnessedInputToJSON reqs
+                    , upFunding =
+                        map witnessedInputToJSON funding
+                    , upTrieRoot = Hex trieRoot
+                    , upTrieRead =
+                        map trieFactToJSON facts
+                    }
+            }
+
+-- ---------------------------------------------------------
 -- Swagger ToSchema instances
 -- ---------------------------------------------------------
 
@@ -1297,3 +1882,251 @@ instance ToSchema RequestsResponse where
             & description
                 ?~ "Proof-bearing pending requests \
                    \response"
+
+instance ToSchema TrieFactJSON where
+    declareNamedSchema _ = do
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        maybeHex <-
+            declareSchemaRef (Proxy @(Maybe Hex))
+        pure
+            $ Swagger.NamedSchema
+                (Just "TrieFactJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("key", hexSchema)
+                    , ("value", maybeHex)
+                    , ("mpf_proof", hexSchema)
+                    ]
+            & required
+                .~ ["key", "value", "mpf_proof"]
+            & description
+                ?~ "Trie read: key, optional value, and \
+                   \MPF proof against a trie root"
+
+instance ToSchema BootProofJSON where
+    declareNamedSchema _ = do
+        utxoListSchema <-
+            declareSchemaRef
+                (Proxy @[WitnessedUtxo])
+        pure
+            $ Swagger.NamedSchema
+                (Just "BootProofJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [("funding", utxoListSchema)]
+            & required .~ ["funding"]
+            & description
+                ?~ "Proof payload for POST /tx/boot"
+
+instance ToSchema RequestProofJSON where
+    declareNamedSchema _ = do
+        utxoListSchema <-
+            declareSchemaRef
+                (Proxy @[WitnessedUtxo])
+        pure
+            $ Swagger.NamedSchema
+                (Just "RequestProofJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [("funding", utxoListSchema)]
+            & required .~ ["funding"]
+            & description
+                ?~ "Proof payload for POST \
+                   \/tx/request/{insert,delete,update}"
+
+instance ToSchema RetractProofJSON where
+    declareNamedSchema _ = do
+        utxoSchema <-
+            declareSchemaRef (Proxy @WitnessedUtxo)
+        utxoListSchema <-
+            declareSchemaRef
+                (Proxy @[WitnessedUtxo])
+        pure
+            $ Swagger.NamedSchema
+                (Just "RetractProofJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("request_in", utxoSchema)
+                    , ("state_ref", utxoSchema)
+                    , ("funding", utxoListSchema)
+                    ]
+            & required
+                .~ [ "request_in"
+                   , "state_ref"
+                   , "funding"
+                   ]
+            & description
+                ?~ "Proof payload for POST /tx/retract"
+
+instance ToSchema RejectProofJSON where
+    declareNamedSchema _ = do
+        utxoSchema <-
+            declareSchemaRef (Proxy @WitnessedUtxo)
+        utxoListSchema <-
+            declareSchemaRef
+                (Proxy @[WitnessedUtxo])
+        pure
+            $ Swagger.NamedSchema
+                (Just "RejectProofJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("state", utxoSchema)
+                    , ("request_ins", utxoListSchema)
+                    , ("funding", utxoListSchema)
+                    ]
+            & required
+                .~ [ "state"
+                   , "request_ins"
+                   , "funding"
+                   ]
+            & description
+                ?~ "Proof payload for POST /tx/reject"
+
+instance ToSchema EndProofJSON where
+    declareNamedSchema _ = do
+        utxoSchema <-
+            declareSchemaRef (Proxy @WitnessedUtxo)
+        utxoListSchema <-
+            declareSchemaRef
+                (Proxy @[WitnessedUtxo])
+        pure
+            $ Swagger.NamedSchema
+                (Just "EndProofJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("state", utxoSchema)
+                    , ("funding", utxoListSchema)
+                    ]
+            & required
+                .~ ["state", "funding"]
+            & description
+                ?~ "Proof payload for POST /tx/end"
+
+instance ToSchema UpdateProofJSON where
+    declareNamedSchema _ = do
+        utxoSchema <-
+            declareSchemaRef (Proxy @WitnessedUtxo)
+        utxoListSchema <-
+            declareSchemaRef
+                (Proxy @[WitnessedUtxo])
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        factListSchema <-
+            declareSchemaRef
+                (Proxy @[TrieFactJSON])
+        pure
+            $ Swagger.NamedSchema
+                (Just "UpdateProofJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("state", utxoSchema)
+                    , ("requests", utxoListSchema)
+                    , ("funding", utxoListSchema)
+                    , ("trie_root", hexSchema)
+                    , ("trie_read", factListSchema)
+                    ]
+            & required
+                .~ [ "state"
+                   , "requests"
+                   , "funding"
+                   , "trie_root"
+                   , "trie_read"
+                   ]
+            & description
+                ?~ "Proof payload for POST /tx/update"
+
+instance ToSchema BootTxResponse where
+    declareNamedSchema _ =
+        txEnvelopeSchema
+            "BootTxResponse"
+            (Proxy @BootProofJSON)
+            "Proof-bearing response for POST /tx/boot"
+
+instance ToSchema RequestTxResponse where
+    declareNamedSchema _ =
+        txEnvelopeSchema
+            "RequestTxResponse"
+            (Proxy @RequestProofJSON)
+            "Proof-bearing response for POST \
+            \/tx/request/{insert,delete,update}"
+
+instance ToSchema RetractTxResponse where
+    declareNamedSchema _ =
+        txEnvelopeSchema
+            "RetractTxResponse"
+            (Proxy @RetractProofJSON)
+            "Proof-bearing response for POST \
+            \/tx/retract"
+
+instance ToSchema RejectTxResponse where
+    declareNamedSchema _ =
+        txEnvelopeSchema
+            "RejectTxResponse"
+            (Proxy @RejectProofJSON)
+            "Proof-bearing response for POST /tx/reject"
+
+instance ToSchema EndTxResponse where
+    declareNamedSchema _ =
+        txEnvelopeSchema
+            "EndTxResponse"
+            (Proxy @EndProofJSON)
+            "Proof-bearing response for POST /tx/end"
+
+instance ToSchema UpdateTxResponse where
+    declareNamedSchema _ =
+        txEnvelopeSchema
+            "UpdateTxResponse"
+            (Proxy @UpdateProofJSON)
+            "Proof-bearing response for POST /tx/update"
+
+-- | Shared schema body for @POST \/tx\/…@ response
+-- envelopes: all carry a hex-encoded tx, a verification
+-- snapshot, and a per-endpoint proof payload.
+txEnvelopeSchema
+    :: (ToSchema proofJson)
+    => Text
+    -> Proxy proofJson
+    -> Text
+    -> Declare
+        (Swagger.Definitions Swagger.Schema)
+        Swagger.NamedSchema
+txEnvelopeSchema name proofProxy desc = do
+    hexSchema <- declareSchemaRef (Proxy @Hex)
+    snapSchema <-
+        declareSchemaRef
+            (Proxy @VerificationSnapshot)
+    proofSchema <- declareSchemaRef proofProxy
+    pure
+        $ Swagger.NamedSchema (Just name)
+        $ mempty
+        & Swagger.type_ ?~ Swagger.SwaggerObject
+        & properties
+            .~ fromList
+                [ ("tx", hexSchema)
+                , ("snapshot", snapSchema)
+                , ("proof", proofSchema)
+                ]
+        & required .~ ["tx", "snapshot", "proof"]
+        & description ?~ desc

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
@@ -8,19 +8,38 @@
 -- cage-protocol action (boot, request insert\/delete,
 -- update, retract, end). The real implementation lives
 -- in "Cardano.MPFS.TxBuilder.Real"; the mock in
--- "Cardano.MPFS.Mock.TxBuilder". Returned transactions
--- are unsigned — callers add key witnesses before
--- submission.
+-- "Cardano.MPFS.Mock.TxBuilder".
+--
+-- Every method returns a 'ProofEnvelope' parameterized
+-- by an endpoint-specific proof shape. The shape makes
+-- the tx's dataflow explicit: each named
+-- 'WitnessedInput' field plays a fixed role (state,
+-- funding, pending request, …) and carries the
+-- UTxO-CSMT inclusion proof that binds its 'TxIn' to
+-- 'snapshotUtxoRoot'. Verification is type-directed:
+-- walk the fields, check every proof against the
+-- snapshot, and cross-reference with @txIns envTx@.
+--
+-- Returned transactions are unsigned — callers add key
+-- witnesses before submission.
 module Cardano.MPFS.TxBuilder
     ( -- * Transaction builder interface
       TxBuilder (..)
 
-      -- * Proof-bearing unsigned-transaction bundles
-    , UnsignedTxBundle (..)
+      -- * Snapshot and witness primitives
     , BundleSnapshot (..)
     , WitnessedInput (..)
     , TrieFact (..)
-    , bareTxBundle
+    , UtxoProofFn
+
+      -- * Per-endpoint proof envelopes
+    , ProofEnvelope (..)
+    , BootProof (..)
+    , RequestProof (..)
+    , RetractProof (..)
+    , RejectProof (..)
+    , EndProof (..)
+    , UpdateProof (..)
     ) where
 
 import Data.ByteString (ByteString)
@@ -38,15 +57,18 @@ import Cardano.MPFS.Core.Types
 
 -- | Interface for constructing proof-bearing
 -- transactions for all MPFS protocol operations.
--- Every method takes the 'BundleSnapshot' that the
--- caller has already resolved so the returned
--- 'UnsignedTxBundle' bakes in a verified root and
--- indexed chain point.
+--
+-- Every method takes the 'BundleSnapshot' the caller
+-- has already resolved, so the returned envelope bakes
+-- in a verified UTxO root and indexed chain point. The
+-- result type is endpoint-specific: each proof shape
+-- names the roles its inputs play, and the set of
+-- 'witnessedRef's covers every @txIn@ of 'envTx'.
 data TxBuilder m = TxBuilder
     { bootToken
         :: BundleSnapshot
         -> Addr
-        -> m UnsignedTxBundle
+        -> m (ProofEnvelope BootProof)
     -- ^ Create a new MPFS token
     , requestInsert
         :: BundleSnapshot
@@ -54,7 +76,7 @@ data TxBuilder m = TxBuilder
         -> ByteString
         -> ByteString
         -> Addr
-        -> m UnsignedTxBundle
+        -> m (ProofEnvelope RequestProof)
     -- ^ Request inserting a key-value pair
     , requestDelete
         :: BundleSnapshot
@@ -62,7 +84,7 @@ data TxBuilder m = TxBuilder
         -> ByteString
         -> ByteString
         -> Addr
-        -> m UnsignedTxBundle
+        -> m (ProofEnvelope RequestProof)
     -- ^ Request deleting a key (key, old value)
     , requestUpdate
         :: BundleSnapshot
@@ -71,66 +93,38 @@ data TxBuilder m = TxBuilder
         -> ByteString
         -> ByteString
         -> Addr
-        -> m UnsignedTxBundle
+        -> m (ProofEnvelope RequestProof)
     -- ^ Request updating a key (key, old val, new val)
     , updateToken
         :: BundleSnapshot
         -> TokenId
         -> Addr
-        -> m UnsignedTxBundle
+        -> m (ProofEnvelope UpdateProof)
     -- ^ Process pending requests for a token
     , retractRequest
         :: BundleSnapshot
         -> TxIn
         -> Addr
-        -> m UnsignedTxBundle
+        -> m (ProofEnvelope RetractProof)
     -- ^ Cancel a pending request
     , rejectRequests
         :: BundleSnapshot
         -> TokenId
         -> Addr
-        -> m UnsignedTxBundle
+        -> m (ProofEnvelope RejectProof)
     -- ^ Reject Phase 3 requests for a token
     , endToken
         :: BundleSnapshot
         -> TokenId
         -> Addr
-        -> m UnsignedTxBundle
+        -> m (ProofEnvelope EndProof)
     -- ^ Retire an MPFS token
     }
 
--- | Proof-bearing unsigned-transaction bundle.
---
--- The output of a proof-carrying tx builder. A client
--- verifies the bundle offline by checking that every
--- consumed input's 'WitnessedInput' and every
--- 'TrieFact' resolves against the bundle's
--- 'BundleSnapshot' root, then re-derives that
--- 'bundleTx' is the unique transaction implied by
--- those witnesses.
---
--- Ledger-native: 'bundleTx' is a full Conway-era
--- 'Tx' and 'WitnessedInput' references ledger 'TxIn'
--- and serialized 'TxOut' CBOR. Serialization for the
--- HTTP boundary lives in "Cardano.MPFS.HTTP.Types".
-data UnsignedTxBundle = UnsignedTxBundle
-    { bundleTx :: Tx ConwayEra
-    -- ^ Unsigned transaction ready for key witnesses
-    , bundleSnapshot :: BundleSnapshot
-    -- ^ UTxO-CSMT root and chain point the bundle
-    -- was built against
-    , bundleInputs :: [WitnessedInput]
-    -- ^ Every consumed input with its UTxO-CSMT
-    -- inclusion proof against 'bundleSnapshot'
-    , bundleFacts :: [TrieFact]
-    -- ^ Trie facts the builder relied on; empty for
-    -- endpoints that consume no trie state
-    }
-
--- | Indexed snapshot a bundle's proofs verify
--- against. Matches the shape of the HTTP-level
--- @VerificationSnapshot@ but carries raw bytes rather
--- than hex-wrapped JSON values.
+-- | Indexed snapshot every proof in an envelope
+-- verifies against. Matches the shape of the
+-- HTTP-level @VerificationSnapshot@ but carries raw
+-- bytes rather than hex-wrapped JSON values.
 data BundleSnapshot = BundleSnapshot
     { snapshotUtxoRoot :: ByteString
     -- ^ UTxO-CSMT Merkle root (raw bytes)
@@ -143,6 +137,12 @@ data BundleSnapshot = BundleSnapshot
 
 -- | A consumed input with its UTxO-CSMT inclusion
 -- proof against 'snapshotUtxoRoot'.
+--
+-- The leaf is @hash (witnessedRef, witnessedTxOut)@,
+-- so re-deriving 'snapshotUtxoRoot' along
+-- 'witnessedCsmtProof' both proves the UTxO was in
+-- the indexed set and binds that specific 'TxIn' to
+-- the snapshot.
 data WitnessedInput = WitnessedInput
     { witnessedRef :: TxIn
     -- ^ The spent input's reference
@@ -153,9 +153,19 @@ data WitnessedInput = WitnessedInput
     }
     deriving (Eq, Show)
 
--- | A trie fact the builder depended on. Surfaces
--- for trie-dependent endpoints so clients can verify
--- the MPF claim alongside the consumed UTxOs.
+-- | Effectful CSMT proof lookup used by the real
+-- builders to bind every witnessed input to the
+-- current UTxO-CSMT root. 'Nothing' means the indexer
+-- does not (yet) know about the input — the verifier
+-- will reject the resulting envelope.
+type UtxoProofFn = TxIn -> IO (Maybe ByteString)
+
+-- | A trie fact the builder depended on. Produced by
+-- endpoints that read from the MPF trie behind a
+-- token's state (currently only batched
+-- @POST \/tx\/update@). Each fact is an MPF proof
+-- against the trie root encoded in the consumed state
+-- datum, not against 'snapshotUtxoRoot'.
 data TrieFact = TrieFact
     { factKey :: ByteString
     -- ^ Trie key the builder looked up
@@ -168,17 +178,101 @@ data TrieFact = TrieFact
     }
     deriving (Eq, Show)
 
--- | Wrap a bare unsigned 'Tx' as a proof-bearing
--- bundle with no bundled inputs or facts. Used by
--- migration steps that have not yet produced
--- witnesses, and by tests that only care about the
--- tx body.
-bareTxBundle
-    :: BundleSnapshot -> Tx ConwayEra -> UnsignedTxBundle
-bareTxBundle snap tx =
-    UnsignedTxBundle
-        { bundleTx = tx
-        , bundleSnapshot = snap
-        , bundleInputs = []
-        , bundleFacts = []
-        }
+-- | Envelope wrapping a tx and its snapshot around an
+-- endpoint-specific proof payload.
+--
+-- The type parameter @p@ selects the proof shape, and
+-- with it the verifier's fixed-shape traversal.
+data ProofEnvelope p = ProofEnvelope
+    { envTx :: Tx ConwayEra
+    -- ^ Unsigned transaction ready for key witnesses
+    , envSnapshot :: BundleSnapshot
+    -- ^ UTxO-CSMT root and chain point all proofs in
+    -- 'envProof' verify against
+    , envProof :: p
+    -- ^ Endpoint-specific proof payload
+    }
+
+-- | Proof payload for @POST \/tx\/boot@. Boot mints a
+-- fresh state UTxO, so there is no state input — only
+-- wallet inputs that fund the minimum ada and fees.
+newtype BootProof = BootProof
+    { bootFunding :: [WitnessedInput]
+    -- ^ Wallet inputs funding the boot tx
+    }
+    deriving (Eq, Show)
+
+-- | Proof payload for
+-- @POST \/tx\/request\/{insert,delete,update}@. The
+-- request tx does not consume or reference the state
+-- UTxO: it only spends wallet inputs and creates a
+-- fresh pending-request output. Tip consistency with
+-- the token's state is verified off-band against
+-- @GET \/tokens\/:id@.
+newtype RequestProof = RequestProof
+    { requestFunding :: [WitnessedInput]
+    -- ^ Wallet inputs funding the request tx
+    }
+    deriving (Eq, Show)
+
+-- | Proof payload for @POST \/tx\/retract@. Consumes
+-- the caller's pending-request UTxO and references
+-- (read-only) the token's state UTxO for its
+-- @process_time@\/@retract_time@ window.
+data RetractProof = RetractProof
+    { retractRequestIn :: WitnessedInput
+    -- ^ The pending-request UTxO being retracted
+    , retractStateRef :: WitnessedInput
+    -- ^ The state UTxO referenced for its timing
+    -- parameters
+    , retractFunding :: [WitnessedInput]
+    -- ^ Wallet inputs covering fees
+    }
+    deriving (Eq, Show)
+
+-- | Proof payload for @POST \/tx\/reject@. Consumes
+-- the state UTxO plus every pending-request UTxO
+-- currently rejected for that token.
+data RejectProof = RejectProof
+    { rejectState :: WitnessedInput
+    -- ^ The consumed state UTxO
+    , rejectRequestIns :: [WitnessedInput]
+    -- ^ The pending-request UTxOs being rejected
+    , rejectFunding :: [WitnessedInput]
+    -- ^ Wallet inputs covering fees
+    }
+    deriving (Eq, Show)
+
+-- | Proof payload for @POST \/tx\/end@. Burns the
+-- token and settles the state UTxO's value to the
+-- caller.
+data EndProof = EndProof
+    { endState :: WitnessedInput
+    -- ^ The consumed state UTxO
+    , endFunding :: [WitnessedInput]
+    -- ^ Wallet inputs covering fees
+    }
+    deriving (Eq, Show)
+
+-- | Proof payload for @POST \/tx\/update@. Consumes
+-- the state UTxO, batches in pending-request UTxOs,
+-- and carries MPF proofs for every trie key touched
+-- during batch application.
+--
+-- The 'updateTrieRoot' must match the trie root
+-- encoded in 'updateState'\''s datum; each
+-- 'updateTrieRead' then verifies against it.
+data UpdateProof = UpdateProof
+    { updateState :: WitnessedInput
+    -- ^ The consumed state UTxO
+    , updateRequests :: [WitnessedInput]
+    -- ^ Pending-request UTxOs batched into this update
+    , updateFunding :: [WitnessedInput]
+    -- ^ Wallet inputs covering fees
+    , updateTrieRoot :: ByteString
+    -- ^ Trie root from 'updateState'\''s datum
+    , updateTrieRead :: [TrieFact]
+    -- ^ MPF proofs for each key touched during batch
+    -- application, rooted at 'updateTrieRoot'
+    }
+    deriving (Eq, Show)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
@@ -38,7 +38,10 @@ module Cardano.MPFS.TxBuilder.Real
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.State (State (..))
 import Cardano.MPFS.Trie (TrieManager (..))
-import Cardano.MPFS.TxBuilder (TxBuilder (..))
+import Cardano.MPFS.TxBuilder
+    ( TxBuilder (..)
+    , UtxoProofFn
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig
     )
@@ -86,21 +89,23 @@ mkRealTxBuilder
     -- ^ Token and request state
     -> TrieManager IO
     -- ^ Per-token trie manager
+    -> UtxoProofFn
+    -- ^ CSMT inclusion proof lookup
     -> TxBuilder IO
-mkRealTxBuilder cfg prov st tm =
+mkRealTxBuilder cfg prov st tm proofFn =
     TxBuilder
-        { bootToken = bootTokenImpl cfg prov
+        { bootToken = bootTokenImpl cfg prov proofFn
         , requestInsert =
-            requestInsertImpl cfg prov st
+            requestInsertImpl cfg prov st proofFn
         , requestDelete =
-            requestDeleteImpl cfg prov st
+            requestDeleteImpl cfg prov st proofFn
         , requestUpdate =
-            requestUpdateImpl cfg prov st
+            requestUpdateImpl cfg prov st proofFn
         , updateToken =
-            updateTokenImpl cfg prov st tm
+            updateTokenImpl cfg prov st tm proofFn
         , retractRequest =
-            retractRequestImpl cfg prov st
+            retractRequestImpl cfg prov st proofFn
         , rejectRequests =
-            rejectRequestsImpl cfg prov st
-        , endToken = endTokenImpl cfg prov
+            rejectRequestsImpl cfg prov st proofFn
+        , endToken = endTokenImpl cfg prov proofFn
         }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
@@ -71,9 +71,10 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder
-    ( BundleSnapshot
-    , UnsignedTxBundle
-    , bareTxBundle
+    ( BootProof (..)
+    , BundleSnapshot
+    , ProofEnvelope (..)
+    , UtxoProofFn
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -90,12 +91,14 @@ bootTokenImpl
     -- ^ Cage script config
     -> Provider IO
     -- ^ Blockchain query interface
+    -> UtxoProofFn
+    -- ^ CSMT inclusion proof lookup
     -> BundleSnapshot
     -- ^ Snapshot this bundle will be anchored to
     -> Addr
     -- ^ Owner address (receives change, owns the token)
-    -> IO UnsignedTxBundle
-bootTokenImpl cfg prov snap addr = do
+    -> IO (ProofEnvelope BootProof)
+bootTokenImpl cfg prov proofFn snap addr = do
     pp <- queryProtocolParams prov
     utxos <- queryUTxOs prov addr
     case utxos of
@@ -208,4 +211,15 @@ bootTokenImpl cfg prov snap addr = do
                     allInputUtxos
                     addr
                     tx
-            pure (bareTxBundle snap balanced)
+            fundingWitnesses <-
+                witnesses proofFn allInputUtxos
+            pure
+                ProofEnvelope
+                    { envTx = balanced
+                    , envSnapshot = snap
+                    , envProof =
+                        BootProof
+                            { bootFunding =
+                                fundingWitnesses
+                            }
+                    }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
@@ -59,8 +59,9 @@ import Cardano.MPFS.Core.Types
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot
-    , UnsignedTxBundle
-    , bareTxBundle
+    , EndProof (..)
+    , ProofEnvelope (..)
+    , UtxoProofFn
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -84,14 +85,16 @@ endTokenImpl
     -- ^ Cage script config
     -> Provider IO
     -- ^ Blockchain query interface
+    -> UtxoProofFn
+    -- ^ CSMT inclusion proof lookup
     -> BundleSnapshot
     -- ^ Snapshot this bundle will be anchored to
     -> TokenId
     -- ^ Token to retire
     -> Addr
     -- ^ Fee-paying address (receives remaining ADA)
-    -> IO UnsignedTxBundle
-endTokenImpl cfg prov snap tid addr = do
+    -> IO (ProofEnvelope EndProof)
+endTokenImpl cfg prov proofFn snap tid addr = do
     -- 1. Query cage UTxOs
     let scriptAddr =
             cageAddrFromCfg cfg (network cfg)
@@ -187,4 +190,15 @@ endTokenImpl cfg prov snap tid addr = do
             [feeUtxo, stateUtxo]
             addr
             tx
-    pure (bareTxBundle snap balanced)
+    stateWitness <- witness proofFn stateUtxo
+    fundingWitnesses <- witnesses proofFn [feeUtxo]
+    pure
+        ProofEnvelope
+            { envTx = balanced
+            , envSnapshot = snap
+            , envProof =
+                EndProof
+                    { endState = stateWitness
+                    , endFunding = fundingWitnesses
+                    }
+            }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
@@ -61,12 +61,17 @@ module Cardano.MPFS.TxBuilder.Real.Internal
 
       -- * Refund computation
     , computeRefund
+
+      -- * CSMT-backed witness construction
+    , witness
+    , witnesses
     ) where
 
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Data.Word (Word32)
 import Lens.Micro ((&), (.~), (^.))
@@ -123,6 +128,10 @@ import Cardano.Ledger.BaseTypes
     , StrictMaybe
     , TxIx (..)
     )
+import Cardano.Ledger.Binary
+    ( natVersion
+    , serialize'
+    )
 import Cardano.Ledger.Core
     ( Script
     , extractHash
@@ -178,6 +187,10 @@ import Control.Exception (SomeException, try)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 
 import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.TxBuilder
+    ( UtxoProofFn
+    , WitnessedInput (..)
+    )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
@@ -633,3 +646,30 @@ computeRefund pp net tipAmount perReqFee reqOut =
     in  mkBasicTxOut
             refundAddr
             (inject (max rawRefund minCoin))
+
+-- | Wrap a @(TxIn, TxOut)@ pair as a 'WitnessedInput',
+-- pulling the CSMT inclusion proof from the indexer
+-- via the injected 'UtxoProofFn'. A missing proof
+-- becomes @BS.empty@; the downstream verifier rejects
+-- that case.
+witness
+    :: UtxoProofFn
+    -> (TxIn, TxOut ConwayEra)
+    -> IO WitnessedInput
+witness proofFn (tin, tout) = do
+    mProof <- proofFn tin
+    pure
+        WitnessedInput
+            { witnessedRef = tin
+            , witnessedTxOut =
+                serialize' (natVersion @11) tout
+            , witnessedCsmtProof =
+                fromMaybe BS.empty mProof
+            }
+
+-- | List version of 'witness'.
+witnesses
+    :: UtxoProofFn
+    -> [(TxIn, TxOut ConwayEra)]
+    -> IO [WitnessedInput]
+witnesses proofFn = traverse (witness proofFn)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
@@ -84,8 +84,9 @@ import Cardano.MPFS.Provider
 import Cardano.MPFS.State (State (..))
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot
-    , UnsignedTxBundle
-    , bareTxBundle
+    , ProofEnvelope (..)
+    , RejectProof (..)
+    , UtxoProofFn
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -109,11 +110,12 @@ rejectRequestsImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> UtxoProofFn
     -> BundleSnapshot
     -> TokenId
     -> Addr
-    -> IO UnsignedTxBundle
-rejectRequestsImpl cfg prov _st snap tid addr = do
+    -> IO (ProofEnvelope RejectProof)
+rejectRequestsImpl cfg prov _st proofFn snap tid addr = do
     -- 1. Query on-chain context
     (stateUtxo, reqUtxos, feeUtxo, pp) <-
         queryRejectContext cfg prov tid addr
@@ -147,7 +149,24 @@ rejectRequestsImpl cfg prov _st snap tid addr = do
             addr
             (prog :: Tx.TxBuild NoCtx Void ())
     case result of
-        Right tx -> pure (bareTxBundle snap tx)
+        Right tx -> do
+            stateWitness <- witness proofFn stateUtxo
+            reqWitnesses <- witnesses proofFn reqUtxos
+            fundingWitnesses <-
+                witnesses proofFn [feeUtxo]
+            pure
+                ProofEnvelope
+                    { envTx = tx
+                    , envSnapshot = snap
+                    , envProof =
+                        RejectProof
+                            { rejectState = stateWitness
+                            , rejectRequestIns =
+                                reqWitnesses
+                            , rejectFunding =
+                                fundingWitnesses
+                            }
+                    }
         Left err ->
             error
                 $ "rejectRequests: build failed: "

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -55,8 +55,9 @@ import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.State (State (..), Tokens (..))
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot
-    , UnsignedTxBundle
-    , bareTxBundle
+    , ProofEnvelope (..)
+    , RequestProof (..)
+    , UtxoProofFn
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -72,6 +73,7 @@ requestInsertImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> UtxoProofFn
     -> BundleSnapshot
     -> TokenId
     -> ByteString
@@ -79,12 +81,13 @@ requestInsertImpl
     -> ByteString
     -- ^ Value to insert
     -> Addr
-    -> IO UnsignedTxBundle
-requestInsertImpl cfg prov st snap tid key value =
+    -> IO (ProofEnvelope RequestProof)
+requestInsertImpl cfg prov st proofFn snap tid key value =
     requestImpl
         cfg
         prov
         st
+        proofFn
         snap
         tid
         key
@@ -95,6 +98,7 @@ requestDeleteImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> UtxoProofFn
     -> BundleSnapshot
     -> TokenId
     -> ByteString
@@ -102,12 +106,13 @@ requestDeleteImpl
     -> ByteString
     -- ^ Old value (for on-chain proof)
     -> Addr
-    -> IO UnsignedTxBundle
-requestDeleteImpl cfg prov st snap tid key val =
+    -> IO (ProofEnvelope RequestProof)
+requestDeleteImpl cfg prov st proofFn snap tid key val =
     requestImpl
         cfg
         prov
         st
+        proofFn
         snap
         tid
         key
@@ -118,6 +123,7 @@ requestUpdateImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> UtxoProofFn
     -> BundleSnapshot
     -> TokenId
     -> ByteString
@@ -127,11 +133,12 @@ requestUpdateImpl
     -> ByteString
     -- ^ New value
     -> Addr
-    -> IO UnsignedTxBundle
+    -> IO (ProofEnvelope RequestProof)
 requestUpdateImpl
     cfg
     prov
     st
+    proofFn
     snap
     tid
     key
@@ -141,6 +148,7 @@ requestUpdateImpl
             cfg
             prov
             st
+            proofFn
             snap
             tid
             key
@@ -159,6 +167,7 @@ requestImpl
     :: CageConfig
     -> Provider IO
     -> State IO
+    -> UtxoProofFn
     -> BundleSnapshot
     -> TokenId
     -> ByteString
@@ -167,8 +176,8 @@ requestImpl
     -- ^ Insert, Delete, or Update
     -> Addr
     -- ^ Requester's address
-    -> IO UnsignedTxBundle
-requestImpl cfg prov st snap tid key op addr = do
+    -> IO (ProofEnvelope RequestProof)
+requestImpl cfg prov st proofFn snap tid key op addr = do
     mTs <- getToken (tokens st) tid
     LocatedTokenState
         { tokenState = TokenState{tip = Coin mf}
@@ -218,8 +227,19 @@ requestImpl cfg prov st snap tid key op addr = do
         Left err ->
             error
                 $ "requestImpl: " <> show err
-        Right br ->
-            pure (bareTxBundle snap (balancedTx br))
+        Right br -> do
+            fundingWitnesses <-
+                witnesses proofFn [feeUtxo]
+            pure
+                ProofEnvelope
+                    { envTx = balancedTx br
+                    , envSnapshot = snap
+                    , envProof =
+                        RequestProof
+                            { requestFunding =
+                                fundingWitnesses
+                            }
+                    }
 
 -- | Compute the ADA to lock in a request output.
 --

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
@@ -74,8 +74,9 @@ import Cardano.MPFS.State
     )
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot
-    , UnsignedTxBundle
-    , bareTxBundle
+    , ProofEnvelope (..)
+    , RetractProof (..)
+    , UtxoProofFn
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -97,14 +98,16 @@ retractRequestImpl
     -- ^ Blockchain query interface
     -> State IO
     -- ^ Request state (to look up the request)
+    -> UtxoProofFn
+    -- ^ CSMT inclusion proof lookup
     -> BundleSnapshot
     -- ^ Snapshot this bundle will be anchored to
     -> TxIn
     -- ^ UTxO reference of the request to retract
     -> Addr
     -- ^ Requester's address (receives refund)
-    -> IO UnsignedTxBundle
-retractRequestImpl cfg prov st snap reqTxIn addr = do
+    -> IO (ProofEnvelope RetractProof)
+retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
     -- 1. Look up the request to find its token
     mReq <- getRequest (requests st) reqTxIn
     req <- case mReq of
@@ -235,4 +238,17 @@ retractRequestImpl cfg prov st snap reqTxIn addr = do
             [feeUtxo, reqUtxoPair]
             addr
             tx
-    pure (bareTxBundle snap balanced)
+    reqWitness <- witness proofFn reqUtxoPair
+    stateWitness <- witness proofFn stateUtxo
+    fundingWitnesses <- witnesses proofFn [feeUtxo]
+    pure
+        ProofEnvelope
+            { envTx = balanced
+            , envSnapshot = snap
+            , envProof =
+                RetractProof
+                    { retractRequestIn = reqWitness
+                    , retractStateRef = stateWitness
+                    , retractFunding = fundingWitnesses
+                    }
+            }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -103,8 +103,9 @@ import Cardano.MPFS.Trie
     )
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot
-    , UnsignedTxBundle
-    , bareTxBundle
+    , ProofEnvelope (..)
+    , UpdateProof (..)
+    , UtxoProofFn
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -126,15 +127,24 @@ updateTokenImpl
     -> Provider IO
     -> State IO
     -> TrieManager IO
+    -> UtxoProofFn
     -> BundleSnapshot
     -> TokenId
     -> Addr
-    -> IO UnsignedTxBundle
-updateTokenImpl cfg prov _st tm snap tid addr = do
+    -> IO (ProofEnvelope UpdateProof)
+updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
     -- 1. Query on-chain context
     (stateUtxo, reqUtxos, feeUtxo, pp) <-
         queryContext cfg prov tid addr
     let (stateIn, stateOut) = stateUtxo
+        oldRootBytes =
+            case extractCageDatum stateOut of
+                Just (StateDatum s) ->
+                    unOnChainRoot (stateRoot s)
+                _ ->
+                    error
+                        "updateToken: invalid \
+                        \state datum (root)"
     -- 2. Compute proofs via speculative trie
     (proofs, newRoot) <-
         computeProofs tm tid reqUtxos
@@ -173,6 +183,10 @@ updateTokenImpl cfg prov _st tm snap tid addr = do
             (prog :: Tx.TxBuild NoCtx Void ())
     case result of
         Right tx -> do
+            stateWitness <- witness proofFn stateUtxo
+            reqWitnesses <- witnesses proofFn reqUtxos
+            fundingWitnesses <-
+                witnesses proofFn [feeUtxo]
             let Coin fee =
                     tx ^. bodyTxL . feeTxBodyL
                 unsignedSize =
@@ -216,7 +230,20 @@ updateTokenImpl cfg prov _st tm snap tid addr = do
                     <> " getMinFee(0)="
                     <> show getMin
                     <> "\n"
-            pure (bareTxBundle snap tx)
+            pure
+                ProofEnvelope
+                    { envTx = tx
+                    , envSnapshot = snap
+                    , envProof =
+                        UpdateProof
+                            { updateState = stateWitness
+                            , updateRequests = reqWitnesses
+                            , updateFunding = fundingWitnesses
+                            , updateTrieRoot =
+                                oldRootBytes
+                            , updateTrieRead = []
+                            }
+                    }
         Left err ->
             error
                 $ "updateToken: build failed: "

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -5,6 +5,7 @@
 
 module Cardano.MPFS.TxBuilderSpec (spec) where
 
+import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
 import Data.Foldable (for_)
@@ -149,9 +150,9 @@ import Cardano.MPFS.Trie.PureManager
     )
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
+    , ProofEnvelope (..)
+    , RequestProof (..)
     , TxBuilder (..)
-    , UnsignedTxBundle (..)
-    , bareTxBundle
     )
 import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
 import Cardano.MPFS.TxBuilder.Real
@@ -235,6 +236,12 @@ mkTestProvider utxos =
         , posixMsToSlot = \_ -> pure (SlotNo 0)
         , posixMsCeilSlot = \_ -> pure (SlotNo 0)
         }
+
+-- | Dummy CSMT proof function that always returns
+-- 'Nothing'. Test 'mkRealTxBuilder' call sites don't
+-- exercise proof content; they only verify tx shape.
+dummyProofFn :: TxIn -> IO (Maybe ByteString)
+dummyProofFn _ = pure Nothing
 
 -- | Dummy TrieManager that errors on use.
 dummyTrieManager :: TrieManager IO
@@ -481,20 +488,20 @@ cageIdentitySpec =
                         "expected Addr, got Bootstrap"
 
 -- ---------------------------------------------------------
--- UnsignedTxBundle shape
+-- ProofEnvelope shape
 -- ---------------------------------------------------------
 
--- | Shape tests for the proof-bearing bundle plumbing.
--- Builders currently return 'bareTxBundle'-wrapped
--- transactions; the dedicated input\/fact witnesses
--- will be populated in later slices.
+-- | Shape tests for the per-endpoint proof envelope
+-- plumbing. Builders return an endpoint-specific
+-- 'ProofEnvelope'; 'witnessedCsmtProof' is stubbed
+-- empty until the UTxO-CSMT view is wired through.
 bundleShapeSpec :: Spec
 bundleShapeSpec =
-    describe "UnsignedTxBundle" $ do
-        it "bareTxBundle preserves the wrapped tx" $ do
+    describe "ProofEnvelope" $ do
+        it "envelope carries the snapshot" $ do
             (_, _, builder, _) <- mkTestFixture
             let feeAddr = testAddr testKh
-            bundle <-
+            env <-
                 requestInsert
                     builder
                     testSnap
@@ -502,33 +509,15 @@ bundleShapeSpec =
                     "mykey"
                     "myvalue"
                     feeAddr
-            let bare =
-                    bareTxBundle
-                        (bundleSnapshot bundle)
-                        (bundleTx bundle)
-            bundleTx bare
-                `shouldBe` bundleTx bundle
-
-        it "builder bundle carries the snapshot" $ do
-            (_, _, builder, _) <- mkTestFixture
-            let feeAddr = testAddr testKh
-            bundle <-
-                requestInsert
-                    builder
-                    testSnap
-                    testTid
-                    "mykey"
-                    "myvalue"
-                    feeAddr
-            snapshotUtxoRoot (bundleSnapshot bundle)
+            snapshotUtxoRoot (envSnapshot env)
                 `shouldBe` snapshotUtxoRoot testSnap
-            snapshotSlot (bundleSnapshot bundle)
+            snapshotSlot (envSnapshot env)
                 `shouldBe` snapshotSlot testSnap
 
-        it "builder bundle has no witnesses yet" $ do
+        it "request envelope lists funding inputs" $ do
             (_, _, builder, _) <- mkTestFixture
             let feeAddr = testAddr testKh
-            bundle <-
+            env <-
                 requestInsert
                     builder
                     testSnap
@@ -536,8 +525,8 @@ bundleShapeSpec =
                     "mykey"
                     "myvalue"
                     feeAddr
-            bundleInputs bundle `shouldSatisfy` null
-            bundleFacts bundle `shouldSatisfy` null
+            requestFunding (envProof env)
+                `shouldSatisfy` (not . null)
 
 -- ---------------------------------------------------------
 -- requestInsert
@@ -1757,14 +1746,14 @@ runRequestInsertWith = do
             "mykey"
             "myvalue"
             feeAddr
-    pure (bundleTx bundle, txIn)
+    pure (envTx bundle, txIn)
 
 -- | Set up state + provider, run requestDelete.
 runRequestDelete :: IO (Tx ConwayEra)
 runRequestDelete = do
     (_st, _prov, builder, _txIn) <- mkTestFixture
     let feeAddr = testAddr testKh
-    bundleTx
+    envTx
         <$> requestDelete
             builder
             testSnap
@@ -1835,9 +1824,10 @@ runRetractRequestWith = do
                 prov
                 st
                 dummyTrieManager
+                dummyProofFn
     bundle <-
         retractRequest builder testSnap reqIn feeAddr
-    pure (bundleTx bundle, reqIn, stateIn)
+    pure (envTx bundle, reqIn, stateIn)
 
 -- | Run updateToken.
 runUpdateToken :: IO (Tx ConwayEra)
@@ -1897,9 +1887,10 @@ runUpdateTokenWith = do
                 prov
                 st
                 trieManager
+                dummyProofFn
     bundle <-
         updateToken builder testSnap testTid feeAddr
-    pure (bundleTx bundle, stateIn, reqIn)
+    pure (envTx bundle, stateIn, reqIn)
 
 -- | Run endToken.
 runEndToken :: IO (Tx ConwayEra)
@@ -1944,8 +1935,9 @@ runEndTokenWith = do
                 prov
                 st
                 dummyTrieManager
+                dummyProofFn
     bundle <- endToken builder testSnap testTid feeAddr
-    pure (bundleTx bundle, stateIn)
+    pure (envTx bundle, stateIn)
 
 -- | Run bootToken with a given CageConfig.
 runBootToken :: CageConfig -> IO (Tx ConwayEra)
@@ -1971,7 +1963,8 @@ runBootToken cfg = do
                 prov
                 st
                 dummyTrieManager
-    bundleTx <$> bootToken builder testSnap feeAddr
+                dummyProofFn
+    envTx <$> bootToken builder testSnap feeAddr
 
 -- | Token ID used across tests.
 testTid :: TokenId
@@ -2006,6 +1999,7 @@ mkTestFixture = do
                 prov
                 st
                 dummyTrieManager
+                dummyProofFn
     pure (st, prov, builder, txIn)
 
 -- ---------------------------------------------------------
@@ -2046,6 +2040,7 @@ mkRealisticFixture = do
                 prov
                 st
                 dummyTrieManager
+                dummyProofFn
     pure (st, prov, builder, txIn)
 
 -- | Run requestInsert with realistic PParams.
@@ -2070,7 +2065,7 @@ runRealisticRequestInsertWith = do
             "mykey"
             "myvalue"
             feeAddr
-    pure (bundleTx bundle, txIn)
+    pure (envTx bundle, txIn)
 
 -- | Run updateToken with realistic PParams.
 runRealisticUpdate :: IO (Tx ConwayEra)
@@ -2127,9 +2122,10 @@ runRealisticUpdateWith = do
                 prov
                 st
                 trieManager
+                dummyProofFn
     bundle <-
         updateToken builder testSnap testTid feeAddr
-    pure (bundleTx bundle, stateIn, reqIn)
+    pure (envTx bundle, stateIn, reqIn)
 
 -- | Run updateToken with tight request locked ADA.
 -- The request UTxO has the minimum locked ADA
@@ -2184,7 +2180,8 @@ runTightUpdate = do
                 prov
                 st
                 trieManager
-    bundleTx
+                dummyProofFn
+    envTx
         <$> updateToken builder testSnap testTid feeAddr
 
 -- | Run retractRequest with realistic PParams
@@ -2241,9 +2238,10 @@ runRealisticRetractWith = do
                 prov
                 st
                 dummyTrieManager
+                dummyProofFn
     bundle <-
         retractRequest builder testSnap reqIn feeAddr
-    pure (bundleTx bundle, reqIn, stateIn)
+    pure (envTx bundle, reqIn, stateIn)
 
 -- | Run endToken with realistic PParams.
 runRealisticEnd :: IO (Tx ConwayEra)
@@ -2290,8 +2288,9 @@ runRealisticEndWith = do
                 prov
                 st
                 dummyTrieManager
+                dummyProofFn
     bundle <- endToken builder testSnap testTid feeAddr
-    pure (bundleTx bundle, stateIn)
+    pure (envTx bundle, stateIn)
 
 -- | Run bootToken with realistic PParams.
 runRealisticBootToken
@@ -2318,7 +2317,8 @@ runRealisticBootToken cfg = do
                 prov
                 st
                 dummyTrieManager
-    bundleTx <$> bootToken builder testSnap feeAddr
+                dummyProofFn
+    envTx <$> bootToken builder testSnap feeAddr
 
 -- | Run rejectRequests with mock expired request.
 -- The request has submittedAt=0, processTime=300s,
@@ -2364,5 +2364,6 @@ runRejectRequests = do
                 prov
                 st
                 trieManager
-    bundleTx
+                dummyProofFn
+    envTx
         <$> rejectRequests builder testSnap testTid feeAddr

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -1,5 +1,20 @@
 {
     "definitions": {
+        "BootProofJSON": {
+            "description": "Proof payload for POST /tx/boot",
+            "properties": {
+                "funding": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedUtxo"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "funding"
+            ],
+            "type": "object"
+        },
         "BootRequest": {
             "description": "Boot a new token",
             "properties": {
@@ -9,6 +24,26 @@
             },
             "required": [
                 "address"
+            ],
+            "type": "object"
+        },
+        "BootTxResponse": {
+            "description": "Proof-bearing response for POST /tx/boot",
+            "properties": {
+                "proof": {
+                    "$ref": "#/definitions/BootProofJSON"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "tx": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "tx",
+                "snapshot",
+                "proof"
             ],
             "type": "object"
         },
@@ -55,6 +90,25 @@
             ],
             "type": "object"
         },
+        "EndProofJSON": {
+            "description": "Proof payload for POST /tx/end",
+            "properties": {
+                "funding": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedUtxo"
+                    },
+                    "type": "array"
+                },
+                "state": {
+                    "$ref": "#/definitions/WitnessedUtxo"
+                }
+            },
+            "required": [
+                "state",
+                "funding"
+            ],
+            "type": "object"
+        },
         "EndRequest": {
             "description": "End a token",
             "properties": {
@@ -68,6 +122,26 @@
             "required": [
                 "token",
                 "address"
+            ],
+            "type": "object"
+        },
+        "EndTxResponse": {
+            "description": "Proof-bearing response for POST /tx/end",
+            "properties": {
+                "proof": {
+                    "$ref": "#/definitions/EndProofJSON"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "tx": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "tx",
+                "snapshot",
+                "proof"
             ],
             "type": "object"
         },
@@ -294,6 +368,32 @@
             ],
             "type": "object"
         },
+        "RejectProofJSON": {
+            "description": "Proof payload for POST /tx/reject",
+            "properties": {
+                "funding": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedUtxo"
+                    },
+                    "type": "array"
+                },
+                "request_ins": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedUtxo"
+                    },
+                    "type": "array"
+                },
+                "state": {
+                    "$ref": "#/definitions/WitnessedUtxo"
+                }
+            },
+            "required": [
+                "state",
+                "request_ins",
+                "funding"
+            ],
+            "type": "object"
+        },
         "RejectRequest": {
             "description": "Reject Phase 3 expired requests for a token",
             "properties": {
@@ -307,6 +407,26 @@
             "required": [
                 "token",
                 "address"
+            ],
+            "type": "object"
+        },
+        "RejectTxResponse": {
+            "description": "Proof-bearing response for POST /tx/reject",
+            "properties": {
+                "proof": {
+                    "$ref": "#/definitions/RejectProofJSON"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "tx": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "tx",
+                "snapshot",
+                "proof"
             ],
             "type": "object"
         },
@@ -345,6 +465,41 @@
             ],
             "type": "object"
         },
+        "RequestProofJSON": {
+            "description": "Proof payload for POST /tx/request/{insert,delete,update}",
+            "properties": {
+                "funding": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedUtxo"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "funding"
+            ],
+            "type": "object"
+        },
+        "RequestTxResponse": {
+            "description": "Proof-bearing response for POST /tx/request/{insert,delete,update}",
+            "properties": {
+                "proof": {
+                    "$ref": "#/definitions/RequestProofJSON"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "tx": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "tx",
+                "snapshot",
+                "proof"
+            ],
+            "type": "object"
+        },
         "RequestsResponse": {
             "description": "Proof-bearing pending requests response",
             "properties": {
@@ -364,6 +519,29 @@
             ],
             "type": "object"
         },
+        "RetractProofJSON": {
+            "description": "Proof payload for POST /tx/retract",
+            "properties": {
+                "funding": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedUtxo"
+                    },
+                    "type": "array"
+                },
+                "request_in": {
+                    "$ref": "#/definitions/WitnessedUtxo"
+                },
+                "state_ref": {
+                    "$ref": "#/definitions/WitnessedUtxo"
+                }
+            },
+            "required": [
+                "request_in",
+                "state_ref",
+                "funding"
+            ],
+            "type": "object"
+        },
         "RetractRequest": {
             "description": "Retract a pending request. UTxO format: txhash#ix",
             "properties": {
@@ -377,6 +555,26 @@
             "required": [
                 "utxo",
                 "address"
+            ],
+            "type": "object"
+        },
+        "RetractTxResponse": {
+            "description": "Proof-bearing response for POST /tx/retract",
+            "properties": {
+                "proof": {
+                    "$ref": "#/definitions/RetractProofJSON"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "tx": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "tx",
+                "snapshot",
+                "proof"
             ],
             "type": "object"
         },
@@ -484,6 +682,26 @@
             ],
             "type": "object"
         },
+        "TrieFactJSON": {
+            "description": "Trie read: key, optional value, and MPF proof against a trie root",
+            "properties": {
+                "key": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "mpf_proof": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "value": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "key",
+                "value",
+                "mpf_proof"
+            ],
+            "type": "object"
+        },
         "TxInJSON": {
             "description": "UTxO reference",
             "properties": {
@@ -503,6 +721,43 @@
             ],
             "type": "object"
         },
+        "UpdateProofJSON": {
+            "description": "Proof payload for POST /tx/update",
+            "properties": {
+                "funding": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedUtxo"
+                    },
+                    "type": "array"
+                },
+                "requests": {
+                    "items": {
+                        "$ref": "#/definitions/WitnessedUtxo"
+                    },
+                    "type": "array"
+                },
+                "state": {
+                    "$ref": "#/definitions/WitnessedUtxo"
+                },
+                "trie_read": {
+                    "items": {
+                        "$ref": "#/definitions/TrieFactJSON"
+                    },
+                    "type": "array"
+                },
+                "trie_root": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "state",
+                "requests",
+                "funding",
+                "trie_root",
+                "trie_read"
+            ],
+            "type": "object"
+        },
         "UpdateRequest": {
             "description": "Process pending requests",
             "properties": {
@@ -516,6 +771,26 @@
             "required": [
                 "token",
                 "address"
+            ],
+            "type": "object"
+        },
+        "UpdateTxResponse": {
+            "description": "Proof-bearing response for POST /tx/update",
+            "properties": {
+                "proof": {
+                    "$ref": "#/definitions/UpdateProofJSON"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "tx": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "tx",
+                "snapshot",
+                "proof"
             ],
             "type": "object"
         },
@@ -852,7 +1127,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/BootTxResponse"
                         }
                     },
                     "400": {
@@ -883,7 +1158,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/EndTxResponse"
                         }
                     },
                     "400": {
@@ -914,7 +1189,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/RejectTxResponse"
                         }
                     },
                     "400": {
@@ -945,7 +1220,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/RequestTxResponse"
                         }
                     },
                     "400": {
@@ -976,7 +1251,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/RequestTxResponse"
                         }
                     },
                     "400": {
@@ -1007,7 +1282,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/RequestTxResponse"
                         }
                     },
                     "400": {
@@ -1038,7 +1313,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/RetractTxResponse"
                         }
                     },
                     "400": {
@@ -1100,7 +1375,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/Hex"
+                            "$ref": "#/definitions/UpdateTxResponse"
                         }
                     },
                     "400": {

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -8,8 +8,7 @@ let
       lib.mkForce [ [ pkgs.libsodium-vrf ] ];
     packages.cardano-crypto-class.components.library.pkgconfig =
       lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ]];
-    packages.lzma.components.library.libs =
-      lib.mkForce [ pkgs.xz ];
+    packages.lzma.components.library.libs = lib.mkForce [ pkgs.xz ];
   };
   shell = { pkgs, ... }: {
     tools = {
@@ -74,23 +73,16 @@ in {
     project.hsPkgs.cardano-mpfs-offchain.components.tests.e2e-tests;
   packages.haddock = haddock;
   packages.cardano-mpfs-swagger =
-    project.hsPkgs.cardano-mpfs-offchain
-      .components
-      .exes
-      .cardano-mpfs-swagger;
-  checks.swagger-up-to-date =
-    pkgs.runCommand "swagger-up-to-date" { } ''
-      ${
-        pkgs.lib.getExe
-          project.hsPkgs.cardano-mpfs-offchain
-            .components
-            .exes
-            .cardano-mpfs-swagger
-      } > $TMPDIR/swagger.json
-      diff -u ${../docs/assets/swagger.json} \
-        $TMPDIR/swagger.json \
-        || (echo "swagger.json is stale — run: \
-just update-swagger" && exit 1)
-      touch $out
-    '';
+    project.hsPkgs.cardano-mpfs-offchain.components.exes.cardano-mpfs-swagger;
+  checks.swagger-up-to-date = pkgs.runCommand "swagger-up-to-date" { } ''
+          ${
+            pkgs.lib.getExe
+            project.hsPkgs.cardano-mpfs-offchain.components.exes.cardano-mpfs-swagger
+          } > $TMPDIR/swagger.json
+          diff -u ${../docs/assets/swagger.json} \
+            $TMPDIR/swagger.json \
+            || (echo "swagger.json is stale — run: \
+    just update-swagger" && exit 1)
+          touch $out
+  '';
 }

--- a/specs/177-proof-carrying-api/plan.md
+++ b/specs/177-proof-carrying-api/plan.md
@@ -151,14 +151,18 @@ response, extract `utxo_root` and `chainpoint`, and verify.
 ### Slice 3: Rich transaction builder boundary
 
 Replace the current `TxBuilder` return type of bare `Tx ConwayEra` with
-a proof-bearing bundle type that can carry:
+a first-cut proof-bearing bundle type that carries:
 
 - the unsigned transaction
 - the set of consumed inputs as witnessed UTxOs
 - baked-in `utxo_root` and indexed `chainpoint`
 - optional trie proof payloads for trie-dependent operations
 
-Update mocks and the top-level wiring in `TxBuilder/Real.hs`.
+Update mocks and the top-level wiring in `TxBuilder/Real.hs`. This
+slice landed as a flat `UnsignedTxBundle` with a single
+`bundleInputs :: [WitnessedInput]` field; slice 4 narrows that shape
+into per-endpoint proof records once the endpoint-specific roles
+(state, pending request, state reference, funding) are clear.
 
 **Files**: `TxBuilder.hs`, `TxBuilder/Real.hs`,
 `Mock/TxBuilder.hs`, `test/Cardano/MPFS/TxBuilderSpec.hs`
@@ -168,31 +172,65 @@ enough to reconstruct MPF proof intent or stable proof-to-request
 association for batched flows. It starts only after the read-side
 HTTP-client scenario is accepted.
 
-### Slice 4: Simple tx endpoints on the new bundle type
+### Slice 4: Per-endpoint proof shapes + WASM verifier + simple tx endpoints
 
-Migrate the tx endpoints that only need witnessed consumed inputs and,
-at most, minimal state context:
+This slice is structured as a typed vertical, not a flat migration.
+It lands three coupled changes behind one merge:
 
-- `POST /tx/boot`
-- `POST /tx/request/insert`
-- `POST /tx/request/delete`
-- `POST /tx/request/update`
-- `POST /tx/retract`
-- `POST /tx/reject`
-- `POST /tx/end`
+1. **Typed per-endpoint proof shapes** replace the flat bundle from
+   slice 3. `TxBuilder` methods return `ProofEnvelope p` where `p` is
+   one of `BootProof`, `RequestProof`, `RetractProof`, `RejectProof`,
+   or `EndProof`. Every `WitnessedInput` inside `p` has a named field
+   (state / requests / state reference / funding) that documents its
+   role, and the verifier walks those fields directly.
 
-Boot omits MPF sections entirely; the others include them only when the
-builder actually relies on trie/state facts that the client must trust.
-All of them still carry `utxo_root` and indexed `chainpoint`.
+2. **WASM-compatible client verifier**. `cardano-mpfs-client` gains a
+   pure-Haskell shallow `TxOut` decoder that extracts
+   `(address bytes, ada lovelace)` from Conway `TxOut` CBOR without
+   depending on `cardano-ledger-*` or any C FFI. A cross-check test
+   suite in `cardano-mpfs-offchain` proves the shallow decoder agrees
+   byte-for-byte with the authoritative ledger decoder across a dense
+   generator and a pinned regression corpus. This is the prerequisite
+   the #208 plan marks as a hard gate for slice 4 (see "Follow-up:
+   cross-compile spike for `cardano-mpfs-client`"): the verifier has
+   no right to exist until it can be cross-compiled to wallet runtimes
+   that cannot pull ledger.
 
-**Files**: `TxBuilder/Real/Boot.hs`,
-`TxBuilder/Real/Request.hs`,
-`TxBuilder/Real/Retract.hs`,
-`TxBuilder/Real/Reject.hs`,
-`TxBuilder/Real/End.hs`,
+3. **Simple tx endpoints on the new shapes**. The five endpoints below
+   migrate to the typed shapes, the new response schemas, and the
+   matching per-endpoint verifiers in `cardano-mpfs-client`:
+
+   - `POST /tx/boot`
+   - `POST /tx/request/insert`
+   - `POST /tx/request/delete`
+   - `POST /tx/request/update`
+   - `POST /tx/retract`
+   - `POST /tx/reject`
+   - `POST /tx/end`
+
+   Boot omits MPF sections entirely; the others include them only when
+   the builder actually relies on trie/state facts that the client must
+   trust. All of them carry `utxo_root` and indexed `chainpoint`.
+
+The slice opens with the shallow decoder and cross-check suite landing
+first (as the narrowest bisect-safe commit). The Real-impl updates then
+produce structurally valid proof payloads that thread through to the
+HTTP response schema and the client verifier. A stub E2E test walks
+each proof shape via the client verifier as soon as the shapes exist,
+so the "traverse the proof" scenario is demonstrated before any of the
+real CSMT proof bytes are wired through.
+
+**Files**: `TxBuilder.hs`, `TxBuilder/Real/Boot.hs`,
+`TxBuilder/Real/Request.hs`, `TxBuilder/Real/Retract.hs`,
+`TxBuilder/Real/Reject.hs`, `TxBuilder/Real/End.hs`,
 `HTTP/API.hs`, `HTTP/Types.hs`, `HTTP/Server.hs`,
+`cardano-mpfs-client/lib/Cardano/MPFS/Client/TxOut.hs`,
+`cardano-mpfs-client/lib/Cardano/MPFS/Client/Bundle.hs`,
+`cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs`,
+`test/Cardano/MPFS/Client/TxOutShallowSpec.hs`,
 `test/Cardano/MPFS/TxBuilderSpec.hs`,
-`e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs`
+`e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs`,
+`test/vectors/txout-regression-corpus/*.hex`
 
 ### Slice 5: `POST /tx/update` proof bundle
 
@@ -368,11 +406,54 @@ For this umbrella the Lean artifacts to land before slice 4 are:
 3. The fold theorem: `verify = foldM verifyNode utxoRoot bundle`
    accepts iff every nested check accepts.
 
+### Shallow `TxOut` decoder and cross-check test suite
+
+Full ledger-native decoding on the client is ruled out: the `TxOut`
+decoder inside `cardano-ledger-conway` transitively pulls
+`cardano-crypto-class`, which binds to `libsodium`, `blst`, and
+`secp256k1` via C FFI. None of those cross-compile to GHC-WASM or
+GHC-JS, and swapping or vendoring them for the verifier adds more
+attack surface than verifying the narrow slice of a `TxOut` we
+actually look at.
+
+The slice 4 answer is a shallow pure-Haskell decoder in
+`cardano-mpfs-client` that extracts only `(address bytes, ada)` from a
+Conway `TxOut` CBOR blob, plus a cross-check test suite in
+`cardano-mpfs-offchain` that proves the shallow decoder agrees
+byte-for-byte with the ledger decoder across the full Conway-era
+generator. This earns the decoder its keep: the server-side test has
+access to both decoders and asserts equality; the client ships only
+the shallow one.
+
+Test coverage:
+
+- **Generator**: every Shelley address shape (payment × stake =
+  KeyHash / ScriptHash / Pointer / absent), every value shape
+  (ada-only, ada + 1 asset, ada + N assets across M policies), every
+  datum variant (none, hash, short inline, long inline), and both
+  presence and absence of a reference script.
+- **Positive property**: for every generated `txOut`, the shallow
+  decoder on `serialize' (natVersion @11) txOut` returns the same
+  `(addr, ada)` pair as `(txOut ^. addrTxOutL, txOut ^. coinTxOutL)`.
+- **Negative property**: every truncated prefix of a valid CBOR blob
+  is rejected with `Left _` and never produces a `Right` or an
+  exception.
+- **Regression corpus**: pinned real hex blobs from preprod / mainnet
+  are re-decoded on every ledger dependency bump, so silent CBOR
+  layout drift fails CI rather than silently diverging verifier
+  behaviour.
+- **Run volume**: ≥ 1000 shrinks per property in CI.
+
+Acceptance: any mismatch blocks the client. We either fix the shallow
+decoder (widen its coverage) or discover an upstream ledger change
+that requires a release bump of the decoder spec. Silent divergence is
+not an option.
+
 ### Follow-up: cross-compile spike for `cardano-mpfs-client`
 
 Principle IX is currently aspirational for this repo — slice 2 ships a
 GHC-native verifier, but no WASM/JS build has been proven. Before
-slice 4 lands we MUST run a half-day spike that:
+slice 4 merges we MUST run a short spike that:
 
 - attempts a GHC-WASM build of `cardano-mpfs-client` end-to-end,
 - attempts the GHC-JS backend build of the same package,
@@ -382,8 +463,10 @@ slice 4 lands we MUST run a half-day spike that:
 
 This spike is a hard prerequisite for slices 4–6: if the verifier
 cannot be compiled to a wallet runtime, the proof-bearing tx
-endpoints have no client. Tracking issue to be filed under the #208
-umbrella.
+endpoints have no client. Because slice 4 introduces the shallow
+`TxOut` decoder inside `cardano-mpfs-client`, the spike also verifies
+that the decoder (and only pure-Haskell transitive deps) survives the
+cross-target matrix.
 
 ## Risks
 

--- a/specs/177-proof-carrying-api/spec.md
+++ b/specs/177-proof-carrying-api/spec.md
@@ -77,9 +77,11 @@ input, and every trie-dependent datum used by the builder.
 2. **Given** `POST /tx/request/insert`, `POST /tx/request/delete`,
    `POST /tx/request/update`, `POST /tx/retract`, `POST /tx/reject`, or
    `POST /tx/end`, **When** the client builds a transaction, **Then**
-   the response includes the unsigned transaction plus proof-bearing
-   input witnesses, `utxo_root`, and indexed `chainpoint` sufficient to
-   verify every consumed UTxO before signing.
+   the response includes the unsigned transaction plus a per-endpoint
+   proof shape that names each witnessed input's role (state, pending
+   request, state reference, or funding), the `utxo_root`, and the
+   indexed `chainpoint` sufficient to verify every consumed UTxO
+   before signing.
 3. **Given** `POST /tx/boot`, **When** the client builds the initial
    boot transaction, **Then** the response includes the unsigned
    transaction and proof-bearing witnesses for all consumed wallet
@@ -89,6 +91,18 @@ input, and every trie-dependent datum used by the builder.
    batch, **When** the response is returned, **Then** proofs remain
    associated with the exact inputs and logical request keys they
    justify.
+5. **Given** any proof-bearing transaction response, **When** the
+   client verifies the proof, **Then** the verification runs entirely in
+   pure Haskell inside `cardano-mpfs-client`, without any dependency on
+   `cardano-ledger-*` libraries, so the same verifier compiles to
+   GHC-WASM and GHC-JS per Constitution IX.
+6. **Given** the shallow `TxOut` decoder shipped inside
+   `cardano-mpfs-client`, **When** the cross-check test suite in the
+   server repo runs, **Then** the shallow decoder produces byte-
+   identical `(address, ada)` output to the authoritative
+   `cardano-ledger-conway` decoder across every generated TxOut and the
+   pinned regression corpus, and rejects every truncated prefix of a
+   valid CBOR blob.
 
 ---
 
@@ -199,6 +213,39 @@ that those values can be compared with `GET /status` and `GET /utxo/root`.
   endpoint that returns the same indexed UTxO-CSMT root as `GET /status`,
   so debugging and isolated deployments can use this service as the root
   source of truth even without a separate CSMT endpoint.
+- **FR-017**: Transaction-building endpoints MUST return per-endpoint
+  proof shapes whose named fields encode the role of every witnessed
+  input (state, pending request, state reference, funding). Flat
+  undifferentiated input lists are not acceptable. The endpoint URL is
+  the discriminator; no tagged-union wrapper is added to the JSON.
+- **FR-018**: `cardano-mpfs-client` MUST ship a pure-Haskell shallow
+  `TxOut` decoder that extracts at minimum the address bytes and the
+  ada (lovelace) amount from Conway-era `TxOut` CBOR. The decoder MUST
+  NOT depend on `cardano-ledger-*` or any C FFI, so the verifier stays
+  buildable with the GHC-WASM and GHC-JS backends per Constitution IX.
+- **FR-019**: A cross-check test suite in `cardano-mpfs-offchain` MUST
+  prove the shallow decoder agrees byte-for-byte with the authoritative
+  `cardano-ledger-conway` decoder. Generator coverage MUST include all
+  Shelley address shapes (payment × stake: KeyHash / ScriptHash / Pointer
+  / absent), all value shapes (ada-only, ada + single asset, ada + many
+  assets across many policies), all datum variants (no datum, datum
+  hash, short inline datum, long inline datum), and both presence and
+  absence of a reference script. The suite MUST also prove the shallow
+  decoder returns `Left` (never diverges or returns `Right`) for every
+  truncated prefix of a valid CBOR blob and for random bytes.
+- **FR-020**: A regression corpus of pinned real `TxOut` hex blobs
+  (preprod / mainnet observations) MUST live beside the cross-check
+  suite and be re-checked on every ledger dependency bump, so accidental
+  CBOR-layout drift across ledger versions fails CI rather than silently
+  diverging verifier behaviour.
+- **FR-021**: For every transaction-building endpoint in scope,
+  `cardano-mpfs-client` MUST expose a pure verifier whose shape is
+  `verify :: TrustedRoot -> ProofEnvelope p -> Either VerifyError ()`,
+  and the verifier MUST execute the documented per-endpoint check list
+  (snapshot well-formedness, snapshot freshness hook, inputs-match-
+  witnesses set equality, per-witness ownership + CSMT-path check, and
+  endpoint-specific output / mint / datum checks). The check list for
+  each endpoint MUST be recorded alongside the verifier source.
 
 ### Key Entities
 
@@ -206,13 +253,44 @@ that those values can be compared with `GET /status` and `GET /utxo/root`.
   `chainpoint` that identifies the snapshot against which the bundled
   proofs are valid.
 - **WitnessedUtxo**: A consumed or returned UTxO represented by its
-  `TxIn`, resolved `TxOut`, and UTxO-CSMT inclusion proof.
+  `TxIn`, resolved `TxOut`, and UTxO-CSMT inclusion proof. Used on
+  read-side responses.
+- **WitnessedInput**: The tx-side analogue of `WitnessedUtxo`: the
+  consumed `TxIn`, the resolved `TxOut` CBOR, and the UTxO-CSMT
+  inclusion proof that binds the pair to the snapshot's `utxo_root`.
 - **FactWitness**: A token state witness plus an MPF inclusion proof
   tying a key/value to the token's reported root.
-- **UnsignedTxWitnessBundle**: An unsigned transaction plus the full set
-  of witnessed inputs and any MPF proofs required before signing.
+- **ProofEnvelope p**: A wrapper around the unsigned transaction, the
+  `VerificationSnapshot`, and an endpoint-specific proof payload `p`.
+  The shape of `p` mirrors the dataflow of the endpoint's tx, so
+  verification is a type-directed walk over named `WitnessedInput`
+  fields rather than a flat list check.
+- **BootProof**: Proof payload for `POST /tx/boot`. Carries only the
+  funding inputs because boot mints a fresh state UTxO and reads no
+  trie data.
+- **RequestProof**: Proof payload for the three `POST /tx/request/*`
+  endpoints. Carries only the funding inputs because the request tx
+  does not consume or reference the state UTxO.
+- **RetractProof**: Proof payload for `POST /tx/retract`. Carries the
+  retracted pending-request witness, the state UTxO reference witness
+  (read-only), and the funding inputs.
+- **RejectProof**: Proof payload for `POST /tx/reject`. Carries the
+  state input witness, the witnesses for every rejected pending-request
+  input, and the funding inputs.
+- **EndProof**: Proof payload for `POST /tx/end`. Carries the state
+  input witness and the funding inputs.
+- **UpdateProof**: Proof payload for `POST /tx/update`. Carries the
+  state input witness, the witnesses for every batched pending-request
+  input, the funding inputs, the trie root from the consumed state
+  datum, and an MPF inclusion proof for every trie key the batch
+  touched.
 - **WitnessedRequest**: A pending request together with the request UTxO
   witness that proves the request existed in the indexed UTxO set.
+- **ShallowTxOut**: The pair `(address bytes, ada lovelace)` extracted
+  from a Conway `TxOut` CBOR blob by the WASM-safe decoder inside
+  `cardano-mpfs-client`. Every tx-proof verifier cross-checks that the
+  extracted address equals the caller's address and that the ada is
+  consistent with the expected fees and locked amounts.
 
 ## Success Criteria
 
@@ -232,6 +310,13 @@ that those values can be compared with `GET /status` and `GET /utxo/root`.
   `GET /utxo/root` returns for the same indexed snapshot.
 - **SC-005**: Swagger/OpenAPI and HTTP tests cover the new response
   contracts for every affected endpoint.
+- **SC-006**: `cardano-mpfs-client` builds and runs the verifier
+  successfully under GHC-native, GHC-WASM, and GHC-JS, with
+  byte-identical `Either VerifyError a` output across the three
+  targets for the same inputs.
+- **SC-007**: The shallow `TxOut` decoder cross-check suite passes
+  with ≥ 1000 shrinks per property in CI, and the pinned regression
+  corpus decodes identically to the ledger reference.
 
 ## Assumptions
 

--- a/specs/177-proof-carrying-api/tasks.md
+++ b/specs/177-proof-carrying-api/tasks.md
@@ -50,47 +50,59 @@ verification metadata.
 
 ---
 
-## Slice 4: Simple proof-bearing tx endpoints (US2, #213)
+## Slice 4: Per-endpoint proof shapes + WASM verifier + simple tx endpoints (US2, #213)
 
-- [ ] T022 Implement witnessed-input bundle generation for `POST /tx/boot` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs`
-- [ ] T023 Implement witnessed-input bundle generation for `POST /tx/request/insert`, `POST /tx/request/delete`, and `POST /tx/request/update` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs`
-- [ ] T024 Implement witnessed-input bundle generation for `POST /tx/retract` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs`
-- [ ] T025 Implement witnessed-input bundle generation for `POST /tx/reject` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs`
-- [ ] T026 Implement witnessed-input bundle generation for `POST /tx/end` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs`
-- [ ] T027 Change transaction endpoint response schemas in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs` and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` for boot, request, retract, reject, and end
-- [ ] T028 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` to serialize bundle responses instead of bare hex CBOR for those endpoints
-- [ ] T029 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` with coverage for proof-bearing bundles on the simple tx endpoints
-- [ ] T030 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` to verify inline bundle data and cross-check against `/utxo/*`
-- [ ] T031 Verify unit and E2E coverage for the simple tx endpoints
+- [ ] T022 Replace `UnsignedTxBundle` in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs` with `ProofEnvelope p` plus per-endpoint proof records `BootProof`, `RequestProof`, `RetractProof`, `RejectProof`, `EndProof`, and `UpdateProof`; update the `TxBuilder` record so every method returns `m (ProofEnvelope <EndpointProof>)`
+- [ ] T023 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs` to match the new per-endpoint return types (polymorphic `error` is enough)
+- [ ] T024 Add pure-Haskell shallow `TxOut` decoder in `cardano-mpfs-client/lib/Cardano/MPFS/Client/TxOut.hs` (extracts `(address bytes, ada lovelace)` via `cborg` / `binary` only — no `cardano-ledger-*`, no C FFI)
+- [ ] T025 Add cross-check test suite in `cardano-mpfs-offchain/test/Cardano/MPFS/Client/TxOutShallowSpec.hs` with positive property (matches ledger decoder across Shelley address × value × datum × ref-script generator), negative property (truncated prefixes and random bytes return `Left`), and regression corpus under `cardano-mpfs-offchain/test/vectors/txout-regression-corpus/`
+- [ ] T026 Add per-endpoint proof envelopes and JSON contracts in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Bundle.hs` (Haskell mirror of the server-side response types: `BootTxResponse`, `RequestTxResponse`, `RetractTxResponse`, `RejectTxResponse`, `EndTxResponse`)
+- [ ] T027 Add per-endpoint verifiers in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs` following the shape `verify :: TrustedRoot -> ProofEnvelope p -> Either VerifyError ()`; the documented check list per endpoint (snapshot well-formedness, inputs-match-witnesses, per-witness ownership via shallow decode + CSMT path, output/datum/mint checks) lives beside the verifier source
+- [ ] T028 Change transaction endpoint response schemas for boot, request, retract, reject, and end in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs` and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` to per-endpoint response types; the endpoint URL is the discriminator, no tagged-union wrapper
+- [ ] T029 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` to serialize per-endpoint proof responses instead of bare hex CBOR for those endpoints
+- [ ] T030 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs` to emit `ProofEnvelope BootProof` with real `TxIn`/`TxOut` on every `WitnessedInput` (CSMT proof bytes may start empty if not yet wired through the CSMT view)
+- [ ] T031 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs` to emit `ProofEnvelope RequestProof` for `insert`, `delete`, and `update`
+- [ ] T032 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs` to emit `ProofEnvelope RetractProof` with named state-reference + request + funding witnesses
+- [ ] T033 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs` to emit `ProofEnvelope RejectProof` with named state + rejected-requests + funding witnesses
+- [ ] T034 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs` to emit `ProofEnvelope EndProof` with named state + funding witnesses
+- [ ] T035 Wire the UTxO-CSMT view access through the builder so `witnessedCsmtProof` carries real proof bytes against `envSnapshot.snapshotUtxoRoot` for every witness in the five migrated endpoints
+- [ ] T036 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` with coverage for proof-bearing envelopes on the simple tx endpoints, including named-field presence, inputs-match-witnesses set equality, and deterministic ordering for list-valued fields
+- [ ] T037 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` with a stub traversal test that calls each migrated endpoint, parses the per-endpoint response, walks every named `WitnessedInput` via the client verifier, and confirms inline proof data cross-checks against `/utxo/*`
+- [ ] T038 Verify unit and E2E coverage for the simple tx endpoints
+- [ ] T039 Run the `cardano-mpfs-client` cross-compile spike (GHC-WASM and GHC-JS) and record the outcome; slice 4 MUST NOT merge until the shallow decoder and verifiers build successfully on both targets
 
 **Checkpoint**: All tx-building endpoints except `POST /tx/update`
-return proof-bearing bundles.
+return typed per-endpoint proof envelopes; a WASM-safe client verifier
+walks every proof shape; the shallow `TxOut` decoder is cross-checked
+against the ledger decoder.
 
 ---
 
 ## Slice 5: `POST /tx/update` proof bundle (US2, #214)
 
-- [ ] T032 Implement proof-bearing update bundles in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs`, including witnessed state input, witnessed request inputs, baked-in `utxo_root`, baked-in indexed `chainpoint`, and MPF proofs for contributing request keys
-- [ ] T033 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` for the `POST /tx/update` response object
-- [ ] T034 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` to verify proof-to-request association in batched update bundles
-- [ ] T035 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs` to verify update bundles before signing
-- [ ] T036 Verify update bundle tests pass
+- [ ] T040 Implement proof-bearing update envelopes in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs`, emitting `ProofEnvelope UpdateProof` with witnessed state input, witnessed request inputs, funding inputs, the trie root from the consumed state datum, and MPF proofs for every contributing request key
+- [ ] T041 Update `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs`, `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs`, and `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` for the `POST /tx/update` response object
+- [ ] T042 Extend `cardano-mpfs-client/lib/Cardano/MPFS/Client/Bundle.hs` and `Verify.hs` with the `UpdateProof` JSON contract and the per-endpoint verifier (walks state input, batched requests, funding, and every `TrieFact` against the datum-encoded trie root)
+- [ ] T043 Extend `cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs` to verify proof-to-request association in batched update envelopes
+- [ ] T044 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs` to verify update envelopes end-to-end via the client verifier before signing
+- [ ] T045 Verify update envelope tests pass
 
 **Checkpoint**: The hardest batch update flow is fully verifiable before
-signing.
+signing by the same WASM-safe client that covers the simple endpoints.
 
 ---
 
 ## Slice 6: Swagger + contract checks (US3, #215)
 
-- [ ] T037 Update Swagger `ToSchema` coverage in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` and tighten docs in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Swagger.hs` if needed
-- [ ] T038 Regenerate `docs/assets/swagger.json` with `just update-swagger`
-- [ ] T039 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` with cross-endpoint contract checks for snapshot/root consistency, including `/status` versus `/utxo/root` and baked-in `chainpoint` matching
-- [ ] T040 Run `just ci`
-- [ ] T041 Update the PR description, push, and wait for CI before merge
+- [ ] T046 Update Swagger `ToSchema` coverage in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` and tighten docs in `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Swagger.hs` if needed
+- [ ] T047 Regenerate `docs/assets/swagger.json` with `just update-swagger`
+- [ ] T048 Extend `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs` with cross-endpoint contract checks for snapshot/root consistency, including `/status` versus `/utxo/root` and baked-in `chainpoint` matching
+- [ ] T049 Wire the `cardano-mpfs-client` cross-target QuickCheck suite (GHC-native / GHC-WASM / GHC-JS byte-identity of `Either VerifyError a`) into CI per Constitution IX
+- [ ] T050 Run `just ci`
+- [ ] T051 Update the PR description, push, and wait for CI before merge
 
 **Checkpoint**: The proof-bearing API contract is documented, tested,
-and ready for review.
+and ready for review on every runtime the verifier ships to.
 
 ---
 
@@ -100,10 +112,10 @@ and ready for review.
 T001-T004 -> T005
 T005 -> T006-T014
 T014 -> T015-T021
-T015-T021 -> T022-T031
-T015-T021 -> T032-T036
-T022-T031 -> T037-T041
-T032-T036 -> T037-T041
+T015-T021 -> T022-T039
+T015-T021 -> T040-T045
+T022-T039 -> T046-T051
+T040-T045 -> T046-T051
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary

- Per-endpoint `ProofEnvelope p` replaces the monolithic `UnsignedTxBundle` for boot/request/retract/reject/end — each endpoint now declares exactly the named witnesses its proof carries (state, request_in, request_ins, funding, …) and emits them in a typed JSON envelope alongside the tx CBOR and `VerificationSnapshot`.
- New `cardano-mpfs-client` exposes `Cardano.MPFS.Client.{Bundle,Verify}`: pure-Haskell response types and structural verifiers that decode hex, check 32-byte hash lengths, and validate every named witness without pulling in `cardano-ledger-*`. Ready for GHC-native, GHC-WASM, and GHC-JS.
- E2E scenario `ProofsSpec` now drives `/tx/boot`, `/tx/request/insert`, `/tx/update`, `/tx/retract`, `/tx/end` over HTTP, decodes each response with the released client DSL, and runs the matching verifier.

## Scope

Patch stack (vertical, bisect-safe):

1. `213-01-server-envelopes` — per-endpoint proof envelopes for boot/request/retract/reject/end
2. `213-02-client-dsl` — `Cardano.MPFS.Client.{Bundle,Verify}` pure-Haskell response contracts
3. `213-03-verify-wiring` — E2E scenarios verify tx endpoints via Client.Verify DSL

## Out of scope

- `/tx/update` proof bundle population (split to follow-up PR).
- `/tx/reject` e2e coverage — requires a request past its `processTime + retractTime` deadline; structural verifier covered by `cardano-mpfs-client:unit-tests`. Tracked in #224.
- Swagger regeneration + full HTTPLifecycleSpec contract coverage + browser-WASM fixture (blocked on haskell-mts#144).

## Test plan

- [x] `just unit` — 371 examples passing
- [x] `cabal test cardano-mpfs-client` — 26 examples passing
- [x] `cabal test cardano-mpfs-offchain:e2e-tests --match verifiable` — 1 example passing
- [x] `just format-check` green on every patch
- [x] `just hlint` clean on every patch
- [x] Each patch builds and passes its own tests in isolation (walked the stack)

Related: #224 (reject e2e coverage follow-up).