### PR TITLE
feat(client): bind tx redeemers to proof roles

### DIFF
--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
@@ -59,10 +59,17 @@ import Cardano.MPFS.Client.Verify.Replay
     )
 import Cardano.MPFS.Client.Verify.TxView
     ( verifyBootAssetBinding
+    , verifyBootRedeemerBinding
     , verifyContinuingStateOutput
     , verifyEndAssetBinding
+    , verifyEndRedeemerBinding
     , verifyNoMint
+    , verifyNoRedeemers
+    , verifyRejectRedeemerBinding
+    , verifyRetractRedeemerBinding
+    , verifyStateRootBinding
     , verifyTxInputBinding
+    , verifyUpdateRedeemerBinding
     )
 
 -- | Structural check for the snapshot that every proof-bearing response
@@ -85,6 +92,7 @@ verifyBootTxResponse (BootTxResponse t s (BootProof fs)) = do
     replayWitnessedUtxos "boot.funding" rootBs fs
     txView <- verifyTxInputBinding "boot" t (witnessInputs fs) []
     verifyBootAssetBinding "boot" txView
+    verifyBootRedeemerBinding "boot" txView
 
 -- | Verify a @POST \/tx\/request\/{insert,delete,update}@ response.
 verifyRequestTxResponse :: RequestTxResponse -> Either VerifyError ()
@@ -96,6 +104,7 @@ verifyRequestTxResponse (RequestTxResponse t s (RequestProof fs)) = do
     replayWitnessedUtxos "request.funding" rootBs fs
     txView <- verifyTxInputBinding "request" t (witnessInputs fs) []
     verifyNoMint "request" txView
+    verifyNoRedeemers "request" txView
 
 -- | Verify a @POST \/tx\/retract@ response.
 verifyRetractTxResponse :: RetractTxResponse -> Either VerifyError ()
@@ -118,6 +127,11 @@ verifyRetractTxResponse
                 (txIn ri : witnessInputs fs)
                 [txIn sr]
         verifyNoMint "retract" txView
+        verifyRetractRedeemerBinding
+            "retract"
+            txView
+            (txIn ri)
+            (txIn sr)
 
 -- | Verify a @POST \/tx\/reject@ response.
 verifyRejectTxResponse :: RejectTxResponse -> Either VerifyError ()
@@ -140,6 +154,11 @@ verifyRejectTxResponse
                 (txIn st : witnessInputs ris <> witnessInputs fs)
                 []
         verifyContinuingStateOutput "reject" txView st
+        verifyRejectRedeemerBinding
+            "reject"
+            txView
+            (txIn st)
+            (witnessInputs ris)
 
 -- | Verify a @POST \/tx\/end@ response.
 verifyEndTxResponse :: EndTxResponse -> Either VerifyError ()
@@ -153,6 +172,7 @@ verifyEndTxResponse (EndTxResponse t s (EndProof st fs)) = do
     replayWitnessedUtxos "end.funding" rootBs fs
     txView <- verifyTxInputBinding "end" t (txIn st : witnessInputs fs) []
     verifyEndAssetBinding "end" txView st
+    verifyEndRedeemerBinding "end" txView (txIn st)
 
 -- | Verify a @POST \/tx\/update@ response.
 verifyUpdateTxResponse :: UpdateTxResponse -> Either VerifyError ()
@@ -171,6 +191,7 @@ verifyUpdateTxResponse
         replayWitnessedUtxos "update.funding" rootBs fs
         trieRootBs <- decodeHex "update.trie_root" tr
         replayTrieFacts "update.trie_read" trieRootBs tread
+        verifyStateRootBinding "update" st tr
         txView <-
             verifyTxInputBinding
                 "update"
@@ -178,6 +199,12 @@ verifyUpdateTxResponse
                 (txIn st : witnessInputs rs <> witnessInputs fs)
                 []
         verifyContinuingStateOutput "update" txView st
+        verifyUpdateRedeemerBinding
+            "update"
+            txView
+            (txIn st)
+            (witnessInputs rs)
+            tread
 
 -- ---------------------------------------------------------------
 -- Structural pass (hex decode, 32-byte hashes, non-empty hex)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
@@ -11,15 +11,24 @@
 module Cardano.MPFS.Client.Verify.TxView
     ( TxAsset (..)
     , TxOutView (..)
+    , TxRedeemerPurpose (..)
+    , TxRedeemerRole (..)
     , TxView (..)
     , decodeTxView
     , decodeTxOutView
     , verifyBootAssetBinding
+    , verifyBootRedeemerBinding
     , verifyContinuingStateOutput
     , verifyEndAssetBinding
+    , verifyEndRedeemerBinding
     , verifyNoMint
+    , verifyNoRedeemers
+    , verifyRejectRedeemerBinding
+    , verifyRetractRedeemerBinding
+    , verifyStateRootBinding
     , verifyTxInputBinding
     , verifyTxBinding
+    , verifyUpdateRedeemerBinding
     ) where
 
 import Codec.CBOR.Read qualified as CBOR
@@ -33,10 +42,12 @@ import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Word (Word64)
 
 import Cardano.MPFS.Client.Bundle
-    ( TxIn (..)
+    ( TrieFact (..)
+    , TxIn (..)
     , WitnessedUtxo (..)
     )
 import Cardano.MPFS.Client.Snapshot
@@ -58,6 +69,33 @@ data TxAsset = TxAsset
 data TxOutView = TxOutView
     { txOutAssets :: [TxAsset]
     , txOutHasInlineDatum :: Bool
+    , txOutInlineDatum :: Maybe CBOR.Term
+    }
+    deriving stock (Eq, Show)
+
+-- | Script purpose for a transaction redeemer.
+data TxRedeemerPurpose
+    = RedeemerSpend Word64
+    | RedeemerMint Word64
+    | RedeemerOther Integer Word64
+    deriving stock (Eq, Ord, Show)
+
+-- | Endpoint role decoded from a transaction redeemer after
+-- resolving spending indexes to concrete transaction inputs.
+data TxRedeemerRole
+    = RoleMinting
+    | RoleBurning
+    | RoleSpendEnd TxIn
+    | RoleSpendContribute TxIn TxIn
+    | RoleSpendModifyRejected TxIn Int
+    | RoleSpendModifyUpdate TxIn [CBOR.Term]
+    | RoleSpendRetract TxIn TxIn
+    | RoleUnsupported TxRedeemerPurpose Text
+    deriving stock (Eq, Ord, Show)
+
+data TxRedeemer = TxRedeemer
+    { txRedeemerPurpose :: TxRedeemerPurpose
+    , txRedeemerData :: CBOR.Term
     }
     deriving stock (Eq, Show)
 
@@ -67,6 +105,7 @@ data TxView = TxView
     , txReferenceInputs :: [TxIn]
     , txMint :: [TxAsset]
     , txOutputs :: [TxOutView]
+    , txRedeemers :: [TxRedeemer]
     }
     deriving stock (Eq, Show)
 
@@ -174,6 +213,97 @@ verifyEndAssetBinding endpoint view stateWitness = do
         (txMint view)
     forbidStateOutput endpoint stateAsset view
 
+-- | Request endpoints currently have no script redeemers.
+verifyNoRedeemers :: Text -> TxView -> Either VerifyError ()
+verifyNoRedeemers endpoint view =
+    compareRedeemerRoles
+        (endpoint <> ".tx.redeemers")
+        []
+        =<< redeemerRoles endpoint view
+
+-- | Boot must carry exactly one minting redeemer.
+verifyBootRedeemerBinding :: Text -> TxView -> Either VerifyError ()
+verifyBootRedeemerBinding endpoint view =
+    compareRedeemerRoles
+        (endpoint <> ".tx.redeemers")
+        [RoleMinting]
+        =<< redeemerRoles endpoint view
+
+-- | Retract must spend the request input with a `Retract` redeemer
+-- that points at the witnessed state reference input.
+verifyRetractRedeemerBinding
+    :: Text -> TxView -> TxIn -> TxIn -> Either VerifyError ()
+verifyRetractRedeemerBinding endpoint view requestIn stateRef =
+    compareRedeemerRoles
+        (endpoint <> ".tx.redeemers")
+        [RoleSpendRetract requestIn stateRef]
+        =<< redeemerRoles endpoint view
+
+-- | Reject must spend the state input with rejected actions and each
+-- request input with a `Contribute` redeemer pointing at the state.
+verifyRejectRedeemerBinding
+    :: Text -> TxView -> TxIn -> [TxIn] -> Either VerifyError ()
+verifyRejectRedeemerBinding endpoint view stateIn requestIns =
+    compareRedeemerRoles
+        (endpoint <> ".tx.redeemers")
+        expected
+        =<< redeemerRoles endpoint view
+  where
+    expected =
+        RoleSpendModifyRejected stateIn (length requestIns)
+            : [ RoleSpendContribute requestIn stateIn
+              | requestIn <- requestIns
+              ]
+
+-- | End must spend the state input with `End` and burn with the
+-- minting-policy `Burning` redeemer.
+verifyEndRedeemerBinding
+    :: Text -> TxView -> TxIn -> Either VerifyError ()
+verifyEndRedeemerBinding endpoint view stateIn =
+    compareRedeemerRoles
+        (endpoint <> ".tx.redeemers")
+        [RoleSpendEnd stateIn, RoleBurning]
+        =<< redeemerRoles endpoint view
+
+-- | Update must spend the state input with `Modify (Update ...)`,
+-- spend every request with `Contribute stateRef`, and carry exactly
+-- the MPF proof payloads advertised in `UpdateProof.trie_read`.
+verifyUpdateRedeemerBinding
+    :: Text
+    -> TxView
+    -> TxIn
+    -> [TxIn]
+    -> [TrieFact]
+    -> Either VerifyError ()
+verifyUpdateRedeemerBinding endpoint view stateIn requestIns trieRead = do
+    proofTerms <- trieReadProofTerms endpoint trieRead
+    roles <- redeemerRoles endpoint view
+    compareRedeemerRoles
+        (endpoint <> ".tx.redeemers")
+        (expected proofTerms)
+        roles
+  where
+    expected proofTerms =
+        RoleSpendModifyUpdate stateIn proofTerms
+            : [ RoleSpendContribute requestIn stateIn
+              | requestIn <- requestIns
+              ]
+
+-- | Bind `UpdateProof.trie_root` to the root stored in the witnessed
+-- state datum consumed by the transaction.
+verifyStateRootBinding
+    :: Text -> WitnessedUtxo -> Hex -> Either VerifyError ()
+verifyStateRootBinding endpoint stateWitness expectedRoot = do
+    actualRoot <- stateRootFromWitness endpoint stateWitness
+    if actualRoot == expectedRoot
+        then Right ()
+        else
+            Left
+                ( TxBindingFailed
+                    (endpoint <> ".state.tx_out.datum.root")
+                    "state root mismatch"
+                )
+
 decodeTxBytes :: Text -> Hex -> Either VerifyError BS.ByteString
 decodeTxBytes field (Hex txt) =
     case Base16.decode (T.encodeUtf8 txt) of
