### PR TITLE
chore(client): prove cross-target verifier builds

### DIFF
--- a/specs/221-client-cross-targets/plan.md
+++ b/specs/221-client-cross-targets/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: Cross-Target Client Verifier Builds
+
+**Branch**: `spike/spike-prove-cardano-mpfs-client-cross-compiles-to-` | **Date**: 2026-04-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/221-client-cross-targets/spec.md`
+**Issue**: [#221](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/221)
+
+## Status
+
+**Completed**: Issue #227 closed; the verifier is now fully tx-bound
+for inputs, assets, redeemers, state roots, and update MPF payloads.
+
+**Current**: Establish the #221 cross-target proof path. First commit is
+speckit documentation and a dependency/build-surface audit. Next step is
+to add the smallest repeatable Nix outputs for the client library
+targets, then run them and record any blockers precisely.
+
+**Blockers**: Unknown until the WASM/JS build attempts run. Likely risk
+areas are haskell.nix cross support for public sublibraries from `mts`
+and any transitive package that assumes native GHC.
+
+## Summary
+
+Prove whether `cardano-mpfs-client` can be built once and shipped across
+native GHC, GHC-WASM, and GHC-JS. Add stable Nix targets for the client
+library cross builds, document any blockers with exact commands and
+errors, and only wire CI as a merge gate for targets that build
+repeatably.
+
+## Technical Context
+
+**Language/Version**: Haskell, repo-pinned GHC 9.8.4 for native builds;
+cross compiler versions to be determined by haskell.nix/ghc-wasm inputs.
+**Primary Dependencies**: `aeson`, `base16-bytestring`, `bytestring`,
+`cborg`, `text`, `operational`, and pure `mts` CSMT/MPF sublibraries.
+**Storage**: N/A for the client verifier.
+**Testing**: `cardano-mpfs-client:unit-tests`; optional cross-target
+parity runner over the existing verifier fixture corpus.
+**Target Platform**: Native GHC, GHC-WASM, GHC-JS.
+**Project Type**: Haskell client library in a multi-package flake.
+**Performance Goals**: Build proof only; runtime performance is out of
+scope except that parity checks must finish in CI.
+**Constraints**: No verifier dependency on `cardano-ledger-*`,
+`crypton`, `unix`, `process`, native C FFI, network, disk, or IO.
+**Scale/Scope**: One client package, flake/Nix outputs, CI wiring, and
+minimal package/release notes if artifacts build.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Ledger-Native Types | N/A | Client verifier intentionally uses API DTOs and generic CBOR terms; no server ledger types touched. |
+| II. Records of Functions | PASS | No service interfaces planned. |
+| III. Atomic Block Processing | N/A | No persistence/indexer path touched. |
+| IV. External Signing | PASS | Verifier remains client-side and offline. |
+| V. Aiken Compatibility | GUARDED | Cross-target builds must preserve the same proof bytes and CBOR decoding surface. |
+| VI. Test Locally First | PASS | All new build checks must have documented local commands. |
+| VII. Nix Reproducibility | GUARDED | The feature is primarily a Nix reproducibility proof. |
+| VIII. Pure Offline Verification | PASS | Library target stays pure; HTTP/anchor tickets remain separate. |
+| IX. One Verifier, Many Targets | GUARDED | This issue exists to satisfy the principle. |
+| X. Lean as Source of Truth | PASS | No new verifier invariant is introduced; this is a build portability proof over the existing Lean-backed verifier. |
+
+No justified violations. Guarded items must be resolved or documented as
+blockers before implementation is complete.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/221-client-cross-targets/
+├── spec.md
+├── plan.md
+├── research.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+flake.nix
+nix/project.nix
+.github/workflows/ci.yml
+cardano-mpfs-client/
+├── cardano-mpfs-client.cabal
+├── README.md
+└── npm/                 # only if packaging can be meaningfully stubbed
+```
+
+**Structure Decision**: keep cross-target build logic in the existing
+flake/Nix layer. Do not split the client package or create a parallel
+verifier package unless a blocker proves that a package boundary is
+required.
+
+## Phase 0: Research
+
+Record:
+
+- current `cardano-mpfs-client` dependency surface
+- available haskell.nix cross compilation mechanisms in this flake
+- command/output for the first GHC-WASM attempt
+- command/output for the first GHC-JS attempt
+- blocker table with owner action for every failure
+
+## Phase 1: Design
+
+Add the smallest Nix outputs that name the desired artifacts:
+
+- `packages.<system>.cardano-mpfs-client-wasm`
+- `packages.<system>.cardano-mpfs-client-js`
+- optional cross-target test/parity outputs only after library builds
+
+CI wiring is allowed only for outputs that build locally.
+
+## Phase 2: Implementation
+
+Implement the Nix outputs, package notes, and CI checks. Keep each commit
+focused:
+
+1. speckit docs and audit
+2. WASM output and blocker/fix
+3. JS output and blocker/fix
+4. CI/package notes
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| *(none yet)* | - | - |

