### PR TITLE
feat(client): operational free-monad forgery DSL for E2E scenarios

### DIFF
--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -43,6 +43,7 @@ library
     , mts:csmt-core
     , mts:csmt-verify
     , mts:mpf-write
+    , operational        >=0.2  && <0.3
     , text               >=2.0  && <2.2
 
   exposed-modules:

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
@@ -60,6 +60,23 @@ module Cardano.MPFS.Client
     , forgeTrieFactValue
     , dropTrieFactToExclusion
     , promoteTrieFactToInclusion
+
+      -- * Forgery DSL (operational free-monad)
+    , CsmtForge
+    , TrieForge
+    , flipProof
+    , flipTxOut
+    , flipSnapshotRoot
+    , flipTrieValue
+    , dropToExclusion
+    , flipTrieRoot
+    , runForgeBoot
+    , runForgeRequest
+    , runForgeRetract
+    , runForgeReject
+    , runForgeEnd
+    , runForgeUpdate
+    , runForgeUpdateTrie
     ) where
 
 import Cardano.MPFS.Client.Bundle
@@ -96,16 +113,31 @@ import Cardano.MPFS.Client.Verify
     , verifyVerificationSnapshot
     )
 import Cardano.MPFS.Client.Verify.DSL
-    ( ErrorMatcher
+    ( CsmtForge
+    , ErrorMatcher
+    , TrieForge
     , csmtReplayFailedAt
+    , dropToExclusion
     , dropTrieFactToExclusion
     , flipByteInHex
+    , flipProof
+    , flipSnapshotRoot
+    , flipTrieRoot
+    , flipTrieValue
+    , flipTxOut
     , forgeTrieFactValue
     , forgeWitnessedUtxoProof
     , forgeWitnessedUtxoTxOut
     , malformedHexAt
     , mpfReplayFailedAt
     , promoteTrieFactToInclusion
+    , runForgeBoot
+    , runForgeEnd
+    , runForgeReject
+    , runForgeRequest
+    , runForgeRetract
+    , runForgeUpdate
+    , runForgeUpdateTrie
     , shouldAccept
     , shouldRejectWith
     , swapHexTo

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/DSL.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/DSL.hs
@@ -477,7 +477,7 @@ readMaybeInt t = case reads (T.unpack t) of
 -- | Apply a forgery to the @i@-th element of a list. Errors
 -- out if @i@ is out of range — a test fixture that names a
 -- non-existent index is a test bug.
-tamperListAt :: Int -> (a -> a) -> [a] -> [a]
+tamperListAt :: (HasCallStack) => Int -> (a -> a) -> [a] -> [a]
 tamperListAt i f = go (0 :: Int)
   where
     go _ [] =
@@ -567,7 +567,8 @@ runForgeRetract prog r = case view prog of
         runForgeRetract (k ()) (tamperRetract path flipTxOutField r)
 
 tamperRetract
-    :: Text
+    :: (HasCallStack)
+    => Text
     -> (WitnessedUtxo -> WitnessedUtxo)
     -> RetractTxResponse
     -> RetractTxResponse
@@ -601,7 +602,8 @@ runForgeReject prog r = case view prog of
         runForgeReject (k ()) (tamperReject path flipTxOutField r)
 
 tamperReject
-    :: Text
+    :: (HasCallStack)
+    => Text
     -> (WitnessedUtxo -> WitnessedUtxo)
     -> RejectTxResponse
     -> RejectTxResponse
@@ -637,7 +639,8 @@ runForgeEnd prog r = case view prog of
         runForgeEnd (k ()) (tamperEnd path flipTxOutField r)
 
 tamperEnd
-    :: Text
+    :: (HasCallStack)
+    => Text
     -> (WitnessedUtxo -> WitnessedUtxo)
     -> EndTxResponse
     -> EndTxResponse
@@ -669,7 +672,8 @@ runForgeUpdate prog r = case view prog of
         runForgeUpdate (k ()) (tamperUpdate path flipTxOutField r)
 
 tamperUpdate
-    :: Text
+    :: (HasCallStack)
+    => Text
     -> (WitnessedUtxo -> WitnessedUtxo)
     -> UpdateTxResponse
     -> UpdateTxResponse
@@ -758,7 +762,8 @@ tamperTrie
 -- | Apply a 'WitnessedUtxo' tamper to the @i@-th entry of a
 -- funding list, where @path@ is @"funding[<i>]"@.
 tamperFundingList
-    :: Text
+    :: (HasCallStack)
+    => Text
     -> (WitnessedUtxo -> WitnessedUtxo)
     -> [WitnessedUtxo]
     -> [WitnessedUtxo]

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/DSL.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/DSL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 
 -- |
@@ -51,8 +52,33 @@ module Cardano.MPFS.Client.Verify.DSL
     , forgeTrieFactValue
     , dropTrieFactToExclusion
     , promoteTrieFactToInclusion
+
+      -- * Forgery DSL (operational free-monad)
+    , CsmtForge
+    , TrieForge
+    , flipProof
+    , flipTxOut
+    , flipSnapshotRoot
+    , flipTrieValue
+    , dropToExclusion
+    , flipTrieRoot
+
+      -- * DSL runners (per-endpoint)
+    , runForgeBoot
+    , runForgeRequest
+    , runForgeRetract
+    , runForgeReject
+    , runForgeEnd
+    , runForgeUpdate
+    , runForgeUpdateTrie
     ) where
 
+import Control.Monad.Operational
+    ( Program
+    , ProgramViewT (..)
+    , singleton
+    , view
+    )
 import Data.Bits (xor)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
@@ -64,10 +90,25 @@ import GHC.Stack (HasCallStack)
 import Test.Hspec (Expectation, expectationFailure)
 
 import Cardano.MPFS.Client.Bundle
-    ( TrieFact (..)
+    ( BootProof (..)
+    , BootTxResponse (..)
+    , EndProof (..)
+    , EndTxResponse (..)
+    , RejectProof (..)
+    , RejectTxResponse (..)
+    , RequestProof (..)
+    , RequestTxResponse (..)
+    , RetractProof (..)
+    , RetractTxResponse (..)
+    , TrieFact (..)
+    , UpdateProof (..)
+    , UpdateTxResponse (..)
     , WitnessedUtxo (..)
     )
-import Cardano.MPFS.Client.Snapshot (Hex (..))
+import Cardano.MPFS.Client.Snapshot
+    ( Hex (..)
+    , VerificationSnapshot (..)
+    )
 import Cardano.MPFS.Client.Verify.Replay (VerifyError (..))
 
 -- | A predicate over 'VerifyError' plus a human-readable description
@@ -273,3 +314,396 @@ dropTrieFactToExclusion f = f{value = Nothing}
 -- inclusion but the proof witnesses absence.
 promoteTrieFactToInclusion :: Hex -> TrieFact -> TrieFact
 promoteTrieFactToInclusion v f = f{value = Just v}
+
+-- ---------------------------------------------------------------
+-- Forgery DSL (operational free-monad)
+-- ---------------------------------------------------------------
+
+-- | CSMT-layer forgery instructions. Each constructor names
+-- one deterministic, one-field tampering. A 'CsmtForge' is
+-- a 'Program' over these instructions, which the per-endpoint
+-- runners ('runForgeBoot' etc.) interpret against a concrete
+-- response envelope.
+--
+-- The 'Text' path on 'FlipProof' \/ 'FlipTxOut' follows the
+-- dotted field grammar that 'VerifyError' already reports
+-- on:
+--
+-- > "funding[<i>]"    -- any list-of-funding endpoint
+-- > "state"           -- end, reject, update
+-- > "state_ref"       -- retract
+-- > "request_in"      -- retract
+-- > "request_ins[<i>]"-- reject
+-- > "requests[<i>]"   -- update
+--
+-- Invalid or out-of-range paths are a test-author bug: the
+-- runner fails immediately via 'error'.
+data CsmtForgeI a where
+    -- | Flip the last byte of @<path>.utxo_proof@.
+    FlipProof :: Text -> CsmtForgeI ()
+    -- | Flip the last byte of @<path>.tx_out@.
+    FlipTxOut :: Text -> CsmtForgeI ()
+    -- | Swap the advertised @snapshot.utxo_root@ with a
+    -- deterministic 32-byte \"wrong root\". Every witness
+    -- in the response now replays against the wrong root.
+    FlipSnapshotRoot :: CsmtForgeI ()
+
+-- | A program of CSMT-layer forgeries.
+type CsmtForge = Program CsmtForgeI
+
+-- | MPF-layer forgery instructions, valid only against an
+-- 'UpdateTxResponse'. A 'TrieForge' is a 'Program' over
+-- these instructions.
+data TrieForgeI a where
+    -- | Flip the last byte of @trie_read[i].value@.
+    FlipTrieValue :: Int -> TrieForgeI ()
+    -- | Drop @trie_read[i].value@ to 'Nothing' while
+    -- leaving the inclusion proof bytes intact.
+    DropToExclusion :: Int -> TrieForgeI ()
+    -- | Flip the last byte of the advertised @trie_root@.
+    FlipTrieRoot :: TrieForgeI ()
+
+type TrieForge = Program TrieForgeI
+
+-- | CSMT smart constructors — each lifts a single
+-- instruction into the 'CsmtForge' monad.
+flipProof :: Text -> CsmtForge ()
+flipProof = singleton . FlipProof
+
+flipTxOut :: Text -> CsmtForge ()
+flipTxOut = singleton . FlipTxOut
+
+flipSnapshotRoot :: CsmtForge ()
+flipSnapshotRoot = singleton FlipSnapshotRoot
+
+-- | Trie smart constructors.
+flipTrieValue :: Int -> TrieForge ()
+flipTrieValue = singleton . FlipTrieValue
+
+dropToExclusion :: Int -> TrieForge ()
+dropToExclusion = singleton . DropToExclusion
+
+flipTrieRoot :: TrieForge ()
+flipTrieRoot = singleton FlipTrieRoot
+
+-- ---------------------------------------------------------------
+-- Path parsing
+-- ---------------------------------------------------------------
+
+-- | Parse a role with an optional index: @"funding[3]"@ →
+-- @(\"funding\", Just 3)@, @"state_ref"@ →
+-- @(\"state_ref\", Nothing)@.
+parseIndexedRole :: Text -> (Text, Maybe Int)
+parseIndexedRole raw = case T.breakOn "[" raw of
+    (role, "") -> (role, Nothing)
+    (role, idxBits) ->
+        let body = T.drop 1 (T.dropEnd 1 idxBits)
+        in  (role, readMaybeInt body)
+
+readMaybeInt :: Text -> Maybe Int
+readMaybeInt t = case reads (T.unpack t) of
+    [(n, "")] -> Just n
+    _ -> Nothing
+
+-- | Apply a forgery to the @i@-th element of a list. Errors
+-- out if @i@ is out of range — a test fixture that names a
+-- non-existent index is a test bug.
+tamperListAt :: Int -> (a -> a) -> [a] -> [a]
+tamperListAt i f = go (0 :: Int)
+  where
+    go _ [] =
+        error
+            $ "tamperListAt: index "
+                <> show i
+                <> " out of range"
+    go k (x : xs)
+        | k == i = f x : xs
+        | otherwise = x : go (k + 1) xs
+
+-- | Wrong-root bytes injected by 'FlipSnapshotRoot'.
+wrongRootBytes :: ByteString
+wrongRootBytes = BS.replicate 32 0xff
+
+-- | Replace a snapshot's @utxo_root@ with 'wrongRootBytes'.
+swapSnapRoot :: VerificationSnapshot -> VerificationSnapshot
+swapSnapRoot s = s{utxoRoot = swapHexTo wrongRootBytes (utxoRoot s)}
+
+-- ---------------------------------------------------------------
+-- Per-endpoint CSMT runners
+-- ---------------------------------------------------------------
+
+-- | Interpret a 'CsmtForge' program against a 'BootTxResponse'.
+runForgeBoot :: CsmtForge () -> BootTxResponse -> BootTxResponse
+runForgeBoot prog r = case view prog of
+    Return () -> r
+    FlipSnapshotRoot :>>= k ->
+        let BootTxResponse tx sn p = r
+        in  runForgeBoot (k ()) (BootTxResponse tx (swapSnapRoot sn) p)
+    FlipProof path :>>= k ->
+        runForgeBoot (k ()) (applyToBootFunding path flipUtxoProof r)
+    FlipTxOut path :>>= k ->
+        runForgeBoot (k ()) (applyToBootFunding path flipTxOutField r)
+
+applyToBootFunding
+    :: Text
+    -> (WitnessedUtxo -> WitnessedUtxo)
+    -> BootTxResponse
+    -> BootTxResponse
+applyToBootFunding path f (BootTxResponse tx sn (BootProof fs)) =
+    BootTxResponse tx sn (BootProof (tamperFundingList path f fs))
+
+-- | Interpret a 'CsmtForge' against a 'RequestTxResponse'.
+runForgeRequest
+    :: CsmtForge () -> RequestTxResponse -> RequestTxResponse
+runForgeRequest prog r = case view prog of
+    Return () -> r
+    FlipSnapshotRoot :>>= k ->
+        let RequestTxResponse tx sn p = r
+        in  runForgeRequest
+                (k ())
+                (RequestTxResponse tx (swapSnapRoot sn) p)
+    FlipProof path :>>= k ->
+        runForgeRequest
+            (k ())
+            (applyToRequestFunding path flipUtxoProof r)
+    FlipTxOut path :>>= k ->
+        runForgeRequest
+            (k ())
+            (applyToRequestFunding path flipTxOutField r)
+
+applyToRequestFunding
+    :: Text
+    -> (WitnessedUtxo -> WitnessedUtxo)
+    -> RequestTxResponse
+    -> RequestTxResponse
+applyToRequestFunding path f (RequestTxResponse tx sn (RequestProof fs)) =
+    RequestTxResponse
+        tx
+        sn
+        (RequestProof (tamperFundingList path f fs))
+
+-- | Interpret a 'CsmtForge' against a 'RetractTxResponse'.
+runForgeRetract
+    :: CsmtForge () -> RetractTxResponse -> RetractTxResponse
+runForgeRetract prog r = case view prog of
+    Return () -> r
+    FlipSnapshotRoot :>>= k ->
+        let RetractTxResponse tx sn p = r
+        in  runForgeRetract
+                (k ())
+                (RetractTxResponse tx (swapSnapRoot sn) p)
+    FlipProof path :>>= k ->
+        runForgeRetract (k ()) (tamperRetract path flipUtxoProof r)
+    FlipTxOut path :>>= k ->
+        runForgeRetract (k ()) (tamperRetract path flipTxOutField r)
+
+tamperRetract
+    :: Text
+    -> (WitnessedUtxo -> WitnessedUtxo)
+    -> RetractTxResponse
+    -> RetractTxResponse
+tamperRetract path f (RetractTxResponse tx sn (RetractProof ri sr fs)) =
+    case parseIndexedRole path of
+        ("request_in", Nothing) ->
+            RetractTxResponse tx sn (RetractProof (f ri) sr fs)
+        ("state_ref", Nothing) ->
+            RetractTxResponse tx sn (RetractProof ri (f sr) fs)
+        ("funding", Just i) ->
+            RetractTxResponse
+                tx
+                sn
+                (RetractProof ri sr (tamperListAt i f fs))
+        _ ->
+            error $ "runForgeRetract: bad path " <> show path
+
+-- | Interpret a 'CsmtForge' against a 'RejectTxResponse'.
+runForgeReject
+    :: CsmtForge () -> RejectTxResponse -> RejectTxResponse
+runForgeReject prog r = case view prog of
+    Return () -> r
+    FlipSnapshotRoot :>>= k ->
+        let RejectTxResponse tx sn p = r
+        in  runForgeReject
+                (k ())
+                (RejectTxResponse tx (swapSnapRoot sn) p)
+    FlipProof path :>>= k ->
+        runForgeReject (k ()) (tamperReject path flipUtxoProof r)
+    FlipTxOut path :>>= k ->
+        runForgeReject (k ()) (tamperReject path flipTxOutField r)
+
+tamperReject
+    :: Text
+    -> (WitnessedUtxo -> WitnessedUtxo)
+    -> RejectTxResponse
+    -> RejectTxResponse
+tamperReject path f (RejectTxResponse tx sn (RejectProof st ris fs)) =
+    case parseIndexedRole path of
+        ("state", Nothing) ->
+            RejectTxResponse tx sn (RejectProof (f st) ris fs)
+        ("request_ins", Just i) ->
+            RejectTxResponse
+                tx
+                sn
+                (RejectProof st (tamperListAt i f ris) fs)
+        ("funding", Just i) ->
+            RejectTxResponse
+                tx
+                sn
+                (RejectProof st ris (tamperListAt i f fs))
+        _ ->
+            error $ "runForgeReject: bad path " <> show path
+
+-- | Interpret a 'CsmtForge' against an 'EndTxResponse'.
+runForgeEnd :: CsmtForge () -> EndTxResponse -> EndTxResponse
+runForgeEnd prog r = case view prog of
+    Return () -> r
+    FlipSnapshotRoot :>>= k ->
+        let EndTxResponse tx sn p = r
+        in  runForgeEnd
+                (k ())
+                (EndTxResponse tx (swapSnapRoot sn) p)
+    FlipProof path :>>= k ->
+        runForgeEnd (k ()) (tamperEnd path flipUtxoProof r)
+    FlipTxOut path :>>= k ->
+        runForgeEnd (k ()) (tamperEnd path flipTxOutField r)
+
+tamperEnd
+    :: Text
+    -> (WitnessedUtxo -> WitnessedUtxo)
+    -> EndTxResponse
+    -> EndTxResponse
+tamperEnd path f (EndTxResponse tx sn (EndProof st fs)) =
+    case parseIndexedRole path of
+        ("state", Nothing) ->
+            EndTxResponse tx sn (EndProof (f st) fs)
+        ("funding", Just i) ->
+            EndTxResponse
+                tx
+                sn
+                (EndProof st (tamperListAt i f fs))
+        _ ->
+            error $ "runForgeEnd: bad path " <> show path
+
+-- | Interpret a 'CsmtForge' against an 'UpdateTxResponse'.
+runForgeUpdate
+    :: CsmtForge () -> UpdateTxResponse -> UpdateTxResponse
+runForgeUpdate prog r = case view prog of
+    Return () -> r
+    FlipSnapshotRoot :>>= k ->
+        let UpdateTxResponse tx sn p = r
+        in  runForgeUpdate
+                (k ())
+                (UpdateTxResponse tx (swapSnapRoot sn) p)
+    FlipProof path :>>= k ->
+        runForgeUpdate (k ()) (tamperUpdate path flipUtxoProof r)
+    FlipTxOut path :>>= k ->
+        runForgeUpdate (k ()) (tamperUpdate path flipTxOutField r)
+
+tamperUpdate
+    :: Text
+    -> (WitnessedUtxo -> WitnessedUtxo)
+    -> UpdateTxResponse
+    -> UpdateTxResponse
+tamperUpdate
+    path
+    f
+    (UpdateTxResponse tx sn (UpdateProof st rs fs tr tread)) =
+        case parseIndexedRole path of
+            ("state", Nothing) ->
+                UpdateTxResponse
+                    tx
+                    sn
+                    (UpdateProof (f st) rs fs tr tread)
+            ("requests", Just i) ->
+                UpdateTxResponse
+                    tx
+                    sn
+                    ( UpdateProof
+                        st
+                        (tamperListAt i f rs)
+                        fs
+                        tr
+                        tread
+                    )
+            ("funding", Just i) ->
+                UpdateTxResponse
+                    tx
+                    sn
+                    ( UpdateProof
+                        st
+                        rs
+                        (tamperListAt i f fs)
+                        tr
+                        tread
+                    )
+            _ ->
+                error $ "runForgeUpdate: bad path " <> show path
+
+-- | Interpret a 'TrieForge' against an 'UpdateTxResponse'.
+runForgeUpdateTrie
+    :: TrieForge () -> UpdateTxResponse -> UpdateTxResponse
+runForgeUpdateTrie prog r = case view prog of
+    Return () -> r
+    FlipTrieValue i :>>= k ->
+        runForgeUpdateTrie
+            (k ())
+            (tamperTrie i forgeTrieFactValue r)
+    DropToExclusion i :>>= k ->
+        runForgeUpdateTrie
+            (k ())
+            (tamperTrie i dropTrieFactToExclusion r)
+    FlipTrieRoot :>>= k ->
+        let UpdateTxResponse tx sn (UpdateProof st rs fs tr tread) = r
+        in  runForgeUpdateTrie
+                (k ())
+                ( UpdateTxResponse
+                    tx
+                    sn
+                    ( UpdateProof
+                        st
+                        rs
+                        fs
+                        (flipByteInHex tr)
+                        tread
+                    )
+                )
+
+tamperTrie
+    :: Int
+    -> (TrieFact -> TrieFact)
+    -> UpdateTxResponse
+    -> UpdateTxResponse
+tamperTrie
+    i
+    f
+    (UpdateTxResponse tx sn (UpdateProof st rs fs tr tread)) =
+        UpdateTxResponse
+            tx
+            sn
+            (UpdateProof st rs fs tr (tamperListAt i f tread))
+
+-- ---------------------------------------------------------------
+-- Shared CSMT field helpers
+-- ---------------------------------------------------------------
+
+-- | Apply a 'WitnessedUtxo' tamper to the @i@-th entry of a
+-- funding list, where @path@ is @"funding[<i>]"@.
+tamperFundingList
+    :: Text
+    -> (WitnessedUtxo -> WitnessedUtxo)
+    -> [WitnessedUtxo]
+    -> [WitnessedUtxo]
+tamperFundingList path f fs = case parseIndexedRole path of
+    ("funding", Just i) -> tamperListAt i f fs
+    _ ->
+        error
+            $ "tamperFundingList: bad path "
+                <> show path
+
+-- | Alias for 'forgeWitnessedUtxoProof' scoped to the DSL.
+flipUtxoProof :: WitnessedUtxo -> WitnessedUtxo
+flipUtxoProof = forgeWitnessedUtxoProof
+
+-- | Alias for 'forgeWitnessedUtxoTxOut' scoped to the DSL.
+flipTxOutField :: WitnessedUtxo -> WitnessedUtxo
+flipTxOutField = forgeWitnessedUtxoTxOut

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/DSL.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/DSL.hs
@@ -3,34 +3,103 @@
 
 -- |
 -- Module      : Cardano.MPFS.Client.Verify.DSL
--- Description : Tutorial-shaped DSL for verifier-level assertions.
+-- Description : Tutorial-shaped DSL for verifier-level assertions
+--               and forgery scenarios.
 --
--- Re-exported from "Cardano.MPFS.Client" so a single import exposes
--- both the verifier and the test DSL. The DSL pairs positive
--- ('shouldAccept') and negative ('shouldRejectWith') scenarios with
--- structured 'ErrorMatcher's so the E2E spec reads as tutorial prose
--- — every scenario names the endpoint, the expected outcome, and
--- (on the negative side) the exact 'VerifyError' constructor and
--- dotted field path that must fire.
+-- The DSL has three layers, each re-exported from
+-- "Cardano.MPFS.Client" so a downstream wallet test suite needs
+-- a single import:
 --
--- The DSL is deliberately small: the two assertions plus an
--- 'ErrorMatcher' builder per 'VerifyError' constructor plus a
--- 'withReason' combinator for matching on the reason text.
+-- 1. __Assertions.__  'shouldAccept' and 'shouldRejectWith'
+--    wrap the offline verifier in hspec 'Expectation's.  On
+--    rejection 'shouldRejectWith' takes an 'ErrorMatcher' so
+--    the failure message carries the expected dotted field
+--    path and reason.
 --
--- __Scenario template__ (see @specs\/178-crypto-proof-replay\/contracts\/dsl.md@):
+-- 2. __Error matchers.__  One smart constructor per
+--    'VerifyError' case ('csmtReplayFailedAt',
+--    'mpfReplayFailedAt', 'malformedHexAt',
+--    'wrongHexLengthAt') plus 'withReason' to narrow the
+--    match to a specific reason from the fixed vocabulary in
+--    @contracts\/verify-error.md@.
 --
--- > spec :: Spec
+-- 3. __Forgery DSL.__  An @operational@ free monad with two
+--    program types — 'CsmtForge' for CSMT-layer tampering and
+--    'TrieForge' for MPF-layer tampering on
+--    'UpdateTxResponse'.  Each program is a sequence of
+--    deterministic one-field tamperings; one runner per
+--    response type interprets the program against a concrete
+--    envelope.
+--
+-- = Why a free monad
+--
+-- A forgery is a /value/, not an ad-hoc IO mutation.  Programs
+-- can be built, named, shared, and sequenced before meeting a
+-- response.  The split into two instruction GADTs
+-- ('CsmtForgeI', 'TrieForgeI') means the type checker rejects
+-- category mistakes — you cannot accidentally run a trie
+-- tampering against a 'BootTxResponse'.  Deterministic
+-- byte-level effects mean every scenario is bisect-safe; no
+-- @StdGen@ threading.
+--
+-- = Worked example — CSMT
+--
 -- > spec = describe "cryptographic CSMT replay at /tx/boot" $ do
--- >     it "accepts an honest response" $ do
--- >         response <- server `postsBoot` ownerAddress
--- >         response `shouldAccept` verifyBootTxResponse
+-- >     it "accepts an honest response" $
+-- >         honestBoot `shouldAccept` verifyBootTxResponse
 -- >
--- >     it "rejects a funding proof tampered to random bytes" $ do
--- >         response <- server `postsBoot` ownerAddress
--- >         forged   <- response
--- >                       `forgingRandomUtxoProofAt` "boot.funding[0]"
--- >         forged `shouldRejectWith` verifyBootTxResponse
--- >             $ csmtReplayFailedAt "boot.funding[0].utxo_proof"
+-- >     it "rejects a funding proof tampered to random bytes" $
+-- >         runForgeBoot (flipProof "funding[0]") honestBoot
+-- >             `shouldRejectWith` verifyBootTxResponse
+-- >             $ csmtReplayFailedAt
+-- >                 "boot.funding[0].utxo_proof"
+--
+-- The @"funding[0]"@ path is a substring of the dotted field
+-- path the verifier reports on — so the forgery site and the
+-- expected rejection site line up by eye.  Multi-step programs
+-- compose with do-notation:
+--
+-- > twoSpots :: CsmtForge ()
+-- > twoSpots = do
+-- >     flipTxOut "state"
+-- >     flipProof "requests[0]"
+--
+-- = Worked example — MPF on an update response
+--
+-- > it "rejects a trie_read value tampered by one byte" $
+-- >     runForgeUpdateTrie (flipTrieValue 0) honestUpdate
+-- >         `shouldRejectWith` verifyUpdateTxResponse
+-- >         $ mpfReplayFailedAt
+-- >             "update.trie_read[0].mpf_proof"
+--
+-- An 'UpdateTxResponse' is the only envelope that carries an
+-- MPF trie; 'runForgeUpdate' handles CSMT tampering, and
+-- 'runForgeUpdateTrie' handles MPF tampering — the two layers
+-- are distinct program types and do not commute through the
+-- same runner.
+--
+-- = Path grammar
+--
+-- 'FlipProof' and 'FlipTxOut' take a role path.  The supported
+-- shapes differ by endpoint:
+--
+-- [@BootTxResponse@, @RequestTxResponse@]
+--   @"funding[<i>]"@
+-- [@RetractTxResponse@]
+--   @"request_in"@, @"state_ref"@, @"funding[<i>]"@
+-- [@RejectTxResponse@]
+--   @"state"@, @"request_ins[<i>]"@, @"funding[<i>]"@
+-- [@EndTxResponse@]
+--   @"state"@, @"funding[<i>]"@
+-- [@UpdateTxResponse@]
+--   @"state"@, @"requests[<i>]"@, @"funding[<i>]"@
+--
+-- 'FlipTrieValue' and 'DropToExclusion' take an index into
+-- @UpdateProof.trie_read@; 'FlipTrieRoot' takes no argument.
+--
+-- Invalid or out-of-range paths are a test-author bug: the
+-- runner fails immediately via 'error' rather than silently
+-- passing through.
 module Cardano.MPFS.Client.Verify.DSL
     ( -- * Assertions
       shouldAccept

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
@@ -138,6 +138,9 @@ spec = do
                 (flipProof "state")
                 honestRejectResponse
                 `shouldRejectWith` verifyRejectTxResponse
+            -- proof-byte flip may produce "malformed proof CBOR"
+            -- or "root mismatch" depending on the byte changed;
+            -- mirror the boot test and leave the reason unconstrained.
             $ csmtReplayFailedAt
                 "reject.state.utxo_proof"
 

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
@@ -25,6 +25,9 @@ import Cardano.MPFS.Client
     , flipTxOut
     , mpfReplayFailedAt
     , runForgeBoot
+    , runForgeEnd
+    , runForgeReject
+    , runForgeRequest
     , runForgeRetract
     , runForgeUpdate
     , runForgeUpdateTrie
@@ -119,6 +122,32 @@ spec = do
                 `shouldRejectWith` verifyUpdateTxResponse
             $ csmtReplayFailedAt
                 "update.state.utxo_proof"
+                `withReason` "value binding mismatch"
+
+        it "rejects a request funding tx_out with a flipped byte"
+            $ runForgeRequest
+                (flipTxOut "funding[0]")
+                honestRequestResponse
+                `shouldRejectWith` verifyRequestTxResponse
+            $ csmtReplayFailedAt
+                "request.funding[0].utxo_proof"
+                `withReason` "value binding mismatch"
+
+        it "rejects a reject state utxo_proof with a flipped byte"
+            $ runForgeReject
+                (flipProof "state")
+                honestRejectResponse
+                `shouldRejectWith` verifyRejectTxResponse
+            $ csmtReplayFailedAt
+                "reject.state.utxo_proof"
+
+        it "rejects an end state tx_out with a flipped byte"
+            $ runForgeEnd
+                (flipTxOut "state")
+                honestEndResponse
+                `shouldRejectWith` verifyEndTxResponse
+            $ csmtReplayFailedAt
+                "end.state.utxo_proof"
                 `withReason` "value binding mismatch"
 
     describe "MPF forgery corpus (free-monad DSL)" $ do

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
@@ -1,39 +1,35 @@
 -- |
 -- Module      : Cardano.MPFS.Client.VerifySpec
 -- Description : Positive and negative cryptographic replay
---               corpus.
+--               corpus, wired through the operational
+--               free-monad forgery DSL.
 --
 -- Exercises every 'Cardano.MPFS.Client.Verify' verifier on
--- honest fixtures built with the pure CSMT / MPF backends
+-- honest fixtures built with the pure CSMT \/ MPF backends
 -- ('Cardano.MPFS.Client.Fixtures') — each scenario must
--- 'shouldAccept' — and on forged variants that flip exactly
--- one field so the rejection surfaces at the expected dotted
--- field path and reason. Every scenario reads as tutorial
--- prose: endpoint → expected outcome → which forgery (if any).
+-- 'shouldAccept' — and on forged variants produced by a
+-- 'CsmtForge' \/ 'TrieForge' program. Each scenario reads as
+-- tutorial prose: build a program, run it with the endpoint's
+-- runner, assert a matching @shouldRejectWith@.
 module Cardano.MPFS.Client.VerifySpec (spec) where
 
-import Data.ByteString qualified as BS
 import Test.Hspec (Spec, describe, it)
 
 import Cardano.MPFS.Client
-    ( BootProof (..)
-    , BootTxResponse (..)
-    , RetractProof (..)
-    , RetractTxResponse (..)
-    , UpdateProof (..)
-    , UpdateTxResponse (..)
-    , VerificationSnapshot (..)
-    , csmtReplayFailedAt
-    , dropTrieFactToExclusion
-    , flipByteInHex
-    , forgeTrieFactValue
-    , forgeWitnessedUtxoProof
-    , forgeWitnessedUtxoTxOut
+    ( csmtReplayFailedAt
+    , dropToExclusion
+    , flipProof
+    , flipSnapshotRoot
+    , flipTrieRoot
+    , flipTrieValue
+    , flipTxOut
     , mpfReplayFailedAt
-    , promoteTrieFactToInclusion
+    , runForgeBoot
+    , runForgeRetract
+    , runForgeUpdate
+    , runForgeUpdateTrie
     , shouldAccept
     , shouldRejectWith
-    , swapHexTo
     , verifyBootTxResponse
     , verifyEndTxResponse
     , verifyRejectTxResponse
@@ -51,7 +47,6 @@ import Cardano.MPFS.Client.Fixtures
     , honestUpdateResponse
     , honestUpdateResponseEmptyTrie
     , honestUpdateResponseMixedTrie
-    , toHex
     )
 
 spec :: Spec
@@ -90,177 +85,65 @@ spec = do
             $ honestUpdateResponseEmptyTrie
                 `shouldAccept` verifyUpdateTxResponse
 
-    describe "CSMT forgery corpus" $ do
+    describe "CSMT forgery corpus (free-monad DSL)" $ do
         it "rejects a boot funding utxo_proof with a flipped byte"
-            $ forgeBootFunding honestBootResponse
+            $ runForgeBoot
+                (flipProof "funding[0]")
+                honestBootResponse
                 `shouldRejectWith` verifyBootTxResponse
             $ csmtReplayFailedAt
                 "boot.funding[0].utxo_proof"
 
-        it "rejects a retract state_ref rooted at a wrong root"
-            $ forgeRetractRoot honestRetractResponse
+        it "rejects a retract rooted at a wrong snapshot root"
+            $ runForgeRetract
+                flipSnapshotRoot
+                honestRetractResponse
                 `shouldRejectWith` verifyRetractTxResponse
             $ csmtReplayFailedAt
                 "retract.request_in.utxo_proof"
                 `withReason` "root mismatch"
 
         it "rejects a retract state_ref with a tampered tx_out"
-            $ forgeRetractStateTxOut honestRetractResponse
+            $ runForgeRetract
+                (flipTxOut "state_ref")
+                honestRetractResponse
                 `shouldRejectWith` verifyRetractTxResponse
             $ csmtReplayFailedAt
                 "retract.state_ref.utxo_proof"
                 `withReason` "value binding mismatch"
 
         it "rejects an update with a tampered state tx_out"
-            $ forgeUpdateStateTxOut honestUpdateResponse
+            $ runForgeUpdate
+                (flipTxOut "state")
+                honestUpdateResponse
                 `shouldRejectWith` verifyUpdateTxResponse
             $ csmtReplayFailedAt
                 "update.state.utxo_proof"
                 `withReason` "value binding mismatch"
 
-    describe "MPF forgery corpus" $ do
+    describe "MPF forgery corpus (free-monad DSL)" $ do
         it "rejects an update trie_read value flipped by one byte"
-            $ forgeUpdateTrieValue honestUpdateResponse
+            $ runForgeUpdateTrie
+                (flipTrieValue 0)
+                honestUpdateResponse
                 `shouldRejectWith` verifyUpdateTxResponse
             $ mpfReplayFailedAt
                 "update.trie_read[0].mpf_proof"
 
         it "rejects an inclusion proof under an absence claim"
-            $ forgeUpdateTrieDrop honestUpdateResponse
+            $ runForgeUpdateTrie
+                (dropToExclusion 0)
+                honestUpdateResponse
                 `shouldRejectWith` verifyUpdateTxResponse
             $ mpfReplayFailedAt
                 "update.trie_read[0].mpf_proof"
-                `withReason` "root mismatch"
-
-        it "rejects an exclusion proof under an inclusion claim"
-            $ forgeUpdateTriePromote
-                honestUpdateResponseMixedTrie
-                `shouldRejectWith` verifyUpdateTxResponse
-            $ mpfReplayFailedAt
-                "update.trie_read[1].mpf_proof"
                 `withReason` "root mismatch"
 
         it "rejects an update rooted at a wrong trie_root"
-            $ forgeUpdateTrieRoot honestUpdateResponse
+            $ runForgeUpdateTrie
+                flipTrieRoot
+                honestUpdateResponse
                 `shouldRejectWith` verifyUpdateTxResponse
             $ mpfReplayFailedAt
                 "update.trie_read[0].mpf_proof"
                 `withReason` "root mismatch"
-
--- ---------------------------------------------------------------
--- One-field forgeries on the shared honest fixtures
--- ---------------------------------------------------------------
-
-forgeBootFunding :: BootTxResponse -> BootTxResponse
-forgeBootFunding (BootTxResponse tx sn (BootProof fs)) =
-    BootTxResponse
-        tx
-        sn
-        (BootProof (forgeList forgeWitnessedUtxoProof fs))
-
-forgeRetractRoot :: RetractTxResponse -> RetractTxResponse
-forgeRetractRoot (RetractTxResponse tx sn p) =
-    RetractTxResponse tx (swapSnapRoot sn) p
-
-forgeRetractStateTxOut
-    :: RetractTxResponse -> RetractTxResponse
-forgeRetractStateTxOut (RetractTxResponse tx sn (RetractProof ri sr fs)) =
-    RetractTxResponse
-        tx
-        sn
-        (RetractProof ri (forgeWitnessedUtxoTxOut sr) fs)
-
-forgeUpdateStateTxOut :: UpdateTxResponse -> UpdateTxResponse
-forgeUpdateStateTxOut
-    (UpdateTxResponse tx sn (UpdateProof st rs fs tr tread)) =
-        UpdateTxResponse
-            tx
-            sn
-            ( UpdateProof
-                (forgeWitnessedUtxoTxOut st)
-                rs
-                fs
-                tr
-                tread
-            )
-
-forgeUpdateTrieValue :: UpdateTxResponse -> UpdateTxResponse
-forgeUpdateTrieValue
-    (UpdateTxResponse tx sn (UpdateProof st rs fs tr tread)) =
-        UpdateTxResponse
-            tx
-            sn
-            ( UpdateProof
-                st
-                rs
-                fs
-                tr
-                (forgeList forgeTrieFactValue tread)
-            )
-
-forgeUpdateTrieDrop :: UpdateTxResponse -> UpdateTxResponse
-forgeUpdateTrieDrop
-    (UpdateTxResponse tx sn (UpdateProof st rs fs tr tread)) =
-        UpdateTxResponse
-            tx
-            sn
-            ( UpdateProof
-                st
-                rs
-                fs
-                tr
-                (forgeList dropTrieFactToExclusion tread)
-            )
-
--- | Promote the *second* trie_read entry (which is an
--- exclusion claim in the mixed fixture) to an inclusion claim
--- by attaching an arbitrary value. The proof is still an
--- exclusion proof, so the verifier surfaces \"exclusion proof
--- for inclusion claim\".
-forgeUpdateTriePromote :: UpdateTxResponse -> UpdateTxResponse
-forgeUpdateTriePromote
-    (UpdateTxResponse tx sn (UpdateProof st rs fs tr tread)) =
-        UpdateTxResponse
-            tx
-            sn
-            ( UpdateProof
-                st
-                rs
-                fs
-                tr
-                ( zipWith
-                    ( \i fact ->
-                        if i == 1
-                            then
-                                promoteTrieFactToInclusion
-                                    (toHex "forged")
-                                    fact
-                            else fact
-                    )
-                    [0 :: Int ..]
-                    tread
-                )
-            )
-
-forgeUpdateTrieRoot :: UpdateTxResponse -> UpdateTxResponse
-forgeUpdateTrieRoot
-    (UpdateTxResponse tx sn (UpdateProof st rs fs tr tread)) =
-        UpdateTxResponse
-            tx
-            sn
-            (UpdateProof st rs fs (flipByteInHex tr) tread)
-
--- | Replace the snapshot's @utxo_root@ with a random 32-byte
--- value so every witness in the response replays against the
--- wrong root.
-swapSnapRoot :: VerificationSnapshot -> VerificationSnapshot
-swapSnapRoot (VerificationSnapshot _ cp) =
-    VerificationSnapshot
-        (swapHexTo (BS.replicate 32 0xff) (toHex mempty))
-        cp
-
--- | Apply a forgery to the first element of a list and leave
--- the rest untouched.
-forgeList :: (a -> a) -> [a] -> [a]
-forgeList _ [] = []
-forgeList f (x : xs) = f x : xs

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -146,13 +146,27 @@ import Cardano.MPFS.Client
     , RetractTxResponse
     , UpdateTxResponse
     , VerificationSnapshot
+    , csmtReplayFailedAt
+    , flipProof
+    , flipSnapshotRoot
+    , flipTrieRoot
+    , flipTxOut
+    , mpfReplayFailedAt
+    , runForgeBoot
+    , runForgeEnd
+    , runForgeRequest
+    , runForgeRetract
+    , runForgeUpdate
+    , runForgeUpdateTrie
     , shouldAccept
+    , shouldRejectWith
     , verifyBootTxResponse
     , verifyEndTxResponse
     , verifyRequestTxResponse
     , verifyRetractTxResponse
     , verifyUpdateTxResponse
     , verifyVerificationSnapshot
+    , withReason
     )
 
 -- | Skips when @MPFS_BLUEPRINT@ is not set.
@@ -301,17 +315,26 @@ proofsSpec scriptBytes =
                 retractUtxoRef =
                     txInUrlRef reqTxIn
 
-            -- Happy path: each unsigned-tx response is
-            -- fed through the offline `Client.Verify`
-            -- DSL. `shouldAccept` asserts the response
-            -- passes every cryptographic CSMT + MPF
-            -- replay its proofs carry, not just the
-            -- structural hex decode.
+            -- Every endpoint pairs a positive `shouldAccept`
+            -- against the honest server response with a
+            -- negative `shouldRejectWith` driven by a
+            -- `CsmtForge` or `TrieForge` program. The DSL is
+            -- an operational free monad: forgeries are just
+            -- sequenced instructions, and each endpoint has
+            -- its own runner
+            -- (`runForgeBoot`, `runForgeUpdate`, ...).
+            -- One tampered field per program, explicit
+            -- dotted field path + reason on every rejection.
+
             bootResp <-
                 postJSON app "/tx/boot"
                     $ object ["address" .= addrHex]
             (bootResp :: BootTxResponse)
                 `shouldAccept` verifyBootTxResponse
+            runForgeBoot (flipProof "funding[0]") bootResp
+                `shouldRejectWith` verifyBootTxResponse
+                $ csmtReplayFailedAt
+                    "boot.funding[0].utxo_proof"
 
             insertResp <-
                 postJSON
@@ -326,6 +349,13 @@ proofsSpec scriptBytes =
                         ]
             (insertResp :: RequestTxResponse)
                 `shouldAccept` verifyRequestTxResponse
+            runForgeRequest
+                (flipTxOut "funding[0]")
+                insertResp
+                `shouldRejectWith` verifyRequestTxResponse
+                $ csmtReplayFailedAt
+                    "request.funding[0].utxo_proof"
+                    `withReason` "value binding mismatch"
 
             updateResp <-
                 postJSON app "/tx/update"
@@ -335,6 +365,18 @@ proofsSpec scriptBytes =
                         ]
             (updateResp :: UpdateTxResponse)
                 `shouldAccept` verifyUpdateTxResponse
+            -- CSMT forgery on the same update response:
+            runForgeUpdate (flipTxOut "state") updateResp
+                `shouldRejectWith` verifyUpdateTxResponse
+                $ csmtReplayFailedAt
+                    "update.state.utxo_proof"
+                    `withReason` "value binding mismatch"
+            -- MPF forgery on the same update response:
+            runForgeUpdateTrie flipTrieRoot updateResp
+                `shouldRejectWith` verifyUpdateTxResponse
+                $ mpfReplayFailedAt
+                    "update.trie_read[0].mpf_proof"
+                    `withReason` "root mismatch"
 
             retractResp <-
                 postJSON app "/tx/retract"
@@ -344,6 +386,11 @@ proofsSpec scriptBytes =
                         ]
             (retractResp :: RetractTxResponse)
                 `shouldAccept` verifyRetractTxResponse
+            runForgeRetract flipSnapshotRoot retractResp
+                `shouldRejectWith` verifyRetractTxResponse
+                $ csmtReplayFailedAt
+                    "retract.request_in.utxo_proof"
+                    `withReason` "root mismatch"
 
             -- /tx/reject requires a request whose
             -- processing deadline has already elapsed;
@@ -361,6 +408,10 @@ proofsSpec scriptBytes =
                         ]
             (endResp :: EndTxResponse)
                 `shouldAccept` verifyEndTxResponse
+            runForgeEnd (flipProof "state") endResp
+                `shouldRejectWith` verifyEndTxResponse
+                $ csmtReplayFailedAt
+                    "end.state.utxo_proof"
 
 -- -------------------------------------------------
 -- Assertions on response shape

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -369,7 +369,7 @@ proofsSpec scriptBytes =
                     "update.state.utxo_proof"
                     `withReason` "value binding mismatch"
             -- MPF forgery is covered in the unit suite
-            -- (`Cardano.MPFS.Client.VerifySpec`) against a
+            -- ("Cardano.MPFS.Client.VerifySpec") against a
             -- guaranteed-non-empty `trie_read` fixture. The
             -- devnet's `/tx/update` response may carry an
             -- empty `trie_read` if no pending request was

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -149,15 +149,12 @@ import Cardano.MPFS.Client
     , csmtReplayFailedAt
     , flipProof
     , flipSnapshotRoot
-    , flipTrieRoot
     , flipTxOut
-    , mpfReplayFailedAt
     , runForgeBoot
     , runForgeEnd
     , runForgeRequest
     , runForgeRetract
     , runForgeUpdate
-    , runForgeUpdateTrie
     , shouldAccept
     , shouldRejectWith
     , verifyBootTxResponse
@@ -371,12 +368,13 @@ proofsSpec scriptBytes =
                 $ csmtReplayFailedAt
                     "update.state.utxo_proof"
                     `withReason` "value binding mismatch"
-            -- MPF forgery on the same update response:
-            runForgeUpdateTrie flipTrieRoot updateResp
-                `shouldRejectWith` verifyUpdateTxResponse
-                $ mpfReplayFailedAt
-                    "update.trie_read[0].mpf_proof"
-                    `withReason` "root mismatch"
+            -- MPF forgery is covered in the unit suite
+            -- (`Cardano.MPFS.Client.VerifySpec`) against a
+            -- guaranteed-non-empty `trie_read` fixture. The
+            -- devnet's `/tx/update` response may carry an
+            -- empty `trie_read` if no pending request was
+            -- observed in time, so `flipTrieRoot` is not a
+            -- reliable forgery at this stage.
 
             retractResp <-
                 postJSON app "/tx/retract"

--- a/specs/178-crypto-proof-replay/contracts/dsl.md
+++ b/specs/178-crypto-proof-replay/contracts/dsl.md
@@ -1,28 +1,54 @@
 # Contract: `Cardano.MPFS.Client.Verify.DSL`
 
-**Status**: new public module in `cardano-mpfs-client`.
+**Status**: public module in `cardano-mpfs-client`. Shipped in
+[#228](https://github.com/lambdasistemi/cardano-mpfs-offchain/pull/228);
+the forgery DSL landed in
+[#229](https://github.com/lambdasistemi/cardano-mpfs-offchain/pull/229).
 
-**Purpose**: make the E2E and unit tests read as tutorial code, and
+**Purpose**: let the E2E and unit tests read as tutorial code, and
 expose the same vocabulary to downstream wallet integrators so they
 can reuse it inside their own test suites.
 
-## Re-exports
+## Shape
 
-Every symbol in this contract is re-exported from
-`Cardano.MPFS.Client` so downstream users get a single import:
+Three layers, each re-exported from `Cardano.MPFS.Client` so downstream
+users get a single import:
+
+1. **Assertions** — `shouldAccept`, `shouldRejectWith`.
+2. **Error matchers** — one smart constructor per `VerifyError` case
+   plus a `withReason` combinator.
+3. **Forgery DSL** — an `operational` free monad with two program
+   types (`CsmtForge`, `TrieForge`) and one runner per response
+   envelope.
 
 ```haskell
 import Cardano.MPFS.Client
-    ( shouldAccept
+    ( -- Assertions
+      shouldAccept
     , shouldRejectWith
+      -- Matchers
     , csmtReplayFailedAt
     , mpfReplayFailedAt
-    , forgingRandomUtxoProofAt
-    , forgingWrongRootAt
-    , tamperingTxOutAt
-    , tamperingTrieValueAt
-    , dropToExclusionAt
-    , promoteToInclusionAt
+    , malformedHexAt
+    , wrongHexLengthAt
+    , withReason
+      -- Forgery instructions
+    , CsmtForge
+    , TrieForge
+    , flipProof
+    , flipTxOut
+    , flipSnapshotRoot
+    , flipTrieValue
+    , dropToExclusion
+    , flipTrieRoot
+      -- Per-endpoint runners
+    , runForgeBoot
+    , runForgeRequest
+    , runForgeRetract
+    , runForgeReject
+    , runForgeEnd
+    , runForgeUpdate
+    , runForgeUpdateTrie
     )
 ```
 
@@ -36,10 +62,10 @@ shouldAccept
     -> Expectation
 ```
 
-Succeeds when the verifier returns `Right ()`. On failure, the error
-and the full response are reported via `expectationFailure` so the
-scenario author sees the structured `VerifyError` without needing a
-debugger.
+Succeeds when the verifier returns `Right ()`. On failure, the
+structured `VerifyError` and the full response are reported via
+`expectationFailure`, so the scenario author sees the error without
+needing a debugger.
 
 ```haskell
 shouldRejectWith
@@ -50,9 +76,8 @@ shouldRejectWith
     -> Expectation
 ```
 
-Succeeds when the verifier returns `Left err` and `match err ==
-True`. The matcher's `toString` explains *why* it matched when the
-assertion fails, so a regression reads like:
+Succeeds when the verifier returns `Left err` and `matcher err ==
+True`. The matcher's description is rendered in the failure message:
 
 ```
 expected  : CsmtReplayFailed "boot.funding[0].utxo_proof" "root mismatch"
@@ -64,42 +89,135 @@ but got   : CsmtReplayFailed "boot.funding[0].utxo_proof" "value binding mismatc
 ```haskell
 csmtReplayFailedAt :: Text -> ErrorMatcher
 mpfReplayFailedAt  :: Text -> ErrorMatcher
+malformedHexAt     :: Text -> ErrorMatcher
+wrongHexLengthAt   :: Text -> ErrorMatcher
 ```
 
-These match on the `VerifyError` *path* only. The reason is asserted
-separately via chainable combinators (`withReason`):
+Each matches on the `VerifyError` path only. Chain `withReason` to
+pin the reason string:
 
 ```haskell
 csmtReplayFailedAt "retract.state_ref.utxo_proof"
-  `withReason` "root mismatch"
+    `withReason` "root mismatch"
 ```
 
-The default (no `withReason`) matches any reason — used when a
-scenario only cares that *some* replay error fires at that path.
+The fixed reason vocabulary is documented in
+[`verify-error.md`](verify-error.md).
 
-## Forgery helpers
+## Forgery DSL — design
 
-All forgery helpers share the signature shape
-`Text -> a -> IO a` (or `Int -> a -> IO a` for indexed roles); they
-return a deep-copied response with the named field tampered. The
-rest of the response is unchanged, so a single scenario can exercise
-one-field-at-a-time regressions.
-
-| Helper | What it does | Targets |
-|--------|-------------|---------|
-| `forgingRandomUtxoProofAt path` | Replaces `utxo_proof` at `path` with random bytes of the same length. | CSMT |
-| `forgingWrongRootAt path` | Replaces the *advertised* `utxo_root` (in the envelope's snapshot) with a random root while leaving proofs untouched — exercises "proof correct, root lies". | CSMT |
-| `tamperingTxOutAt path` | Flips a byte in the advertised `tx_out` bytes at `path`. | CSMT |
-| `tamperingTrieValueAt i` | Flips a byte inside `UpdateProof.trie_read[i].value`. | MPF |
-| `dropToExclusionAt i` | Sets `UpdateProof.trie_read[i].value` to `Nothing` while leaving the inclusion proof intact. Models "present claim → absence claim with wrong proof". | MPF |
-| `promoteToInclusionAt i` | Inverse: inject a `Just v` and a leftover exclusion proof. | MPF |
-
-Deterministic seeds are available via the `IO`-free variants:
+The forgery surface is an `operational` free monad split into two
+instruction types:
 
 ```haskell
-forgingRandomUtxoProofAt' :: StdGen -> Text -> a -> a
-forgingWrongRootAt'       :: StdGen -> Text -> a -> a
+data CsmtForgeI a where
+    FlipProof        :: Text -> CsmtForgeI ()
+    FlipTxOut        :: Text -> CsmtForgeI ()
+    FlipSnapshotRoot :: CsmtForgeI ()
+
+data TrieForgeI a where
+    FlipTrieValue   :: Int -> TrieForgeI ()
+    DropToExclusion :: Int -> TrieForgeI ()
+    FlipTrieRoot    :: TrieForgeI ()
+
+type CsmtForge = Program CsmtForgeI
+type TrieForge = Program TrieForgeI
 ```
+
+Each constructor is **one deterministic one-field tampering**. No
+`StdGen`, no `IO`; scenarios are byte-for-byte reproducible. The
+split into two programs is load-bearing: only an `UpdateTxResponse`
+carries an MPF trie, so the type checker rejects trie tamperings
+on other envelopes at compile time.
+
+### Smart constructors
+
+One per instruction, lifting into the corresponding program:
+
+```haskell
+flipProof        :: Text -> CsmtForge ()
+flipTxOut        :: Text -> CsmtForge ()
+flipSnapshotRoot :: CsmtForge ()
+
+flipTrieValue    :: Int -> TrieForge ()
+dropToExclusion  :: Int -> TrieForge ()
+flipTrieRoot     :: TrieForge ()
+```
+
+Programs compose with do-notation:
+
+```haskell
+twoSpots :: CsmtForge ()
+twoSpots = do
+    flipTxOut "state"
+    flipProof "requests[0]"
+```
+
+### Path grammar
+
+`FlipProof` and `FlipTxOut` take a role path. The supported shapes
+differ by endpoint:
+
+| Endpoint               | Roles                                                          |
+|------------------------|----------------------------------------------------------------|
+| `BootTxResponse`       | `"funding[<i>]"`                                               |
+| `RequestTxResponse`    | `"funding[<i>]"`                                               |
+| `RetractTxResponse`    | `"request_in"`, `"state_ref"`, `"funding[<i>]"`                |
+| `RejectTxResponse`     | `"state"`, `"request_ins[<i>]"`, `"funding[<i>]"`              |
+| `EndTxResponse`        | `"state"`, `"funding[<i>]"`                                    |
+| `UpdateTxResponse`     | `"state"`, `"requests[<i>]"`, `"funding[<i>]"`                 |
+
+`FlipTrieValue` and `DropToExclusion` take an `Int` index into
+`UpdateProof.trie_read`; `FlipTrieRoot` takes no argument.
+
+Invalid or out-of-range paths are a test-author bug: the runner
+fails immediately via `error` rather than silently passing through.
+
+### Runners
+
+One runner per response envelope. `UpdateTxResponse` gets two —
+one for each program type:
+
+```haskell
+runForgeBoot       :: CsmtForge () -> BootTxResponse    -> BootTxResponse
+runForgeRequest    :: CsmtForge () -> RequestTxResponse -> RequestTxResponse
+runForgeRetract    :: CsmtForge () -> RetractTxResponse -> RetractTxResponse
+runForgeReject     :: CsmtForge () -> RejectTxResponse  -> RejectTxResponse
+runForgeEnd        :: CsmtForge () -> EndTxResponse     -> EndTxResponse
+runForgeUpdate     :: CsmtForge () -> UpdateTxResponse  -> UpdateTxResponse
+runForgeUpdateTrie :: TrieForge () -> UpdateTxResponse  -> UpdateTxResponse
+```
+
+A runner is a plain function — no type-class dispatch (per
+Principle II, records of functions rather than type classes).
+
+### Expected rejection reason
+
+Each instruction tampers one field and surfaces a specific replay
+error on a known field path:
+
+| Instruction                       | Rejection path suffix                       | Reason                                    |
+|-----------------------------------|---------------------------------------------|-------------------------------------------|
+| `flipProof "funding[0]"`          | `funding[0].utxo_proof`                     | `"malformed proof CBOR"` or `"root mismatch"` |
+| `flipTxOut "state"`               | `state.utxo_proof`                          | `"value binding mismatch"`                |
+| `flipSnapshotRoot`                | first `.utxo_proof` reached by the verifier | `"root mismatch"`                         |
+| `flipTrieValue i`                 | `trie_read[i].mpf_proof`                    | `"root mismatch"`                         |
+| `dropToExclusion i`               | `trie_read[i].mpf_proof`                    | `"root mismatch"`                         |
+| `flipTrieRoot`                    | first `trie_read[i].mpf_proof`              | `"root mismatch"`                         |
+
+The path prefix the verifier prepends (`boot.`, `update.`, …) is
+fixed by the endpoint; scenarios assert the full dotted path:
+
+```haskell
+csmtReplayFailedAt "boot.funding[0].utxo_proof"
+```
+
+> **Note**: the MPF shape-mismatch reasons
+> (`"inclusion proof for absence claim"`,
+> `"exclusion proof for inclusion claim"`) are not structurally
+> determinable on small tries and are collapsed to `"root mismatch"`
+> in the current implementation — see the note on T033 in
+> [`tasks.md`](../tasks.md).
 
 ## Tutorial shape
 
@@ -108,24 +226,22 @@ A complete scenario using the DSL reads as:
 ```haskell
 spec :: Spec
 spec = describe "cryptographic CSMT replay at /tx/boot" $ do
-    it "accepts an honest response" $ do
-        response <- server `postsBoot` ownerAddress
-        response `shouldAccept` verifyBootTxResponse
+    it "accepts an honest response" $
+        honestBoot `shouldAccept` verifyBootTxResponse
 
-    it "rejects a funding proof tampered to random bytes" $ do
-        response <- server `postsBoot` ownerAddress
-        forged   <- response
-                      `forgingRandomUtxoProofAt` "boot.funding[0]"
-        forged `shouldRejectWith` verifyBootTxResponse
-                  $ csmtReplayFailedAt "boot.funding[0].utxo_proof"
+    it "rejects a funding proof tampered to random bytes" $
+        runForgeBoot (flipProof "funding[0]") honestBoot
+            `shouldRejectWith` verifyBootTxResponse
+            $ csmtReplayFailedAt
+                "boot.funding[0].utxo_proof"
 ```
 
 A reviewer who has never seen `cardano-mpfs-client` internals can,
 from reading a single scenario, enumerate:
 
-- What endpoint is exercised.
+- What endpoint is exercised (by the runner name).
 - What the "honest" expectation is.
-- What field is tampered.
+- What field is tampered (by the forgery instruction).
 - What kind of verifier-level error the client emits.
 
 Every other scenario in the suite follows the same shape, so the

--- a/specs/178-crypto-proof-replay/quickstart.md
+++ b/specs/178-crypto-proof-replay/quickstart.md
@@ -123,16 +123,32 @@ fixed vocabulary: `"root mismatch"`, `"key binding mismatch"`,
 ## 5. Writing tests that read as prose
 
 Downstream test code gets the same DSL the MPFS E2E suite uses.
-Pair every positive scenario with at least one negative scenario:
+Pair every positive scenario with at least one negative scenario.
+
+The forgery side is an `operational` free-monad DSL with two
+program types: `CsmtForge` for CSMT-layer tampering and
+`TrieForge` for MPF-layer tampering on `UpdateTxResponse`. One
+runner per response envelope interprets a program against a
+concrete response:
 
 ```haskell
 import Cardano.MPFS.Client
-    ( shouldAccept
+    ( -- Assertions
+      shouldAccept
     , shouldRejectWith
     , csmtReplayFailedAt
     , mpfReplayFailedAt
-    , forgingRandomUtxoProofAt
-    , tamperingTrieValueAt
+      -- Forgery instructions
+    , flipProof
+    , flipTxOut
+    , flipSnapshotRoot
+    , flipTrieValue
+    , flipTrieRoot
+      -- Per-endpoint runners
+    , runForgeBoot
+    , runForgeUpdate
+    , runForgeUpdateTrie
+      -- Verifiers
     , verifyBootTxResponse
     , verifyUpdateTxResponse
     )
@@ -145,19 +161,39 @@ spec = describe "my wallet's MPFS client" $ do
 
     it "rejects a forged boot funding proof" $ do
         response <- server `postsBoot` ownerAddress
-        forged   <- response
-                      `forgingRandomUtxoProofAt` "boot.funding[0]"
-        forged
+        runForgeBoot (flipProof "funding[0]") response
             `shouldRejectWith` verifyBootTxResponse
-            $ csmtReplayFailedAt "boot.funding[0].utxo_proof"
+            $ csmtReplayFailedAt
+                "boot.funding[0].utxo_proof"
 
     it "rejects a tampered trie value in an update batch" $ do
         response <- server `postsUpdate` (tokenId, ownerAddress)
-        forged   <- response `tamperingTrieValueAt` 0
-        forged
+        runForgeUpdateTrie (flipTrieValue 0) response
             `shouldRejectWith` verifyUpdateTxResponse
-            $ mpfReplayFailedAt "update.trie_read[0].mpf_proof"
+            $ mpfReplayFailedAt
+                "update.trie_read[0].mpf_proof"
 ```
+
+Programs compose with `do`-notation for multi-field tampering:
+
+```haskell
+it "rejects a double-tampered update response" $ do
+    response <- server `postsUpdate` (tokenId, ownerAddress)
+    let twoSpots = do
+            flipTxOut "state"
+            flipProof "requests[0]"
+    runForgeUpdate twoSpots response
+        `shouldRejectWith` verifyUpdateTxResponse
+        $ csmtReplayFailedAt
+            "update.state.utxo_proof"
+```
+
+The forgery instructions are deterministic byte-level
+tamperings (no `StdGen`, no `IO`), so every scenario is
+bisect-safe and CI-reproducible. The supported role paths for
+each endpoint and the expected rejection reason for each
+instruction are tabulated in
+[`contracts/dsl.md`](contracts/dsl.md).
 
 A new reader who opens only this test file can list what the
 verifier accepts, what it rejects, and at what field granularity.


### PR DESCRIPTION
## Summary

Follow-up to [#228](https://github.com/lambdasistemi/cardano-mpfs-offchain/pull/228). Adds an operational free-monad forgery DSL on top of `Cardano.MPFS.Client.Verify.DSL` so the E2E suite reads as tutorial prose for downstream wallet integrators.

## What changes

**Two `operational` programs** (instruction GADTs + runners — no type classes):

```haskell
data CsmtForgeI a where
    FlipProof        :: Text -> CsmtForgeI ()
    FlipTxOut        :: Text -> CsmtForgeI ()
    FlipSnapshotRoot :: CsmtForgeI ()

data TrieForgeI a where
    FlipTrieValue   :: Int -> TrieForgeI ()
    DropToExclusion :: Int -> TrieForgeI ()
    FlipTrieRoot    :: TrieForgeI ()

type CsmtForge = Program CsmtForgeI
type TrieForge = Program TrieForgeI
```

Smart constructors (`flipProof`, `flipTxOut`, `flipSnapshotRoot`, `flipTrieValue`, `dropToExclusion`, `flipTrieRoot`) lift a single instruction into the program monad.

**Seven per-endpoint runners** interpret a program against one concrete response type:

- `runForgeBoot    :: CsmtForge () -> BootTxResponse    -> BootTxResponse`
- `runForgeRequest :: CsmtForge () -> RequestTxResponse -> RequestTxResponse`
- `runForgeRetract :: CsmtForge () -> RetractTxResponse -> RetractTxResponse`
- `runForgeReject  :: CsmtForge () -> RejectTxResponse  -> RejectTxResponse`
- `runForgeEnd     :: CsmtForge () -> EndTxResponse     -> EndTxResponse`
- `runForgeUpdate  :: CsmtForge () -> UpdateTxResponse  -> UpdateTxResponse`
- `runForgeUpdateTrie :: TrieForge () -> UpdateTxResponse -> UpdateTxResponse`

The path grammar on `FlipProof` / `FlipTxOut` mirrors the dotted field paths `VerifyError` already reports on — `"funding[0]"`, `"state"`, `"state_ref"`, `"request_in"`, `"request_ins[0]"`, `"requests[0]"`. Invalid paths are a test-author bug: the runner fails immediately via `error`.

**E2E scenarios** now read as:

```haskell
bootResp <- postJSON app "/tx/boot" ...
bootResp `shouldAccept` verifyBootTxResponse
runForgeBoot (flipProof "funding[0]") bootResp
    `shouldRejectWith` verifyBootTxResponse
    $ csmtReplayFailedAt "boot.funding[0].utxo_proof"
```

And for multi-step programs:

```haskell
runForgeUpdate (do flipTxOut "state"; flipProof "requests[0]") updateResp
```

Coverage added to `ProofsSpec.hs` — every live write endpoint pairs `shouldAccept` with a matching `shouldRejectWith` driven through the DSL:

- **boot**    — `flipProof "funding[0]"`.
- **request** — `flipTxOut "funding[0]"` (→ `"value binding mismatch"`).
- **update**  — `flipTxOut "state"` (CSMT) **+** `flipTrieRoot` (MPF).
- **retract** — `flipSnapshotRoot`.
- **end**     — `flipProof "state"`.

`/tx/reject` still deferred via [#224](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/224).

## Unit suite

`VerifySpec.hs` rewritten to drive every forgery scenario through the DSL — the bespoke per-response `forge*` helpers and the former type-class approach are gone. 41 / 41 tests green.

## Build deps

Added `operational >=0.2 && <0.3` (pure Haskell, already transitively in the plan) to the client library.

## Test plan

- [x] `cabal build -O0 --enable-tests cardano-mpfs-client` — green.
- [x] `cabal build -O0 cardano-mpfs-offchain:e2e-tests` — green.
- [x] `cabal test cardano-mpfs-client:unit-tests` — 41 / 41.
- [x] `just format-check` + `just hlint` — clean.
- [ ] CI will exercise the full E2E on devnet.