### PR TITLE
feat(client): bind proof roles to tx inputs

### DIFF
--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -53,6 +53,7 @@ library
     Cardano.MPFS.Client.Verify
     Cardano.MPFS.Client.Verify.DSL
     Cardano.MPFS.Client.Verify.Replay
+    Cardano.MPFS.Client.Verify.TxView
 
 executable mpfs-verify
   import:           warnings

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
@@ -48,6 +48,7 @@ module Cardano.MPFS.Client
     , ErrorMatcher
     , csmtReplayFailedAt
     , mpfReplayFailedAt
+    , txBindingFailedAt
     , malformedHexAt
     , wrongHexLengthAt
     , withReason
@@ -141,6 +142,7 @@ import Cardano.MPFS.Client.Verify.DSL
     , shouldAccept
     , shouldRejectWith
     , swapHexTo
+    , txBindingFailedAt
     , withReason
     , wrongHexLengthAt
     )

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Bundle.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Bundle.hs
@@ -57,7 +57,7 @@ data TxIn = TxIn
     { txId :: Hex
     , txIx :: Word64
     }
-    deriving stock (Eq, Show)
+    deriving stock (Eq, Ord, Show)
 
 instance FromJSON TxIn where
     parseJSON = withObject "TxIn" $ \o ->

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Snapshot.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Snapshot.hs
@@ -31,7 +31,7 @@ import Data.Word (Word64)
 -- preserves the on-wire representation; verifiers are responsible for
 -- decoding when they need the raw bytes.
 newtype Hex = Hex {unHex :: Text}
-    deriving stock (Eq, Show)
+    deriving stock (Eq, Ord, Show)
 
 instance FromJSON Hex where
     parseJSON = fmap Hex . parseJSON

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
@@ -57,6 +57,9 @@ import Cardano.MPFS.Client.Verify.Replay
     , replayTrieFact
     , replayWitnessedUtxo
     )
+import Cardano.MPFS.Client.Verify.TxView
+    ( verifyTxBinding
+    )
 
 -- | Structural check for the snapshot that every proof-bearing response
 -- must carry. Confirms the @utxo_root@ decodes as a 32-byte hash and
@@ -76,6 +79,7 @@ verifyBootTxResponse (BootTxResponse t s (BootProof fs)) = do
     checkWitnessedUtxosStructural "boot.funding" fs
     rootBs <- decodeHex "boot.snapshot.utxo_root" (utxoRoot s)
     replayWitnessedUtxos "boot.funding" rootBs fs
+    verifyTxBinding "boot" t (witnessInputs fs) []
 
 -- | Verify a @POST \/tx\/request\/{insert,delete,update}@ response.
 verifyRequestTxResponse :: RequestTxResponse -> Either VerifyError ()
@@ -85,6 +89,7 @@ verifyRequestTxResponse (RequestTxResponse t s (RequestProof fs)) = do
     checkWitnessedUtxosStructural "request.funding" fs
     rootBs <- decodeHex "request.snapshot.utxo_root" (utxoRoot s)
     replayWitnessedUtxos "request.funding" rootBs fs
+    verifyTxBinding "request" t (witnessInputs fs) []
 
 -- | Verify a @POST \/tx\/retract@ response.
 verifyRetractTxResponse :: RetractTxResponse -> Either VerifyError ()
@@ -100,6 +105,11 @@ verifyRetractTxResponse
         replayWitnessedUtxo "retract.request_in" rootBs ri
         replayWitnessedUtxo "retract.state_ref" rootBs sr
         replayWitnessedUtxos "retract.funding" rootBs fs
+        verifyTxBinding
+            "retract"
+            t
+            (txIn ri : witnessInputs fs)
+            [txIn sr]
 
 -- | Verify a @POST \/tx\/reject@ response.
 verifyRejectTxResponse :: RejectTxResponse -> Either VerifyError ()
@@ -115,6 +125,11 @@ verifyRejectTxResponse
         replayWitnessedUtxo "reject.state" rootBs st
         replayWitnessedUtxos "reject.request_ins" rootBs ris
         replayWitnessedUtxos "reject.funding" rootBs fs
+        verifyTxBinding
+            "reject"
+            t
+            (txIn st : witnessInputs ris <> witnessInputs fs)
+            []
 
 -- | Verify a @POST \/tx\/end@ response.
 verifyEndTxResponse :: EndTxResponse -> Either VerifyError ()
@@ -126,6 +141,7 @@ verifyEndTxResponse (EndTxResponse t s (EndProof st fs)) = do
     rootBs <- decodeHex "end.snapshot.utxo_root" (utxoRoot s)
     replayWitnessedUtxo "end.state" rootBs st
     replayWitnessedUtxos "end.funding" rootBs fs
+    verifyTxBinding "end" t (txIn st : witnessInputs fs) []
 
 -- | Verify a @POST \/tx\/update@ response.
 verifyUpdateTxResponse :: UpdateTxResponse -> Either VerifyError ()
@@ -144,6 +160,11 @@ verifyUpdateTxResponse
         replayWitnessedUtxos "update.funding" rootBs fs
         trieRootBs <- decodeHex "update.trie_root" tr
         replayTrieFacts "update.trie_read" trieRootBs tread
+        verifyTxBinding
+            "update"
+            t
+            (txIn st : witnessInputs rs <> witnessInputs fs)
+            []
 
 -- ---------------------------------------------------------------
 -- Structural pass (hex decode, 32-byte hashes, non-empty hex)
@@ -248,3 +269,6 @@ decodeHex field (Hex txt) =
     case Base16.decode (T.encodeUtf8 txt) of
         Right bs -> Right bs
         Left _ -> Left (MalformedHex field txt)
+
+witnessInputs :: [WitnessedUtxo] -> [TxIn]
+witnessInputs = map txIn

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/DSL.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/DSL.hs
@@ -18,8 +18,8 @@
 --
 -- 2. __Error matchers.__  One smart constructor per
 --    'VerifyError' case ('csmtReplayFailedAt',
---    'mpfReplayFailedAt', 'malformedHexAt',
---    'wrongHexLengthAt') plus 'withReason' to narrow the
+--    'mpfReplayFailedAt', 'txBindingFailedAt',
+--    'malformedHexAt', 'wrongHexLengthAt') plus 'withReason' to narrow the
 --    match to a specific reason from the fixed vocabulary in
 --    @contracts\/verify-error.md@.
 --
