### PR TITLE
test: cover reject proof response in e2e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,29 +1,82 @@
-# cardano-mpfs-offchain-issue-226 Development Guidelines
+# cardano-mpfs-offchain Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-23
+Auto-generated from active feature plans and maintained by hand where
+repo-wide guidance is stable. Last updated: 2026-04-25.
+
+## Source of Truth
+
+- Project constitution: `.specify/memory/constitution.md`
+- Architecture overview: `docs/architecture/overview.md`
+- Testing guide: `docs/architecture/testing.md`
+- Public API surface: `docs/assets/swagger.json`
+
+The constitution is authoritative for architectural decisions. Feature
+plans must include a Constitution Check before research and re-check it
+after design.
 
 ## Active Technologies
 
-- Haskell — GHC 9.10.1 (native) plus GHC-WASM and (178-crypto-proof-replay)
+- Haskell with GHC 9.10.1 for native builds.
+- `cardano-mpfs-client` verifiers must remain compatible with native
+  GHC, GHC-WASM, and GHC-JS targets.
+- Nix flakes provide the development shell and CI environment.
+- Cabal drives Haskell builds inside the nix shell.
+- Fourmolu and HLint enforce formatting and linting.
 
 ## Project Structure
 
 ```text
-src/
-tests/
+cardano-mpfs-offchain/   Main service, API, e2e tests, docs
+cardano-mpfs-client/     Offline proof-bearing response verifier
+merkle-patricia-forestry/
+                         MPF trie implementation and tests
+docs/                    Architecture, API docs, Swagger UI assets
+specs/                   Speckit feature specs, plans, and tasks
 ```
 
 ## Commands
 
-# Add commands for Haskell — GHC 9.10.1 (native) plus GHC-WASM and
+Use `just` recipes from `nix develop`:
 
-## Code Style
+```bash
+just build                 # Build all components
+just unit                  # MPF/client unit tests
+just unit-offchain         # Offchain interface/unit tests
+just e2e                   # E2E tests with cardano-node subprocess
+just format                # Apply Fourmolu formatting
+just format-check          # Check formatting
+just hlint                 # Run HLint
+just ci                    # Full local CI mirror
+just update-swagger        # Regenerate docs/assets/swagger.json
+```
 
-Haskell — GHC 9.10.1 (native) plus GHC-WASM and: Follow standard conventions
+## Core Constraints
+
+- Use ledger-native Cardano types; do not introduce shadow ledger
+  representations.
+- Service boundaries use records of functions, not typeclasses.
+- Block processing must be atomic across RocksDB column families.
+- The server builds unsigned transactions only; signing stays client-side.
+- Proof encoding, trie hashing, and datum/redeemer construction must stay
+  compatible with the Aiken validators in `cardano-mpfs-onchain`.
+- Client verifiers are pure offline functions. No `IO`, networking,
+  filesystem, time, or non-determinism in verifier paths.
+- Verifier dependencies must cross-compile to GHC-WASM and GHC-JS before
+  they are admitted.
+
+## Spec Kit Workflow
+
+Every issue starts with speckit artifacts before implementation:
+
+1. `spec.md` states the user-visible requirement and acceptance criteria.
+2. `plan.md` records the technical approach and Constitution Check.
+3. `tasks.md` decomposes the implementation into ordered, testable work.
+4. Implementation follows the task list, updating status as work lands.
 
 ## Recent Changes
 
-- 178-crypto-proof-replay: Added Haskell — GHC 9.10.1 (native) plus GHC-WASM and
+- `178-crypto-proof-replay`: added proof-bearing response verification,
+  cryptographic replay constraints, and verifier portability principles.
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -4,11 +4,11 @@
 
 -- |
 -- Module      : Cardano.MPFS.E2E.ProofsSpec
--- Description : Verify proof-bearing read endpoints end-to-end
+-- Description : Verify proof-bearing envelopes end-to-end
 -- License     : Apache-2.0
 --
 -- Boot a token, insert a fact, process it, then call the
--- four proof-bearing read endpoints against a real devnet.
+-- proof-bearing read and write endpoints against a real devnet.
 -- For each response we:
 --
 --   * parse the embedded verification snapshot;