@@ -194,12 +324,19 @@ decodeTerm field bs =
 
 parseTx :: Text -> CBOR.Term -> Either VerifyError TxView
 parseTx field = \case
-    CBOR.TList [body, _wits, _valid, _aux] ->
-        parseBody field body
-    CBOR.TListI [body, _wits, _valid, _aux] ->
-        parseBody field body
+    CBOR.TList [body, wits, _valid, _aux] ->
+        parseTxParts field body wits
+    CBOR.TListI [body, wits, _valid, _aux] ->
+        parseTxParts field body wits
     _ ->
         Left (TxBindingFailed field "unsupported tx CBOR")
+
+parseTxParts
+    :: Text -> CBOR.Term -> CBOR.Term -> Either VerifyError TxView
+parseTxParts field body wits = do
+    view <- parseBody field body
+    redeemers <- parseWitnessRedeemers (field <> ".redeemers") wits
+    pure view{txRedeemers = redeemers}
 
 parseBody :: Text -> CBOR.Term -> Either VerifyError TxView
 parseBody field body = do
@@ -239,6 +376,76 @@ parseBody field body = do
             , txReferenceInputs = refs
             , txMint = mint
             , txOutputs = outputs
+            , txRedeemers = []
+            }
+
+parseWitnessRedeemers
+    :: Text -> CBOR.Term -> Either VerifyError [TxRedeemer]
+parseWitnessRedeemers field wits = do
+    entries <- case wits of
+        CBOR.TMap xs -> Right xs
+        CBOR.TMapI xs -> Right xs
+        _ ->
+            Left
+                ( TxBindingFailed
+                    field
+                    "unsupported witness set CBOR"
+                )
+    case lookupIntKey 5 entries of
+        Nothing -> Right []
+        Just t -> parseRedeemers field t
+
+parseRedeemers :: Text -> CBOR.Term -> Either VerifyError [TxRedeemer]
+parseRedeemers field = \case
+    CBOR.TList xs ->
+        traverse (parseFlatRedeemer field) xs
+    CBOR.TListI xs ->
+        traverse (parseFlatRedeemer field) xs
+    CBOR.TMap xs ->
+        traverse (uncurry (parseMapRedeemer field)) xs
+    CBOR.TMapI xs ->
+        traverse (uncurry (parseMapRedeemer field)) xs
+    _ -> Left (TxBindingFailed field "unsupported redeemers CBOR")
+
+parseFlatRedeemer
+    :: Text -> CBOR.Term -> Either VerifyError TxRedeemer
+parseFlatRedeemer field = \case
+    CBOR.TList [tagTerm, ixTerm, datumTerm, _exUnits] ->
+        mkRedeemer field tagTerm ixTerm datumTerm
+    CBOR.TListI [tagTerm, ixTerm, datumTerm, _exUnits] ->
+        mkRedeemer field tagTerm ixTerm datumTerm
+    _ -> Left (TxBindingFailed field "unsupported flat redeemer CBOR")
+
+parseMapRedeemer
+    :: Text -> CBOR.Term -> CBOR.Term -> Either VerifyError TxRedeemer
+parseMapRedeemer field keyTerm valueTerm = case (keyTerm, valueTerm) of
+    (CBOR.TList [tagTerm, ixTerm], CBOR.TList [datumTerm, _exUnits]) ->
+        mkRedeemer field tagTerm ixTerm datumTerm
+    (CBOR.TListI [tagTerm, ixTerm], CBOR.TListI [datumTerm, _exUnits]) ->
+        mkRedeemer field tagTerm ixTerm datumTerm
+    (CBOR.TList [tagTerm, ixTerm], CBOR.TListI [datumTerm, _exUnits]) ->
+        mkRedeemer field tagTerm ixTerm datumTerm
+    (CBOR.TListI [tagTerm, ixTerm], CBOR.TList [datumTerm, _exUnits]) ->
+        mkRedeemer field tagTerm ixTerm datumTerm
+    _ -> Left (TxBindingFailed field "unsupported map redeemer CBOR")
+
+mkRedeemer
+    :: Text
+    -> CBOR.Term
+    -> CBOR.Term
+    -> CBOR.Term
+    -> Either VerifyError TxRedeemer
+mkRedeemer field tagTerm ixTerm datumTerm = do
+    tag <- parseNonNegativeInteger (field <> ".purpose") tagTerm
+    ix <- parseWord64Unbounded (field <> ".index") ixTerm
+    let purpose = case tag of
+            0 -> RedeemerSpend ix
+            1 -> RedeemerMint ix
+            _ -> RedeemerOther tag ix
+    pure
+        TxRedeemer
+            { txRedeemerPurpose = purpose
+            , txRedeemerData = normalizeTerm datumTerm
             }
 
 lookupIntKey :: Integer -> [(CBOR.Term, CBOR.Term)] -> Maybe CBOR.Term
@@ -291,6 +498,21 @@ parseWord64 field t =
                 Right (fromInteger n)
         _ -> Left (TxBindingFailed field "input index out of range")
 
+parseWord64Unbounded :: Text -> CBOR.Term -> Either VerifyError Word64
+parseWord64Unbounded field t =
+    case termInteger t of
+        Just n
+            | n >= 0 && n <= toInteger (maxBound :: Word64) ->
+                Right (fromInteger n)
+        _ -> Left (TxBindingFailed field "index out of range")
+
+parseNonNegativeInteger
+    :: Text -> CBOR.Term -> Either VerifyError Integer
+parseNonNegativeInteger field t =
+    case termInteger t of
+        Just n | n >= 0 -> Right n
+        _ -> Left (TxBindingFailed field "expected non-negative integer")
+
 maxTxInputIndex :: Integer
 maxTxInputIndex = 65535
 
@@ -324,26 +546,40 @@ parseBabbageTxOut field entries = do
             Left (TxBindingFailed (field <> ".value") "missing value")
         Just t -> Right t
     assets <- parseValue (field <> ".value") valueTerm
-    hasInlineDatum <- case lookupIntKey 2 entries of
-        Nothing -> Right False
+    inlineDatum <- case lookupIntKey 2 entries of
+        Nothing -> Right Nothing
         Just t -> parseDatumOption (field <> ".datum") t
     pure
-        TxOutView{txOutAssets = assets, txOutHasInlineDatum = hasInlineDatum}
+        TxOutView
+            { txOutAssets = assets
+            , txOutHasInlineDatum = isJust inlineDatum
+            , txOutInlineDatum = inlineDatum
+            }
 
 txOutWithoutInlineDatum
     :: Text -> CBOR.Term -> Either VerifyError TxOutView
 txOutWithoutInlineDatum field valueTerm = do
     assets <- parseValue (field <> ".value") valueTerm
-    pure TxOutView{txOutAssets = assets, txOutHasInlineDatum = False}
+    pure
+        TxOutView
+            { txOutAssets = assets
+            , txOutHasInlineDatum = False
+            , txOutInlineDatum = Nothing
+            }
 
-parseDatumOption :: Text -> CBOR.Term -> Either VerifyError Bool
+parseDatumOption
+    :: Text -> CBOR.Term -> Either VerifyError (Maybe CBOR.Term)
 parseDatumOption field = \case
     CBOR.TList [tagTerm, _]
-        | termInteger tagTerm == Just 0 -> Right False
-        | termInteger tagTerm == Just 1 -> Right True
+        | termInteger tagTerm == Just 0 -> Right Nothing
+    CBOR.TList [tagTerm, datumTerm]
+        | termInteger tagTerm == Just 1 ->
+            Right (Just (normalizeTerm datumTerm))
     CBOR.TListI [tagTerm, _]
-        | termInteger tagTerm == Just 0 -> Right False
-        | termInteger tagTerm == Just 1 -> Right True
+        | termInteger tagTerm == Just 0 -> Right Nothing
+    CBOR.TListI [tagTerm, datumTerm]
+        | termInteger tagTerm == Just 1 ->
+            Right (Just (normalizeTerm datumTerm))
     _ -> Left (TxBindingFailed field "unsupported datum option CBOR")
 
 parseValue :: Text -> CBOR.Term -> Either VerifyError [TxAsset]
@@ -421,6 +657,26 @@ quantityAllowed :: QuantityMode -> Integer -> Bool
 quantityAllowed SignedMint n = n /= 0
 quantityAllowed PositiveValue n = n > 0
 
+normalizeTerm :: CBOR.Term -> CBOR.Term
+normalizeTerm = \case
+    CBOR.TInt n -> CBOR.TInteger (fromIntegral n)
+    CBOR.TBytesI bs -> CBOR.TBytes (BSL.toStrict bs)
+    CBOR.TStringI txt -> CBOR.TString (TL.toStrict txt)
+    CBOR.TList xs -> CBOR.TList (map normalizeTerm xs)
+    CBOR.TListI xs -> CBOR.TList (map normalizeTerm xs)
+    CBOR.TMap xs ->
+        CBOR.TMap
+            [ (normalizeTerm k, normalizeTerm v)
+            | (k, v) <- xs
+            ]
+    CBOR.TMapI xs ->
+        CBOR.TMap
+            [ (normalizeTerm k, normalizeTerm v)
+            | (k, v) <- xs
+            ]
+    CBOR.TTagged tag t -> CBOR.TTagged tag (normalizeTerm t)
+    t -> t
+
 minInt64, maxInt64 :: Integer
 minInt64 = -9223372036854775808
 maxInt64 = 9223372036854775807
@@ -473,6 +729,223 @@ compareTxAssets field reason expected actual
     renderCount xs =
         T.pack (show (length xs)) <> " asset(s)"
 
