### PR TITLE
feat(client): bind mint and state outputs

### DIFF
--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
@@ -58,7 +58,11 @@ import Cardano.MPFS.Client.Verify.Replay
     , replayWitnessedUtxo
     )
 import Cardano.MPFS.Client.Verify.TxView
-    ( verifyTxBinding
+    ( verifyBootAssetBinding
+    , verifyContinuingStateOutput
+    , verifyEndAssetBinding
+    , verifyNoMint
+    , verifyTxInputBinding
     )
 
 -- | Structural check for the snapshot that every proof-bearing response
@@ -79,7 +83,8 @@ verifyBootTxResponse (BootTxResponse t s (BootProof fs)) = do
     checkWitnessedUtxosStructural "boot.funding" fs
     rootBs <- decodeHex "boot.snapshot.utxo_root" (utxoRoot s)
     replayWitnessedUtxos "boot.funding" rootBs fs
-    verifyTxBinding "boot" t (witnessInputs fs) []
+    txView <- verifyTxInputBinding "boot" t (witnessInputs fs) []
+    verifyBootAssetBinding "boot" txView
 
 -- | Verify a @POST \/tx\/request\/{insert,delete,update}@ response.
 verifyRequestTxResponse :: RequestTxResponse -> Either VerifyError ()
@@ -89,7 +94,8 @@ verifyRequestTxResponse (RequestTxResponse t s (RequestProof fs)) = do
     checkWitnessedUtxosStructural "request.funding" fs
     rootBs <- decodeHex "request.snapshot.utxo_root" (utxoRoot s)
     replayWitnessedUtxos "request.funding" rootBs fs
-    verifyTxBinding "request" t (witnessInputs fs) []
+    txView <- verifyTxInputBinding "request" t (witnessInputs fs) []
+    verifyNoMint "request" txView
 
 -- | Verify a @POST \/tx\/retract@ response.
 verifyRetractTxResponse :: RetractTxResponse -> Either VerifyError ()
@@ -105,11 +111,13 @@ verifyRetractTxResponse
         replayWitnessedUtxo "retract.request_in" rootBs ri
         replayWitnessedUtxo "retract.state_ref" rootBs sr
         replayWitnessedUtxos "retract.funding" rootBs fs
-        verifyTxBinding
-            "retract"
-            t
-            (txIn ri : witnessInputs fs)
-            [txIn sr]
+        txView <-
+            verifyTxInputBinding
+                "retract"
+                t
+                (txIn ri : witnessInputs fs)
+                [txIn sr]
+        verifyNoMint "retract" txView
 
 -- | Verify a @POST \/tx\/reject@ response.
 verifyRejectTxResponse :: RejectTxResponse -> Either VerifyError ()
@@ -125,11 +133,13 @@ verifyRejectTxResponse
         replayWitnessedUtxo "reject.state" rootBs st
         replayWitnessedUtxos "reject.request_ins" rootBs ris
         replayWitnessedUtxos "reject.funding" rootBs fs
-        verifyTxBinding
-            "reject"
-            t
-            (txIn st : witnessInputs ris <> witnessInputs fs)
-            []
+        txView <-
+            verifyTxInputBinding
+                "reject"
+                t
+                (txIn st : witnessInputs ris <> witnessInputs fs)
+                []
+        verifyContinuingStateOutput "reject" txView st
 
 -- | Verify a @POST \/tx\/end@ response.
 verifyEndTxResponse :: EndTxResponse -> Either VerifyError ()
@@ -141,7 +151,8 @@ verifyEndTxResponse (EndTxResponse t s (EndProof st fs)) = do
     rootBs <- decodeHex "end.snapshot.utxo_root" (utxoRoot s)
     replayWitnessedUtxo "end.state" rootBs st
     replayWitnessedUtxos "end.funding" rootBs fs
-    verifyTxBinding "end" t (txIn st : witnessInputs fs) []
+    txView <- verifyTxInputBinding "end" t (txIn st : witnessInputs fs) []
+    verifyEndAssetBinding "end" txView st
 
 -- | Verify a @POST \/tx\/update@ response.
 verifyUpdateTxResponse :: UpdateTxResponse -> Either VerifyError ()
@@ -160,11 +171,13 @@ verifyUpdateTxResponse
         replayWitnessedUtxos "update.funding" rootBs fs
         trieRootBs <- decodeHex "update.trie_root" tr
         replayTrieFacts "update.trie_read" trieRootBs tread
-        verifyTxBinding
-            "update"
-            t
-            (txIn st : witnessInputs rs <> witnessInputs fs)
-            []
+        txView <-
+            verifyTxInputBinding
+                "update"
+                t
+                (txIn st : witnessInputs rs <> witnessInputs fs)
+                []
+        verifyContinuingStateOutput "update" txView st
 
 -- ---------------------------------------------------------------
 -- Structural pass (hex decode, 32-byte hashes, non-empty hex)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
@@ -9,17 +9,27 @@
 -- does not decode the whole ledger transaction and does not depend on
 -- @cardano-ledger-*@.
 module Cardano.MPFS.Client.Verify.TxView
-    ( TxView (..)
+    ( TxAsset (..)
+    , TxOutView (..)
+    , TxView (..)
     , decodeTxView
+    , decodeTxOutView
+    , verifyBootAssetBinding
+    , verifyContinuingStateOutput
+    , verifyEndAssetBinding
+    , verifyNoMint
+    , verifyTxInputBinding
     , verifyTxBinding
     ) where
 
 import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Term qualified as CBOR
+import Control.Monad (void)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Lazy qualified as BSL
 import Data.List (sort)
+import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
@@ -27,6 +37,7 @@ import Data.Word (Word64)
 
 import Cardano.MPFS.Client.Bundle
     ( TxIn (..)
+    , WitnessedUtxo (..)
     )
 import Cardano.MPFS.Client.Snapshot
     ( Hex (..)
@@ -36,9 +47,26 @@ import Cardano.MPFS.Client.Verify.Replay
     )
 
 -- | The transaction-body fragment needed by proof binding.
+data TxAsset = TxAsset
+    { assetPolicy :: Hex
+    , assetName :: Hex
+    , assetQuantity :: Integer
+    }
+    deriving stock (Eq, Ord, Show)
+
+-- | The output fragment needed to identify continuing state outputs.
+data TxOutView = TxOutView
+    { txOutAssets :: [TxAsset]
+    , txOutHasInlineDatum :: Bool
+    }
+    deriving stock (Eq, Show)
+
+-- | The transaction-body fragment needed by proof binding.
 data TxView = TxView
     { txInputs :: [TxIn]
     , txReferenceInputs :: [TxIn]
+    , txMint :: [TxAsset]
+    , txOutputs :: [TxOutView]
     }
     deriving stock (Eq, Show)
 
@@ -53,6 +81,14 @@ decodeTxView field h = do
     term <- decodeTerm field bs
     parseTx field term
 
+-- | Decode a serialized Conway TxOut enough to read its non-ADA
+-- assets and whether it carries an inline datum.
+decodeTxOutView :: Text -> Hex -> Either VerifyError TxOutView
+decodeTxOutView field h = do
+    bs <- decodeTxBytes field h
+    term <- decodeTerm field bs
+    parseTxOut field term
+
 -- | Compare decoded tx roles with the endpoint proof roles.
 -- Ordering is ignored because Cardano encodes these values as sets.
 verifyTxBinding
@@ -64,8 +100,25 @@ verifyTxBinding
     -> [TxIn]
     -- ^ Proof roles that must be tx reference inputs.
     -> Either VerifyError ()
-verifyTxBinding endpoint tx expectedInputs expectedRefs = do
-    TxView actualInputs actualRefs <-
+verifyTxBinding endpoint tx expectedInputs expectedRefs =
+    void (verifyTxInputBinding endpoint tx expectedInputs expectedRefs)
+
+-- | Compare decoded tx input roles with the endpoint proof roles,
+-- returning the parsed view for additional endpoint checks.
+verifyTxInputBinding
+    :: Text
+    -- ^ Endpoint prefix, e.g. @"retract"@.
+    -> Hex
+    -> [TxIn]
+    -- ^ Proof roles that must be regular tx inputs.
+    -> [TxIn]
+    -- ^ Proof roles that must be tx reference inputs.
+    -> Either VerifyError TxView
+verifyTxInputBinding endpoint tx expectedInputs expectedRefs = do
+    view@TxView
+        { txInputs = actualInputs
+        , txReferenceInputs = actualRefs
+        } <-
         decodeTxView (endpoint <> ".tx") tx
     compareTxIns
         (endpoint <> ".tx.inputs")
@@ -77,6 +130,49 @@ verifyTxBinding endpoint tx expectedInputs expectedRefs = do
         "reference input set mismatch"
         expectedRefs
         actualRefs
+    pure view
+
+-- | Assert that an endpoint must not mint or burn assets.
+verifyNoMint :: Text -> TxView -> Either VerifyError ()
+verifyNoMint endpoint TxView{txMint} =
+    compareTxAssets
+        (endpoint <> ".tx.mint")
+        "mint set mismatch"
+        []
+        txMint
+
+-- | Boot must mint exactly one token and create exactly one inline
+-- datum output carrying that same token.
+verifyBootAssetBinding :: Text -> TxView -> Either VerifyError ()
+verifyBootAssetBinding endpoint view = do
+    minted <- expectSingletonMint endpoint 1 view
+    requireStateOutput endpoint minted view
+
+-- | Update/reject must preserve the consumed state token into
+-- exactly one inline datum output and must not mint or burn.
+verifyContinuingStateOutput
+    :: Text -> TxView -> WitnessedUtxo -> Either VerifyError ()
+verifyContinuingStateOutput endpoint view stateWitness = do
+    verifyNoMint endpoint view
+    stateAsset <- stateAssetFromWitness endpoint stateWitness
+    requireStateOutput endpoint stateAsset view
+
+-- | End must burn the consumed state token and must not leave a
+-- continuing inline state output carrying that token.
+verifyEndAssetBinding
+    :: Text -> TxView -> WitnessedUtxo -> Either VerifyError ()
+verifyEndAssetBinding endpoint view stateWitness = do
+    stateAsset <- stateAssetFromWitness endpoint stateWitness
+    let burnAsset =
+            stateAsset
+                { assetQuantity = negate (assetQuantity stateAsset)
+                }
+    compareTxAssets
+        (endpoint <> ".tx.mint")
+        "burn set mismatch"
+        [burnAsset]
+        (txMint view)
+    forbidStateOutput endpoint stateAsset view
 
 decodeTxBytes :: Text -> Hex -> Either VerifyError BS.ByteString
 decodeTxBytes field (Hex txt) =
@@ -127,7 +223,23 @@ parseBody field body = do
             Nothing -> Right []
             Just t ->
                 parseInputSet (field <> ".reference_inputs") t
-    pure TxView{txInputs = inputs, txReferenceInputs = refs}
+    outputs <-
+        case lookupIntKey 1 entries of
+            Nothing -> Right []
+            Just t ->
+                parseOutputs (field <> ".outputs") t
+    mint <-
+        case lookupIntKey 9 entries of
+            Nothing -> Right []
+            Just t ->
+                parseMultiAsset SignedMint (field <> ".mint") t
+    pure
+        TxView
+            { txInputs = inputs
+            , txReferenceInputs = refs
+            , txMint = mint
+            , txOutputs = outputs
+            }
 
 lookupIntKey :: Integer -> [(CBOR.Term, CBOR.Term)] -> Maybe CBOR.Term
 lookupIntKey wanted = go
@@ -182,6 +294,137 @@ parseWord64 field t =
 maxTxInputIndex :: Integer
 maxTxInputIndex = 65535
 
+data QuantityMode = SignedMint | PositiveValue
+
+parseOutputs :: Text -> CBOR.Term -> Either VerifyError [TxOutView]
+parseOutputs field = \case
+    CBOR.TList xs -> traverse (parseTxOut field) xs
+    CBOR.TListI xs -> traverse (parseTxOut field) xs
+    _ -> Left (TxBindingFailed field "unsupported outputs CBOR")
+
+parseTxOut :: Text -> CBOR.Term -> Either VerifyError TxOutView
+parseTxOut field = \case
+    CBOR.TMap xs -> parseBabbageTxOut field xs
+    CBOR.TMapI xs -> parseBabbageTxOut field xs
+    CBOR.TList [_, valueTerm] ->
+        txOutWithoutInlineDatum field valueTerm
+    CBOR.TList [_, valueTerm, _datumHash] ->
+        txOutWithoutInlineDatum field valueTerm
+    CBOR.TListI [_, valueTerm] ->
+        txOutWithoutInlineDatum field valueTerm
+    CBOR.TListI [_, valueTerm, _datumHash] ->
+        txOutWithoutInlineDatum field valueTerm
+    _ -> Left (TxBindingFailed field "unsupported tx output CBOR")
+
+parseBabbageTxOut
+    :: Text -> [(CBOR.Term, CBOR.Term)] -> Either VerifyError TxOutView
+parseBabbageTxOut field entries = do
+    valueTerm <- case lookupIntKey 1 entries of
+        Nothing ->
+            Left (TxBindingFailed (field <> ".value") "missing value")
+        Just t -> Right t
+    assets <- parseValue (field <> ".value") valueTerm
+    hasInlineDatum <- case lookupIntKey 2 entries of
+        Nothing -> Right False
+        Just t -> parseDatumOption (field <> ".datum") t
+    pure
+        TxOutView{txOutAssets = assets, txOutHasInlineDatum = hasInlineDatum}
+
+txOutWithoutInlineDatum
+    :: Text -> CBOR.Term -> Either VerifyError TxOutView
+txOutWithoutInlineDatum field valueTerm = do
+    assets <- parseValue (field <> ".value") valueTerm
+    pure TxOutView{txOutAssets = assets, txOutHasInlineDatum = False}
+
+parseDatumOption :: Text -> CBOR.Term -> Either VerifyError Bool
+parseDatumOption field = \case
+    CBOR.TList [tagTerm, _]
+        | termInteger tagTerm == Just 0 -> Right False
+        | termInteger tagTerm == Just 1 -> Right True
+    CBOR.TListI [tagTerm, _]
+        | termInteger tagTerm == Just 0 -> Right False
+        | termInteger tagTerm == Just 1 -> Right True
+    _ -> Left (TxBindingFailed field "unsupported datum option CBOR")
+
+parseValue :: Text -> CBOR.Term -> Either VerifyError [TxAsset]
+parseValue field = \case
+    t | isJust (termInteger t) -> Right []
+    CBOR.TList [_coinTerm, maTerm] ->
+        parseMultiAsset PositiveValue (field <> ".assets") maTerm
+    CBOR.TListI [_coinTerm, maTerm] ->
+        parseMultiAsset PositiveValue (field <> ".assets") maTerm
+    _ -> Left (TxBindingFailed field "unsupported value CBOR")
+
+parseMultiAsset
+    :: QuantityMode -> Text -> CBOR.Term -> Either VerifyError [TxAsset]
+parseMultiAsset mode field term = do
+    policies <- parseMap field term
+    concat
+        <$> traverse (uncurry (parsePolicyAssets mode field)) policies
+
+parsePolicyAssets
+    :: QuantityMode
+    -> Text
+    -> CBOR.Term
+    -> CBOR.Term
+    -> Either VerifyError [TxAsset]
+parsePolicyAssets mode field policyTerm assetMapTerm = do
+    policy <- parseBoundedBytes (field <> ".policy_id") 28 28 policyTerm
+    assets <- parseMap (field <> ".assets") assetMapTerm
+    traverse (uncurry (parseAsset mode field policy)) assets
+
+parseAsset
+    :: QuantityMode
+    -> Text
+    -> Hex
+    -> CBOR.Term
+    -> CBOR.Term
+    -> Either VerifyError TxAsset
+parseAsset mode field policy nameTerm quantityTerm = do
+    name <- parseBoundedBytes (field <> ".asset_name") 0 32 nameTerm
+    quantity <-
+        parseAssetQuantity mode (field <> ".quantity") quantityTerm
+    pure
+        TxAsset
+            { assetPolicy = policy
+            , assetName = name
+            , assetQuantity = quantity
+            }
+
+parseMap
+    :: Text -> CBOR.Term -> Either VerifyError [(CBOR.Term, CBOR.Term)]
+parseMap field = \case
+    CBOR.TMap xs -> Right xs
+    CBOR.TMapI xs -> Right xs
+    _ -> Left (TxBindingFailed field "unsupported map CBOR")
+
+parseBoundedBytes
+    :: Text -> Int -> Int -> CBOR.Term -> Either VerifyError Hex
+parseBoundedBytes field minLen maxLen = \case
+    CBOR.TBytes bs
+        | BS.length bs >= minLen && BS.length bs <= maxLen ->
+            Right (Hex (T.decodeUtf8 (Base16.encode bs)))
+        | otherwise ->
+            Left (TxBindingFailed field "byte length mismatch")
+    _ -> Left (TxBindingFailed field "expected bytes")
+
+parseAssetQuantity
+    :: QuantityMode -> Text -> CBOR.Term -> Either VerifyError Integer
+parseAssetQuantity mode field t =
+    case termInteger t of
+        Just n
+            | n >= minInt64 && n <= maxInt64 && quantityAllowed mode n ->
+                Right n
+        _ -> Left (TxBindingFailed field "asset quantity out of range")
+
+quantityAllowed :: QuantityMode -> Integer -> Bool
+quantityAllowed SignedMint n = n /= 0
+quantityAllowed PositiveValue n = n > 0
+
+minInt64, maxInt64 :: Integer
+minInt64 = -9223372036854775808
+maxInt64 = 9223372036854775807
+
 compareTxIns
     :: Text
     -> Text
@@ -205,3 +448,93 @@ compareTxIns field reason expected actual
     canonical = sort
     renderCount xs =
         T.pack (show (length xs)) <> " tx input(s)"
+
+compareTxAssets
+    :: Text
+    -> Text
+    -> [TxAsset]
+    -> [TxAsset]
+    -> Either VerifyError ()
+compareTxAssets field reason expected actual
+    | canonical expected == canonical actual = Right ()
+    | otherwise =
+        Left
+            ( TxBindingFailed
+                field
+                ( reason
+                    <> ": expected "
+                    <> renderCount expected
+                    <> ", got "
+                    <> renderCount actual
+                )
+            )
+  where
+    canonical = sort
+    renderCount xs =
+        T.pack (show (length xs)) <> " asset(s)"
+
+expectSingletonMint
+    :: Text -> Integer -> TxView -> Either VerifyError TxAsset
+expectSingletonMint endpoint expectedQuantity TxView{txMint} =
+    case txMint of
+        [asset]
+            | assetQuantity asset == expectedQuantity -> Right asset
+        _ ->
+            Left
+                ( TxBindingFailed
+                    (endpoint <> ".tx.mint")
+                    "expected exactly one mint asset"
+                )
+
+stateAssetFromWitness
+    :: Text -> WitnessedUtxo -> Either VerifyError TxAsset
+stateAssetFromWitness endpoint WitnessedUtxo{txOut} = do
+    TxOutView{txOutAssets} <-
+        decodeTxOutView (endpoint <> ".state.tx_out") txOut
+    case txOutAssets of
+        [asset] -> Right asset
+        [] ->
+            Left
+                ( TxBindingFailed
+                    (endpoint <> ".state.tx_out.value")
+                    "state token missing"
+                )
+        _ ->
+            Left
+                ( TxBindingFailed
+                    (endpoint <> ".state.tx_out.value")
+                    "state token ambiguous"
+                )
+
+requireStateOutput
+    :: Text -> TxAsset -> TxView -> Either VerifyError ()
+requireStateOutput endpoint asset TxView{txOutputs} =
+    case filter (outputCarries asset) txOutputs of
+        [TxOutView{txOutHasInlineDatum = True}] -> Right ()
+        _ ->
+            Left
+                ( TxBindingFailed
+                    (endpoint <> ".tx.state_outputs")
+                    "state output mismatch"
+                )
+
+forbidStateOutput
+    :: Text -> TxAsset -> TxView -> Either VerifyError ()
+forbidStateOutput endpoint asset TxView{txOutputs}
+    | any (outputCarries asset) txOutputs =
+        Left
+            ( TxBindingFailed
+                (endpoint <> ".tx.state_outputs")
+                "unexpected continuing state output"
+            )
+    | otherwise = Right ()
+
+outputCarries :: TxAsset -> TxOutView -> Bool
+outputCarries expected TxOutView{txOutAssets} =
+    any (sameAsset expected) txOutAssets
+
+sameAsset :: TxAsset -> TxAsset -> Bool
+sameAsset expected actual =
+    assetPolicy expected == assetPolicy actual
+        && assetName expected == assetName actual
+        && assetQuantity expected == assetQuantity actual

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
@@ -27,7 +27,9 @@ module Cardano.MPFS.Client.Fixtures
 
       -- * Hex utilities
     , toHex
+    , sampleStateAsset
     , txCborFromTxIns
+    , txCborFromTxParts
     ) where
 
 import Codec.CBOR.Encoding qualified as CBOR
@@ -36,6 +38,7 @@ import Codec.CBOR.Write qualified as CBOR
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
+import Data.List (nub)
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T
 import Data.Word (Word64)
@@ -89,6 +92,9 @@ import Cardano.MPFS.Client.Snapshot
     , Hex (..)
     , VerificationSnapshot (..)
     )