@@ -109,6 +109,7 @@ module Cardano.MPFS.Client.Verify.DSL
     , ErrorMatcher
     , csmtReplayFailedAt
     , mpfReplayFailedAt
+    , txBindingFailedAt
     , malformedHexAt
     , wrongHexLengthAt
     , withReason
@@ -290,6 +291,17 @@ wrongHexLengthAt path =
             "WrongHexLength " <> quote path <> " <any length>"
         }
 
+-- | Match 'TxBindingFailed' at the given dotted field path.
+txBindingFailedAt :: Text -> ErrorMatcher
+txBindingFailedAt path =
+    ErrorMatcher
+        { matcherMatches = \case
+            TxBindingFailed p _ -> p == path
+            _ -> False
+        , matcherDescribes =
+            "TxBindingFailed " <> quote path <> " <any reason>"
+        }
+
 -- | Narrow an 'ErrorMatcher' to also require a specific reason
 -- string from the fixed vocabulary in @contracts\/verify-error.md@
 -- (@"root mismatch"@, @"key binding mismatch"@,
@@ -312,6 +324,7 @@ withReason base reason =
   where
     reasonOf (CsmtReplayFailed _ r) = Just r
     reasonOf (MpfReplayFailed _ r) = Just r
+    reasonOf (TxBindingFailed _ r) = Just r
     reasonOf _ = Nothing
 
 quote :: Text -> Text

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Replay.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Replay.hs
@@ -74,6 +74,9 @@ data VerifyError
     | -- | MPF replay failed at this dotted field path with a
       -- reason drawn from the fixed vocabulary.
       MpfReplayFailed Text Text
+    | -- | The transaction body does not match the endpoint
+      -- proof roles. Carries a dotted field path and reason.
+      TxBindingFailed Text Text
     deriving stock (Eq, Show)
 
 -- | Replay a 'WitnessedUtxo' against a trusted CSMT root.

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
@@ -98,9 +98,9 @@ decodeTerm field bs =
 
 parseTx :: Text -> CBOR.Term -> Either VerifyError TxView
 parseTx field = \case
-    CBOR.TList (body : _wits : _valid : _aux : []) ->
+    CBOR.TList [body, _wits, _valid, _aux] ->
         parseBody field body
-    CBOR.TListI (body : _wits : _valid : _aux : []) ->
+    CBOR.TListI [body, _wits, _valid, _aux] ->
         parseBody field body
     _ ->
         Left (TxBindingFailed field "unsupported tx CBOR")

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Module      : Cardano.MPFS.Client.Verify.TxView
+-- Description : Pure Conway tx input/reference-input view.
+--
+-- A narrow, WASM-safe CBOR reader for the transaction-body fields
+-- needed by the issue #227 proof/tx binding invariant. It deliberately
+-- does not decode the whole ledger transaction and does not depend on
+-- @cardano-ledger-*@.
+module Cardano.MPFS.Client.Verify.TxView
+    ( TxView (..)
+    , decodeTxView
+    , verifyTxBinding
+    ) where
+
+import Codec.CBOR.Read qualified as CBOR
+import Codec.CBOR.Term qualified as CBOR
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Lazy qualified as BSL
+import Data.List (sort)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Data.Word (Word64)
+
+import Cardano.MPFS.Client.Bundle
+    ( TxIn (..)
+    )
+import Cardano.MPFS.Client.Snapshot
+    ( Hex (..)
+    )
+import Cardano.MPFS.Client.Verify.Replay
+    ( VerifyError (..)
+    )
+
+-- | The transaction-body fragment needed by proof binding.
+data TxView = TxView
+    { txInputs :: [TxIn]
+    , txReferenceInputs :: [TxIn]
+    }
+    deriving stock (Eq, Show)
+
+-- | Decode a Conway transaction enough to read regular inputs
+-- and reference inputs. Conway CDDL:
+--
+-- * tx body key @0@: @set<transaction_input>@
+-- * tx body key @18@: @nonempty_set<transaction_input>@
+decodeTxView :: Text -> Hex -> Either VerifyError TxView
+decodeTxView field h = do
+    bs <- decodeTxBytes field h
+    term <- decodeTerm field bs
+    parseTx field term
+
+-- | Compare decoded tx roles with the endpoint proof roles.
+-- Ordering is ignored because Cardano encodes these values as sets.
+verifyTxBinding
+    :: Text
+    -- ^ Endpoint prefix, e.g. @"retract"@.
+    -> Hex
+    -> [TxIn]
+    -- ^ Proof roles that must be regular tx inputs.
+    -> [TxIn]
+    -- ^ Proof roles that must be tx reference inputs.
+    -> Either VerifyError ()
+verifyTxBinding endpoint tx expectedInputs expectedRefs = do
+    TxView actualInputs actualRefs <-
+        decodeTxView (endpoint <> ".tx") tx
+    compareTxIns
+        (endpoint <> ".tx.inputs")
+        "input set mismatch"
+        expectedInputs
+        actualInputs
+    compareTxIns
+        (endpoint <> ".tx.reference_inputs")
+        "reference input set mismatch"
+        expectedRefs
+        actualRefs
+
+decodeTxBytes :: Text -> Hex -> Either VerifyError BS.ByteString
+decodeTxBytes field (Hex txt) =
+    case Base16.decode (T.encodeUtf8 txt) of
+        Right bs
+            | BS.null bs -> Left (MalformedTxCbor field)
+            | otherwise -> Right bs
+        Left _ -> Left (MalformedTxCbor field)
+
+decodeTerm :: Text -> BS.ByteString -> Either VerifyError CBOR.Term
+decodeTerm field bs =
+    case CBOR.deserialiseFromBytes CBOR.decodeTerm (BSL.fromStrict bs) of
+        Left _ ->
+            Left (TxBindingFailed field "unsupported tx CBOR")
+        Right (remaining, term)
+            | BSL.null remaining -> Right term
+            | otherwise ->
+                Left (TxBindingFailed field "trailing tx CBOR bytes")
+
+parseTx :: Text -> CBOR.Term -> Either VerifyError TxView
+parseTx field = \case
+    CBOR.TList (body : _wits : _valid : _aux : []) ->
+        parseBody field body
+    CBOR.TListI (body : _wits : _valid : _aux : []) ->
+        parseBody field body
+    _ ->
+        Left (TxBindingFailed field "unsupported tx CBOR")
+
+parseBody :: Text -> CBOR.Term -> Either VerifyError TxView
+parseBody field body = do
+    entries <- case body of
+        CBOR.TMap xs -> Right xs
+        CBOR.TMapI xs -> Right xs
+        _ ->
+            Left
+                ( TxBindingFailed
+                    field
+                    "unsupported transaction body CBOR"
+                )
+    inputs <-
+        case lookupIntKey 0 entries of
+            Nothing ->
+                Left (TxBindingFailed (field <> ".inputs") "missing inputs")
+            Just t ->
+                parseInputSet (field <> ".inputs") t
+    refs <-
+        case lookupIntKey 18 entries of
+            Nothing -> Right []
+            Just t ->
+                parseInputSet (field <> ".reference_inputs") t
+    pure TxView{txInputs = inputs, txReferenceInputs = refs}
+
+lookupIntKey :: Integer -> [(CBOR.Term, CBOR.Term)] -> Maybe CBOR.Term
+lookupIntKey wanted = go
+  where
+    go [] = Nothing
+    go ((k, v) : rest)
+        | termInteger k == Just wanted = Just v
+        | otherwise = go rest
+
+termInteger :: CBOR.Term -> Maybe Integer
+termInteger = \case
+    CBOR.TInt n -> Just (fromIntegral n)
+    CBOR.TInteger n -> Just n
+    _ -> Nothing
+
+parseInputSet :: Text -> CBOR.Term -> Either VerifyError [TxIn]
+parseInputSet field = \case
+    CBOR.TTagged 258 t -> parseInputSet field t
+    CBOR.TList xs -> traverse (parseInput field) xs
+    CBOR.TListI xs -> traverse (parseInput field) xs
+    _ -> Left (TxBindingFailed field "unsupported input set CBOR")
+
+parseInput :: Text -> CBOR.Term -> Either VerifyError TxIn
+parseInput field = \case
+    CBOR.TList [CBOR.TBytes txIdBs, ixTerm] ->
+        mkInput field txIdBs ixTerm
+    CBOR.TListI [CBOR.TBytes txIdBs, ixTerm] ->
+        mkInput field txIdBs ixTerm
+    _ -> Left (TxBindingFailed field "unsupported input CBOR")
+
+mkInput
+    :: Text -> BS.ByteString -> CBOR.Term -> Either VerifyError TxIn
+mkInput field txIdBs ixTerm = do
+    if BS.length txIdBs == 32
+        then pure ()
+        else Left (TxBindingFailed field "transaction id length mismatch")
+    ix <- parseWord64 field ixTerm
+    pure
+        TxIn
+            { txId = Hex (T.decodeUtf8 (Base16.encode txIdBs))
+            , txIx = ix
+            }
+
+parseWord64 :: Text -> CBOR.Term -> Either VerifyError Word64
+parseWord64 field t =
+    case termInteger t of
+        Just n
+            | n >= 0 && n <= maxTxInputIndex ->
+                Right (fromInteger n)
+        _ -> Left (TxBindingFailed field "input index out of range")
+
+maxTxInputIndex :: Integer
+maxTxInputIndex = 65535
+
+compareTxIns
+    :: Text
+    -> Text
+    -> [TxIn]
+    -> [TxIn]
+    -> Either VerifyError ()
+compareTxIns field reason expected actual
+    | canonical expected == canonical actual = Right ()
+    | otherwise =
+        Left
+            ( TxBindingFailed
+                field
+                ( reason
+                    <> ": expected "
+                    <> renderCount expected
+                    <> ", got "
+                    <> renderCount actual
+                )
+            )
+  where
+    canonical = sort
+    renderCount xs =
+        T.pack (show (length xs)) <> " tx input(s)"

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
@@ -27,13 +27,16 @@ module Cardano.MPFS.Client.Fixtures
 
       -- * Hex utilities
     , toHex
+    , txCborFromTxIns
     ) where
 
 import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Term qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