@@ -142,6 +142,7 @@ import Cardano.MPFS.Client
     ( BootTxResponse
     , EndTxResponse
     , Hex (..)
+    , RejectTxResponse
     , RequestTxResponse
     , RetractTxResponse
     , UpdateTxResponse
@@ -152,6 +153,7 @@ import Cardano.MPFS.Client
     , flipTxOut
     , runForgeBoot
     , runForgeEnd
+    , runForgeReject
     , runForgeRequest
     , runForgeRetract
     , runForgeUpdate
@@ -159,6 +161,7 @@ import Cardano.MPFS.Client
     , shouldRejectWith
     , verifyBootTxResponse
     , verifyEndTxResponse
+    , verifyRejectTxResponse
     , verifyRequestTxResponse
     , verifyRetractTxResponse
     , verifyUpdateTxResponse
@@ -168,7 +171,7 @@ import Cardano.MPFS.Client
 
 -- | Skips when @MPFS_BLUEPRINT@ is not set.
 spec :: Spec
-spec = describe "Proof-bearing reads E2E" $ do
+spec = describe "Proof-bearing envelopes E2E" $ do
     mPath <- runIO $ lookupEnv "MPFS_BLUEPRINT"
     case mPath of
         Nothing ->
@@ -201,6 +204,18 @@ spec = describe "Proof-bearing reads E2E" $ do
 awaitTimeout :: Int
 awaitTimeout = 60
 
+-- | Wait just past the devnet reject deadline. The
+-- local 'CageConfig' uses millisecond windows; add a
+-- small safety margin for wall-clock and indexing jitter.
+rejectDeadlineDelay :: CageConfig -> Int
+rejectDeadlineDelay cfg =
+    fromIntegral
+        ( defaultProcessTime cfg
+            + defaultRetractTime cfg
+            + 2_000
+        )
+        * 1_000
+
 -- | Fact key and value used throughout the scenario.
 factKey :: ByteString
 factKey = "hello"
@@ -210,7 +225,7 @@ factValue = "world"
 
 proofsSpec :: SBS.ShortByteString -> Spec
 proofsSpec scriptBytes =
-    it "all four reads carry a verifiable snapshot"
+    it "read and write envelopes carry verifiable proofs"
         $ withE2E scriptBytes
         $ \cfg ctx -> do
             let app = mkApp ctx
@@ -390,13 +405,20 @@ proofsSpec scriptBytes =
                     "retract.request_in.utxo_proof"
                     `withReason` "root mismatch"
 
-            -- /tx/reject requires a request whose
-            -- processing deadline has already elapsed;
-            -- the fresh insert above does not qualify.
-            -- Reject coverage lives in the client
-            -- structural unit tests — skip it here.
-            -- Tracked separately by issue
-            -- lambdasistemi/cardano-mpfs-offchain#224.
+            threadDelay (rejectDeadlineDelay cfg)
+
+            rejectResp <-
+                postJSON app "/tx/reject"
+                    $ object
+                        [ "token" .= Hex (TE.decodeUtf8 tidHex)
+                        , "address" .= addrHex
+                        ]
+            (rejectResp :: RejectTxResponse)
+                `shouldAccept` verifyRejectTxResponse
+            runForgeReject (flipProof "request_ins[0]") rejectResp
+                `shouldRejectWith` verifyRejectTxResponse
+                $ csmtReplayFailedAt
+                    "reject.request_ins[0].utxo_proof"
 
             endResp <-
                 postJSON app "/tx/end"

--- a/specs/224-e2e-tx-reject/plan.md
+++ b/specs/224-e2e-tx-reject/plan.md
@@ -11,7 +11,7 @@ PR #234; feature spec, research, plan, quickstart, and tasks drafted;
 `ProofsSpec` now covers `POST /tx/reject`; focused formatter and E2E
 validation passed.
 
-**Current**: Commit, push, and update PR #234.
+**Current**: Await CI on PR #234, then merge through merge-guard.
 
 **Blockers**: `just e2e` wrapper is blocked by a stale
 `mpfs-bootstrap-genesis` recipe target; direct Cabal E2E validation

--- a/specs/224-e2e-tx-reject/plan.md
+++ b/specs/224-e2e-tx-reject/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: E2E /tx/reject proof verification
+
+**Branch**: `feat/e2e-cover-txreject-in-proofsspec-verifiable-snapsh` (spec dir `224-e2e-tx-reject`) | **Date**: 2026-04-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/224-e2e-tx-reject/spec.md`
+**Issue**: [#224](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/224)
+
+## Status
+
+**Completed**: Constitution baseline confirmed; repo guidance refreshed in
+PR #234; feature spec, research, plan, quickstart, and tasks drafted;
+`ProofsSpec` now covers `POST /tx/reject`; focused formatter and E2E
+validation passed.
+
+**Current**: Commit, push, and update PR #234.
+
+**Blockers**: `just e2e` wrapper is blocked by a stale
+`mpfs-bootstrap-genesis` recipe target; direct Cabal E2E validation
+passes.
+
+## Summary
+
+Extend `Cardano.MPFS.E2E.ProofsSpec` so the proof-bearing write endpoint
+coverage includes `POST /tx/reject`. The scenario already creates a
+pending request and the local devnet uses a 10 second reject deadline, so
+the implementation waits just past that deadline, posts `/tx/reject`,
+decodes `RejectTxResponse`, asserts `verifyRejectTxResponse` accepts it,
+then tampers one proof with the existing verifier DSL and asserts a
+structured `CsmtReplayFailed`.
+
+## Technical Context
+
+**Language/Version**: Haskell with GHC 9.10.1 in the repo dev shell.
+**Primary Dependencies**: Existing `cardano-mpfs-offchain` E2E harness,
+`cardano-mpfs-client` verifier DSL, Servant/WAI test session helpers.
+No new dependency.
+**Storage**: Existing temporary RocksDB database created by `withE2E`.
+No schema change.
+**Testing**: Focused `ProofsSpec` E2E via `just e2e` or Cabal with a
+match pattern; optional client unit tests for existing reject fixtures.
+**Target Platform**: Native devnet E2E test. The client verifier path
+remains pure and cross-target compatible.
+**Project Type**: Multi-package Haskell repository.
+**Performance Goals**: Add only the minimum deadline wait required by the
+devnet cage config, expected about 11 to 12 seconds.
+**Constraints**: Do not submit the built reject transaction; do not
+change HTTP JSON contracts; do not introduce new verifier dependencies;
+keep the E2E scenario readable as client documentation.
+**Scale/Scope**: One E2E test module, one small speckit feature
+directory, no production code changes expected.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Ledger-Native Types | PASS | Test continues to use ledger `Tx`, `TxIn`, `TxId`, and `Addr` types. |
+| II. Records of Functions | PASS | Reuses existing `Context` record and `TxBuilder` record fields; no typeclasses introduced. |
+| III. Atomic Block Processing | PASS | The scenario relies on existing follower/indexer behavior and does not change block processing. |
+| IV. External Signing | PASS | `/tx/reject` response is verified but not signed or submitted in this scenario. |
+| V. Aiken Compatibility | PASS | No proof encoding changes; the existing server and client verifier produce/consume the same bytes. |
+| VI. Test Locally First | PASS | The coverage runs in the local devnet E2E harness. |
+| VII. Nix Reproducibility | PASS | No new system dependency or flake input. |
+| VIII. Pure Offline Verification | PASS | The verifier call remains `verifyRejectTxResponse :: RejectTxResponse -> Either VerifyError ()`. |
+| IX. One Verifier, Many Targets | PASS | No client dependency or verifier implementation change. |
+| X. Lean as Source of Truth | N/A | This ticket adds E2E coverage for an already specified verifier path; it does not change verifier invariants. |
+
+No violations. Complexity tracking is empty.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/224-e2e-tx-reject/
+├── spec.md
+├── research.md
+├── plan.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+cardano-mpfs-offchain/
+└── e2e-test/
+    └── Cardano/MPFS/E2E/
+        └── ProofsSpec.hs
+```
+
+**Structure Decision**: keep the reject coverage in the existing
+`ProofsSpec` scenario so the write endpoint verifier examples stay in
+one place.
+
+## Post-design Constitution Re-check
+
+Re-checked after research: all applicable principles remain PASS. The
+chosen design is test-only, uses existing ledger-native response types,
+and does not alter the verifier model or server contract.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| *(none)* | - | - |

--- a/specs/224-e2e-tx-reject/quickstart.md
+++ b/specs/224-e2e-tx-reject/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: E2E /tx/reject proof verification
+
+## Prerequisites
+
+- Enter the repository dev shell with `nix develop`.
+- Set `MPFS_BLUEPRINT` to the cage blueprint used by the E2E suite.
+
+## Focused validation
+
+Run the proof scenario only:
+
+```bash
+just e2e "Proof-bearing reads E2E"
+```
+
+If running through Cabal directly, keep development builds at `-O0`.
+
+## Expected behavior
+
+The scenario should:
+
+1. Start a local Cardano devnet.
+2. Boot a token.
+3. Submit an insert request and update it.
+4. Submit a second insert request and wait past its reject deadline.
+5. Verify read-side proof envelopes.
+6. Verify write-side proof envelopes for boot, request, update,
+   retract, reject, and end.
+7. Confirm a tampered reject response fails at an explicit CSMT proof
+   path.
+
+The reject branch adds about 11 to 12 seconds to the scenario.

--- a/specs/224-e2e-tx-reject/research.md
+++ b/specs/224-e2e-tx-reject/research.md
@@ -1,0 +1,44 @@
+# Research: E2E /tx/reject proof verification
+
+## Decision: wait past the existing devnet deadline
+
+`ProofsSpec` already uses a test-only `CageConfig` with:
+
+- `defaultProcessTime = 5_000`
+- `defaultRetractTime = 5_000`
+
+`rejectRequestsImpl` filters pending requests with:
+
+```text
+now > requestSubmittedAt + stateProcessTime + stateRetractTime
+```
+
+Because the scenario already submits and awaits a second pending request
+before exercising write endpoints, the smallest reliable path is to wait
+slightly past `defaultProcessTime + defaultRetractTime` and then build
+the reject transaction through HTTP.
+
+## Alternatives considered
+
+### Add a devnet-only config knob
+
+Rejected for this ticket. The local deadline is already 10 seconds, so a
+new knob would add production API or harness plumbing for only a few
+seconds of savings.
+
+### Use CageFlowSpec instead
+
+Rejected. `CageFlowSpec` already proves a submitted reject transaction
+can consume expired requests, but issue #224 is specifically about the
+proof-bearing HTTP response in `ProofsSpec` and the client verifier DSL.
+
+### Hand-crafted client fixture only
+
+Rejected. The client fixture already covers `RejectTxResponse`; the
+missing coverage is the server HTTP path.
+
+## Runtime impact
+
+The scenario adds one wait just past the 10 second reject deadline. The
+expected runtime increase is about 11 to 12 seconds, plus normal devnet
+block/indexing jitter.

--- a/specs/224-e2e-tx-reject/spec.md
+++ b/specs/224-e2e-tx-reject/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: E2E /tx/reject proof verification
+
+**Feature Branch**: `feat/e2e-cover-txreject-in-proofsspec-verifiable-snapsh`
+**Created**: 2026-04-25
+**Status**: Draft
+**Input**: Issue [#224](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/224) - "e2e: cover /tx/reject in ProofsSpec verifiable-snapshot scenario"
+
+## User Scenarios & Testing
+
+### User Story 1 - Verify reject tx response in the E2E proof scenario (Priority: P1)
+
+A downstream client reads the proof-oriented E2E scenario as the example
+for how to consume every proof-bearing write endpoint. The scenario must
+include `POST /tx/reject`, decode its response as a `RejectTxResponse`,
+and run the exported offline verifier before any signing step.
+
+**Why this priority**: `/tx/reject` is already part of the proof-bearing
+write API, but it is the only write endpoint missing from the HTTP E2E
+proof scenario. Without it, regressions in the server response shape or
+the client verifier wiring can pass while one endpoint is unexercised.
+
+**Independent Test**: run `ProofsSpec` against the devnet harness with
+`MPFS_BLUEPRINT` set. The scenario creates a pending request, waits until
+that request is rejectable, posts `/tx/reject`, and asserts
+`verifyRejectTxResponse` accepts the response.
+
+**Acceptance Scenarios**:
+
+1. **Given** a booted token with a pending request whose
+   `submitted_at + process_time + retract_time` deadline has elapsed,
+   **When** the scenario posts `/tx/reject`, **Then** the HTTP response
+   decodes as `RejectTxResponse`.
+2. **Given** that decoded `RejectTxResponse`, **When**
+   `verifyRejectTxResponse` runs through `shouldAccept`, **Then** it
+   returns `Right ()`.
+3. **Given** that same response, **When** the scenario tampers one reject
+   proof field through the exported DSL, **Then** `shouldRejectWith`
+   reports `CsmtReplayFailed` at the expected dotted field path.
+
+### Edge Cases
+
+- The reject request is time-gated. The scenario must wait only as long
+  as the devnet `CageConfig` requires, not a hard-coded production
+  timeout.
+- The scenario builds the unsigned reject transaction only; it must not
+  submit it, so later assertions in the same scenario are not affected by
+  consuming the pending request.
+- If the response cannot be built because the request is not rejectable,
+  the failure must stay visible as an E2E failure rather than being
+  silently skipped.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `ProofsSpec` MUST post `/tx/reject` after creating an
+  actually rejectable pending request.
+- **FR-002**: The response MUST decode as the client package's
+  `RejectTxResponse`.
+- **FR-003**: The scenario MUST assert the honest response is accepted by
+  `verifyRejectTxResponse` through the same `shouldAccept` DSL used for
+  other write endpoints.
+- **FR-004**: The scenario MUST assert a tampered reject response is
+  rejected with `CsmtReplayFailed` at an explicit reject proof path.
+- **FR-005**: The scenario MUST call out any runtime increase caused by
+  waiting for the reject deadline.
+- **FR-006**: The implementation MUST keep the verifier path pure and
+  must not change the wire response contract.
+
+### Key Entities
+
+- **Rejectable request**: A pending request UTxO whose request deadline
+  has elapsed according to the token state's process and retract windows.
+- **RejectTxResponse**: The proof-bearing unsigned transaction response
+  returned by `POST /tx/reject`.
+- **Verifier DSL assertion**: The exported `shouldAccept` /
+  `shouldRejectWith` checks used by `ProofsSpec` as executable client
+  documentation.
+
+## Success Criteria
+
+- **SC-001**: `ProofsSpec` covers `BootTxResponse`, `RequestTxResponse`,
+  `UpdateTxResponse`, `RetractTxResponse`, `RejectTxResponse`, and
+  `EndTxResponse` in one E2E scenario.
+- **SC-002**: The focused E2E command for `ProofsSpec` passes with a real
+  blueprint.
+- **SC-003**: The PR description records the extra wait time added for
+  `/tx/reject`.
+
+## Assumptions
+
+- The devnet `CageConfig` in `ProofsSpec` remains intentionally small
+  (`defaultProcessTime = 5_000`, `defaultRetractTime = 5_000`) so the
+  reject deadline can be reached with a short wait.
+- The request created for the `/tokens/:id/requests` read-side check can
+  also serve as the pending request used by `/tx/reject`.
+- `verifyRejectTxResponse`, `runForgeReject`, and the CSMT matcher DSL
+  already exist in `cardano-mpfs-client`.

--- a/specs/224-e2e-tx-reject/tasks.md
+++ b/specs/224-e2e-tx-reject/tasks.md
@@ -1,0 +1,65 @@
+---
+description: "Task list for feature 224-e2e-tx-reject"
+---
+
+# Tasks: E2E /tx/reject proof verification
+
+**Input**: Design documents from `specs/224-e2e-tx-reject/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [quickstart.md](quickstart.md)
+**Issue**: [#224](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/224)
+
+**Tests**: This feature is itself E2E test coverage. The implementation
+must include the reject positive path and one reject negative verifier
+assertion.
+
+## Phase 1: Setup
+
+**Purpose**: Speckit prerequisites and import audit.
+
+- [X] T001 Confirm `.specify/memory/constitution.md` exists and is not a placeholder.
+- [X] T002 Refresh `CLAUDE.md` so future feature work points at the real constitution and current repo commands.
+- [X] T003 Create `specs/224-e2e-tx-reject/` with spec, research, plan, quickstart, and tasks artifacts.
+- [X] T004 Audit existing `ProofsSpec` imports for the reject response type and forge runner.
+
+## Phase 2: User Story 1 - Verify reject tx response (P1)
+
+**Goal**: `ProofsSpec` exercises the `/tx/reject` HTTP path and verifies
+the proof-bearing response with `cardano-mpfs-client`.
+
+**Independent Test**: focused `ProofsSpec` E2E run with `MPFS_BLUEPRINT`
+set.
+
+- [X] T005 [US1] Add `RejectTxResponse`, `runForgeReject`, and any needed matcher imports to `cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs`.
+- [X] T006 [US1] Compute a reject wait from the local `CageConfig` process and retract windows, with a small safety margin.
+- [X] T007 [US1] POST `/tx/reject` after the request is old enough and decode the response as `RejectTxResponse`.
+- [X] T008 [US1] Assert the honest reject response with `shouldAccept verifyRejectTxResponse`.
+- [X] T009 [US1] Tamper one reject proof via the DSL and assert `shouldRejectWith` reports the expected `CsmtReplayFailed` path.
+- [X] T010 [US1] Remove the stale comment that says reject E2E coverage is skipped.
+
+## Phase 3: Validation
+
+**Purpose**: prove the speckit artifacts and E2E change are coherent.
+
+- [X] T011 Run `git diff --check`.
+- [X] T012 Run a focused formatter or formatting check for the touched Haskell file.
+- [X] T013 Run focused `ProofsSpec` E2E if `MPFS_BLUEPRINT` is available.
+- [X] T014 If focused E2E cannot run locally, document the blocker in the PR and rely on CI for full validation. **Note:** the scenario did run successfully through direct Cabal; the `just e2e` wrapper is separately blocked by a stale `mpfs-bootstrap-genesis` recipe target.
+
+## Phase 4: PR Update
+
+**Purpose**: keep the PR body current.
+
+- [ ] T015 Commit the speckit artifacts and E2E change.
+- [ ] T016 Push the branch.
+- [ ] T017 Update PR #234 with the reject coverage narrative, runtime impact, and validation status.
+
+## Dependencies & Execution Order
+
+- Phase 1 must finish before editing `ProofsSpec`.
+- Phase 2 tasks are sequential because they touch the same scenario.
+- Phase 3 follows the implementation.
+- Phase 4 follows validation.
+
+## Parallel Opportunities
+
+None. This is a narrow single-file E2E change plus documentation.

--- a/specs/224-e2e-tx-reject/tasks.md
+++ b/specs/224-e2e-tx-reject/tasks.md
@@ -49,9 +49,9 @@ set.
 
 **Purpose**: keep the PR body current.
 
-- [ ] T015 Commit the speckit artifacts and E2E change.
-- [ ] T016 Push the branch.
-- [ ] T017 Update PR #234 with the reject coverage narrative, runtime impact, and validation status.
+- [X] T015 Commit the speckit artifacts and E2E change.
+- [X] T016 Push the branch.
+- [X] T017 Update PR #234 with the reject coverage narrative, runtime impact, and validation status.
 
 ## Dependencies & Execution Order
 


### PR DESCRIPTION
Closes #224

## Summary

This PR is the full issue #224 implementation. The repository already had a ratified constitution at `.specify/memory/constitution.md`, so the first commit refreshed `CLAUDE.md` to point future work at the real constitution, architecture docs, and current `just` recipes. The later commits add the issue #224 speckit artifacts, mark their task status complete, and extend `ProofsSpec` so `/tx/reject` is covered by the same proof-verifier path as the other write endpoints.

## What changed

### Speckit baseline

- Added `specs/224-e2e-tx-reject/spec.md`, `research.md`, `plan.md`, `quickstart.md`, and `tasks.md`.
- Captured the Constitution Check for the ticket. The important point is that this is test-only coverage: it does not change verifier invariants, server contracts, proof encoding, or client dependencies.
- Recorded the design choice to wait past the existing local devnet deadline instead of adding a new test-only config knob.

### E2E proof coverage

- Updated `Cardano.MPFS.E2E.ProofsSpec` to describe proof-bearing read and write envelopes, not only read endpoints.
- Added `RejectTxResponse`, `runForgeReject`, and `verifyRejectTxResponse` to the scenario imports.
- Added `rejectDeadlineDelay`, derived from `defaultProcessTime + defaultRetractTime + 2s`, so the test waits only as long as the devnet cage config requires.
- After the scenario creates and indexes a pending request, it now waits past the reject deadline, posts `/tx/reject`, decodes the response as `RejectTxResponse`, and asserts:
  - the honest response passes `shouldAccept verifyRejectTxResponse`
  - a tampered `request_ins[0]` proof fails with `CsmtReplayFailed "reject.request_ins[0].utxo_proof"`
- Removed the old comment that said reject coverage was skipped and tracked by this issue.

## Runtime impact

The reject branch adds one deadline wait to `ProofsSpec`: with the current local devnet config, that is `5s process + 5s retract + 2s margin`, so about 12 seconds plus normal devnet/indexing jitter.

## Validation

- `git diff --check`
- `nix develop --quiet -c just format-check`
- `nix develop --quiet -c cabal test cardano-mpfs-offchain:e2e-tests -O0 --test-show-details=direct --test-option=--match --test-option="Proof-bearing envelopes E2E"`
  - Result: 1 example, 0 failures.

`nix develop --quiet -c just e2e "Proof-bearing envelopes E2E"` is currently blocked before the test suite by the repo recipe trying to build `mpfs-bootstrap-genesis`, which Cabal reports is not in this project. The direct Cabal command above was used to validate the focused E2E target.