+import Cardano.MPFS.Client.Verify.TxView
+    ( TxAsset (..)
+    )
 
 -- ---------------------------------------------------------------
 -- Shared sample inputs
@@ -105,13 +111,30 @@ stateTxIn = (BS.replicate 32 0xA0, 0)
 requestTxIn = (BS.replicate 32 0xB1, 1)
 fundingTxIn = (BS.replicate 32 0xC2, 2)
 
+samplePolicyId, sampleAssetName :: ByteString
+samplePolicyId = BS.replicate 28 0xD3
+sampleAssetName = BS.replicate 32 0xE4
+
+sampleStateAsset :: Integer -> TxAsset
+sampleStateAsset quantity =
+    TxAsset
+        { assetPolicy = toHex samplePolicyId
+        , assetName = toHex sampleAssetName
+        , assetQuantity = quantity
+        }
+
 stateTxOut, requestTxOut, fundingTxOut :: ByteString
-stateTxOut = "state-tx-out-bytes"
-requestTxOut = "request-tx-out-bytes"
-fundingTxOut = "funding-tx-out-bytes"
+stateTxOut = txOutCbor True [sampleStateAsset 1]
+requestTxOut = txOutCbor True []
+fundingTxOut = txOutCbor False []
 
 txCborFromTxIns :: [TxIn] -> [TxIn] -> Hex
 txCborFromTxIns inputs refs =