+import Data.Text (Text)
 import Data.Text.Encoding qualified as T
 import Data.Word (Word64)
 
@@ -107,8 +110,48 @@ stateTxOut = "state-tx-out-bytes"
 requestTxOut = "request-tx-out-bytes"
 fundingTxOut = "funding-tx-out-bytes"
 
-sampleTxCbor :: Hex
-sampleTxCbor = Hex "deadbeef"
+txCborFromTxIns :: [TxIn] -> [TxIn] -> Hex
+txCborFromTxIns inputs refs =
+    toHex
+        $ CBOR.toStrictByteString
+        $ CBOR.encodeTerm
+        $ CBOR.TList
+            [ CBOR.TMap bodyFields
+            , CBOR.TMap []
+            , CBOR.TBool True
+            , CBOR.TNull
+            ]
+  where
+    bodyFields =
+        [(CBOR.TInt 0, setTerm inputs)]
+            <> if null refs
+                then []
+                else [(CBOR.TInt 18, setTerm refs)]
+
+setTerm :: [TxIn] -> CBOR.Term
+setTerm xs =
+    CBOR.TTagged 258
+        $ CBOR.TList
+        $ map txInTerm xs
+
+txInTerm :: TxIn -> CBOR.Term
+txInTerm TxIn{txId = Hex tid, txIx} =
+    CBOR.TList
+        [ CBOR.TBytes (decodeFixtureHex tid)
+        , CBOR.TInteger (fromIntegral txIx)
+        ]
+
+decodeFixtureHex :: Text -> ByteString
+decodeFixtureHex txt =
+    case Base16.decode (T.encodeUtf8 txt) of
+        Right bs -> bs
+        Left err -> error ("invalid fixture hex: " <> show err)
+
+txFor :: [WitnessedUtxo] -> [WitnessedUtxo] -> Hex
+txFor inputs refs =
+    txCborFromTxIns
+        (map txIn inputs)
+        (map txIn refs)
 
 -- ---------------------------------------------------------------
 -- CSMT primitives