+compareRedeemerRoles
+    :: Text -> [TxRedeemerRole] -> [TxRedeemerRole] -> Either VerifyError ()
+compareRedeemerRoles field expected actual
+    | canonical expected == canonical actual = Right ()
+    | otherwise =
+        Left
+            ( TxBindingFailed
+                field
+                ( "redeemer role mismatch: expected "
+                    <> renderCount expected
+                    <> ", got "
+                    <> renderCount actual
+                )
+            )
+  where
+    canonical = sort
+    renderCount xs =
+        T.pack (show (length xs)) <> " redeemer(s)"
+
+redeemerRoles :: Text -> TxView -> Either VerifyError [TxRedeemerRole]
+redeemerRoles endpoint view@TxView{txRedeemers} =
+    traverse (redeemerRole endpoint view) txRedeemers
+
+redeemerRole
+    :: Text -> TxView -> TxRedeemer -> Either VerifyError TxRedeemerRole
+redeemerRole endpoint view TxRedeemer{..} =
+    case txRedeemerPurpose of
+        RedeemerMint _ ->
+            parseMintRedeemerRole
+                (endpoint <> ".tx.redeemers.mint")
+                txRedeemerPurpose
+                txRedeemerData
+        RedeemerSpend ix -> do
+            input <- redeemerInput endpoint view ix
+            parseSpendRedeemerRole
+                (endpoint <> ".tx.redeemers.spend")
+                input
+                txRedeemerData
+        RedeemerOther{} ->
+            pure
+                ( RoleUnsupported
+                    txRedeemerPurpose
+                    "unsupported redeemer purpose"
+                )
+
+redeemerInput
+    :: Text -> TxView -> Word64 -> Either VerifyError TxIn
+redeemerInput endpoint TxView{txInputs} ix =
+    case drop (fromIntegral ix) txInputs of
+        input : _ -> Right input
+        [] ->
+            Left
+                ( TxBindingFailed
+                    (endpoint <> ".tx.redeemers.spend")
+                    "spending redeemer index out of range"
+                )
+
+parseMintRedeemerRole
+    :: Text
+    -> TxRedeemerPurpose
+    -> CBOR.Term
+    -> Either VerifyError TxRedeemerRole
+parseMintRedeemerRole field purpose term = do
+    (tag, _fields) <- parseConstr field term
+    case tag of
+        0 -> Right RoleMinting
+        2 -> Right RoleBurning
+        _ ->
+            Right
+                ( RoleUnsupported
+                    purpose
+                    "unsupported mint redeemer"
+                )
+
+parseSpendRedeemerRole
+    :: Text -> TxIn -> CBOR.Term -> Either VerifyError TxRedeemerRole
+parseSpendRedeemerRole field input term = do
+    (tag, fields) <- parseConstr field term
+    case (tag, fields) of
+        (0, []) -> Right (RoleSpendEnd input)
+        (1, [refTerm]) ->
+            RoleSpendContribute input
+                <$> parseTxOutRef (field <> ".contribute") refTerm
+        (2, [actionsTerm]) ->
+            parseModifyRole field input actionsTerm
+        (3, [refTerm]) ->
+            RoleSpendRetract input
+                <$> parseTxOutRef (field <> ".retract") refTerm
+        _ ->
+            Right
+                ( RoleUnsupported
+                    (RedeemerSpend 0)
+                    "unsupported spend redeemer"
+                )
+
+parseModifyRole
+    :: Text -> TxIn -> CBOR.Term -> Either VerifyError TxRedeemerRole
+parseModifyRole field input actionsTerm = do
+    actions <- parseList (field <> ".modify.actions") actionsTerm
+    parsed <- traverse (parseRequestAction field) actions
+    case parsed of
+        [] -> Right (RoleSpendModifyUpdate input [])
+        xs
+            | all isRejectedAction xs ->
+                Right (RoleSpendModifyRejected input (length xs))
+            | all isUpdateAction xs ->
+                Right
+                    ( RoleSpendModifyUpdate
+                        input
+                        [ proof
+                        | ParsedUpdateAction proof <- xs
+                        ]
+                    )
+            | otherwise ->
+                Right
+                    ( RoleUnsupported
+                        (RedeemerSpend 0)
+                        "mixed request action redeemer"
+                    )
+
+data ParsedRequestAction
+    = ParsedUpdateAction CBOR.Term
+    | ParsedRejectedAction
+    deriving stock (Eq, Show)
+
+isRejectedAction :: ParsedRequestAction -> Bool
+isRejectedAction ParsedRejectedAction = True
+isRejectedAction _ = False
+
+isUpdateAction :: ParsedRequestAction -> Bool
+isUpdateAction ParsedUpdateAction{} = True
+isUpdateAction _ = False
+
+parseRequestAction
+    :: Text -> CBOR.Term -> Either VerifyError ParsedRequestAction
+parseRequestAction field term = do
+    (tag, fields) <- parseConstr (field <> ".action") term
+    case (tag, fields) of
+        (0, [proofTerm]) ->
+            Right (ParsedUpdateAction (normalizeTerm proofTerm))
+        (1, []) -> Right ParsedRejectedAction
+        _ ->
+            Left
+                ( TxBindingFailed
+                    (field <> ".action")
+                    "unsupported request action redeemer"
+                )
+
+parseTxOutRef :: Text -> CBOR.Term -> Either VerifyError TxIn
+parseTxOutRef field term = do
+    (tag, fields) <- parseConstr field term
+    case (tag, fields) of
+        (0, [CBOR.TBytes txIdBs, ixTerm])
+            | BS.length txIdBs == 32 -> do
+                ix <- parseWord64Unbounded (field <> ".tx_ix") ixTerm
+                Right
+                    TxIn
+                        { txId = Hex (T.decodeUtf8 (Base16.encode txIdBs))
+                        , txIx = ix
+                        }
+        _ ->
+            Left
+                ( TxBindingFailed
+                    field
+                    "unsupported tx out ref CBOR"
+                )
+
+parseConstr
+    :: Text -> CBOR.Term -> Either VerifyError (Integer, [CBOR.Term])
+parseConstr field = \case
+    CBOR.TTagged tag fieldsTerm -> do
+        constr <- constructorIndex tag
+        fields <- parseList field fieldsTerm
+        Right (constr, fields)
+    _ -> Left (TxBindingFailed field "expected constructor data")
+  where
+    constructorIndex tag
+        | tag >= 121 && tag <= 127 =
+            Right (toInteger tag - 121)
+        | tag >= 1280 && tag <= 1400 =
+            Right (toInteger tag - 1280 + 7)
+        | tag == 102 =
+            Left
+                ( TxBindingFailed
+                    field
+                    "generic constructor data unsupported"
+                )
+        | otherwise =
+            Left (TxBindingFailed field "unsupported constructor tag")
+
+parseList :: Text -> CBOR.Term -> Either VerifyError [CBOR.Term]
+parseList field = \case
+    CBOR.TList xs -> Right (map normalizeTerm xs)
+    CBOR.TListI xs -> Right (map normalizeTerm xs)
+    _ -> Left (TxBindingFailed field "expected list data")
+
+trieReadProofTerms
+    :: Text -> [TrieFact] -> Either VerifyError [CBOR.Term]
+trieReadProofTerms endpoint = go (0 :: Int)
+  where
+    go _ [] = Right []
+    go i (TrieFact{mpfProof} : rest) = do
+        let field =
+                endpoint
+                    <> ".trie_read["
+                    <> T.pack (show i)
+                    <> "].mpf_proof"
+        proofBs <- decodeHexBinding field mpfProof
+        term <- decodeTerm field proofBs
+        (normalizeTerm term :) <$> go (i + 1) rest
+
+decodeHexBinding :: Text -> Hex -> Either VerifyError BS.ByteString
+decodeHexBinding field (Hex txt) =
+    case Base16.decode (T.encodeUtf8 txt) of
+        Right bs -> Right bs
+        Left _ -> Left (TxBindingFailed field "malformed hex")
+
 expectSingletonMint
     :: Text -> Integer -> TxView -> Either VerifyError TxAsset
 expectSingletonMint endpoint expectedQuantity TxView{txMint} =
@@ -504,6 +977,44 @@ stateAssetFromWitness endpoint WitnessedUtxo{txOut} = do
                 ( TxBindingFailed
                     (endpoint <> ".state.tx_out.value")
                     "state token ambiguous"
+                )
+
+stateRootFromWitness
+    :: Text -> WitnessedUtxo -> Either VerifyError Hex
+stateRootFromWitness endpoint WitnessedUtxo{txOut} = do
+    TxOutView{txOutInlineDatum} <-
+        decodeTxOutView (endpoint <> ".state.tx_out") txOut
+    case txOutInlineDatum of
+        Nothing ->
+            Left
+                ( TxBindingFailed
+                    (endpoint <> ".state.tx_out.datum")
+                    "state datum missing"
+                )
+        Just datum ->
+            parseStateDatumRoot
+                (endpoint <> ".state.tx_out.datum")
+                datum
+
+parseStateDatumRoot :: Text -> CBOR.Term -> Either VerifyError Hex
+parseStateDatumRoot field datum = do
+    (datumTag, datumFields) <- parseConstr field datum
+    case (datumTag, datumFields) of
+        (1, [stateTerm]) -> parseTokenStateRoot field stateTerm
+        _ -> Left (TxBindingFailed field "expected state datum")
+
+parseTokenStateRoot :: Text -> CBOR.Term -> Either VerifyError Hex
+parseTokenStateRoot field stateTerm = do
+    (stateTag, stateFields) <- parseConstr (field <> ".state") stateTerm
+    case (stateTag, stateFields) of
+        (0, [_owner, CBOR.TBytes rootBs, _fee, _process, _retract])
+            | BS.length rootBs == 32 ->
+                Right (Hex (T.decodeUtf8 (Base16.encode rootBs)))
+        _ ->
+            Left
+                ( TxBindingFailed
+                    (field <> ".state.root")
+                    "state root missing"
                 )
 
 requireStateOutput

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/TxView.hs
@@ -573,14 +573,26 @@ parseDatumOption field = \case
     CBOR.TList [tagTerm, _]
         | termInteger tagTerm == Just 0 -> Right Nothing
     CBOR.TList [tagTerm, datumTerm]
-        | termInteger tagTerm == Just 1 ->
-            Right (Just (normalizeTerm datumTerm))
+        | termInteger tagTerm == Just 1 -> do
+            datum <- parseInlineDatum (field <> ".inline") datumTerm
+            Right (Just datum)
     CBOR.TListI [tagTerm, _]
         | termInteger tagTerm == Just 0 -> Right Nothing
     CBOR.TListI [tagTerm, datumTerm]
-        | termInteger tagTerm == Just 1 ->
-            Right (Just (normalizeTerm datumTerm))
+        | termInteger tagTerm == Just 1 -> do
+            datum <- parseInlineDatum (field <> ".inline") datumTerm
+            Right (Just datum)
     _ -> Left (TxBindingFailed field "unsupported datum option CBOR")
+
+parseInlineDatum :: Text -> CBOR.Term -> Either VerifyError CBOR.Term
+parseInlineDatum field = \case
+    CBOR.TTagged 24 (CBOR.TBytes encoded) -> do
+        term <- decodeTerm field encoded
+        Right (normalizeTerm term)
+    CBOR.TTagged 24 _ ->
+        Left (TxBindingFailed field "unsupported encoded datum CBOR")
+    datumTerm ->
+        Right (normalizeTerm datumTerm)
 
 parseValue :: Text -> CBOR.Term -> Either VerifyError [TxAsset]
 parseValue field = \case

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
@@ -25,6 +25,21 @@ module Cardano.MPFS.Client.Fixtures
     , honestTrieInclusion
     , honestTrieExclusion
 