--- a/specs/221-client-cross-targets/quickstart.md
+++ b/specs/221-client-cross-targets/quickstart.md
@@ -1,0 +1,25 @@
+# Quickstart: Cross-Target Client Verifier Builds
+
+From the repository root:
+
+```bash
+nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests -O0 --test-show-details=direct
+```
+
+After the Nix outputs are added, the expected local proof commands are:
+
+```bash
+nix build .#cardano-mpfs-client-wasm --quiet
+nix build .#cardano-mpfs-client-js --quiet
+```
+
+If a target fails, update `research.md` with:
+
+- exact command
+- first failing package or derivation
+- shortest useful error excerpt
+- root-cause hypothesis
+- next action
+
+Before merge, run the native client tests and every cross-target output
+that the PR claims as working.

--- a/specs/221-client-cross-targets/research.md
+++ b/specs/221-client-cross-targets/research.md
@@ -1,0 +1,47 @@
+# Research: Cross-Target Client Verifier Builds
+
+## Current client dependency surface
+
+`cardano-mpfs-client` library dependencies are currently pure Haskell
+and verifier-oriented:
+
+- `aeson`
+- `base`
+- `base16-bytestring`
+- `bytestring`
+- `cborg`
+- `hspec`
+- `mts:csmt-core`
+- `mts:csmt-verify`
+- `mts:mpf-write`
+- `operational`
+- `text`
+
+The library does not depend on `cardano-ledger-*`, `crypton`, `unix`,
+`process`, RocksDB, network clients, or the offchain service package.
+This is the expected starting point for Principle IX.
+
+## Current Nix surface
+
+The flake imports `nix/project.nix`, which defines a single native
+haskell.nix project:
+
+- `compiler-nix-name = "ghc984"`
+- native packages include `cardano-mpfs-offchain`, `mpfs-serve`,
+  `offchain-tests`, `e2e-tests`, `docker-image`, and Haddock outputs
+- no current `cardano-mpfs-client` package output
+- no current WASM/JS package output
+
+## Open research questions
+
+| Question | Initial Finding | Next Action |
+|----------|-----------------|-------------|
+| Can haskell.nix build the client library with GHC-WASM directly from this project? | Unknown. | Add or prototype a WASM project/output and run `nix build`. |
+| Can haskell.nix build the client library with GHC-JS directly from this project? | Unknown. | Add or prototype a JS project/output and run `nix build`. |
+| Do `mts` public sublibraries expose correctly in cross package databases? | Risk from prior dev-shell behavior around public sublibraries. | Treat missing sublibrary units as a first-class blocker/fix. |
+| Should the `mpfs-verify` executable be part of the cross proof? | Not for the hard gate. | Start with the library; revisit CLI only if library builds are green. |
+| How should parity tests run across targets? | Larger conformance suite belongs to #233. | Use a minimal existing verifier corpus if artifacts are runnable. |
+
+## Blocker Log
+
+No cross-target attempts have run yet in this worktree.