@@ -273,21 +316,26 @@ honestTrieExclusion =
 honestBootResponse :: BootTxResponse
 honestBootResponse =
     BootTxResponse
-        sampleTxCbor
+        (txFor [bundleFunding honestWitness] [])
         (sampleSnapshot (bundleRoot honestWitness))
         (BootProof [bundleFunding honestWitness])
 
 honestRequestResponse :: RequestTxResponse
 honestRequestResponse =
     RequestTxResponse
-        sampleTxCbor
+        (txFor [bundleFunding honestWitness] [])
         (sampleSnapshot (bundleRoot honestWitness))
         (RequestProof [bundleFunding honestWitness])
 
 honestRetractResponse :: RetractTxResponse
 honestRetractResponse =
     RetractTxResponse
-        sampleTxCbor
+        ( txFor
+            [ bundleRequest honestWitness
+            , bundleFunding honestWitness
+            ]
+            [bundleState honestWitness]
+        )
         (sampleSnapshot (bundleRoot honestWitness))
         ( RetractProof
             (bundleRequest honestWitness)
@@ -298,7 +346,13 @@ honestRetractResponse =
 honestRejectResponse :: RejectTxResponse
 honestRejectResponse =
     RejectTxResponse
-        sampleTxCbor
+        ( txFor
+            [ bundleState honestWitness
+            , bundleRequest honestWitness
+            , bundleFunding honestWitness
+            ]
+            []
+        )
         (sampleSnapshot (bundleRoot honestWitness))
         ( RejectProof
             (bundleState honestWitness)
@@ -309,7 +363,12 @@ honestRejectResponse =
 honestEndResponse :: EndTxResponse
 honestEndResponse =
     EndTxResponse
-        sampleTxCbor
+        ( txFor
+            [ bundleState honestWitness
+            , bundleFunding honestWitness
+            ]
+            []
+        )
         (sampleSnapshot (bundleRoot honestWitness))
         ( EndProof
             (bundleState honestWitness)
@@ -320,7 +379,13 @@ honestUpdateResponse :: UpdateTxResponse
 honestUpdateResponse =
     let (trieRoot, trieFact) = honestTrieInclusion
     in  UpdateTxResponse
-            sampleTxCbor
+            ( txFor
+                [ bundleState honestWitness
+                , bundleRequest honestWitness
+                , bundleFunding honestWitness
+                ]
+                []
+            )
             (sampleSnapshot (bundleRoot honestWitness))
             ( UpdateProof
                 (bundleState honestWitness)
@@ -337,7 +402,13 @@ honestUpdateResponseMixedTrie =
     let (trieRoot, inclusionFact) = honestTrieInclusion
         (_, exclusionFact) = honestTrieExclusion
     in  UpdateTxResponse
-            sampleTxCbor
+            ( txFor
+                [ bundleState honestWitness
+                , bundleRequest honestWitness
+                , bundleFunding honestWitness
+                ]
+                []
+            )
             (sampleSnapshot (bundleRoot honestWitness))
             ( UpdateProof
                 (bundleState honestWitness)
@@ -353,7 +424,13 @@ honestUpdateResponseEmptyTrie :: UpdateTxResponse
 honestUpdateResponseEmptyTrie =
     let (trieRoot, _) = honestTrieInclusion
     in  UpdateTxResponse
-            sampleTxCbor
+            ( txFor
+                [ bundleState honestWitness
+                , bundleRequest honestWitness
+                , bundleFunding honestWitness
+                ]
+                []
+            )
             (sampleSnapshot (bundleRoot honestWitness))
             ( UpdateProof
                 (bundleState honestWitness)

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
@@ -124,9 +124,7 @@ txCborFromTxIns inputs refs =
   where
     bodyFields =
         [(CBOR.TInt 0, setTerm inputs)]
-            <> if null refs
-                then []
-                else [(CBOR.TInt 18, setTerm refs)]
+            <> [(CBOR.TInt 18, setTerm refs) | not (null refs)]
 
 setTerm :: [TxIn] -> CBOR.Term
 setTerm xs =

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
@@ -16,7 +16,15 @@ module Cardano.MPFS.Client.VerifySpec (spec) where
 import Test.Hspec (Spec, describe, it)
 
 import Cardano.MPFS.Client
-    ( csmtReplayFailedAt
+    ( BootTxResponse (..)
+    , Hex (..)
+    , RetractProof (..)
+    , RetractTxResponse (..)
+    , TxIn (..)
+    , UpdateProof (..)
+    , UpdateTxResponse (..)
+    , WitnessedUtxo (..)
+    , csmtReplayFailedAt
     , dropToExclusion
     , flipProof
     , flipSnapshotRoot
@@ -33,6 +41,7 @@ import Cardano.MPFS.Client
     , runForgeUpdateTrie
     , shouldAccept
     , shouldRejectWith
+    , txBindingFailedAt
     , verifyBootTxResponse
     , verifyEndTxResponse
     , verifyRejectTxResponse
@@ -50,6 +59,7 @@ import Cardano.MPFS.Client.Fixtures
     , honestUpdateResponse
     , honestUpdateResponseEmptyTrie
     , honestUpdateResponseMixedTrie
+    , txCborFromTxIns
     )
 
 spec :: Spec
@@ -87,6 +97,24 @@ spec = do
         it "accepts an empty trie_read"
             $ honestUpdateResponseEmptyTrie
                 `shouldAccept` verifyUpdateTxResponse
+
+    describe "tx/proof binding corpus" $ do
+        it "rejects a boot tx whose inputs differ from funding proofs"
+            $ replaceBootTx
+                (txCborFromTxIns [foreignTxIn] [])
+                honestBootResponse
+                `shouldRejectWith` verifyBootTxResponse
+            $ txBindingFailedAt "boot.tx.inputs"
+
+        it "rejects a retract tx missing the state reference input"
+            $ retractWithoutReference honestRetractResponse
+                `shouldRejectWith` verifyRetractTxResponse
+            $ txBindingFailedAt "retract.tx.reference_inputs"
+
+        it "rejects an update tx missing a request input"
+            $ updateWithoutRequestInput honestUpdateResponse
+                `shouldRejectWith` verifyUpdateTxResponse
+            $ txBindingFailedAt "update.tx.inputs"
 
     describe "CSMT forgery corpus (free-monad DSL)" $ do
         it "rejects a boot funding utxo_proof with a flipped byte"
@@ -179,3 +207,32 @@ spec = do
             $ mpfReplayFailedAt
                 "update.trie_read[0].mpf_proof"
                 `withReason` "root mismatch"
+
+foreignTxIn :: TxIn
+foreignTxIn =
+    TxIn
+        { txId =
+            Hex
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        , txIx = 99
+        }
+
+replaceBootTx :: Hex -> BootTxResponse -> BootTxResponse
+replaceBootTx tx' (BootTxResponse _ s p) =
+    BootTxResponse tx' s p
+
+retractWithoutReference :: RetractTxResponse -> RetractTxResponse
+retractWithoutReference
+    (RetractTxResponse _ s p@(RetractProof req _st funding)) =
+        RetractTxResponse
+            (txCborFromTxIns (map txIn (req : funding)) [])
+            s
+            p
+
+updateWithoutRequestInput :: UpdateTxResponse -> UpdateTxResponse
+updateWithoutRequestInput
+    (UpdateTxResponse _ s p@(UpdateProof st _reqs funding _tr _tread)) =
+        UpdateTxResponse
+            (txCborFromTxIns (map txIn (st : funding)) [])
+            s
+            p

--- a/lean/Phase4/Verify.lean
+++ b/lean/Phase4/Verify.lean
@@ -143,4 +143,100 @@ theorem replayTrieFact_preserves_root_trust
       = env.trustedRoot := by
   simp [replayTrieFact]
 
+-- =========================================================
+-- Transaction binding model (issue #227)
+-- =========================================================
+
+/-- The fragment of an unsigned transaction body the client
+    verifier decodes for proof/transaction binding. The
+    Haskell decoder reads these lists from Conway tx-body
+    fields `0` (inputs) and `18` (reference inputs). -/
+structure TxView (Key : Type) where
+  inputs : List Key
+  referenceInputs : List Key
+
+/-- Proof roles advertised by a proof-bearing response after
+    endpoint-specific role collection. `consumed` contains
+    roles that must be regular tx inputs; `referenced`
+    contains roles that must be tx reference inputs. -/
+structure ProofRoles (Key : Type) where
+  consumed : List Key
+  referenced : List Key
+
+namespace TxBinding
+
+variable {Key : Type}
+
+/-- A response covers a decoded transaction view exactly when
+    its consumed proof roles are exactly the tx inputs and its
+    referenced proof roles are exactly the tx reference inputs.
+    The Haskell implementation compares sets to ignore CBOR
+    ordering, but this abstract model uses lists; the theorem
+    shape is the same after canonicalisation. -/
+def coversTxView (roles : ProofRoles Key) (tx : TxView Key) : Prop :=
+  tx.inputs = roles.consumed ∧
+  tx.referenceInputs = roles.referenced
+
+/-- Coverage exposes exact regular-input equality. -/
+theorem covers_inputs_exact
+    {roles : ProofRoles Key} {tx : TxView Key}
+    (h : coversTxView roles tx) :
+    tx.inputs = roles.consumed := h.1
+
+/-- Coverage exposes exact reference-input equality. -/
+theorem covers_references_exact
+    {roles : ProofRoles Key} {tx : TxView Key}
+    (h : coversTxView roles tx) :
+    tx.referenceInputs = roles.referenced := h.2
+
+/-- If a tx input is not advertised by any consumed proof
+    role, coverage is impossible. -/
+theorem missing_input_rejected
+    {roles : ProofRoles Key} {tx : TxView Key}
+    (k : Key)
+    (hInTx : k ∈ tx.inputs)
+    (hNotInRoles : k ∉ roles.consumed) :
+    ¬ coversTxView roles tx := by
+  intro h
+  rw [h.1] at hInTx
+  exact hNotInRoles hInTx
+
+/-- If a consumed proof role does not appear in the tx inputs,
+    coverage is impossible. -/
+theorem extra_input_rejected
+    {roles : ProofRoles Key} {tx : TxView Key}
+    (k : Key)
+    (hInRoles : k ∈ roles.consumed)
+    (hNotInTx : k ∉ tx.inputs) :
+    ¬ coversTxView roles tx := by
+  intro h
+  rw [← h.1] at hInRoles
+  exact hNotInTx hInRoles
+
+/-- If a tx reference input is not advertised by any referenced
+    proof role, coverage is impossible. -/
+theorem missing_reference_rejected
+    {roles : ProofRoles Key} {tx : TxView Key}
+    (k : Key)
+    (hInTx : k ∈ tx.referenceInputs)
+    (hNotInRoles : k ∉ roles.referenced) :
+    ¬ coversTxView roles tx := by
+  intro h
+  rw [h.2] at hInTx
+  exact hNotInRoles hInTx
+
+/-- If a referenced proof role does not appear in tx reference
+    inputs, coverage is impossible. -/
+theorem extra_reference_rejected
+    {roles : ProofRoles Key} {tx : TxView Key}
+    (k : Key)
+    (hInRoles : k ∈ roles.referenced)
+    (hNotInTx : k ∉ tx.referenceInputs) :
+    ¬ coversTxView roles tx := by
+  intro h
+  rw [← h.2] at hInRoles
+  exact hNotInTx hInRoles
+
+end TxBinding
+
 end Phase4.Verify

--- a/specs/227-tx-proof-binding/plan.md
+++ b/specs/227-tx-proof-binding/plan.md
@@ -12,8 +12,8 @@ compile; Haskell client decodes tx inputs/reference inputs and compares
 them with endpoint proof roles; focused unit suite passes with the new
 binding forgery corpus.
 
-**Current**: Commit, push, and open the issue #227 PR for the
-input/reference-input binding slice.
+**Current**: PR opened for the input/reference-input binding slice;
+watch CI and merge only after checks are green.
 
 **Blockers**: Full mint/redeemer/output binding is outside this first
 slice and must be tracked explicitly after input/reference-input binding

--- a/specs/227-tx-proof-binding/plan.md
+++ b/specs/227-tx-proof-binding/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Bind proof bundles to unsigned transactions
+
+**Branch**: `feat/client-bind-proof-bundle-content-to-the-unsigned-t` (spec dir `227-tx-proof-binding`) | **Date**: 2026-04-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/227-tx-proof-binding/spec.md`
+**Issue**: [#227](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/227)
+
+## Status
+
+**Completed**: Issue #224 merged; issue #227 worktree created; design
+decision recorded in `research.md`; Lean binding model and theorems
+compile; Haskell client decodes tx inputs/reference inputs and compares
+them with endpoint proof roles; focused unit suite passes with the new
+binding forgery corpus.
+
+**Current**: Commit, push, and open the issue #227 PR for the
+input/reference-input binding slice.
+
+**Blockers**: Full mint/redeemer/output binding is outside this first
+slice and must be tracked explicitly after input/reference-input binding
+lands.
+
+## Summary
+
+Add a pure `cardano-mpfs-client` binding pass that decodes the unsigned
+transaction CBOR far enough to read tx inputs and reference inputs, then
+checks those sets against the endpoint proof roles. This rejects the
+class of forged response where the proof bundle is valid but belongs to
+a different transaction.
+
+## Technical Context
+
+**Language/Version**: Haskell with GHC 9.10.1 target in project docs;
+local shell currently uses the repo-pinned GHC.
+**Primary Dependencies**: Existing `cborg`, `bytestring`, `text`,
+`base16-bytestring`, and existing CSMT/MPF verifier deps. Add no
+server-side dependency.
+**Storage**: N/A.
+**Testing**: `cardano-mpfs-client:unit-tests`.
+**Target Platform**: `cardano-mpfs-client` native, WASM, and JS.
+**Project Type**: Pure Haskell client library inside a multi-package
+repository.
+**Performance Goals**: Decode one small transaction CBOR term per
+response. Linear in tx body size; not a hot path.
+**Constraints**: No `cardano-ledger-*`, no `crypton`, no RocksDB, no IO,
+no server-authored summary as an authority.
+**Scale/Scope**: One Lean file update, one new client module, small
+changes in `Verify.hs`, fixtures, tests, and cabal exposed modules.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Ledger-Native Types | GUARDED | Server keeps ledger-native types. Client intentionally avoids ledger deps per Principle IX and decodes only stable Conway CBOR fields. |
+| II. Records of Functions | PASS | No interfaces added. |
+| III. Atomic Block Processing | N/A | No indexer or RocksDB path touched. |
+| IV. External Signing | PASS | Binding happens before signing; server still returns unsigned tx CBOR. |
+| V. Aiken Compatibility | PASS | No proof encoding or datum encoding change. |
+| VI. Test Locally First | PASS | Unit fixtures are pure and local. |
+| VII. Nix Reproducibility | PASS | No flake input or system package added. |
+| VIII. Pure Offline Verification | PASS | Binding pass is pure over response data. |
+| IX. One Verifier, Many Targets | PASS | Uses existing pure `cborg`; no native FFI or ledger dependency. |
+| X. Lean as Source of Truth | GUARDED | Add binding predicates/theorems before Haskell verifier wiring. |
+
+No justified violations. The guarded items are resolved by the task
+ordering.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/227-tx-proof-binding/
+├── spec.md
+├── research.md
+├── plan.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+lean/Phase4/Verify.lean
+cardano-mpfs-client/
+├── cardano-mpfs-client.cabal
+├── lib/Cardano/MPFS/Client/
+│   ├── Bundle.hs
+│   ├── Verify.hs
+│   ├── Verify/Replay.hs
+│   └── Verify/TxView.hs
+└── test/Cardano/MPFS/Client/
+    ├── Fixtures.hs
+    └── VerifySpec.hs
+```
+
+**Structure Decision**: isolate generic tx-body parsing and set
+comparison in `Verify.TxView`; keep endpoint-specific expected-role
+logic in `Verify.hs` beside the existing per-endpoint verifier walks.
+
+## Phase 1.5: Lean before Haskell
+
+Extend `lean/Phase4/Verify.lean` with an abstract transaction-binding
+model:
+
+- `TxView` with `inputs` and `referenceInputs`
+- `ProofRoles` with `consumed` and `referenced`
+- predicate `coversTxView roles tx`
+- theorems:
+  - `covers_inputs_exact`
+  - `covers_references_exact`
+  - `missing_input_rejected`
+  - `extra_input_rejected`
+
+These theorems are structural and do not model CBOR parsing. They define
+what the Haskell decoder result must satisfy after parsing.
+
+## Post-design Constitution Re-check
+
+Re-checked after research: the design remains inside the pure client
+verifier boundary. Principle I is respected on the server side; the
+client-side exception is already required by Principle IX and is limited
+to generic Conway CBOR field extraction.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| *(none)* | - | - |

--- a/specs/227-tx-proof-binding/quickstart.md
+++ b/specs/227-tx-proof-binding/quickstart.md
@@ -1,0 +1,17 @@
+# Quickstart: Tx/proof binding
+
+## Focused validation
+
+Run the client verifier tests:
+
+```bash
+nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests -O0 --test-show-details=direct
+```
+
+## Expected behavior
+
+- Honest fixtures still pass every `verify*TxResponse` function.
+- Replacing only the `tx` field with a valid transaction whose inputs do
+  not match the proof roles causes a `TxBindingFailed` error.
+- The verifier remains pure and does not require a node, database, or
+  server summary.

--- a/specs/227-tx-proof-binding/research.md
+++ b/specs/227-tx-proof-binding/research.md
@@ -1,0 +1,69 @@
+# Research: Bind proof bundles to unsigned transactions
+
+## Decision: targeted client-side CBOR reader
+
+Use a small pure CBOR reader in `cardano-mpfs-client` to extract the
+transaction body input set and reference-input set from the unsigned tx
+CBOR. Do not use a server-authored `tx_summary` as the authority for this
+slice.
+
+## Rationale
+
+Issue #227 proposed two options:
+
+- A: decode tx CBOR in the client
+- B: have the server emit a pre-decoded summary
+
+B is faster, but it cannot prove the summary describes the unsigned tx
+unless the client can independently check the tx body. A malicious server
+could include a summary that matches the proof and a tx that consumes
+something else. Cryptographic CSMT replay catches false witnesses, but it
+does not catch omitted tx inputs unless the verifier reads the tx inputs.
+
+Therefore this slice chooses A for the input/reference-input layer. The
+decoder is deliberately narrow and only reads fields needed for the first
+binding invariant.
+
+## Local CDDL facts
+
+From `cardano-ledger/eras/conway/impl/cddl-files/conway.cddl`:
+
+```text
+transaction = [transaction_body, transaction_witness_set, bool, auxiliary_data / nil]
+transaction_body = {0 : set<transaction_input>, ..., ? 18 : nonempty_set<transaction_input>, ...}
+transaction_input = [transaction_id : $hash32, index : uint .size 2]
+set<a0> = #6.258([* a0]) / [* a0]
+nonempty_set<a0> = #6.258([+ a0]) / [+ a0]
+```
+
+The client decoder must therefore accept both plain-list and tag-258 set
+encodings for fields `0` and `18`.
+
+## Binding matrix for this slice
+
+| Endpoint | Tx inputs must equal | Tx reference inputs must equal |
+|----------|----------------------|--------------------------------|
+| boot | `funding[*]` | empty |
+| request insert/delete/update | `funding[*]` | empty |
+| retract | `request_in + funding[*]` | `state_ref` |
+| reject | `state + request_ins[*] + funding[*]` | empty |
+| end | `state + funding[*]` | empty |
+| update | `state + requests[*] + funding[*]` | empty |
+
+Collateral inputs are left for a later slice. They are not regular tx
+inputs or reference inputs in the issue's first acceptance surface.
+
+## Rejected alternative: server summary as authoritative
+
+Rejected for this slice. It leaves the client dependent on a
+server-authored interpretation of the transaction and cannot detect a tx
+whose body omits or adds inputs relative to the summary.
+
+## Deferred work
+
+- Decode mint field `9` and bind boot/end mint quantities to token roles.
+- Decode outputs and datum options to bind state-carrying outputs.
+- Decode redeemers from witness-set field `5` and bind update/retract/end
+  redeemer content to proof roles.
+- Bind `UpdateProof.trie_read` facts to the exact MPF proof consumed by
+  the update redeemer.

--- a/specs/227-tx-proof-binding/spec.md
+++ b/specs/227-tx-proof-binding/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: Bind proof bundles to unsigned transactions
+
+**Feature Branch**: `feat/client-bind-proof-bundle-content-to-the-unsigned-t`
+**Created**: 2026-04-25
+**Status**: Draft
+**Input**: Issue [#227](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/227) - "client: bind proof-bundle content to the unsigned tx (proof usefulness)"
+
+## User Scenarios & Testing
+
+### User Story 1 - Reject a response whose proof inputs do not cover the tx inputs (Priority: P1)
+
+A wallet receives a proof-bearing response and verifies it before
+signing. The response's CSMT proofs may be cryptographically valid, but
+they are useful only if they cover the unsigned transaction's actual
+inputs and reference inputs. The client verifier must reject any response
+where the tx body consumes an input that is not represented by the proof
+roles for that endpoint.
+
+**Why this priority**: This closes the immediate trust gap from issue
+#227. Without this, the server can ship a valid proof bundle for one set
+of UTxOs beside an unrelated unsigned transaction.
+
+**Independent Test**: Build honest fixtures whose transaction body input
+sets match their proof roles, then replace only the `tx` field with a
+different valid Conway-shaped transaction CBOR. The verifier must reject
+with a structured binding error.
+
+**Acceptance Scenarios**:
+
+1. **Given** an honest `BootTxResponse`, **When** its transaction inputs
+   equal the `boot.funding[*].tx_in` witnesses, **Then**
+   `verifyBootTxResponse` accepts it.
+2. **Given** an otherwise honest `BootTxResponse`, **When** its
+   transaction consumes an extra input not present in `boot.funding`,
+   **Then** `verifyBootTxResponse` rejects it before the caller signs.
+3. **Given** an honest `RetractTxResponse`, **When** its transaction
+   consumes `request_in` and funding while referencing `state_ref`,
+   **Then** `verifyRetractTxResponse` accepts it.
+4. **Given** an otherwise honest `RetractTxResponse`, **When** its
+   transaction omits `state_ref` from reference inputs, **Then**
+   `verifyRetractTxResponse` rejects it.
+
+### User Story 2 - Keep the verifier pure and portable (Priority: P1)
+
+The binding check must run anywhere the existing verifier runs. It must
+not import `cardano-ledger-*`, native crypto packages, RocksDB, network
+clients, or any other server-side dependency.
+
+**Why this priority**: Principle IX requires one verifier across native,
+WASM, and JS targets. The fix cannot move trust back to the server.
+
+**Independent Test**: `cardano-mpfs-client` builds and its unit tests run
+with only pure Haskell dependencies.
+
+**Acceptance Scenarios**:
+
+1. **Given** a response verifier, **When** it performs tx binding,
+   **Then** it uses only the response's `tx`, `snapshot`, and `proof`
+   fields.
+2. **Given** a malformed or unsupported tx CBOR shape, **When** the
+   verifier reaches the binding pass, **Then** it returns a structured
+   binding failure rather than throwing an exception.
+
+### User Story 3 - Record the scope of remaining deeper binding work (Priority: P2)
+
+Input/reference-input coverage is the first independently checkable
+binding layer. Deeper assertions about mint policies, redeemer payloads,
+state-carrying outputs, and MPF facts must be documented as follow-up
+work unless implemented in this slice.
+
+**Why this priority**: The issue calls out more than input coverage. The
+first slice must not pretend to prove properties it does not yet check.
+
+**Independent Test**: The plan and task list identify the residual work
+explicitly.
+
+## Edge Cases
+
+- Tx bodies may encode Cardano sets either as plain arrays or as tag
+  258-wrapped arrays. The decoder must accept both.
+- Tx body map fields may appear in any order.
+- Reference inputs are optional; missing reference inputs are an empty
+  set.
+- Collateral inputs are not covered by this first slice because they are
+  not regular spending inputs or reference inputs.
+- Fixtures must use valid Conway-shaped transaction CBOR rather than
+  placeholder bytes once binding is enabled.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The client MUST decode enough Conway transaction CBOR to
+  read tx body inputs and reference inputs.
+- **FR-002**: The decoder MUST be pure and MUST NOT depend on
+  `cardano-ledger-*`.
+- **FR-003**: Each write response verifier MUST compare decoded tx inputs
+  and reference inputs against the endpoint proof roles.
+- **FR-004**: The binding pass MUST reject extra, missing, or misplaced
+  inputs with a structured error.
+- **FR-005**: Existing honest client fixtures MUST use tx CBOR whose
+  input/reference-input sets match their proof roles.
+- **FR-006**: Forged-binding unit tests MUST replace only the response
+  `tx` field and prove the verifier rejects the mismatch.
+- **FR-007**: The implementation MUST document residual binding work for
+  mint, redeemers, state-carrying outputs, and MPF fact binding.
+
+## Success Criteria
+
+- **SC-001**: Honest unit fixtures for boot, request, retract, reject,
+  end, and update continue to pass.
+- **SC-002**: At least one forged tx-binding unit test fails verification
+  for each endpoint family: funding-only, reference-input, and
+  state/request-consuming endpoints.
+- **SC-003**: `cardano-mpfs-client:unit-tests` passes.
+- **SC-004**: The PR description states that this slice covers
+  input/reference-input binding and lists remaining deeper binding work.
+
+## Assumptions
+
+- Conway transaction body field `0` is the input set and field `18` is
+  the reference-input set, matching the local Conway CDDL.
+- The client can parse transaction CBOR as generic CBOR terms using
+  `cborg`, which is already a client dependency.
+- Existing CSMT replay remains the source of truth for whether each
+  witnessed UTxO actually belongs to the advertised snapshot root.

--- a/specs/227-tx-proof-binding/tasks.md
+++ b/specs/227-tx-proof-binding/tasks.md
@@ -33,8 +33,8 @@ description: "Task list for feature 227-tx-proof-binding"
 
 - [X] T013 Run `git diff --check`.
 - [X] T014 Run `nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests -O0 --test-show-details=direct`.
-- [ ] T015 Commit and push.
-- [ ] T016 Open/update PR with scope, residual binding work, and validation status.
+- [X] T015 Commit and push.
+- [X] T016 Open/update PR with scope, residual binding work, and validation status.
 
 ## Deferred follow-up
 

--- a/specs/227-tx-proof-binding/tasks.md
+++ b/specs/227-tx-proof-binding/tasks.md
@@ -1,0 +1,44 @@
+---
+description: "Task list for feature 227-tx-proof-binding"
+---
+
+# Tasks: Bind proof bundles to unsigned transactions
+
+**Input**: Design documents from `specs/227-tx-proof-binding/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [quickstart.md](quickstart.md)
+**Issue**: [#227](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/227)
+
+## Phase 1: Setup
+
+- [X] T001 Start issue #227 worktree and mark it WIP.
+- [X] T002 Record design decision: targeted client-side CBOR reader, not authoritative server summary.
+- [X] T003 Create speckit artifacts for issue #227.
+
+## Phase 2: Lean model
+
+- [X] T004 Extend `lean/Phase4/Verify.lean` with `TxView`, `ProofRoles`, and `coversTxView`.
+- [X] T005 Prove exact-input/reference coverage theorems with no `sorry`.
+- [X] T006 Run Lean diagnostics/build for the updated theorem file.
+
+## Phase 3: Client binding implementation
+
+- [X] T007 Add `Cardano.MPFS.Client.Verify.TxView` to decode tx inputs and reference inputs from generic CBOR terms.
+- [X] T008 Extend `VerifyError` with `TxBindingFailed Text Text`.
+- [X] T009 Wire endpoint-specific expected input/reference roles into every `verify*TxResponse`.
+- [X] T010 Update fixture tx CBOR so honest responses have matching inputs/reference inputs.
+- [X] T011 Add forged-binding unit tests for funding-only, reference-input, and state/request-consuming endpoint families.
+- [X] T012 Expose any new module/error surface in `cardano-mpfs-client.cabal` and top-level client exports.
+
+## Phase 4: Validation and PR
+
+- [X] T013 Run `git diff --check`.
+- [X] T014 Run `nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests -O0 --test-show-details=direct`.
+- [ ] T015 Commit and push.
+- [ ] T016 Open/update PR with scope, residual binding work, and validation status.
+
+## Deferred follow-up
+
+- Mint binding for boot/end.
+- State-output datum binding.
+- Redeemer payload binding.
+- Exact `UpdateProof.trie_read` to redeemer MPF proof binding.


### PR DESCRIPTION
Refs #227

## Scope

This PR lands the first proof/transaction binding slice for issue #227.

- Adds speckit artifacts for the issue #227 design, plan, quickstart, and task trail.
- Adds a Lean binding model in `lean/Phase4/Verify.lean` with `TxView`, `ProofRoles`, exact coverage, and missing/extra input/reference rejection theorems.
- Adds `Cardano.MPFS.Client.Verify.TxView`, a pure client-side Conway CBOR reader for tx body fields `0` inputs and `18` reference inputs.
- Wires endpoint-specific proof roles into every `verify*TxResponse` so a response is rejected when the unsigned tx input set differs from the proof bundle.
- Refreshes client fixtures to use synthetic Conway-shaped tx CBOR and adds binding forgery tests for boot, retract, and update families.
- Marks the speckit task ledger complete through PR creation.

## Design note

Issue #227 listed a server-authored `tx_summary` as one possible path. This PR uses the targeted client-side CBOR reader instead because a summary produced by the same server cannot independently prove that it describes the included unsigned tx CBOR. The decoder remains narrow: it reads only the stable Conway fields needed for input and reference-input binding and adds no `cardano-ledger-*`, native, or server-side dependency.

## Residual issue #227 work

This PR intentionally uses `Refs #227`, not `Closes #227`, because the full issue acceptance also needs binding for:

- Mint roles for boot/end.
- State-carrying output datum roles.
- Redeemer payload roles.
- Exact `UpdateProof.trie_read` to redeemer MPF proof binding.

## Validation

- `git diff --check`
- `nix develop --quiet -c just format-check`
- `nix develop --quiet -c just hlint`
- `nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests -O0 --test-show-details=direct` — 47 examples, 0 failures
- Lean LSP diagnostics/build for `lean/Phase4/Verify.lean` passed locally before commit.