+    txCborFromTxParts inputs refs [] []
+
+txCborFromTxParts
+    :: [TxIn] -> [TxIn] -> [TxAsset] -> [CBOR.Term] -> Hex
+txCborFromTxParts inputs refs mint outputs =
     toHex
         $ CBOR.toStrictByteString
         $ CBOR.encodeTerm
@@ -123,8 +146,57 @@ txCborFromTxIns inputs refs =
             ]
   where
     bodyFields =
-        [(CBOR.TInt 0, setTerm inputs)]
+        [ (CBOR.TInt 0, setTerm inputs)
+        , (CBOR.TInt 1, CBOR.TList outputs)
+        ]
             <> [(CBOR.TInt 18, setTerm refs) | not (null refs)]
+            <> [(CBOR.TInt 9, multiAssetTerm mint) | not (null mint)]
+
+txOutCbor :: Bool -> [TxAsset] -> ByteString
+txOutCbor hasInlineDatum assets =
+    CBOR.toStrictByteString
+        $ CBOR.encodeTerm
+        $ txOutTerm hasInlineDatum assets
+
+txOutTerm :: Bool -> [TxAsset] -> CBOR.Term
+txOutTerm hasInlineDatum assets =
+    CBOR.TMap
+        $ [ (CBOR.TInt 0, CBOR.TBytes "addr")
+          , (CBOR.TInt 1, valueTerm assets)
+          ]
+            <> [ (CBOR.TInt 2, inlineDatumTerm)
+               | hasInlineDatum
+               ]
+
+inlineDatumTerm :: CBOR.Term
+inlineDatumTerm =
+    CBOR.TList
+        [ CBOR.TInt 1
+        , CBOR.TTagged 121 (CBOR.TList [])
+        ]
+
+valueTerm :: [TxAsset] -> CBOR.Term
+valueTerm [] = CBOR.TInteger 2_000_000
+valueTerm assets =
+    CBOR.TList
+        [ CBOR.TInteger 2_000_000
+        , multiAssetTerm assets
+        ]
+
+multiAssetTerm :: [TxAsset] -> CBOR.Term
+multiAssetTerm assets =
+    CBOR.TMap
+        [ ( CBOR.TBytes (decodeFixtureHex (unHex policy))
+          , CBOR.TMap
+                [ ( CBOR.TBytes (decodeFixtureHex (unHex assetName))
+                  , CBOR.TInteger assetQuantity
+                  )
+                | TxAsset{..} <- assets
+                , assetPolicy == policy
+                ]
+          )
+        | policy <- nub (map assetPolicy assets)
+        ]
 
 setTerm :: [TxIn] -> CBOR.Term
 setTerm xs =