+      -- * Transaction fixture builders
+    , TxRedeemerFixture (..)
+    , burningRedeemerTerm
+    , mintRedeemerFixture
+    , mintingRedeemerTerm
+    , rejectedActionTerm
+    , spendContributeRedeemerTerm
+    , spendEndRedeemerTerm
+    , spendModifyRedeemerTerm
+    , spendRedeemerFixture
+    , spendRetractRedeemerTerm
+    , txCborFromTxPartsWithRedeemers
+    , txOutTerm
+    , updateActionTermFromProof
+
       -- * Hex utilities
     , toHex
     , sampleStateAsset
@@ -33,11 +48,13 @@ module Cardano.MPFS.Client.Fixtures
     ) where
 
 import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Term qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Lazy qualified as BSL
 import Data.List (nub)
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T
@@ -106,14 +123,22 @@ sampleSlot = 42
 sampleBlockId :: ByteString
 sampleBlockId = BS.replicate 32 0x11
 
-stateTxIn, requestTxIn, fundingTxIn :: (ByteString, Word64)
+stateTxIn
+    , requestTxIn
+    , requestTxIn2
+    , fundingTxIn
+        :: (ByteString, Word64)
 stateTxIn = (BS.replicate 32 0xA0, 0)
 requestTxIn = (BS.replicate 32 0xB1, 1)
+requestTxIn2 = (BS.replicate 32 0xB2, 3)
 fundingTxIn = (BS.replicate 32 0xC2, 2)
 
 samplePolicyId, sampleAssetName :: ByteString
 samplePolicyId = BS.replicate 28 0xD3
 sampleAssetName = BS.replicate 32 0xE4
+
+sampleStateRoot :: ByteString
+sampleStateRoot = BS.replicate 32 0x00
 
 sampleStateAsset :: Integer -> TxAsset
 sampleStateAsset quantity =
@@ -123,10 +148,15 @@ sampleStateAsset quantity =
         , assetQuantity = quantity
         }
 
-stateTxOut, requestTxOut, fundingTxOut :: ByteString
-stateTxOut = txOutCbor True [sampleStateAsset 1]
+requestTxOut, fundingTxOut :: ByteString
 requestTxOut = txOutCbor True []
 fundingTxOut = txOutCbor False []
+
+stateTxOutWithRoot :: ByteString -> ByteString
+stateTxOutWithRoot root =
+    txOutCborWithDatum
+        [sampleStateAsset 1]
+        (Just (stateDatumTerm root))
 
 txCborFromTxIns :: [TxIn] -> [TxIn] -> Hex
 txCborFromTxIns inputs refs =
@@ -135,12 +165,22 @@ txCborFromTxIns inputs refs =
 txCborFromTxParts
     :: [TxIn] -> [TxIn] -> [TxAsset] -> [CBOR.Term] -> Hex
 txCborFromTxParts inputs refs mint outputs =
+    txCborFromTxPartsWithRedeemers inputs refs mint outputs []
+
+txCborFromTxPartsWithRedeemers
+    :: [TxIn]
+    -> [TxIn]
+    -> [TxAsset]
+    -> [CBOR.Term]
+    -> [TxRedeemerFixture]
+    -> Hex
+txCborFromTxPartsWithRedeemers inputs refs mint outputs redeemers =
     toHex
         $ CBOR.toStrictByteString
         $ CBOR.encodeTerm
         $ CBOR.TList
             [ CBOR.TMap bodyFields
-            , CBOR.TMap []
+            , witnessSetTerm redeemers
             , CBOR.TBool True
             , CBOR.TNull
             ]
@@ -152,28 +192,148 @@ txCborFromTxParts inputs refs mint outputs =
             <> [(CBOR.TInt 18, setTerm refs) | not (null refs)]
             <> [(CBOR.TInt 9, multiAssetTerm mint) | not (null mint)]
 
+data TxRedeemerFixture = TxRedeemerFixture
+    { redeemerFixtureTag :: Integer
+    , redeemerFixtureIndex :: Word64
+    , redeemerFixtureData :: CBOR.Term
+    }
+    deriving stock (Eq, Show)
+
+spendRedeemerFixture :: Word64 -> CBOR.Term -> TxRedeemerFixture
+spendRedeemerFixture = TxRedeemerFixture 0
+
+mintRedeemerFixture :: Word64 -> CBOR.Term -> TxRedeemerFixture
+mintRedeemerFixture = TxRedeemerFixture 1
+
+witnessSetTerm :: [TxRedeemerFixture] -> CBOR.Term
+witnessSetTerm [] = CBOR.TMap []
+witnessSetTerm redeemers =
+    CBOR.TMap [(CBOR.TInt 5, redeemerMapTerm redeemers)]
+
+redeemerMapTerm :: [TxRedeemerFixture] -> CBOR.Term
+redeemerMapTerm redeemers =
+    CBOR.TMap
+        [ ( CBOR.TList
+                [ CBOR.TInteger redeemerFixtureTag
+                , CBOR.TInteger (fromIntegral redeemerFixtureIndex)
+                ]
+          , CBOR.TList
+                [ redeemerFixtureData
+                , CBOR.TList [CBOR.TInteger 0, CBOR.TInteger 0]
+                ]
+          )
+        | TxRedeemerFixture{..} <- redeemers
+        ]
+
 txOutCbor :: Bool -> [TxAsset] -> ByteString
 txOutCbor hasInlineDatum assets =
     CBOR.toStrictByteString
         $ CBOR.encodeTerm
         $ txOutTerm hasInlineDatum assets
 
+txOutCborWithDatum :: [TxAsset] -> Maybe CBOR.Term -> ByteString
+txOutCborWithDatum assets datum =
+    CBOR.toStrictByteString
+        $ CBOR.encodeTerm
+        $ txOutTermWithDatum assets datum
+
 txOutTerm :: Bool -> [TxAsset] -> CBOR.Term
 txOutTerm hasInlineDatum assets =
+    txOutTermWithDatum
+        assets
+        (if hasInlineDatum then Just inlineDatumDataTerm else Nothing)
+
+txOutTermWithDatum :: [TxAsset] -> Maybe CBOR.Term -> CBOR.Term
+txOutTermWithDatum assets datum =
     CBOR.TMap
         $ [ (CBOR.TInt 0, CBOR.TBytes "addr")
           , (CBOR.TInt 1, valueTerm assets)
           ]
-            <> [ (CBOR.TInt 2, inlineDatumTerm)
-               | hasInlineDatum
-               ]
+            <> maybe
+                []
+                (\d -> [(CBOR.TInt 2, inlineDatumOption d)])
+                datum
 
-inlineDatumTerm :: CBOR.Term
-inlineDatumTerm =
+inlineDatumOption :: CBOR.Term -> CBOR.Term
+inlineDatumOption datum =
     CBOR.TList
         [ CBOR.TInt 1
-        , CBOR.TTagged 121 (CBOR.TList [])
+        , datum
         ]
+
+inlineDatumDataTerm :: CBOR.Term
+inlineDatumDataTerm =
+    CBOR.TTagged 121 (CBOR.TList [])
+
+stateDatumTerm :: ByteString -> CBOR.Term
+stateDatumTerm root =
+    constr
+        1
+        [ constr
+            0
+            [ CBOR.TBytes (BS.replicate 28 0xAA)
+            , CBOR.TBytes root
+            , CBOR.TInteger 1_000_000
+            , CBOR.TInteger 60_000
+            , CBOR.TInteger 30_000
+            ]
+        ]
+
+mintingRedeemerTerm :: TxIn -> CBOR.Term
+mintingRedeemerTerm seedRef =
+    constr 0 [constr 0 [txOutRefTerm seedRef]]
+
+burningRedeemerTerm :: CBOR.Term
+burningRedeemerTerm = constr 2 []
+
+spendEndRedeemerTerm :: CBOR.Term
+spendEndRedeemerTerm = constr 0 []
+
+spendContributeRedeemerTerm :: TxIn -> CBOR.Term
+spendContributeRedeemerTerm stateRef =
+    constr 1 [txOutRefTerm stateRef]
+
+spendModifyRedeemerTerm :: [CBOR.Term] -> CBOR.Term
+spendModifyRedeemerTerm actions =
+    constr 2 [CBOR.TList actions]
+
+spendRetractRedeemerTerm :: TxIn -> CBOR.Term
+spendRetractRedeemerTerm stateRef =
+    constr 3 [txOutRefTerm stateRef]
+
+rejectedActionTerm :: CBOR.Term
+rejectedActionTerm = constr 1 []
+
+updateActionTermFromProof :: TrieFact -> CBOR.Term
+updateActionTermFromProof TrieFact{mpfProof} =
+    constr 0 [decodeProofTerm mpfProof]
+
+txOutRefTerm :: TxIn -> CBOR.Term
+txOutRefTerm TxIn{txId = Hex tid, txIx} =
+    constr
+        0
+        [ CBOR.TBytes (decodeFixtureHex tid)
+        , CBOR.TInteger (fromIntegral txIx)
+        ]
+
+constr :: Integer -> [CBOR.Term] -> CBOR.Term
+constr n fields
+    | n >= 0 && n <= 6 =
+        CBOR.TTagged (fromInteger (121 + n)) (CBOR.TList fields)
+    | n >= 7 && n <= 127 =
+        CBOR.TTagged (fromInteger (1280 + n - 7)) (CBOR.TList fields)
+    | otherwise =
+        error ("unsupported fixture constructor: " <> show n)
+
+decodeProofTerm :: Hex -> CBOR.Term
+decodeProofTerm proofHex =
+    let proofBytes = decodeFixtureHex (unHex proofHex)
+    in  case CBOR.deserialiseFromBytes
+            CBOR.decodeTerm
+            (BSL.fromStrict proofBytes) of
+            Right (remaining, term)
+                | BSL.null remaining -> term
+            _ -> error "invalid fixture proof CBOR"
 
 valueTerm :: [TxAsset] -> CBOR.Term
 valueTerm [] = CBOR.TInteger 2_000_000
@@ -242,16 +402,23 @@ data CsmtBundle = CsmtBundle
     { bundleRoot :: ByteString
     , bundleState :: WitnessedUtxo
     , bundleRequest :: WitnessedUtxo
+    , bundleRequest2 :: WitnessedUtxo
     , bundleFunding :: WitnessedUtxo
     }
 
 buildBundle :: CsmtBundle
-buildBundle = evalPureFromEmptyDB $ do
-    insertUtxo stateTxIn stateTxOut
+buildBundle = buildBundleWithStateRoot sampleStateRoot
+
+buildBundleWithStateRoot :: ByteString -> CsmtBundle
+buildBundleWithStateRoot stateRoot = evalPureFromEmptyDB $ do
+    let rootedStateTxOut = stateTxOutWithRoot stateRoot
+    insertUtxo stateTxIn rootedStateTxOut
     insertUtxo requestTxIn requestTxOut
+    insertUtxo requestTxIn2 requestTxOut
     insertUtxo fundingTxIn fundingTxOut