--- a/specs/221-client-cross-targets/spec.md
+++ b/specs/221-client-cross-targets/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Cross-Target Client Verifier Builds
+
+**Feature Branch**: `spike/spike-prove-cardano-mpfs-client-cross-compiles-to-`  
+**Created**: 2026-04-25  
+**Status**: Draft  
+**Input**: Issue [#221](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/221) - "spike: prove cardano-mpfs-client cross-compiles to GHC-WASM and GHC-JS"
+
+## User Scenarios & Testing
+
+### User Story 1 - Prove the verifier is portable (Priority: P1)
+
+A wallet integrator needs to know whether the same
+`cardano-mpfs-client` verifier can run outside native GHC. The project
+must produce repeatable GHC-WASM and GHC-JS builds, or document the exact
+dependency blockers that prevent that result.
+
+**Why this priority**: Constitution Principle IX requires one verifier
+across native, WASM, and JS targets. If this fails, the later MOOG-ready
+HTTP/read/anchor tickets cannot honestly claim wallet portability.
+
+**Independent Test**: Run the documented Nix build commands for the
+client WASM and JS targets from a clean checkout.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean checkout, **When** the client WASM build command
+   runs, **Then** it either produces a client verifier artifact or fails
+   with a documented dependency blocker.
+2. **Given** a clean checkout, **When** the client JS build command runs,
+   **Then** it either produces a client verifier artifact or fails with a
+   documented dependency blocker.
+3. **Given** a documented blocker, **When** a maintainer reads the
+   research notes, **Then** they can see which dependency, toolchain, or
+   package stanza must change next.
+
+### User Story 2 - Gate future changes in CI (Priority: P1)
+
+A reviewer needs CI to prevent native-only dependencies from slipping
+back into `cardano-mpfs-client`. The repository must expose stable Nix
+targets for the cross builds and wire those targets into the PR gate once
+they are buildable.
+
+**Why this priority**: A one-time local spike does not enforce the
+constitution. CI is the mechanism that turns the portability proof into a
+maintenance guard.
+
+**Independent Test**: Open a PR and verify the GitHub CI run builds the
+cross-target client outputs, or marks the spike as blocked with a
+failing/explicit non-mergeable task list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR that changes `cardano-mpfs-client`, **When** CI runs,
+   **Then** the cross-target client build checks execute.
+2. **Given** a native-only dependency is added to the client package,
+   **When** CI reaches the cross-target build checks, **Then** the PR
+   fails before merge.
+
+### User Story 3 - Prepare release packaging (Priority: P2)
+
+A JavaScript or browser consumer needs a predictable package shape, even
+before the first full wallet integration. The repository should include
+the minimal npm package skeleton or document why packaging is blocked by
+the build proof.
+
+**Why this priority**: Buildability is the security gate; packaging is
+the release ergonomics layer that can follow once the artifacts exist.
+
+**Independent Test**: Inspect the package skeleton and confirm it points
+at the generated WASM/JS artifacts without duplicating verifier logic.
+
+**Acceptance Scenarios**:
+
+1. **Given** a successful WASM or JS build, **When** the npm package is
+   assembled, **Then** it references those artifacts as generated
+   outputs.
+2. **Given** the cross build is blocked, **When** a maintainer reads the
+   package notes, **Then** the missing artifact boundary is explicit.
+
+## Edge Cases
+
+- A dependency may build natively through Cabal but fail in the
+  haskell.nix cross package set because a public sublibrary is not
+  exposed in the cross package database.
+- `cardano-mpfs-client` may stay portable while the `mpfs-verify`
+  executable does not; the library is the hard gate, the native CLI is
+  secondary.
+- WASM and JS may fail for different reasons; blockers must be recorded
+  separately.
+- CI must not depend on local build artifacts or a developer's package
+  database.
+- Cross-target parity tests should use the existing honest/forged vector
+  corpus where possible, not hand-written examples that bypass the real
+  verifier surface.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The repository MUST expose a repeatable Nix target for the
+  GHC-WASM build of the `cardano-mpfs-client` library.
+- **FR-002**: The repository MUST expose a repeatable Nix target for the
+  GHC-JS build of the `cardano-mpfs-client` library.
+- **FR-003**: The build targets MUST keep `cardano-mpfs-client` free of
+  `cardano-ledger-*`, `crypton`, native C FFI, `unix`, `process`, and
+  other verifier-host dependencies.
+- **FR-004**: Any cross-target blocker MUST be documented with the
+  failing command, observed error, root cause, and next action.
+- **FR-005**: CI MUST include the successful cross-target build outputs
+  before this issue is closed as complete.
+- **FR-006**: If parity execution is feasible in this slice, CI MUST run
+  a small cross-target verifier corpus and compare verdicts against the
+  native verifier.
+- **FR-007**: If parity execution is not feasible in this slice, the
+  plan MUST document the smallest remaining step needed to run the
+  corpus after artifacts build.
+- **FR-008**: Release packaging MUST avoid a second verifier
+  implementation; generated WASM/JS artifacts are the only verifier code
+  shipped to npm.
+
+## Success Criteria
+
+- **SC-001**: Maintainers can run one documented command for each of
+  native, WASM, and JS client verifier builds.
+- **SC-002**: CI blocks PRs that break any cross-target client verifier
+  build that was proven by this spike.
+- **SC-003**: The research notes identify every dependency/toolchain
+  blocker left after the spike, with no ambiguous "does not work" entry.
+- **SC-004**: `cardano-mpfs-client:unit-tests` continues to pass
+  natively after cross-target Nix changes.
+
+## Assumptions
+
+- The deliverable can be a spike PR that either lands working
+  cross-target outputs or lands precise blockers with the repository
+  changes needed to continue.
+- The library build is the first portability proof; the CLI executable
+  and npm packaging can remain secondary if they would obscure the core
+  verifier result.
+- The existing verifier fixtures are enough for the first parity corpus;
+  the larger conformance-vector suite belongs to issue #233.

--- a/specs/221-client-cross-targets/tasks.md
+++ b/specs/221-client-cross-targets/tasks.md
@@ -1,0 +1,54 @@
+---
+description: "Task list for feature 221-client-cross-targets"
+---
+
+# Tasks: Cross-Target Client Verifier Builds
+
+**Input**: Design documents from `specs/221-client-cross-targets/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [quickstart.md](quickstart.md)
+**Issue**: [#221](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/221)
+
+## Phase 1: Setup and Speckit
+
+- [X] T001 Start issue #221 worktree and move the issue to WIP.
+- [X] T002 Create speckit spec, plan, research, quickstart, and tasks artifacts.
+- [ ] T003 Commit and push initial speckit artifacts, then open a PR.
+
+## Phase 2: Native Baseline
+
+- [ ] T004 Run `cardano-mpfs-client:unit-tests` natively and record the result.
+- [ ] T005 Add or expose a native `cardano-mpfs-client` library Nix package output if needed for cross-output symmetry.
+- [ ] T006 Confirm the client library dependency surface remains verifier-only and pure.
+
+## Phase 3: GHC-WASM Build Proof
+
+- [ ] T007 Prototype the smallest Nix output for `cardano-mpfs-client-wasm`.
+- [ ] T008 Run `nix build .#cardano-mpfs-client-wasm --quiet`.
+- [ ] T009 If the WASM build fails, record the exact blocker in `research.md`.
+- [ ] T010 Fix dependency or Nix exposure blockers that are local to this repository.
+- [ ] T011 Mark the WASM target as working only after a clean local build.
+
+## Phase 4: GHC-JS Build Proof
+
+- [ ] T012 Prototype the smallest Nix output for `cardano-mpfs-client-js`.
+- [ ] T013 Run `nix build .#cardano-mpfs-client-js --quiet`.
+- [ ] T014 If the JS build fails, record the exact blocker in `research.md`.
+- [ ] T015 Fix dependency or Nix exposure blockers that are local to this repository.
+- [ ] T016 Mark the JS target as working only after a clean local build.
+
+## Phase 5: Cross-Target Guarding
+
+- [ ] T017 Add CI checks for every cross-target output that builds locally.
+- [ ] T018 Add a minimal parity/check output if the artifacts are runnable in CI without introducing a second verifier.
+- [ ] T019 Add `cardano-mpfs-client` README/package notes documenting supported targets and any remaining blockers.
+- [ ] T020 Update `quickstart.md` with final commands and known limitations.
+
+## Phase 6: Validation and Merge
+
+- [ ] T021 Run `git diff --check`.
+- [ ] T022 Run `nix develop --quiet -c just format-check`.
+- [ ] T023 Run `nix develop --quiet -c just hlint`.
+- [ ] T024 Run native client unit tests.
+- [ ] T025 Run all claimed cross-target `nix build` outputs.
+- [ ] T026 Update the PR body with scope, blockers, and validation.
+- [ ] T027 Wait for green CI and merge through merge-guard.


### PR DESCRIPTION
Refs #221

## Scope

This PR starts the MOOG-ready cross-target spike for `cardano-mpfs-client`.

Initial commit only adds the speckit artifacts for the work:

- `specs/221-client-cross-targets/spec.md`
- `specs/221-client-cross-targets/plan.md`
- `specs/221-client-cross-targets/research.md`
- `specs/221-client-cross-targets/quickstart.md`
- `specs/221-client-cross-targets/tasks.md`

The plan is intentionally explicit about the spike boundary: either this PR lands repeatable WASM/JS client build outputs and CI gates, or it records exact blockers with failing commands, error excerpts, root-cause hypotheses, and next actions.

## Current Findings

- `cardano-mpfs-client` has a pure verifier-oriented dependency surface today: `aeson`, `bytestring`, `cborg`, `text`, `operational`, and pure `mts` CSMT/MPF sublibraries.
- The existing flake exposes native offchain/test outputs but no `cardano-mpfs-client` package output and no WASM/JS outputs.
- Likely risk areas are haskell.nix cross support and public sublibrary exposure for the `mts` dependencies.

## Next Implementation Steps

- Add/expose a native `cardano-mpfs-client` Nix output for symmetry.
- Prototype `.#cardano-mpfs-client-wasm` and run it locally.
- Prototype `.#cardano-mpfs-client-js` and run it locally.
- Wire CI only for outputs that build repeatably.

## Validation

- `git diff --check` passed for the speckit commit.

CI is pending on the initial documentation commit.