@@ -144,12 +216,6 @@ decodeFixtureHex txt =
     case Base16.decode (T.encodeUtf8 txt) of
         Right bs -> bs
         Left err -> error ("invalid fixture hex: " <> show err)
-
-txFor :: [WitnessedUtxo] -> [WitnessedUtxo] -> Hex
-txFor inputs refs =
-    txCborFromTxIns
-        (map txIn inputs)
-        (map txIn refs)
 
 -- ---------------------------------------------------------------
 -- CSMT primitives
@@ -314,25 +380,40 @@ honestTrieExclusion =
 honestBootResponse :: BootTxResponse
 honestBootResponse =
     BootTxResponse
-        (txFor [bundleFunding honestWitness] [])
+        ( txCborFromTxParts
+            [txIn (bundleFunding honestWitness)]
+            []
+            [sampleStateAsset 1]
+            [txOutTerm True [sampleStateAsset 1]]
+        )
         (sampleSnapshot (bundleRoot honestWitness))
         (BootProof [bundleFunding honestWitness])
 
 honestRequestResponse :: RequestTxResponse
 honestRequestResponse =
     RequestTxResponse
-        (txFor [bundleFunding honestWitness] [])
+        ( txCborFromTxParts
+            [txIn (bundleFunding honestWitness)]
+            []
+            []
+            [txOutTerm True []]
+        )
         (sampleSnapshot (bundleRoot honestWitness))
         (RequestProof [bundleFunding honestWitness])
 
 honestRetractResponse :: RetractTxResponse
 honestRetractResponse =
     RetractTxResponse