-    stateWitness <- mkWitness stateTxIn stateTxOut
+    stateWitness <- mkWitness stateTxIn rootedStateTxOut
     requestWitness <- mkWitness requestTxIn requestTxOut
+    requestWitness2 <- mkWitness requestTxIn2 requestTxOut
     fundingWitness <- mkWitness fundingTxIn fundingTxOut
     mRoot <- getRootHashM
     let rootBytes = maybe BS.empty renderHash mRoot
@@ -260,6 +427,7 @@ buildBundle = evalPureFromEmptyDB $ do
             { bundleRoot = rootBytes
             , bundleState = stateWitness
             , bundleRequest = requestWitness
+            , bundleRequest2 = requestWitness2
             , bundleFunding = fundingWitness
             }
   where
@@ -379,15 +547,20 @@ honestTrieExclusion =
 
 honestBootResponse :: BootTxResponse
 honestBootResponse =
-    BootTxResponse
-        ( txCborFromTxParts
-            [txIn (bundleFunding honestWitness)]
-            []
-            [sampleStateAsset 1]
-            [txOutTerm True [sampleStateAsset 1]]
-        )
-        (sampleSnapshot (bundleRoot honestWitness))
-        (BootProof [bundleFunding honestWitness])
+    let funding = bundleFunding honestWitness
+    in  BootTxResponse
+            ( txCborFromTxPartsWithRedeemers
+                [txIn funding]
+                []
+                [sampleStateAsset 1]
+                [txOutTerm True [sampleStateAsset 1]]
+                [ mintRedeemerFixture
+                    0
+                    (mintingRedeemerTerm (txIn funding))
+                ]
+            )
+            (sampleSnapshot (bundleRoot honestWitness))
+            (BootProof [funding])
 
 honestRequestResponse :: RequestTxResponse
 honestRequestResponse =
@@ -403,88 +576,90 @@ honestRequestResponse =
 
 honestRetractResponse :: RetractTxResponse
 honestRetractResponse =