-        ( txFor
-            [ bundleRequest honestWitness
-            , bundleFunding honestWitness
-            ]
-            [bundleState honestWitness]
+        ( txCborFromTxParts
+            ( map
+                txIn
+                [ bundleRequest honestWitness
+                , bundleFunding honestWitness
+                ]
+            )
+            [txIn (bundleState honestWitness)]
+            []
+            [txOutTerm False []]
         )
         (sampleSnapshot (bundleRoot honestWitness))
         ( RetractProof
@@ -344,12 +425,17 @@ honestRetractResponse =
 honestRejectResponse :: RejectTxResponse
 honestRejectResponse =
     RejectTxResponse
-        ( txFor
-            [ bundleState honestWitness
-            , bundleRequest honestWitness
-            , bundleFunding honestWitness
-            ]
+        ( txCborFromTxParts
+            ( map
+                txIn
+                [ bundleState honestWitness
+                , bundleRequest honestWitness
+                , bundleFunding honestWitness
+                ]
+            )
             []
+            []
+            [txOutTerm True [sampleStateAsset 1]]
         )
         (sampleSnapshot (bundleRoot honestWitness))
         ( RejectProof
@@ -361,11 +447,16 @@ honestRejectResponse =
 honestEndResponse :: EndTxResponse
 honestEndResponse =
     EndTxResponse
-        ( txFor
-            [ bundleState honestWitness
-            , bundleFunding honestWitness
-            ]
+        ( txCborFromTxParts
+            ( map
+                txIn
+                [ bundleState honestWitness
+                , bundleFunding honestWitness
+                ]
+            )
             []
+            [sampleStateAsset (-1)]
+            [txOutTerm False []]
         )
         (sampleSnapshot (bundleRoot honestWitness))
         ( EndProof
@@ -377,12 +468,17 @@ honestUpdateResponse :: UpdateTxResponse
 honestUpdateResponse =
     let (trieRoot, trieFact) = honestTrieInclusion
     in  UpdateTxResponse
-            ( txFor
-                [ bundleState honestWitness
-                , bundleRequest honestWitness
-                , bundleFunding honestWitness
-                ]
+            ( txCborFromTxParts
+                ( map
+                    txIn
+                    [ bundleState honestWitness
+                    , bundleRequest honestWitness
+                    , bundleFunding honestWitness
+                    ]
+                )
                 []
+                []
+                [txOutTerm True [sampleStateAsset 1]]
             )
             (sampleSnapshot (bundleRoot honestWitness))
             ( UpdateProof
@@ -400,12 +496,17 @@ honestUpdateResponseMixedTrie =
     let (trieRoot, inclusionFact) = honestTrieInclusion
         (_, exclusionFact) = honestTrieExclusion
     in  UpdateTxResponse
-            ( txFor
-                [ bundleState honestWitness
-                , bundleRequest honestWitness
-                , bundleFunding honestWitness
-                ]
+            ( txCborFromTxParts
+                ( map
+                    txIn
+                    [ bundleState honestWitness
+                    , bundleRequest honestWitness
+                    , bundleFunding honestWitness
+                    ]
+                )
                 []
+                []
+                [txOutTerm True [sampleStateAsset 1]]
             )
             (sampleSnapshot (bundleRoot honestWitness))
             ( UpdateProof
@@ -422,12 +523,17 @@ honestUpdateResponseEmptyTrie :: UpdateTxResponse
 honestUpdateResponseEmptyTrie =
     let (trieRoot, _) = honestTrieInclusion
     in  UpdateTxResponse
-            ( txFor
-                [ bundleState honestWitness
-                , bundleRequest honestWitness
-                , bundleFunding honestWitness
-                ]
+            ( txCborFromTxParts
+                ( map
+                    txIn
+                    [ bundleState honestWitness
+                    , bundleRequest honestWitness
+                    , bundleFunding honestWitness
+                    ]
+                )
                 []
+                []
+                [txOutTerm True [sampleStateAsset 1]]
             )
             (sampleSnapshot (bundleRoot honestWitness))
             ( UpdateProof

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
@@ -16,7 +16,10 @@ module Cardano.MPFS.Client.VerifySpec (spec) where
 import Test.Hspec (Spec, describe, it)
 
 import Cardano.MPFS.Client
-    ( BootTxResponse (..)
+    ( BootProof (..)
+    , BootTxResponse (..)
+    , EndProof (..)
+    , EndTxResponse (..)
     , Hex (..)
     , RetractProof (..)
     , RetractTxResponse (..)
@@ -59,7 +62,9 @@ import Cardano.MPFS.Client.Fixtures
     , honestUpdateResponse
     , honestUpdateResponseEmptyTrie
     , honestUpdateResponseMixedTrie
+    , sampleStateAsset
     , txCborFromTxIns
+    , txCborFromTxParts
     )
 
 spec :: Spec
@@ -115,6 +120,21 @@ spec = do
             $ updateWithoutRequestInput honestUpdateResponse
                 `shouldRejectWith` verifyUpdateTxResponse
             $ txBindingFailedAt "update.tx.inputs"
+
+        it "rejects a boot tx without a continuing state output"
+            $ bootWithoutStateOutput honestBootResponse
+                `shouldRejectWith` verifyBootTxResponse
+            $ txBindingFailedAt "boot.tx.state_outputs"
+
+        it "rejects an end tx that burns the wrong state token quantity"
+            $ endBurnsWrongQuantity honestEndResponse
+                `shouldRejectWith` verifyEndTxResponse
+            $ txBindingFailedAt "end.tx.mint"
+
+        it "rejects an update tx without a continuing state output"
+            $ updateWithoutStateOutput honestUpdateResponse
+                `shouldRejectWith` verifyUpdateTxResponse
+            $ txBindingFailedAt "update.tx.state_outputs"
 
     describe "CSMT forgery corpus (free-monad DSL)" $ do
         it "rejects a boot funding utxo_proof with a flipped byte"
@@ -221,6 +241,18 @@ replaceBootTx :: Hex -> BootTxResponse -> BootTxResponse
 replaceBootTx tx' (BootTxResponse _ s p) =
     BootTxResponse tx' s p
 
+bootWithoutStateOutput :: BootTxResponse -> BootTxResponse
+bootWithoutStateOutput (BootTxResponse _ s p@(BootProof funding)) =
+    BootTxResponse
+        ( txCborFromTxParts
+            (map txIn funding)
+            []
+            [sampleStateAsset 1]
+            []
+        )
+        s
+        p
+
 retractWithoutReference :: RetractTxResponse -> RetractTxResponse
 retractWithoutReference
     (RetractTxResponse _ s p@(RetractProof req _st funding)) =
@@ -234,5 +266,30 @@ updateWithoutRequestInput
     (UpdateTxResponse _ s p@(UpdateProof st _reqs funding _tr _tread)) =
         UpdateTxResponse
             (txCborFromTxIns (map txIn (st : funding)) [])
+            s
+            p
+
+endBurnsWrongQuantity :: EndTxResponse -> EndTxResponse
+endBurnsWrongQuantity (EndTxResponse _ s p@(EndProof st funding)) =
+    EndTxResponse
+        ( txCborFromTxParts
+            (map txIn (st : funding))
+            []
+            [sampleStateAsset (-2)]
+            []
+        )
+        s
+        p
+
+updateWithoutStateOutput :: UpdateTxResponse -> UpdateTxResponse
+updateWithoutStateOutput
+    (UpdateTxResponse _ s p@(UpdateProof st reqs funding _tr _tread)) =
+        UpdateTxResponse
+            ( txCborFromTxParts
+                (map txIn (st : reqs <> funding))
+                []
+                []
+                []
+            )
             s
             p

--- a/lean/Phase4/Verify.lean
+++ b/lean/Phase4/Verify.lean
@@ -163,9 +163,27 @@ structure ProofRoles (Key : Type) where
   consumed : List Key
   referenced : List Key
 
+/-- The asset fragment of an unsigned transaction body used
+    by the client verifier. `minted` contains signed mint
+    quantities from tx-body field `9`; `stateOutputs` contains
+    token assets carried by continuing state outputs. -/
+structure TxAssetView (Asset : Type) where
+  minted : List Asset
+  stateOutputs : List Asset
+
+/-- Asset roles implied by the endpoint proof payload. Burned
+    assets are represented as negative mint quantities in the
+    Haskell verifier; this abstract model keeps minted and
+    burned roles separate so the proof obligations are explicit. -/
+structure ProofAssetRoles (Asset : Type) where
+  minted : List Asset
+  burned : List Asset
+  continuingState : List Asset
+
 namespace TxBinding
 
 variable {Key : Type}
+variable {Asset : Type}
 
 /-- A response covers a decoded transaction view exactly when
     its consumed proof roles are exactly the tx inputs and its
@@ -233,6 +251,51 @@ theorem extra_reference_rejected
     (hInRoles : k ∈ roles.referenced)
     (hNotInTx : k ∉ tx.referenceInputs) :
     ¬ coversTxView roles tx := by
+  intro h
+  rw [← h.2] at hInRoles
+  exact hNotInTx hInRoles
+
+/-- Asset coverage is exact for mints, burns, and continuing
+    state outputs after the Haskell verifier has canonicalised
+    signed mint quantities into role-specific lists. -/
+def coversAssetView
+    (roles : ProofAssetRoles Asset)
+    (tx : TxAssetView Asset) : Prop :=
+  tx.minted = roles.minted ++ roles.burned ∧
+  tx.stateOutputs = roles.continuingState
+
+/-- Coverage exposes exact mint/burn equality. -/
+theorem covers_mint_exact
+    {roles : ProofAssetRoles Asset} {tx : TxAssetView Asset}
+    (h : coversAssetView roles tx) :
+    tx.minted = roles.minted ++ roles.burned := h.1
+
+/-- Coverage exposes exact continuing-state-output equality. -/
+theorem covers_state_outputs_exact
+    {roles : ProofAssetRoles Asset} {tx : TxAssetView Asset}
+    (h : coversAssetView roles tx) :
+    tx.stateOutputs = roles.continuingState := h.2
+
+/-- If a tx mints or burns an asset not present in the proof
+    roles, asset coverage is impossible. -/
+theorem missing_mint_role_rejected
+    {roles : ProofAssetRoles Asset} {tx : TxAssetView Asset}
+    (a : Asset)
+    (hInTx : a ∈ tx.minted)
+    (hNotInRoles : a ∉ roles.minted ++ roles.burned) :
+    ¬ coversAssetView roles tx := by
+  intro h
+  rw [h.1] at hInTx
+  exact hNotInRoles hInTx
+
+/-- If the proof roles expect a continuing state asset that
+    is absent from tx outputs, asset coverage is impossible. -/
+theorem missing_state_output_rejected
+    {roles : ProofAssetRoles Asset} {tx : TxAssetView Asset}
+    (a : Asset)
+    (hInRoles : a ∈ roles.continuingState)
+    (hNotInTx : a ∉ tx.stateOutputs) :
+    ¬ coversAssetView roles tx := by
   intro h
   rw [← h.2] at hInRoles
   exact hNotInTx hInRoles

--- a/specs/227-tx-proof-binding/plan.md
+++ b/specs/227-tx-proof-binding/plan.md
@@ -6,26 +6,27 @@
 
 ## Status
 
-**Completed**: Issue #224 merged; issue #227 worktree created; design
-decision recorded in `research.md`; Lean binding model and theorems
-compile; Haskell client decodes tx inputs/reference inputs and compares
-them with endpoint proof roles; focused unit suite passes with the new
-binding forgery corpus.
+**Completed**: Issue #224 merged; issue #227 first PR #235 merged;
+design decision recorded in `research.md`; Lean binding model and
+theorems compile; Haskell client decodes tx inputs/reference inputs and
+compares them with endpoint proof roles; focused unit suite passes with
+the input/reference binding forgery corpus.
 
-**Current**: PR opened for the input/reference-input binding slice;
-watch CI and merge only after checks are green.
+**Current**: Second slice on `feat/227-bind-mint-output-redeemer`
+extends the pure CBOR reader to bind mint/burn assets and continuing
+state outputs; local client unit, format, lint, and diff checks pass.
 
-**Blockers**: Full mint/redeemer/output binding is outside this first
-slice and must be tracked explicitly after input/reference-input binding
-lands.
+**Blockers**: Full redeemer and MPF proof binding remains after this
+slice. `UpdateProof.trie_read` is still not bound to the exact on-chain
+redeemer proof payload.
 
 ## Summary
 
 Add a pure `cardano-mpfs-client` binding pass that decodes the unsigned
-transaction CBOR far enough to read tx inputs and reference inputs, then
-checks those sets against the endpoint proof roles. This rejects the
-class of forged response where the proof bundle is valid but belongs to
-a different transaction.
+transaction CBOR far enough to read tx inputs, reference inputs, mint
+assets, and continuing state outputs, then checks those sets against the
+endpoint proof roles. This rejects the class of forged response where
+the proof bundle is valid but belongs to a different transaction.
 
 ## Technical Context
 
@@ -43,8 +44,9 @@ repository.
 response. Linear in tx body size; not a hot path.
 **Constraints**: No `cardano-ledger-*`, no `crypton`, no RocksDB, no IO,
 no server-authored summary as an authority.
-**Scale/Scope**: One Lean file update, one new client module, small
-changes in `Verify.hs`, fixtures, tests, and cabal exposed modules.
+**Scale/Scope**: One Lean file update, the existing client tx-view
+module, small changes in `Verify.hs`, fixtures, tests, and cabal exposed
+modules.
 
 ## Constitution Check
 
@@ -115,6 +117,20 @@ model:
 
 These theorems are structural and do not model CBOR parsing. They define
 what the Haskell decoder result must satisfy after parsing.
+
+## Phase 2.5: Asset Binding Model
+
+Extend the same Lean section with an abstract asset binding model:
+
+- `TxAssetView` with signed `minted` assets and continuing
+  `stateOutputs`
+- `ProofAssetRoles` with `minted`, `burned`, and `continuingState`
+- predicate `coversAssetView roles tx`
+- theorems:
+  - `covers_mint_exact`
+  - `covers_state_outputs_exact`
+  - `missing_mint_role_rejected`
+  - `missing_state_output_rejected`
 
 ## Post-design Constitution Re-check
 

--- a/specs/227-tx-proof-binding/plan.md
+++ b/specs/227-tx-proof-binding/plan.md
@@ -12,9 +12,9 @@ theorems compile; Haskell client decodes tx inputs/reference inputs and
 compares them with endpoint proof roles; focused unit suite passes with
 the input/reference binding forgery corpus.
 
-**Current**: Second slice on `feat/227-bind-mint-output-redeemer`
-extends the pure CBOR reader to bind mint/burn assets and continuing
-state outputs; local client unit, format, lint, and diff checks pass.
+**Current**: PR #236 is open for the mint/burn and continuing
+state-output binding slice; wait for CI and merge only after checks are
+green.
 
 **Blockers**: Full redeemer and MPF proof binding remains after this
 slice. `UpdateProof.trie_read` is still not bound to the exact on-chain

--- a/specs/227-tx-proof-binding/research.md
+++ b/specs/227-tx-proof-binding/research.md
@@ -53,6 +53,32 @@ encodings for fields `0` and `18`.
 Collateral inputs are left for a later slice. They are not regular tx
 inputs or reference inputs in the issue's first acceptance surface.
 
+## Second slice: mint and state-output binding
+
+Extend the same targeted CBOR reader to decode:
+
+- tx-body field `9` (`mint = multiasset<nonZeroInt64>`)
+- tx-body field `1` transaction outputs
+- Shelley/Babbage output `value` assets
+- Babbage inline-datum markers
+- witnessed state `tx_out` values from proof payloads
+
+The verifier can then enforce:
+
+| Endpoint | Mint/burn rule | State-output rule |
+|----------|----------------|-------------------|
+| boot | exactly one `+1` asset | exactly one inline-datum output carries the minted asset |
+| request | empty mint | no state-output assertion |
+| retract | empty mint | no state-output assertion |
+| reject | empty mint | exactly one inline-datum output carries the witnessed state token |
+| end | exactly one burn matching the witnessed state token | no output carries the state token |
+| update | empty mint | exactly one inline-datum output carries the witnessed state token |
+
+This still deliberately avoids `cardano-ledger-*` in the client. It does
+not attempt to derive the boot asset name or decode full Aiken datum
+contents; those are covered by the on-chain script and will be tightened
+further when redeemer binding lands.
+
 ## Rejected alternative: server summary as authoritative
 
 Rejected for this slice. It leaves the client dependent on a
@@ -61,8 +87,6 @@ whose body omits or adds inputs relative to the summary.
 
 ## Deferred work
 
-- Decode mint field `9` and bind boot/end mint quantities to token roles.
-- Decode outputs and datum options to bind state-carrying outputs.
 - Decode redeemers from witness-set field `5` and bind update/retract/end
   redeemer content to proof roles.
 - Bind `UpdateProof.trie_read` facts to the exact MPF proof consumed by

--- a/specs/227-tx-proof-binding/spec.md
+++ b/specs/227-tx-proof-binding/spec.md
@@ -74,6 +74,24 @@ first slice must not pretend to prove properties it does not yet check.
 **Independent Test**: The plan and task list identify the residual work
 explicitly.
 
+### User Story 4 - Reject mint and continuing-state-output mismatches (Priority: P1)
+
+A wallet receives a proof-bearing response whose consumed inputs match
+the proof roles, but whose mint field or continuing state output does
+not match the endpoint role. The verifier must reject boot, reject, end,
+and update responses where the transaction mints/burns an unexpected
+asset or fails to carry the state token forward in exactly one inline
+datum output.
+
+**Why this priority**: Input binding alone proves which UTxOs the tx
+uses. Mint and state-output binding proves that token lifecycle
+endpoints act on the same state token represented by the proof bundle.
+
+**Independent Test**: Build honest fixtures with mint/output fields,
+then replace only the `tx` field so the tx omits the continuing state
+output or burns the wrong state token quantity. Verification must reject
+with `TxBindingFailed`.
+
 ## Edge Cases
 
 - Tx bodies may encode Cardano sets either as plain arrays or as tag
@@ -104,6 +122,13 @@ explicitly.
   `tx` field and prove the verifier rejects the mismatch.
 - **FR-007**: The implementation MUST document residual binding work for
   mint, redeemers, state-carrying outputs, and MPF fact binding.
+- **FR-008**: Boot responses MUST mint exactly one asset and include
+  exactly one inline-datum state output carrying that same asset.
+- **FR-009**: End responses MUST burn the asset carried by the witnessed
+  state input and MUST NOT leave a continuing state output carrying it.
+- **FR-010**: Reject and update responses MUST preserve the asset carried
+  by the witnessed state input into exactly one inline-datum state output
+  and MUST NOT mint or burn assets.
 
 ## Success Criteria
 
@@ -113,8 +138,8 @@ explicitly.
   for each endpoint family: funding-only, reference-input, and
   state/request-consuming endpoints.
 - **SC-003**: `cardano-mpfs-client:unit-tests` passes.
-- **SC-004**: The PR description states that this slice covers
-  input/reference-input binding and lists remaining deeper binding work.
+- **SC-004**: The PR description states which binding layers are covered
+  and lists remaining deeper binding work.
 
 ## Assumptions
 

--- a/specs/227-tx-proof-binding/tasks.md
+++ b/specs/227-tx-proof-binding/tasks.md
@@ -50,4 +50,4 @@ description: "Task list for feature 227-tx-proof-binding"
 - [X] T021 Bind end burn to the witnessed state token and reject continuing state outputs.
 - [X] T022 Refresh fixtures and forged-binding tests for mint/output mismatches.
 - [X] T023 Run Lean build, `git diff --check`, `just format-check`, `just hlint`, and focused client unit tests.
-- [ ] T024 Commit, push, open PR, and wait for merge.
+- [X] T024 Commit, push, open PR, and wait for merge.

--- a/specs/227-tx-proof-binding/tasks.md
+++ b/specs/227-tx-proof-binding/tasks.md
@@ -38,7 +38,16 @@ description: "Task list for feature 227-tx-proof-binding"
 
 ## Deferred follow-up
 
-- Mint binding for boot/end.
-- State-output datum binding.
 - Redeemer payload binding.
 - Exact `UpdateProof.trie_read` to redeemer MPF proof binding.
+
+## Phase 5: Mint and continuing-state-output binding
+
+- [X] T017 Extend Lean with `TxAssetView`, `ProofAssetRoles`, and asset coverage theorems.
+- [X] T018 Extend `TxView` to decode mint field `9`, tx outputs, value multiassets, and inline datum markers.
+- [X] T019 Bind boot mint to exactly one continuing inline state output.
+- [X] T020 Bind reject/update continuing state output to the witnessed state token and reject mint/burns.
+- [X] T021 Bind end burn to the witnessed state token and reject continuing state outputs.
+- [X] T022 Refresh fixtures and forged-binding tests for mint/output mismatches.
+- [X] T023 Run Lean build, `git diff --check`, `just format-check`, `just hlint`, and focused client unit tests.
+- [ ] T024 Commit, push, open PR, and wait for merge.


### PR DESCRIPTION
Refs #227

## Scope

This PR lands the second client-side proof/transaction binding slice for issue #227, after PR #235 merged input and reference-input binding.

- Extends the Lean binding model with `TxAssetView`, `ProofAssetRoles`, and exact mint/state-output coverage theorems.
- Extends `Cardano.MPFS.Client.Verify.TxView` to decode tx-body field `9` mint assets, tx-body field `1` outputs, Shelley/Babbage output values, and Babbage inline datum markers.
- Binds boot responses to exactly one `+1` minted asset and exactly one inline-datum output carrying that asset.
- Binds reject/update responses to no mint/burn and exactly one continuing inline-datum state output carrying the witnessed state token.
- Binds end responses to a burn matching the witnessed state token and rejects a continuing state output carrying it.
- Refreshes client fixtures so honest synthetic tx CBOR includes mint/output/value fields and adds forged-binding tests for boot state output, end burn quantity, and update state output.
- Marks the speckit task ledger complete through PR creation.

## Design note

The client still avoids `cardano-ledger-*`, native crypto, RocksDB, and server-authored tx summaries. This slice parses only stable Conway CBOR fields and compares decoded assets to the proof roles already replayed against the advertised snapshot root.

This does not derive the boot asset name in the client. Boot asset derivation is enforced by the on-chain minting policy through its redeemer; client-side redeemer binding is the remaining layer that will connect that policy input to the proof bundle.

## Residual issue #227 work

This PR intentionally uses `Refs #227`, not `Closes #227`, because the full issue acceptance still needs:

- Spending and minting redeemer payload binding from witness-set field `5`.
- Exact `UpdateProof.trie_read` to on-chain `RequestAction.Update` MPF proof binding.
- A server-side fix may be needed for real update envelopes if `updateTrieRead` remains empty while the tx redeemer carries proof steps.

## Validation

- Lean build for `lean/Phase4/Verify.lean` through the `lean/` Lake project — passed
- `git diff --check`
- `nix develop --quiet -c just format-check`
- `nix develop --quiet -c just hlint`
- `nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests -O0 --test-show-details=direct` — 50 examples, 0 failures