-    RetractTxResponse
-        ( txCborFromTxParts
-            ( map
-                txIn
-                [ bundleRequest honestWitness
-                , bundleFunding honestWitness
+    let state = bundleState honestWitness
+        request = bundleRequest honestWitness
+        funding = bundleFunding honestWitness
+    in  RetractTxResponse
+            ( txCborFromTxPartsWithRedeemers
+                (map txIn [request, funding])
+                [txIn state]
+                []
+                [txOutTerm False []]
+                [ spendRedeemerFixture
+                    0
+                    (spendRetractRedeemerTerm (txIn state))
                 ]
             )
-            [txIn (bundleState honestWitness)]
-            []
-            [txOutTerm False []]
-        )
-        (sampleSnapshot (bundleRoot honestWitness))
-        ( RetractProof
-            (bundleRequest honestWitness)
-            (bundleState honestWitness)
-            [bundleFunding honestWitness]
-        )
+            (sampleSnapshot (bundleRoot honestWitness))
+            (RetractProof request state [funding])
 
 honestRejectResponse :: RejectTxResponse
 honestRejectResponse =
-    RejectTxResponse
-        ( txCborFromTxParts
-            ( map
-                txIn
-                [ bundleState honestWitness
-                , bundleRequest honestWitness
-                , bundleFunding honestWitness
+    let state = bundleState honestWitness
+        request = bundleRequest honestWitness
+        funding = bundleFunding honestWitness
+    in  RejectTxResponse
+            ( txCborFromTxPartsWithRedeemers
+                (map txIn [state, request, funding])
+                []
+                []
+                [txOutTerm True [sampleStateAsset 1]]
+                [ spendRedeemerFixture
+                    0
+                    (spendModifyRedeemerTerm [rejectedActionTerm])
+                , spendRedeemerFixture
+                    1
+                    (spendContributeRedeemerTerm (txIn state))
                 ]
             )
-            []
-            []
-            [txOutTerm True [sampleStateAsset 1]]
-        )
-        (sampleSnapshot (bundleRoot honestWitness))
-        ( RejectProof
-            (bundleState honestWitness)
-            [bundleRequest honestWitness]
-            [bundleFunding honestWitness]
-        )
+            (sampleSnapshot (bundleRoot honestWitness))
+            (RejectProof state [request] [funding])
 
 honestEndResponse :: EndTxResponse
 honestEndResponse =
-    EndTxResponse
-        ( txCborFromTxParts
-            ( map
-                txIn
-                [ bundleState honestWitness
-                , bundleFunding honestWitness
+    let state = bundleState honestWitness
+        funding = bundleFunding honestWitness
+    in  EndTxResponse
+            ( txCborFromTxPartsWithRedeemers
+                (map txIn [state, funding])
+                []
+                [sampleStateAsset (-1)]
+                [txOutTerm False []]
+                [ spendRedeemerFixture 0 spendEndRedeemerTerm
+                , mintRedeemerFixture 0 burningRedeemerTerm
                 ]
             )
-            []
-            [sampleStateAsset (-1)]
-            [txOutTerm False []]
-        )
-        (sampleSnapshot (bundleRoot honestWitness))
-        ( EndProof
-            (bundleState honestWitness)
-            [bundleFunding honestWitness]
-        )
+            (sampleSnapshot (bundleRoot honestWitness))
+            (EndProof state [funding])
 
 honestUpdateResponse :: UpdateTxResponse
 honestUpdateResponse =
     let (trieRoot, trieFact) = honestTrieInclusion
+        witness = buildBundleWithStateRoot trieRoot
+        state = bundleState witness
+        request = bundleRequest witness
+        funding = bundleFunding witness
     in  UpdateTxResponse
-            ( txCborFromTxParts
-                ( map
-                    txIn
-                    [ bundleState honestWitness
-                    , bundleRequest honestWitness
-                    , bundleFunding honestWitness
-                    ]
-                )
+            ( txCborFromTxPartsWithRedeemers
+                (map txIn [state, request, funding])
                 []
                 []
                 [txOutTerm True [sampleStateAsset 1]]
+                [ spendRedeemerFixture
+                    0
+                    ( spendModifyRedeemerTerm
+                        [updateActionTermFromProof trieFact]
+                    )
+                , spendRedeemerFixture
+                    1
+                    (spendContributeRedeemerTerm (txIn state))
+                ]
             )
-            (sampleSnapshot (bundleRoot honestWitness))
+            (sampleSnapshot (bundleRoot witness))
             ( UpdateProof
-                (bundleState honestWitness)
-                [bundleRequest honestWitness]
-                [bundleFunding honestWitness]
+                state
+                [request]
+                [funding]
                 (toHex trieRoot)
                 [trieFact]
             )
@@ -495,24 +670,37 @@ honestUpdateResponseMixedTrie :: UpdateTxResponse
 honestUpdateResponseMixedTrie =
     let (trieRoot, inclusionFact) = honestTrieInclusion
         (_, exclusionFact) = honestTrieExclusion
+        witness = buildBundleWithStateRoot trieRoot
+        state = bundleState witness
+        request = bundleRequest witness
+        request2 = bundleRequest2 witness
+        funding = bundleFunding witness
     in  UpdateTxResponse
-            ( txCborFromTxParts
-                ( map
-                    txIn
-                    [ bundleState honestWitness
-                    , bundleRequest honestWitness
-                    , bundleFunding honestWitness
-                    ]
-                )
+            ( txCborFromTxPartsWithRedeemers
+                (map txIn [state, request, request2, funding])
                 []
                 []
                 [txOutTerm True [sampleStateAsset 1]]
+                [ spendRedeemerFixture
+                    0
+                    ( spendModifyRedeemerTerm
+                        [ updateActionTermFromProof inclusionFact
+                        , updateActionTermFromProof exclusionFact
+                        ]
+                    )
+                , spendRedeemerFixture
+                    1
+                    (spendContributeRedeemerTerm (txIn state))
+                , spendRedeemerFixture
+                    2
+                    (spendContributeRedeemerTerm (txIn state))
+                ]
             )
-            (sampleSnapshot (bundleRoot honestWitness))
+            (sampleSnapshot (bundleRoot witness))
             ( UpdateProof
-                (bundleState honestWitness)
-                [bundleRequest honestWitness]
-                [bundleFunding honestWitness]
+                state
+                [request, request2]
+                [funding]
                 (toHex trieRoot)
                 [inclusionFact, exclusionFact]
             )
@@ -522,24 +710,29 @@ honestUpdateResponseMixedTrie =
 honestUpdateResponseEmptyTrie :: UpdateTxResponse
 honestUpdateResponseEmptyTrie =
     let (trieRoot, _) = honestTrieInclusion
+        witness = buildBundleWithStateRoot trieRoot
+        state = bundleState witness
+        request = bundleRequest witness
+        funding = bundleFunding witness
     in  UpdateTxResponse
-            ( txCborFromTxParts
-                ( map
-                    txIn
-                    [ bundleState honestWitness
-                    , bundleRequest honestWitness
-                    , bundleFunding honestWitness
-                    ]
-                )
+            ( txCborFromTxPartsWithRedeemers
+                (map txIn [state, request, funding])
                 []
                 []
                 [txOutTerm True [sampleStateAsset 1]]
+                [ spendRedeemerFixture
+                    0
+                    (spendModifyRedeemerTerm [])
+                , spendRedeemerFixture
+                    1
+                    (spendContributeRedeemerTerm (txIn state))
+                ]
             )
-            (sampleSnapshot (bundleRoot honestWitness))
+            (sampleSnapshot (bundleRoot witness))
             ( UpdateProof
-                (bundleState honestWitness)
-                [bundleRequest honestWitness]
-                [bundleFunding honestWitness]
+                state
+                [request]
+                [funding]
                 (toHex trieRoot)
                 []
             )

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
@@ -258,7 +258,13 @@ inlineDatumOption :: CBOR.Term -> CBOR.Term
 inlineDatumOption datum =
     CBOR.TList
         [ CBOR.TInt 1
-        , datum
+        , CBOR.TTagged
+            24
+            ( CBOR.TBytes
+                ( CBOR.toStrictByteString
+                    (CBOR.encodeTerm datum)
+                )
+            )
         ]
 
 inlineDatumDataTerm :: CBOR.Term

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
@@ -23,6 +23,7 @@ import Cardano.MPFS.Client
     , Hex (..)
     , RetractProof (..)
     , RetractTxResponse (..)
+    , TrieFact (..)
     , TxIn (..)
     , UpdateProof (..)
     , UpdateTxResponse (..)
@@ -54,17 +55,26 @@ import Cardano.MPFS.Client
     , withReason
     )
 import Cardano.MPFS.Client.Fixtures
-    ( honestBootResponse
+    ( TxRedeemerFixture (..)
+    , honestBootResponse
     , honestEndResponse
     , honestRejectResponse
     , honestRequestResponse
     , honestRetractResponse
+    , honestTrieExclusion
     , honestUpdateResponse
     , honestUpdateResponseEmptyTrie
     , honestUpdateResponseMixedTrie
     , sampleStateAsset
+    , spendContributeRedeemerTerm
+    , spendEndRedeemerTerm
+    , spendModifyRedeemerTerm
+    , spendRedeemerFixture
     , txCborFromTxIns
     , txCborFromTxParts
+    , txCborFromTxPartsWithRedeemers
+    , txOutTerm
+    , updateActionTermFromProof
     )
 
 spec :: Spec
@@ -135,6 +145,21 @@ spec = do
             $ updateWithoutStateOutput honestUpdateResponse
                 `shouldRejectWith` verifyUpdateTxResponse
             $ txBindingFailedAt "update.tx.state_outputs"
+
+        it "rejects a boot tx without its minting redeemer"
+            $ bootWithoutRedeemer honestBootResponse
+                `shouldRejectWith` verifyBootTxResponse
+            $ txBindingFailedAt "boot.tx.redeemers"
+
+        it "rejects a retract tx with the wrong spending redeemer"
+            $ retractWithEndRedeemer honestRetractResponse
+                `shouldRejectWith` verifyRetractTxResponse
+            $ txBindingFailedAt "retract.tx.redeemers"
+
+        it "rejects an update tx with mismatched MPF proof payload"
+            $ updateWithMismatchedRedeemerProof honestUpdateResponse
+                `shouldRejectWith` verifyUpdateTxResponse
+            $ txBindingFailedAt "update.tx.redeemers"
 
     describe "CSMT forgery corpus (free-monad DSL)" $ do
         it "rejects a boot funding utxo_proof with a flipped byte"
@@ -293,3 +318,60 @@ updateWithoutStateOutput
             )
             s
             p
+
+bootWithoutRedeemer :: BootTxResponse -> BootTxResponse
+bootWithoutRedeemer (BootTxResponse _ s p@(BootProof funding)) =
+    BootTxResponse
+        ( txCborFromTxParts
+            (map txIn funding)
+            []
+            [sampleStateAsset 1]
+            [txOutTerm True [sampleStateAsset 1]]
+        )
+        s
+        p
+
+retractWithEndRedeemer :: RetractTxResponse -> RetractTxResponse
+retractWithEndRedeemer
+    (RetractTxResponse _ s p@(RetractProof req st funding)) =
+        RetractTxResponse
+            ( txCborFromTxPartsWithRedeemers
+                (map txIn (req : funding))
+                [txIn st]
+                []
+                [txOutTerm False []]
+                [spendRedeemerFixture 0 spendEndRedeemerTerm]
+            )
+            s
+            p
+
+updateWithMismatchedRedeemerProof
+    :: UpdateTxResponse -> UpdateTxResponse
+updateWithMismatchedRedeemerProof
+    (UpdateTxResponse _ s p@(UpdateProof st reqs funding _tr _tread)) =
+        let (_, exclusionFact) = honestTrieExclusion
+        in  UpdateTxResponse
+                ( txCborFromTxPartsWithRedeemers
+                    (map txIn (st : reqs <> funding))
+                    []
+                    []
+                    [txOutTerm True [sampleStateAsset 1]]
+                    ( updateRedeemers
+                        (txIn st)
+                        (length reqs)
+                        exclusionFact
+                    )
+                )
+                s
+                p
+
+updateRedeemers :: TxIn -> Int -> TrieFact -> [TxRedeemerFixture]
+updateRedeemers stateIn requestCount trieFact =
+    spendRedeemerFixture
+        0
+        (spendModifyRedeemerTerm [updateActionTermFromProof trieFact])
+        : [ spendRedeemerFixture
+                (fromIntegral ix)
+                (spendContributeRedeemerTerm stateIn)
+          | ix <- [1 .. requestCount]
+          ]

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -19,6 +19,7 @@ module Cardano.MPFS.TxBuilder.Real.Update
 
 import Control.Exception (SomeException, try)
 import Control.Monad (when)
+import Data.Foldable (fold)
 import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -67,6 +68,8 @@ import Cardano.Ledger.Keys
     , KeyRole (..)
     )
 import Cardano.Ledger.Plutus.ExUnits (ExUnits)
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Lazy qualified as BSL
@@ -77,11 +80,12 @@ import PlutusTx.Builtins.Internal
 
 import Cardano.MPFS.Core.OnChain
     ( CageDatum (..)
+    , Neighbor (..)
     , OnChainOperation (..)
     , OnChainRequest (..)
     , OnChainRoot (..)
     , OnChainTokenState (..)
-    , ProofStep
+    , ProofStep (..)
     , RequestAction (..)
     , UpdateRedeemer (..)
     )
@@ -104,6 +108,7 @@ import Cardano.MPFS.Trie
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot
     , ProofEnvelope (..)
+    , TrieFact (..)
     , UpdateProof (..)
     , UtxoProofFn
     )
@@ -146,7 +151,7 @@ updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
                         "updateToken: invalid \
                         \state datum (root)"
     -- 2. Compute proofs via speculative trie
-    (proofs, newRoot) <-
+    (trieReads, newRoot) <-
         computeProofs tm tid reqUtxos
     -- 3. Extract state and build new datum
     let (oldState, newStateOut, script, ownerKh) =
@@ -171,7 +176,7 @@ updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
                 newStateOut
                 script
                 ownerKh
-                proofs
+                (map readProofSteps trieReads)
                 upperSlot
     result <-
         Tx.build
@@ -241,7 +246,8 @@ updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
                             , updateFunding = fundingWitnesses
                             , updateTrieRoot =
                                 oldRootBytes
-                            , updateTrieRead = []
+                            , updateTrieRead =
+                                map readTrieFact trieReads
                             }
                     }
         Left err ->
@@ -296,12 +302,17 @@ computeProofs
     :: TrieManager IO
     -> TokenId
     -> [(TxIn, TxOut ConwayEra)]
-    -> IO ([[ProofStep]], Root)
+    -> IO ([RequestTrieRead], Root)
 computeProofs tm tid reqUtxos =
     withSpeculativeTrie tm tid $ \trie -> do
         ps <- mapM (processRequest trie) reqUtxos
         r <- getRoot trie
         pure (ps, r)
+
+data RequestTrieRead = RequestTrieRead
+    { readProofSteps :: [ProofStep]
+    , readTrieFact :: TrieFact
+    }
 
 -- | Extract old state, build new state output,
 -- cage script, and owner key hash.
@@ -543,7 +554,7 @@ processRequest
     :: Monad m
     => Trie m
     -> (TxIn, TxOut ConwayEra)
-    -> m [ProofStep]
+    -> m RequestTrieRead
 processRequest trie (_txIn, txOut) = do
     let OnChainRequest
             { requestKey = key
@@ -558,13 +569,101 @@ processRequest trie (_txIn, txOut) = do
         OpInsert v -> do
             _ <- insert trie key v
             mSteps <- getProofSteps trie key
-            pure (fromMaybe [] mSteps)
+            pure
+                ( mkRequestTrieRead
+                    key
+                    Nothing
+                    (fromMaybe [] mSteps)
+                )
         OpDelete _ -> do
             mSteps <- getProofSteps trie key
             _ <- Cardano.MPFS.Trie.delete trie key
-            pure (fromMaybe [] mSteps)
+            pure
+                ( mkRequestTrieRead
+                    key
+                    (Just (operationOldValue op))
+                    (fromMaybe [] mSteps)
+                )
         OpUpdate _ v -> do
             mSteps <- getProofSteps trie key
             _ <- Cardano.MPFS.Trie.delete trie key
             _ <- insert trie key v
-            pure (fromMaybe [] mSteps)
+            pure
+                ( mkRequestTrieRead
+                    key
+                    (Just (operationOldValue op))
+                    (fromMaybe [] mSteps)
+                )
+
+mkRequestTrieRead
+    :: BS.ByteString -> Maybe BS.ByteString -> [ProofStep] -> RequestTrieRead
+mkRequestTrieRead key value steps =
+    RequestTrieRead
+        { readProofSteps = steps
+        , readTrieFact =
+            TrieFact
+                { factKey = key
+                , factValue = value
+                , factMpfProof = renderProofSteps steps
+                }
+        }
+
+operationOldValue :: OnChainOperation -> BS.ByteString
+operationOldValue = \case
+    OpInsert v -> v
+    OpDelete v -> v
+    OpUpdate old _new -> old
+
+renderProofSteps :: [ProofStep] -> BS.ByteString
+renderProofSteps steps =
+    CBOR.toStrictByteString
+        $ CBOR.encodeListLenIndef
+            <> foldMap encodeProofStep steps
+            <> CBOR.encodeBreak
+
+encodeProofStep :: ProofStep -> CBOR.Encoding
+encodeProofStep = \case
+    Branch skip neighbors ->
+        encodeConstr
+            0
+            [ CBOR.encodeInteger skip
+            , encodeIndefBytes (split64 neighbors)
+            ]
+    Fork skip Neighbor{..} ->
+        encodeConstr
+            1
+            [ CBOR.encodeInteger skip
+            , encodeConstr
+                0
+                [ CBOR.encodeInteger neighborNibble
+                , CBOR.encodeBytes neighborPrefix
+                , CBOR.encodeBytes neighborRoot
+                ]
+            ]
+    Leaf skip key value ->
+        encodeConstr
+            2
+            [ CBOR.encodeInteger skip
+            , CBOR.encodeBytes key
+            , CBOR.encodeBytes value
+            ]
+
+encodeConstr :: Word -> [CBOR.Encoding] -> CBOR.Encoding
+encodeConstr tag fields =
+    CBOR.encodeTag (121 + tag)
+        <> CBOR.encodeListLenIndef
+        <> fold fields
+        <> CBOR.encodeBreak
+
+encodeIndefBytes :: [BS.ByteString] -> CBOR.Encoding
+encodeIndefBytes chunks =
+    CBOR.encodeBytesIndef
+        <> foldMap CBOR.encodeBytes chunks
+        <> CBOR.encodeBreak
+
+split64 :: BS.ByteString -> [BS.ByteString]
+split64 bs
+    | BS.null bs = []
+    | otherwise =
+        let (chunk, rest) = BS.splitAt 64 bs
+        in  chunk : split64 rest

--- a/lean/Phase4/Verify.lean
+++ b/lean/Phase4/Verify.lean
@@ -180,10 +180,27 @@ structure ProofAssetRoles (Asset : Type) where
   burned : List Asset
   continuingState : List Asset
 
+/-- The redeemer fragment of an unsigned transaction witness set
+    used by the client verifier. `scriptRoles` records endpoint
+    script actions after resolving redeemer purposes to transaction
+    input/mint roles. `updateReads` records the MPF proof payloads
+    carried by update actions. -/
+structure TxRedeemerView (Role Proof : Type) where
+  scriptRoles : List Role
+  updateReads : List Proof
+
+/-- Redeemer roles implied by the endpoint proof payload. For update,
+    `expectedUpdateReads` is the exact list of MPF proof payloads from
+    `UpdateProof.trie_read`. -/
+structure ProofRedeemerRoles (Role Proof : Type) where
+  scriptRoles : List Role
+  expectedUpdateReads : List Proof
+
 namespace TxBinding
 
 variable {Key : Type}
 variable {Asset : Type}
+variable {Role Proof : Type}
 
 /-- A response covers a decoded transaction view exactly when
     its consumed proof roles are exactly the tx inputs and its
@@ -299,6 +316,67 @@ theorem missing_state_output_rejected
   intro h
   rw [← h.2] at hInRoles
   exact hNotInTx hInRoles
+
+/-- Redeemer coverage is exact for endpoint script roles and for the
+    update MPF read payloads carried in `Modify (Update ...)` actions. -/
+def coversRedeemerView
+    (roles : ProofRedeemerRoles Role Proof)
+    (tx : TxRedeemerView Role Proof) : Prop :=
+  tx.scriptRoles = roles.scriptRoles ∧
+  tx.updateReads = roles.expectedUpdateReads
+
+/-- Coverage exposes exact endpoint redeemer-role equality. -/
+theorem covers_redeemer_roles_exact
+    {roles : ProofRedeemerRoles Role Proof}
+    {tx : TxRedeemerView Role Proof}
+    (h : coversRedeemerView roles tx) :
+    tx.scriptRoles = roles.scriptRoles := h.1
+
+/-- Coverage exposes exact update MPF-read equality. -/
+theorem covers_update_reads_exact
+    {roles : ProofRedeemerRoles Role Proof}
+    {tx : TxRedeemerView Role Proof}
+    (h : coversRedeemerView roles tx) :
+    tx.updateReads = roles.expectedUpdateReads := h.2
+
+/-- If a transaction carries a redeemer role not implied by the proof
+    payload, redeemer coverage is impossible. -/
+theorem missing_redeemer_role_rejected
+    {roles : ProofRedeemerRoles Role Proof}
+    {tx : TxRedeemerView Role Proof}
+    (r : Role)
+    (hInTx : r ∈ tx.scriptRoles)
+    (hNotInRoles : r ∉ roles.scriptRoles) :
+    ¬ coversRedeemerView roles tx := by
+  intro h
+  rw [h.1] at hInTx
+  exact hNotInRoles hInTx
+
+/-- If the proof payload expects a redeemer role that is absent from
+    the transaction witness set, redeemer coverage is impossible. -/
+theorem extra_redeemer_role_rejected
+    {roles : ProofRedeemerRoles Role Proof}
+    {tx : TxRedeemerView Role Proof}
+    (r : Role)
+    (hInRoles : r ∈ roles.scriptRoles)
+    (hNotInTx : r ∉ tx.scriptRoles) :
+    ¬ coversRedeemerView roles tx := by
+  intro h
+  rw [← h.1] at hInRoles
+  exact hNotInTx hInRoles
+
+/-- If an update redeemer carries an MPF read payload not present in
+    `UpdateProof.trie_read`, redeemer coverage is impossible. -/
+theorem update_read_mismatch_rejected
+    {roles : ProofRedeemerRoles Role Proof}
+    {tx : TxRedeemerView Role Proof}
+    (p : Proof)
+    (hInTx : p ∈ tx.updateReads)
+    (hNotInRoles : p ∉ roles.expectedUpdateReads) :
+    ¬ coversRedeemerView roles tx := by
+  intro h
+  rw [h.2] at hInTx
+  exact hNotInRoles hInTx
 
 end TxBinding
 

--- a/specs/227-tx-proof-binding/plan.md
+++ b/specs/227-tx-proof-binding/plan.md
@@ -7,18 +7,22 @@
 ## Status
 
 **Completed**: Issue #224 merged; issue #227 first PR #235 merged;
-design decision recorded in `research.md`; Lean binding model and
-theorems compile; Haskell client decodes tx inputs/reference inputs and
-compares them with endpoint proof roles; focused unit suite passes with
-the input/reference binding forgery corpus.
+issue #227 second PR #236 merged; design decision recorded in
+`research.md`; Lean input/reference and asset binding models compile;
+Haskell client decodes tx inputs, reference inputs, mint assets, and
+continuing state outputs; focused unit suite passes with forged-binding
+coverage for those layers.
 
-**Current**: PR #236 is open for the mint/burn and continuing
-state-output binding slice; wait for CI and merge only after checks are
-green.
+**Current**: Implement the redeemer and MPF proof binding slice. Decode
+witness-set redeemers from the unsigned transaction, bind endpoint
+redeemer tags to proof roles, and bind the update redeemer's embedded
+MPF proof to `UpdateProof.trie_read`.
 
-**Blockers**: Full redeemer and MPF proof binding remains after this
-slice. `UpdateProof.trie_read` is still not bound to the exact on-chain
-redeemer proof payload.
+**Blockers**: Real update tx construction currently records an empty
+`UpdateProof.trie_read` in at least one path while the on-chain redeemer
+may carry proof steps. If confirmed, the server response builder must be
+fixed in the same slice or the client cannot perform exact MPF binding
+for real update responses.
 
 ## Summary
 
@@ -131,6 +135,19 @@ Extend the same Lean section with an abstract asset binding model:
   - `covers_state_outputs_exact`
   - `missing_mint_role_rejected`
   - `missing_state_output_rejected`
+
+## Phase 3.5: Redeemer and MPF Proof Binding Model
+
+Extend the Lean model with endpoint redeemer roles:
+
+- spending roles for state/request inputs
+- minting roles for boot/end token lifecycle actions
+- update action payloads with trie root and MPF read facts
+- predicate `coversRedeemerView roles tx`
+- theorems:
+  - endpoint redeemer role coverage is exact
+  - missing or extra redeemer roles are rejected
+  - update MPF reads must match the redeemer payload exactly
 
 ## Post-design Constitution Re-check
 

--- a/specs/227-tx-proof-binding/plan.md
+++ b/specs/227-tx-proof-binding/plan.md
@@ -8,29 +8,26 @@
 
 **Completed**: Issue #224 merged; issue #227 first PR #235 merged;
 issue #227 second PR #236 merged; design decision recorded in
-`research.md`; Lean input/reference and asset binding models compile;
-Haskell client decodes tx inputs, reference inputs, mint assets, and
-continuing state outputs; focused unit suite passes with forged-binding
-coverage for those layers.
+`research.md`; Lean input/reference, asset, and redeemer binding models
+compile; Haskell client decodes tx inputs, reference inputs, mint assets,
+continuing state outputs, inline state datums, and supported witness-set
+redeemers. The server update response builder now emits the trie read
+facts needed for exact update redeemer binding.
 
-**Current**: Implement the redeemer and MPF proof binding slice. Decode
-witness-set redeemers from the unsigned transaction, bind endpoint
-redeemer tags to proof roles, and bind the update redeemer's embedded
-MPF proof to `UpdateProof.trie_read`.
+**Current**: Final validation and PR #237 review/merge. Local validation
+covers Lean build, formatting, linting, client verifier tests, full build,
+and the offchain unit suite.
 
-**Blockers**: Real update tx construction currently records an empty
-`UpdateProof.trie_read` in at least one path while the on-chain redeemer
-may carry proof steps. If confirmed, the server response builder must be
-fixed in the same slice or the client cannot perform exact MPF binding
-for real update responses.
+**Blockers**: None known.
 
 ## Summary
 
 Add a pure `cardano-mpfs-client` binding pass that decodes the unsigned
 transaction CBOR far enough to read tx inputs, reference inputs, mint
-assets, and continuing state outputs, then checks those sets against the
-endpoint proof roles. This rejects the class of forged response where
-the proof bundle is valid but belongs to a different transaction.
+assets, continuing state outputs, inline state datum roots, and supported
+redeemers, then checks those sets and payloads against the endpoint proof
+roles. This rejects the class of forged response where the proof bundle
+is valid but belongs to a different transaction.
 
 ## Technical Context
 

--- a/specs/227-tx-proof-binding/research.md
+++ b/specs/227-tx-proof-binding/research.md
@@ -101,10 +101,11 @@ The binding target is:
 | retract | spending redeemer tag must be `Retract` and refer to the same state reference role |
 | reject | spending redeemer tags must be `Rejected` for the request inputs being rejected |
 | end | spending redeemer tag must end the state and minting redeemer tag must burn the same state token |
-| update | spending redeemer tag must be `Update`; embedded trie root and MPF proof facts must match `UpdateProof.trie_root` and `UpdateProof.trie_read` exactly |
+| update | spending redeemer tag must be `Update`; the witnessed state datum root must match `UpdateProof.trie_root`; embedded MPF proof facts must match `UpdateProof.trie_read` exactly |
 
 This is the last client-side binding layer called out by issue #227.
-If implementation confirms that real update responses still publish an
-empty `trie_read` while the unsigned tx redeemer embeds MPF steps, the
-server-side response proof must be fixed before exact update redeemer
-binding can pass real fixtures.
+Implementation confirmed that real update responses needed to publish the
+same MPF read facts already used to build the on-chain redeemer. The
+server-side response builder now records those facts in
+`UpdateProof.trie_read`, so exact update redeemer binding can pass real
+fixtures.

--- a/specs/227-tx-proof-binding/research.md
+++ b/specs/227-tx-proof-binding/research.md
@@ -85,9 +85,26 @@ Rejected for this slice. It leaves the client dependent on a
 server-authored interpretation of the transaction and cannot detect a tx
 whose body omits or adds inputs relative to the summary.
 
-## Deferred work
+## Third slice: redeemer and MPF proof binding
 
-- Decode redeemers from witness-set field `5` and bind update/retract/end
-  redeemer content to proof roles.
-- Bind `UpdateProof.trie_read` facts to the exact MPF proof consumed by
-  the update redeemer.
+Extend the targeted reader to decode transaction witness-set field `5`
+for the redeemer shapes produced by this repository. The verifier should
+fail closed for unsupported redeemer encodings instead of accepting an
+unknown script payload.
+
+The binding target is:
+
+| Endpoint | Redeemer rule |
+|----------|---------------|
+| boot | exactly the expected minting redeemer tag for token creation |
+| request | no script redeemer binding required in this issue slice |
+| retract | spending redeemer tag must be `Retract` and refer to the same state reference role |
+| reject | spending redeemer tags must be `Rejected` for the request inputs being rejected |
+| end | spending redeemer tag must end the state and minting redeemer tag must burn the same state token |
+| update | spending redeemer tag must be `Update`; embedded trie root and MPF proof facts must match `UpdateProof.trie_root` and `UpdateProof.trie_read` exactly |
+
+This is the last client-side binding layer called out by issue #227.
+If implementation confirms that real update responses still publish an
+empty `trie_read` while the unsigned tx redeemer embeds MPF steps, the
+server-side response proof must be fixed before exact update redeemer
+binding can pass real fixtures.

--- a/specs/227-tx-proof-binding/spec.md
+++ b/specs/227-tx-proof-binding/spec.md
@@ -98,8 +98,9 @@ A wallet receives a proof-bearing response whose inputs, mint, and state
 outputs match the proof roles, but whose on-chain redeemers act on a
 different request action or MPF proof. The verifier must reject write
 responses where the transaction's redeemer set is missing, has an
-unexpected endpoint tag, or embeds update MPF facts that do not exactly
-match `UpdateProof.trie_root` and `UpdateProof.trie_read`.
+unexpected endpoint tag, consumes a state datum root different from
+`UpdateProof.trie_root`, or embeds update MPF facts that do not exactly
+match `UpdateProof.trie_read`.
 
 **Why this priority**: The transaction can still be substituted after
 input and asset binding if the redeemer payload describes a different
@@ -161,9 +162,9 @@ from `UpdateProof.trie_read`. Verification must reject with
   the expected token lifecycle action.
 - **FR-013**: Retract, reject, and update responses MUST bind spending
   redeemer tags to the expected request/state action roles.
-- **FR-014**: Update responses MUST bind the update redeemer's trie root
-  and MPF proof payload exactly to `UpdateProof.trie_root` and
-  `UpdateProof.trie_read`.
+- **FR-014**: Update responses MUST bind the consumed state datum root
+  exactly to `UpdateProof.trie_root` and the update redeemer MPF proof
+  payload exactly to `UpdateProof.trie_read`.
 
 ## Success Criteria
 

--- a/specs/227-tx-proof-binding/spec.md
+++ b/specs/227-tx-proof-binding/spec.md
@@ -92,6 +92,26 @@ then replace only the `tx` field so the tx omits the continuing state
 output or burns the wrong state token quantity. Verification must reject
 with `TxBindingFailed`.
 
+### User Story 5 - Reject redeemer and MPF proof mismatches (Priority: P1)
+
+A wallet receives a proof-bearing response whose inputs, mint, and state
+outputs match the proof roles, but whose on-chain redeemers act on a
+different request action or MPF proof. The verifier must reject write
+responses where the transaction's redeemer set is missing, has an
+unexpected endpoint tag, or embeds update MPF facts that do not exactly
+match `UpdateProof.trie_root` and `UpdateProof.trie_read`.
+
+**Why this priority**: The transaction can still be substituted after
+input and asset binding if the redeemer payload describes a different
+script action. Exact redeemer binding is the final issue #227 layer that
+makes the proof bundle useful for the transaction being signed.
+
+**Independent Test**: Build honest fixtures with supported redeemer
+CBOR, then replace only the `tx` field so the tx has a wrong redeemer
+tag, omits a required redeemer, or carries an update MPF proof different
+from `UpdateProof.trie_read`. Verification must reject with
+`TxBindingFailed`.
+
 ## Edge Cases
 
 - Tx bodies may encode Cardano sets either as plain arrays or as tag
@@ -103,6 +123,12 @@ with `TxBindingFailed`.
   not regular spending inputs or reference inputs.
 - Fixtures must use valid Conway-shaped transaction CBOR rather than
   placeholder bytes once binding is enabled.
+- Redeemer CBOR may use legacy map encoding or the Conway array form.
+  The decoder may initially support only the shapes produced by this
+  repository's transaction builder, but unsupported shapes must fail
+  closed with a structured binding error.
+- Update responses with an empty `trie_read` may be valid only when the
+  transaction's update redeemer also carries no MPF read facts.
 
 ## Requirements
 
@@ -129,6 +155,15 @@ with `TxBindingFailed`.
 - **FR-010**: Reject and update responses MUST preserve the asset carried
   by the witnessed state input into exactly one inline-datum state output
   and MUST NOT mint or burn assets.
+- **FR-011**: The client MUST decode enough transaction witness-set CBOR
+  to read redeemer purposes and redeemer data for the endpoint scripts.
+- **FR-012**: Boot and end responses MUST bind minting redeemer tags to
+  the expected token lifecycle action.
+- **FR-013**: Retract, reject, and update responses MUST bind spending
+  redeemer tags to the expected request/state action roles.
+- **FR-014**: Update responses MUST bind the update redeemer's trie root
+  and MPF proof payload exactly to `UpdateProof.trie_root` and
+  `UpdateProof.trie_read`.
 
 ## Success Criteria
 
@@ -140,6 +175,9 @@ with `TxBindingFailed`.
 - **SC-003**: `cardano-mpfs-client:unit-tests` passes.
 - **SC-004**: The PR description states which binding layers are covered
   and lists remaining deeper binding work.
+- **SC-005**: Forged redeemer-binding unit tests fail verification for
+  wrong endpoint action, missing redeemer, and mismatched update MPF
+  proof payload.
 
 ## Assumptions
 

--- a/specs/227-tx-proof-binding/tasks.md
+++ b/specs/227-tx-proof-binding/tasks.md
@@ -51,3 +51,15 @@ description: "Task list for feature 227-tx-proof-binding"
 - [X] T022 Refresh fixtures and forged-binding tests for mint/output mismatches.
 - [X] T023 Run Lean build, `git diff --check`, `just format-check`, `just hlint`, and focused client unit tests.
 - [X] T024 Commit, push, open PR, and wait for merge.
+
+## Phase 6: Redeemer and MPF proof binding
+
+- [ ] T025 Extend Lean with redeemer-role and update MPF-read coverage predicates.
+- [ ] T026 Prove exact redeemer coverage and update MPF-read mismatch rejection theorems with no `sorry`.
+- [ ] T027 Extend `TxView` to decode witness-set field `5` redeemers from supported Conway transaction CBOR.
+- [ ] T028 Bind boot/end minting redeemer tags and retract/reject/update spending redeemer tags to endpoint proof roles.
+- [ ] T029 Bind update redeemer trie root and MPF proof payload to `UpdateProof.trie_root` and `UpdateProof.trie_read`.
+- [ ] T030 Fix server-side update proof emission if real tx redeemers carry MPF reads not present in the response proof.
+- [ ] T031 Add forged-binding fixtures/tests for wrong redeemer tag, missing redeemer, and mismatched update MPF proof.
+- [ ] T032 Run Lean build, `git diff --check`, `just format-check`, `just hlint`, focused unit tests, and any needed E2E coverage.
+- [ ] T033 Commit, push, update PR, wait for green CI, and merge through merge-guard.

--- a/specs/227-tx-proof-binding/tasks.md
+++ b/specs/227-tx-proof-binding/tasks.md
@@ -54,12 +54,12 @@ description: "Task list for feature 227-tx-proof-binding"
 
 ## Phase 6: Redeemer and MPF proof binding
 
-- [ ] T025 Extend Lean with redeemer-role and update MPF-read coverage predicates.
-- [ ] T026 Prove exact redeemer coverage and update MPF-read mismatch rejection theorems with no `sorry`.
-- [ ] T027 Extend `TxView` to decode witness-set field `5` redeemers from supported Conway transaction CBOR.
-- [ ] T028 Bind boot/end minting redeemer tags and retract/reject/update spending redeemer tags to endpoint proof roles.
-- [ ] T029 Bind update redeemer trie root and MPF proof payload to `UpdateProof.trie_root` and `UpdateProof.trie_read`.
-- [ ] T030 Fix server-side update proof emission if real tx redeemers carry MPF reads not present in the response proof.
-- [ ] T031 Add forged-binding fixtures/tests for wrong redeemer tag, missing redeemer, and mismatched update MPF proof.
-- [ ] T032 Run Lean build, `git diff --check`, `just format-check`, `just hlint`, focused unit tests, and any needed E2E coverage.
+- [X] T025 Extend Lean with redeemer-role and update MPF-read coverage predicates.
+- [X] T026 Prove exact redeemer coverage and update MPF-read mismatch rejection theorems with no `sorry`.
+- [X] T027 Extend `TxView` to decode witness-set field `5` redeemers from supported Conway transaction CBOR.
+- [X] T028 Bind boot/end minting redeemer tags and retract/reject/update spending redeemer tags to endpoint proof roles.
+- [X] T029 Bind update state datum root and redeemer MPF proof payload to `UpdateProof.trie_root` and `UpdateProof.trie_read`.
+- [X] T030 Fix server-side update proof emission if real tx redeemers carry MPF reads not present in the response proof.
+- [X] T031 Add forged-binding fixtures/tests for wrong redeemer tag, missing redeemer, and mismatched update MPF proof.
+- [X] T032 Run Lean build, `git diff --check`, `just format-check`, `just hlint`, focused unit tests, and any needed E2E coverage.
 - [ ] T033 Commit, push, update PR, wait for green CI, and merge through merge-guard.


### PR DESCRIPTION
Closes #227

## Scope

This is the final planned proof/transaction binding slice for issue #227, after the input/reference-input slice in #235 and the mint/continuing-state-output slice in #236.

This PR adds exact binding for the remaining script payload surface:

- extends the Lean model with redeemer roles and update MPF-read coverage theorems
- decodes supported Conway witness-set redeemers in the pure `cardano-mpfs-client` tx view
- binds boot/end minting redeemers and retract/reject/update spending redeemers to endpoint proof roles
- binds update `UpdateProof.trie_root` to the consumed state datum root
- binds update redeemer MPF proof payloads exactly to `UpdateProof.trie_read`
- fixes real update response construction so `UpdateProof.trie_read` contains the same MPF facts used for the on-chain update redeemer
- decodes ledger-style tag-24 encoded inline datums for real Babbage TxOut state witnesses
- adds forged-binding fixtures/tests for missing redeemers, wrong redeemer tags, and mismatched update MPF proof payloads
- refreshes the speckit plan/spec/research/tasks for the completed #227 binding matrix

## Validation

Local validation passed:

- `lean_build` for `lean/`
- `lean_verify` for `Phase4.Verify.TxBinding.update_read_mismatch_rejected`
- `git diff --check`
- `nix develop --quiet -c just format`
- `nix develop --quiet -c just format-check`
- `nix develop --quiet -c just hlint`
- `nix develop --quiet -c just build`
- `nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests -O0 --test-show-details=direct` (53 examples, 0 failures)
- `nix develop --quiet -c just unit` (371 examples, 0 failures)
- `nix build .#e2e-tests --quiet`
- `E2E_GENESIS_DIR=cardano-mpfs-offchain/e2e-test/genesis nix develop --quiet -c ./result/bin/e2e-tests --match "/Proof-bearing envelopes E2E/read and write envelopes carry verifiable proofs/" --seed 1754845389` (1 example, 0 failures)

Latest GitHub CI before merge: Build Gate, build, e2e, and docs deploy all passed.
