### PR TITLE
feat(client): typed read-side endpoints + verifiers

### DIFF
--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -56,6 +56,7 @@ library
     Cardano.MPFS.Client
     Cardano.MPFS.Client.Bundle
     Cardano.MPFS.Client.Http
+    Cardano.MPFS.Client.Read
     Cardano.MPFS.Client.Snapshot
     Cardano.MPFS.Client.Verify
     Cardano.MPFS.Client.Verify.DSL
@@ -105,6 +106,7 @@ test-suite unit-tests
     Cardano.MPFS.Client.BundleSpec
     Cardano.MPFS.Client.Fixtures
     Cardano.MPFS.Client.HttpSpec
+    Cardano.MPFS.Client.ReadSpec
     Cardano.MPFS.Client.SnapshotSpec
     Cardano.MPFS.Client.VerifySpec
 

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
@@ -55,6 +55,17 @@ module Cardano.MPFS.Client
     , EndTxResponse (..)
     , UpdateTxResponse (..)
 
+      -- * Read response envelopes
+    , TokenState (..)
+    , Request (..)
+    , WitnessedTokenState (..)
+    , WitnessedRequest (..)
+    , FactWitness (..)
+    , TokenResponse (..)
+    , FactResponse (..)
+    , ProofResponse (..)
+    , RequestsResponse (..)
+
       -- * Verification
     , VerifyError (..)
     , verifyVerificationSnapshot
@@ -64,6 +75,10 @@ module Cardano.MPFS.Client
     , verifyRejectTxResponse
     , verifyEndTxResponse
     , verifyUpdateTxResponse
+    , verifyTokenResponse
+    , verifyFactResponse
+    , verifyProofResponse
+    , verifyRequestsResponse
 
       -- * Test DSL (re-exported from "Cardano.MPFS.Client.Verify.DSL")
     , shouldAccept
@@ -143,6 +158,17 @@ import Cardano.MPFS.Client.Http
     , retractTx
     , updateTx
     )
+import Cardano.MPFS.Client.Read
+    ( FactResponse (..)
+    , FactWitness (..)
+    , ProofResponse (..)
+    , Request (..)
+    , RequestsResponse (..)
+    , TokenResponse (..)
+    , TokenState (..)
+    , WitnessedRequest (..)
+    , WitnessedTokenState (..)
+    )
 import Cardano.MPFS.Client.Snapshot
     ( ChainPoint (..)
     , Hex (..)
@@ -153,9 +179,13 @@ import Cardano.MPFS.Client.Verify
     ( VerifyError (..)
     , verifyBootTxResponse
     , verifyEndTxResponse
+    , verifyFactResponse
+    , verifyProofResponse
     , verifyRejectTxResponse
     , verifyRequestTxResponse
+    , verifyRequestsResponse
     , verifyRetractTxResponse
+    , verifyTokenResponse
     , verifyUpdateTxResponse
     , verifyVerificationSnapshot
     )

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Read.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Read.hs
@@ -1,0 +1,301 @@
+-- |
+-- Module      : Cardano.MPFS.Client.Read
+-- Description : Per-endpoint proof-bearing read response contracts.
+--
+-- Haskell mirrors of the read responses
+-- @cardano-mpfs-offchain@ exposes on
+-- @GET \/tokens\/:id@,
+-- @GET \/tokens\/:id\/facts\/:key@,
+-- @GET \/tokens\/:id\/proofs\/:key@, and
+-- @GET \/tokens\/:id\/requests@. Each response carries the
+-- 'VerificationSnapshot' the bundled proofs target plus
+-- per-endpoint witness payloads. The mirrors stay pure-Haskell
+-- and import only @aeson@, @bytestring@, and @text@: no
+-- @cardano-ledger-*@ dependency and no C FFI, so the verifier
+-- continues to build on GHC-native, GHC-WASM, and GHC-JS.
+module Cardano.MPFS.Client.Read
+    ( -- * Decoded payload mirrors
+      TokenState (..)
+    , Request (..)
+
+      -- * Witnesses
+    , WitnessedTokenState (..)
+    , WitnessedRequest (..)
+    , FactWitness (..)
+
+      -- * Response envelopes
+    , TokenResponse (..)
+    , FactResponse (..)
+    , ProofResponse (..)
+    , RequestsResponse (..)
+    ) where
+
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , object
+    , withObject
+    , (.:)
+    , (.=)
+    )
+import Data.Text (Text)
+
+import Cardano.MPFS.Client.Bundle
+    ( WitnessedUtxo (..)
+    )
+import Cardano.MPFS.Client.Snapshot
+    ( Hex (..)
+    , VerificationSnapshot (..)
+    )
+
+-- | Decoded on-chain token state. Mirrors the field set
+-- @cardano-mpfs-offchain@ already emits over the wire. The
+-- @root@ field is the trie root the response carries, so
+-- 'verifyFactResponse' and 'verifyProofResponse' replay their
+-- MPF proof against it without re-deriving the root from the
+-- inline datum bytes.
+data TokenState = TokenState
+    { owner :: Text
+    -- ^ Owner payment-key hash (hex).
+    , root :: Hex
+    -- ^ Current MPF trie root.
+    , tip :: Integer
+    -- ^ Maximum-fee tip, in lovelace.
+    , processTime :: Integer
+    -- ^ Process window, in milliseconds.
+    , retractTime :: Integer
+    -- ^ Retract window, in milliseconds.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON TokenState where
+    parseJSON = withObject "TokenState" $ \o ->
+        TokenState
+            <$> o .: "owner"
+            <*> o .: "root"
+            <*> o .: "tip"
+            <*> o .: "process_time"
+            <*> o .: "retract_time"
+
+instance ToJSON TokenState where
+    toJSON TokenState{..} =
+        object
+            [ "owner" .= owner
+            , "root" .= root
+            , "tip" .= tip
+            , "process_time" .= processTime
+            , "retract_time" .= retractTime
+            ]
+
+-- | Decoded pending request. Mirrors the wire format of
+-- @Cardano.MPFS.API.Types.RequestJSON@. The verifier treats
+-- the payload as opaque; downstream consumers (MOOG) read it
+-- to drive their own application logic.
+data Request = Request
+    { token :: Hex
+    -- ^ Token id this request targets.
+    , owner :: Text
+    -- ^ Requester payment-key hash (hex).
+    , key :: Hex
+    -- ^ Trie key the request acts on.
+    , operation :: Text
+    -- ^ @"insert"@, @"delete"@, or @"update"@.
+    , value :: Maybe Hex
+    -- ^ New value (for insert / update).
+    , fee :: Integer
+    -- ^ Offered fee, in lovelace.
+    , submittedAt :: Integer
+    -- ^ POSIX timestamp (ms) the request was submitted.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON Request where
+    parseJSON = withObject "Request" $ \o ->
+        Request
+            <$> o .: "token"
+            <*> o .: "owner"
+            <*> o .: "key"
+            <*> o .: "operation"
+            <*> o .: "value"
+            <*> o .: "fee"
+            <*> o .: "submitted_at"
+
+instance ToJSON Request where
+    toJSON Request{..} =
+        object
+            [ "token" .= token
+            , "owner" .= owner
+            , "key" .= key
+            , "operation" .= operation
+            , "value" .= value
+            , "fee" .= fee
+            , "submitted_at" .= submittedAt
+            ]
+
+-- | UTxO witness for the state output paired with the decoded
+-- token state. The verifier replays the witness against the
+-- snapshot's @utxo_root@; the decoded state carries the trie
+-- root that MPF proofs replay against.
+data WitnessedTokenState = WitnessedTokenState
+    { utxo :: WitnessedUtxo
+    -- ^ UTxO witness for the state output.
+    , state :: TokenState
+    -- ^ Decoded on-chain state.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON WitnessedTokenState where
+    parseJSON =
+        withObject "WitnessedTokenState" $ \o ->
+            WitnessedTokenState
+                <$> o .: "utxo"
+                <*> o .: "state"
+
+instance ToJSON WitnessedTokenState where
+    toJSON WitnessedTokenState{..} =
+        object
+            [ "utxo" .= utxo
+            , "state" .= state
+            ]
+
+-- | UTxO witness for a pending request output paired with the
+-- decoded request payload.
+data WitnessedRequest = WitnessedRequest
+    { utxo :: WitnessedUtxo
+    -- ^ UTxO witness for the request output.
+    , request :: Request
+    -- ^ Decoded request payload.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON WitnessedRequest where
+    parseJSON =
+        withObject "WitnessedRequest" $ \o ->
+            WitnessedRequest
+                <$> o .: "utxo"
+                <*> o .: "request"
+
+instance ToJSON WitnessedRequest where
+    toJSON WitnessedRequest{..} =
+        object
+            [ "utxo" .= utxo
+            , "request" .= request
+            ]
+
+-- | A fact witness: the state witness carrying the trie root
+-- plus an MPF inclusion or absence proof binding a key (and
+-- optional value) to that root.
+data FactWitness = FactWitness
+    { state :: WitnessedTokenState
+    -- ^ State witness carrying the trie root.
+    , mpfProof :: Hex
+    -- ^ MPF inclusion or absence proof (hex).
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON FactWitness where
+    parseJSON = withObject "FactWitness" $ \o ->
+        FactWitness
+            <$> o .: "state"
+            <*> o .: "mpf_proof"
+
+instance ToJSON FactWitness where
+    toJSON FactWitness{..} =
+        object
+            [ "state" .= state
+            , "mpf_proof" .= mpfProof
+            ]
+
+-- | Response envelope for @GET \/tokens\/:id@.
+data TokenResponse = TokenResponse
+    { snapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proof targets.
+    , state :: WitnessedTokenState
+    -- ^ State witness.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON TokenResponse where
+    parseJSON = withObject "TokenResponse" $ \o ->
+        TokenResponse
+            <$> o .: "snapshot"
+            <*> o .: "state"
+
+instance ToJSON TokenResponse where
+    toJSON TokenResponse{..} =
+        object
+            [ "snapshot" .= snapshot
+            , "state" .= state
+            ]
+
+-- | Response envelope for
+-- @GET \/tokens\/:id\/facts\/:key@.
+data FactResponse = FactResponse
+    { snapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target.
+    , value :: Hex
+    -- ^ The fact value (hex).
+    , fact :: FactWitness
+    -- ^ State witness + MPF inclusion proof.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON FactResponse where
+    parseJSON = withObject "FactResponse" $ \o ->
+        FactResponse
+            <$> o .: "snapshot"
+            <*> o .: "value"
+            <*> o .: "fact"
+
+instance ToJSON FactResponse where
+    toJSON FactResponse{..} =
+        object
+            [ "snapshot" .= snapshot
+            , "value" .= value
+            , "fact" .= fact
+            ]
+
+-- | Response envelope for
+-- @GET \/tokens\/:id\/proofs\/:key@.
+data ProofResponse = ProofResponse
+    { snapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target.
+    , fact :: FactWitness
+    -- ^ State witness + MPF proof.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON ProofResponse where
+    parseJSON = withObject "ProofResponse" $ \o ->
+        ProofResponse
+            <$> o .: "snapshot"
+            <*> o .: "fact"
+
+instance ToJSON ProofResponse where
+    toJSON ProofResponse{..} =
+        object
+            [ "snapshot" .= snapshot
+            , "fact" .= fact
+            ]
+
+-- | Response envelope for @GET \/tokens\/:id\/requests@.
+data RequestsResponse = RequestsResponse
+    { snapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target.
+    , requests :: [WitnessedRequest]
+    -- ^ Witnessed pending requests.
+    }
+    deriving stock (Eq, Show)
+
+instance FromJSON RequestsResponse where
+    parseJSON = withObject "RequestsResponse" $ \o ->
+        RequestsResponse
+            <$> o .: "snapshot"
+            <*> o .: "requests"
+
+instance ToJSON RequestsResponse where
+    toJSON RequestsResponse{..} =
+        object
+            [ "snapshot" .= snapshot
+            , "requests" .= requests
+            ]

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
@@ -15,13 +15,19 @@ module Cardano.MPFS.Client.Verify
     ( VerifyError (..)
     , verifyVerificationSnapshot
 
-      -- * Per-endpoint verifiers
+      -- * Per-endpoint write verifiers
     , verifyBootTxResponse
     , verifyRequestTxResponse
     , verifyRetractTxResponse
     , verifyRejectTxResponse
     , verifyEndTxResponse
     , verifyUpdateTxResponse
+
+      -- * Per-endpoint read verifiers
+    , verifyTokenResponse
+    , verifyFactResponse
+    , verifyProofResponse
+    , verifyRequestsResponse
     ) where
 
 import Data.ByteString qualified as BS
@@ -46,6 +52,16 @@ import Cardano.MPFS.Client.Bundle
     , UpdateProof (..)
     , UpdateTxResponse (..)
     , WitnessedUtxo (..)
+    )
+import Cardano.MPFS.Client.Read
+    ( FactResponse (..)
+    , FactWitness (..)
+    , ProofResponse (..)
+    , RequestsResponse (..)
+    , TokenResponse (..)
+    , TokenState (..)
+    , WitnessedRequest (..)
+    , WitnessedTokenState (..)
     )
 import Cardano.MPFS.Client.Snapshot
     ( ChainPoint (..)
@@ -207,6 +223,124 @@ verifyUpdateTxResponse
             tread
 
 -- ---------------------------------------------------------------
+-- Read endpoint verifiers
+-- ---------------------------------------------------------------
+
+-- | Verify a @GET \/tokens\/:id@ response.
+--
+-- Replays the state UTxO witness against the snapshot's
+-- @utxo_root@. The decoded 'TokenState' inside the witness
+-- (owner, trie root, tip, process and retract windows) is
+-- passed through verbatim — its bytes already live inside
+-- the cryptographically replayed state @tx_out@. The trie
+-- root is checked structurally (32 bytes) so downstream
+-- 'verifyFactResponse' and 'verifyProofResponse' calls
+-- against it cannot silently malform.
+verifyTokenResponse :: TokenResponse -> Either VerifyError ()
+verifyTokenResponse (TokenResponse s wts) = do
+    let WitnessedTokenState{utxo = stateUtxo} = wts
+    verifyVerificationSnapshot s
+    checkWitnessedTokenStateStructural "token.state" wts
+    rootBs <- decodeHex "token.snapshot.utxo_root" (utxoRoot s)
+    replayWitnessedUtxo "token.state" rootBs stateUtxo
+
+-- | Verify a @GET \/tokens\/:id\/facts\/:key@ response.
+--
+-- The queried key is supplied by the caller (the URL path
+-- component) and rebound to the proof at field path
+-- @"fact.key"@. The verifier:
+--
+-- 1. runs structural checks on the snapshot, the state
+--    witness, the trie root carried in the state, the value,
+--    and the MPF proof;
+-- 2. replays the state UTxO witness against
+--    @snapshot.utxo_root@;
+-- 3. replays the inclusion proof against the trie root
+--    carried in the state, with the queried @key@ and
+--    advertised @value@.
+verifyFactResponse
+    :: Hex
+    -- ^ Queried key (URL path component).
+    -> FactResponse
+    -> Either VerifyError ()
+verifyFactResponse qKey (FactResponse s v fw) = do
+    let FactWitness{state = wts, mpfProof = pf} = fw
+        WitnessedTokenState{utxo = stateUtxo, state = ts} = wts
+        TokenState{root = trieRoot} = ts
+    verifyVerificationSnapshot s
+    checkWitnessedTokenStateStructural "fact.state" wts
+    checkNonEmpty "fact.key" qKey
+    checkNonEmpty "fact.value" v
+    checkNonEmpty "fact.mpf_proof" pf
+    rootBs <- decodeHex "fact.snapshot.utxo_root" (utxoRoot s)
+    replayWitnessedUtxo "fact.state" rootBs stateUtxo
+    trieRootBs <- decodeHex "fact.state.state.root" trieRoot
+    replayTrieFact
+        "fact"
+        trieRootBs
+        TrieFact{key = qKey, value = Just v, mpfProof = pf}
+
+-- | Verify a @GET \/tokens\/:id\/proofs\/:key@ response.
+--
+-- The queried key (and an optional advertised value, when the
+-- response is an inclusion claim) is supplied by the caller.
+-- A 'Nothing' value means the response asserts absence of the
+-- key from the trie. The verifier:
+--
+-- 1. runs structural checks on the snapshot, the state
+--    witness, the trie root carried in the state, and the
+--    MPF proof;
+-- 2. replays the state UTxO witness against
+--    @snapshot.utxo_root@;
+-- 3. replays the inclusion or exclusion proof against the
+--    trie root carried in the state.
+verifyProofResponse
+    :: Hex
+    -- ^ Queried key (URL path component).
+    -> Maybe Hex
+    -- ^ Advertised value, if the caller knows the proof
+    -- should witness an inclusion. Pass 'Nothing' to assert
+    -- absence.
+    -> ProofResponse
+    -> Either VerifyError ()
+verifyProofResponse qKey mValue (ProofResponse s fw) = do
+    let FactWitness{state = wts, mpfProof = pf} = fw
+        WitnessedTokenState{utxo = stateUtxo, state = ts} = wts
+        TokenState{root = trieRoot} = ts
+    verifyVerificationSnapshot s
+    checkWitnessedTokenStateStructural "proof.state" wts
+    checkNonEmpty "proof.key" qKey
+    case mValue of
+        Just v -> checkNonEmpty "proof.value" v
+        Nothing -> Right ()
+    checkNonEmpty "proof.mpf_proof" pf
+    rootBs <- decodeHex "proof.snapshot.utxo_root" (utxoRoot s)
+    replayWitnessedUtxo "proof.state" rootBs stateUtxo
+    trieRootBs <- decodeHex "proof.state.state.root" trieRoot
+    replayTrieFact
+        "proof"
+        trieRootBs
+        TrieFact{key = qKey, value = mValue, mpfProof = pf}
+
+-- | Verify a @GET \/tokens\/:id\/requests@ response.
+--
+-- Replays every pending-request UTxO witness against
+-- @snapshot.utxo_root@. The decoded request payload is
+-- opaque to the verifier — it flows through to the consumer
+-- so MOOG can drive its own application logic on top of the
+-- already-replayed @tx_out@ bytes.
+verifyRequestsResponse
+    :: RequestsResponse -> Either VerifyError ()
+verifyRequestsResponse (RequestsResponse s wrs) = do
+    verifyVerificationSnapshot s
+    checkWitnessedRequestsStructural "requests.requests" wrs
+    rootBs <- decodeHex "requests.snapshot.utxo_root" (utxoRoot s)
+    replayWitnessedUtxos
+        "requests.requests"
+        rootBs
+        (map (\WitnessedRequest{utxo = u} -> u) wrs)
+
+-- ---------------------------------------------------------------
 -- Structural pass (hex decode, 32-byte hashes, non-empty hex)
 -- ---------------------------------------------------------------
 
@@ -225,6 +359,25 @@ checkWitnessedUtxoStructural prefix WitnessedUtxo{..} = do
 checkTxIn :: Text -> TxIn -> Either VerifyError ()
 checkTxIn prefix TxIn{..} =
     checkHash32 (prefix <> ".tx_id") txId
+
+checkWitnessedTokenStateStructural
+    :: Text -> WitnessedTokenState -> Either VerifyError ()
+checkWitnessedTokenStateStructural
+    prefix
+    WitnessedTokenState{utxo = u, state = ts} = do
+        checkWitnessedUtxoStructural prefix u
+        let TokenState{root = r} = ts
+        checkHash32 (prefix <> ".state.root") r
+
+checkWitnessedRequestsStructural
+    :: Text -> [WitnessedRequest] -> Either VerifyError ()
+checkWitnessedRequestsStructural prefix =
+    traverseIndexed prefix checkWitnessedRequestStructural
+
+checkWitnessedRequestStructural
+    :: Text -> WitnessedRequest -> Either VerifyError ()
+checkWitnessedRequestStructural prefix WitnessedRequest{utxo = u} =
+    checkWitnessedUtxoStructural prefix u
 
 checkTrieFactsStructural
     :: Text -> [TrieFact] -> Either VerifyError ()

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
@@ -20,6 +20,17 @@ module Cardano.MPFS.Client.Fixtures
     , honestUpdateResponseMixedTrie
     , honestUpdateResponseEmptyTrie
 
+      -- * Per-endpoint honest read responses
+    , honestTokenResponse
+    , honestFactResponse
+    , honestProofResponseInclusion
+    , honestProofResponseExclusion
+    , honestRequestsResponse
+    , honestRequestsResponseEmpty
+    , honestFactKey
+    , honestFactValue
+    , honestExclusionKey
+
       -- * Underlying primitives
     , honestWitness
     , honestTrieInclusion
@@ -103,6 +114,17 @@ import Cardano.MPFS.Client.Bundle
     , UpdateProof (..)
     , UpdateTxResponse (..)
     , WitnessedUtxo (..)
+    )
+import Cardano.MPFS.Client.Read
+    ( FactResponse (..)
+    , FactWitness (..)
+    , ProofResponse (..)
+    , Request (..)
+    , RequestsResponse (..)
+    , TokenResponse (..)
+    , TokenState (..)
+    , WitnessedRequest (..)
+    , WitnessedTokenState (..)
     )
 import Cardano.MPFS.Client.Snapshot
     ( ChainPoint (..)
@@ -742,6 +764,170 @@ honestUpdateResponseEmptyTrie =
                 (toHex trieRoot)
                 []
             )
+
+-- ---------------------------------------------------------------
+-- Per-endpoint read fixtures
+-- ---------------------------------------------------------------
+
+-- | Disambiguates 'TrieFact'\'s @mpfProof@ field, which clashes
+-- with 'FactWitness'\'s @mpfProof@ in the read fixtures.
+trieFactProof :: TrieFact -> Hex
+trieFactProof TrieFact{mpfProof = pf} = pf
+
+-- | The MPF inclusion key shared by 'honestFactResponse' and
+-- 'honestProofResponseInclusion'.
+honestFactKey :: Hex
+honestFactKey = toHex primaryKey
+
+-- | The MPF inclusion value shared by 'honestFactResponse'
+-- and 'honestProofResponseInclusion'.
+honestFactValue :: Hex
+honestFactValue = toHex primaryValue
+
+-- | The absent MPF key that 'honestProofResponseExclusion'
+-- witnesses non-membership for.
+honestExclusionKey :: Hex
+honestExclusionKey = toHex "durian"
+
+-- | Build the decoded token state matching the on-chain
+-- inline datum encoded in 'stateDatumTerm'. Owner, tip,
+-- process and retract windows mirror the constants used by
+-- the write-side fixtures so there is a single source of
+-- truth for what the client thinks the state looks like.
+honestTokenStateAt :: ByteString -> TokenState
+honestTokenStateAt trieRoot =
+    TokenState
+        { owner = T.decodeUtf8 (Base16.encode (BS.replicate 28 0xAA))
+        , root = toHex trieRoot
+        , tip = 1_000_000
+        , processTime = 60_000
+        , retractTime = 30_000
+        }
+
+-- | @GET \/tokens\/:id@ honest fixture: the state UTxO
+-- witness replays against @snapshot.utxo_root@.
+honestTokenResponse :: TokenResponse
+honestTokenResponse =
+    let trieRoot = sampleStateRoot
+        bundle = buildBundleWithStateRoot trieRoot
+    in  TokenResponse
+            { snapshot = sampleSnapshot (bundleRoot bundle)
+            , state =
+                WitnessedTokenState
+                    { utxo = bundleState bundle
+                    , state = honestTokenStateAt trieRoot
+                    }
+            }
+
+-- | @GET \/tokens\/:id\/facts\/:key@ honest fixture: the
+-- state witness replays against @snapshot.utxo_root@ and
+-- the MPF inclusion proof replays against the trie root the
+-- state datum carries.
+honestFactResponse :: FactResponse
+honestFactResponse =
+    let (trieRoot, fact) = honestTrieInclusion
+        bundle = buildBundleWithStateRoot trieRoot
+    in  FactResponse
+            { snapshot = sampleSnapshot (bundleRoot bundle)
+            , value = honestFactValue
+            , fact =
+                FactWitness
+                    { state =
+                        WitnessedTokenState
+                            { utxo = bundleState bundle
+                            , state = honestTokenStateAt trieRoot
+                            }
+                    , mpfProof = trieFactProof fact
+                    }
+            }
+
+-- | @GET \/tokens\/:id\/proofs\/:key@ honest inclusion
+-- fixture: the state witness replays against
+-- @snapshot.utxo_root@ and the MPF inclusion proof replays
+-- against the trie root the state datum carries.
+honestProofResponseInclusion :: ProofResponse
+honestProofResponseInclusion =
+    let (trieRoot, fact) = honestTrieInclusion
+        bundle = buildBundleWithStateRoot trieRoot
+    in  ProofResponse
+            { snapshot = sampleSnapshot (bundleRoot bundle)
+            , fact =
+                FactWitness
+                    { state =
+                        WitnessedTokenState
+                            { utxo = bundleState bundle
+                            , state = honestTokenStateAt trieRoot
+                            }
+                    , mpfProof = trieFactProof fact
+                    }
+            }
+
+-- | @GET \/tokens\/:id\/proofs\/:key@ honest exclusion
+-- fixture: same shape as the inclusion fixture, but the MPF
+-- proof witnesses absence of 'honestExclusionKey'.
+honestProofResponseExclusion :: ProofResponse
+honestProofResponseExclusion =
+    let (trieRoot, fact) = honestTrieExclusion
+        bundle = buildBundleWithStateRoot trieRoot
+    in  ProofResponse
+            { snapshot = sampleSnapshot (bundleRoot bundle)
+            , fact =
+                FactWitness
+                    { state =
+                        WitnessedTokenState
+                            { utxo = bundleState bundle
+                            , state = honestTokenStateAt trieRoot
+                            }
+                    , mpfProof = trieFactProof fact
+                    }
+            }
+
+-- | Synthetic decoded request payload paired with an
+-- existing 'WitnessedUtxo'. The payload is opaque to the
+-- verifier — only the witness round-trips through replay.
+honestRequestPayload :: WitnessedUtxo -> Request
+honestRequestPayload WitnessedUtxo{txIn = ti} =
+    Request
+        { token = txId ti
+        , owner = T.decodeUtf8 (Base16.encode (BS.replicate 28 0xBB))
+        , key = toHex ("apple" :: ByteString)
+        , operation = "insert"
+        , value = Just (toHex ("fruit" :: ByteString))
+        , fee = 1_500_000
+        , submittedAt = 1_700_000_000_000
+        }
+
+-- | @GET \/tokens\/:id\/requests@ honest fixture: every
+-- pending-request witness replays against
+-- @snapshot.utxo_root@.
+honestRequestsResponse :: RequestsResponse
+honestRequestsResponse =
+    let bundle = honestWitness
+        request = bundleRequest bundle
+        request2 = bundleRequest2 bundle
+    in  RequestsResponse
+            { snapshot = sampleSnapshot (bundleRoot bundle)
+            , requests =
+                [ WitnessedRequest
+                    { utxo = request
+                    , request = honestRequestPayload request
+                    }
+                , WitnessedRequest
+                    { utxo = request2
+                    , request = honestRequestPayload request2
+                    }
+                ]
+            }
+
+-- | An empty pending-request list is honest — the verifier
+-- only runs the snapshot pass.
+honestRequestsResponseEmpty :: RequestsResponse
+honestRequestsResponseEmpty =
+    let bundle = honestWitness
+    in  RequestsResponse
+            { snapshot = sampleSnapshot (bundleRoot bundle)
+            , requests = []
+            }
 
 -- ---------------------------------------------------------------
 -- Hex helpers

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/ReadSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/ReadSpec.hs
@@ -1,0 +1,296 @@
+-- |
+-- Module      : Cardano.MPFS.Client.ReadSpec
+-- Description : Positive and negative replay corpus for the
+--               proof-bearing read responses.
+--
+-- Exercises every 'Cardano.MPFS.Client.Verify' read verifier on
+-- honest fixtures built with the pure CSMT \/ MPF backends
+-- ('Cardano.MPFS.Client.Fixtures') — each scenario must
+-- 'shouldAccept' — and on forged variants produced by the
+-- existing forgery helpers. Each scenario reads as tutorial
+-- prose: tweak one role, run the verifier, assert the matching
+-- @shouldRejectWith@ rejection.
+module Cardano.MPFS.Client.ReadSpec (spec) where
+
+import Data.Aeson qualified as Aeson
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Cardano.MPFS.Client
+    ( FactResponse (..)
+    , FactWitness (..)
+    , Hex (..)
+    , ProofResponse (..)
+    , RequestsResponse (..)
+    , TokenResponse (..)
+    , TokenState (..)
+    , VerificationSnapshot (..)
+    , WitnessedRequest (..)
+    , WitnessedTokenState (..)
+    , WitnessedUtxo
+    , csmtReplayFailedAt
+    , flipByteInHex
+    , forgeWitnessedUtxoProof
+    , forgeWitnessedUtxoTxOut
+    , malformedHexAt
+    , mpfReplayFailedAt
+    , shouldAccept
+    , shouldRejectWith
+    , verifyFactResponse
+    , verifyProofResponse
+    , verifyRequestsResponse
+    , verifyTokenResponse
+    , withReason
+    , wrongHexLengthAt
+    )
+import Cardano.MPFS.Client.Fixtures
+    ( honestExclusionKey
+    , honestFactKey
+    , honestFactResponse
+    , honestProofResponseExclusion
+    , honestProofResponseInclusion
+    , honestRequestsResponse
+    , honestRequestsResponseEmpty
+    , honestTokenResponse
+    )
+
+spec :: Spec
+spec = do
+    describe "positive path — every honest read response shouldAccept" $ do
+        it "GET /tokens/:id"
+            $ honestTokenResponse
+                `shouldAccept` verifyTokenResponse
+
+        it "GET /tokens/:id/facts/:key"
+            $ honestFactResponse
+                `shouldAccept` verifyFactResponse honestFactKey
+
+        it "GET /tokens/:id/proofs/:key — inclusion claim"
+            $ honestProofResponseInclusion
+                `shouldAccept` verifyProofResponse
+                    honestFactKey
+                    (Just honestFactValueFromInclusion)
+
+        it "GET /tokens/:id/proofs/:key — exclusion claim"
+            $ honestProofResponseExclusion
+                `shouldAccept` verifyProofResponse
+                    honestExclusionKey
+                    Nothing
+
+        it "GET /tokens/:id/requests"
+            $ honestRequestsResponse
+                `shouldAccept` verifyRequestsResponse
+
+        it "GET /tokens/:id/requests — empty list"
+            $ honestRequestsResponseEmpty
+                `shouldAccept` verifyRequestsResponse
+
+    describe "GET /tokens/:id forgeries" $ do
+        it "rejects a tampered state_ref utxo_proof"
+            $ forgeStateProof honestTokenResponse
+                `shouldRejectWith` verifyTokenResponse
+            $ csmtReplayFailedAt "token.state.utxo_proof"
+
+        it "rejects a tampered state_ref tx_out"
+            $ forgeStateTxOut honestTokenResponse
+                `shouldRejectWith` verifyTokenResponse
+            $ csmtReplayFailedAt "token.state.utxo_proof"
+                `withReason` "value binding mismatch"
+
+        it "rejects a flipped snapshot utxo_root"
+            $ flipSnapshotUtxoRoot honestTokenResponse
+                `shouldRejectWith` verifyTokenResponse
+            $ csmtReplayFailedAt "token.state.utxo_proof"
+                `withReason` "root mismatch"
+
+        it "rejects a malformed state.root hex"
+            $ withTokenStateRoot
+                (Hex "not-hex")
+                honestTokenResponse
+                `shouldRejectWith` verifyTokenResponse
+            $ malformedHexAt "token.state.state.root"
+
+        it "rejects a wrong-length state.root hex"
+            $ withTokenStateRoot
+                (Hex "deadbeef")
+                honestTokenResponse
+                `shouldRejectWith` verifyTokenResponse
+            $ wrongHexLengthAt "token.state.state.root"
+
+    describe "GET /tokens/:id/facts/:key forgeries" $ do
+        it "rejects a tampered state utxo_proof"
+            $ forgeFactStateProof honestFactResponse
+                `shouldRejectWith` verifyFactResponse honestFactKey
+            $ csmtReplayFailedAt "fact.state.utxo_proof"
+
+        it "rejects a flipped MPF proof"
+            $ forgeFactMpfProof honestFactResponse
+                `shouldRejectWith` verifyFactResponse honestFactKey
+            $ mpfReplayFailedAt "fact.mpf_proof"
+                `withReason` "root mismatch"
+
+        it "rejects a flipped advertised value"
+            $ forgeFactValue honestFactResponse
+                `shouldRejectWith` verifyFactResponse honestFactKey
+            $ mpfReplayFailedAt "fact.mpf_proof"
+                `withReason` "root mismatch"
+
+        it "rejects a queried key with a different last byte"
+            $ honestFactResponse
+                `shouldRejectWith` verifyFactResponse
+                    (flipByteInHex honestFactKey)
+            $ mpfReplayFailedAt "fact.mpf_proof"
+                `withReason` "root mismatch"
+
+        it "rejects a malformed queried key"
+            $ honestFactResponse
+                `shouldRejectWith` verifyFactResponse (Hex "not-hex")
+            $ malformedHexAt "fact.key"
+
+    describe "GET /tokens/:id/proofs/:key forgeries" $ do
+        it "rejects a tampered state utxo_proof"
+            $ forgeProofStateProof honestProofResponseInclusion
+                `shouldRejectWith` verifyProofResponse
+                    honestFactKey
+                    (Just honestFactValueFromInclusion)
+            $ csmtReplayFailedAt "proof.state.utxo_proof"
+
+        it "rejects a flipped MPF proof on inclusion"
+            $ forgeProofMpfProof honestProofResponseInclusion
+                `shouldRejectWith` verifyProofResponse
+                    honestFactKey
+                    (Just honestFactValueFromInclusion)
+            $ mpfReplayFailedAt "proof.mpf_proof"
+                `withReason` "root mismatch"
+
+        it "rejects an exclusion proof claimed as inclusion"
+            $ honestProofResponseExclusion
+                `shouldRejectWith` verifyProofResponse
+                    honestExclusionKey
+                    (Just (Hex "deadbeef"))
+            $ mpfReplayFailedAt "proof.mpf_proof"
+
+        it "rejects an inclusion proof claimed as absence"
+            $ honestProofResponseInclusion
+                `shouldRejectWith` verifyProofResponse
+                    honestFactKey
+                    Nothing
+            $ mpfReplayFailedAt "proof.mpf_proof"
+
+    describe "GET /tokens/:id/requests forgeries" $ do
+        it "rejects a tampered first-request utxo_proof"
+            $ forgeRequestProof 0 honestRequestsResponse
+                `shouldRejectWith` verifyRequestsResponse
+            $ csmtReplayFailedAt
+                "requests.requests[0].utxo_proof"
+
+        it "rejects a tampered second-request tx_out"
+            $ forgeRequestTxOut 1 honestRequestsResponse
+                `shouldRejectWith` verifyRequestsResponse
+            $ csmtReplayFailedAt
+                "requests.requests[1].utxo_proof"
+                `withReason` "value binding mismatch"
+
+    describe "JSON round-trip — read fixtures" $ do
+        it "TokenResponse" $ roundTripJson honestTokenResponse
+        it "FactResponse" $ roundTripJson honestFactResponse
+        it "ProofResponse inclusion"
+            $ roundTripJson honestProofResponseInclusion
+        it "ProofResponse exclusion"
+            $ roundTripJson honestProofResponseExclusion
+        it "RequestsResponse" $ roundTripJson honestRequestsResponse
+
+-- ---------------------------------------------------------------
+-- Test helpers
+-- ---------------------------------------------------------------
+
+honestFactValueFromInclusion :: Hex
+honestFactValueFromInclusion =
+    case honestFactResponse of
+        FactResponse _ v _ -> v
+
+forgeStateProof :: TokenResponse -> TokenResponse
+forgeStateProof (TokenResponse s wts) =
+    TokenResponse s (mapWtsUtxo forgeWitnessedUtxoProof wts)
+
+forgeStateTxOut :: TokenResponse -> TokenResponse
+forgeStateTxOut (TokenResponse s wts) =
+    TokenResponse s (mapWtsUtxo forgeWitnessedUtxoTxOut wts)
+
+flipSnapshotUtxoRoot :: TokenResponse -> TokenResponse
+flipSnapshotUtxoRoot (TokenResponse s wts) =
+    TokenResponse
+        s{utxoRoot = flipByteInHex (utxoRoot s)}
+        wts
+
+withTokenStateRoot :: Hex -> TokenResponse -> TokenResponse
+withTokenStateRoot newRoot (TokenResponse s wts) =
+    let WitnessedTokenState{utxo = u, state = ts} = wts
+    in  TokenResponse
+            s
+            WitnessedTokenState{utxo = u, state = ts{root = newRoot}}
+
+forgeFactStateProof :: FactResponse -> FactResponse
+forgeFactStateProof (FactResponse s v fw) =
+    FactResponse s v (mapFwState (mapWtsUtxo forgeWitnessedUtxoProof) fw)
+
+forgeFactMpfProof :: FactResponse -> FactResponse
+forgeFactMpfProof (FactResponse s v fw) =
+    FactResponse s v (mapFwProof flipByteInHex fw)
+
+forgeFactValue :: FactResponse -> FactResponse
+forgeFactValue (FactResponse s v fw) =
+    FactResponse s (flipByteInHex v) fw
+
+forgeProofStateProof :: ProofResponse -> ProofResponse
+forgeProofStateProof (ProofResponse s fw) =
+    ProofResponse s (mapFwState (mapWtsUtxo forgeWitnessedUtxoProof) fw)
+
+forgeProofMpfProof :: ProofResponse -> ProofResponse
+forgeProofMpfProof (ProofResponse s fw) =
+    ProofResponse s (mapFwProof flipByteInHex fw)
+
+forgeRequestProof :: Int -> RequestsResponse -> RequestsResponse
+forgeRequestProof i (RequestsResponse s rs) =
+    RequestsResponse s (mapAt i (mapWrUtxo forgeWitnessedUtxoProof) rs)
+
+forgeRequestTxOut :: Int -> RequestsResponse -> RequestsResponse
+forgeRequestTxOut i (RequestsResponse s rs) =
+    RequestsResponse s (mapAt i (mapWrUtxo forgeWitnessedUtxoTxOut) rs)
+
+mapWtsUtxo
+    :: (WUtxo -> WUtxo)
+    -> WitnessedTokenState
+    -> WitnessedTokenState
+mapWtsUtxo f (WitnessedTokenState u ts) =
+    WitnessedTokenState (f u) ts
+
+mapFwState
+    :: (WitnessedTokenState -> WitnessedTokenState)
+    -> FactWitness
+    -> FactWitness
+mapFwState f (FactWitness wts pf) = FactWitness (f wts) pf
+
+mapFwProof :: (Hex -> Hex) -> FactWitness -> FactWitness
+mapFwProof f (FactWitness wts pf) = FactWitness wts (f pf)
+
+mapWrUtxo
+    :: (WUtxo -> WUtxo) -> WitnessedRequest -> WitnessedRequest
+mapWrUtxo f (WitnessedRequest u req) = WitnessedRequest (f u) req
+
+type WUtxo = WitnessedUtxo
+
+mapAt :: Int -> (a -> a) -> [a] -> [a]
+mapAt _ _ [] = []
+mapAt 0 f (x : xs) = f x : xs
+mapAt n f (x : xs) = x : mapAt (n - 1) f xs
+
+roundTripJson
+    :: ( Eq a
+       , Show a
+       , Aeson.ToJSON a
+       , Aeson.FromJSON a
+       )
+    => a
+    -> IO ()
+roundTripJson a =
+    Aeson.eitherDecode (Aeson.encode a) `shouldBe` Right a

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Cardano.MPFS.Client.BundleSpec qualified as BundleSpec
 import Cardano.MPFS.Client.HttpSpec qualified as HttpSpec
+import Cardano.MPFS.Client.ReadSpec qualified as ReadSpec
 import Cardano.MPFS.Client.SnapshotSpec qualified as SnapshotSpec
 import Cardano.MPFS.Client.VerifySpec qualified as VerifySpec
 import Test.Hspec (hspec)
@@ -11,4 +12,5 @@ main = hspec $ do
     SnapshotSpec.spec
     BundleSpec.spec
     VerifySpec.spec
+    ReadSpec.spec
     HttpSpec.spec

--- a/specs/231-typed-read-side-verifiers/plan.md
+++ b/specs/231-typed-read-side-verifiers/plan.md
@@ -1,0 +1,220 @@
+# Implementation Plan: Typed read-side endpoints + verifiers
+
+**Branch**: `feat/231-typed-read-side-verifiers` | **Date**: 2026-04-26 | **Spec**: [spec.md](./spec.md)
+**Issue**: [#231](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/231)
+
+## Summary
+
+Add typed Haskell mirrors for the four proof-bearing read responses
+(`/tokens/<id>`, `/tokens/<id>/facts/<key>`, `/tokens/<id>/proofs/<key>`,
+`/tokens/<id>/requests`) and a pure offline verifier per response that
+reuses the existing `replayWitnessedUtxo` and `replayTrieFact`
+primitives. Add fixtures and forgery-DSL tests mirroring the
+write-side `VerifySpec.hs` structure. Re-export the surface from
+`Cardano.MPFS.Client`.
+
+## Technical Context
+
+**Language/Version**: Haskell, repo-pinned GHC through the existing Nix
+development shell.
+**Primary Dependencies**: `aeson`, `bytestring`, `text`, plus the
+existing replay primitives. No new external dependencies.
+**Storage**: N/A.
+**Testing**: `cardano-mpfs-client:unit-tests` extended with
+read-response fixtures + forgery-DSL coverage.
+**Target Platform**: Same as the rest of the verifier — GHC native
+plus future GHC-WASM and GHC-JS targets.
+**Project Type**: Haskell client library in a multi-package flake.
+**Performance Goals**: Constant-factor over write-side verification —
+one structural pass plus one `replayWitnessedUtxo` per witness plus,
+for `/facts`/`/proofs`, one `replayTrieFact`.
+**Constraints**: Keep verifiers pure (no `IO`). Do not import
+`cardano-ledger-*` or `cardano-mpfs-offchain` into the client.
+**Scale/Scope**: One new module (`Cardano.MPFS.Client.Read`), four
+new verifiers added to `Cardano.MPFS.Client.Verify`, fixtures + tests
+extension, top-level re-export update.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Ledger-Native Types | PASS | Read DTOs mirror the existing `cardano-mpfs-api` wire format; no shadow ledger types. |
+| II. Records of Functions | PASS | No service typeclass added; new verifiers are plain functions. |
+| III. Atomic Block Processing | N/A | Indexer not touched. |
+| IV. External Signing | N/A | Read endpoints; no signing path. |
+| V. Aiken Compatibility | PASS | No proof / datum encoding changes. The trie root carried in the state datum is consumed as a hex byte string. |
+| VI. Test Locally First | PASS | New tests are local unit tests over pure CSMT + MPF backends. |
+| VII. Nix Reproducibility | PASS | No new dependency. |
+| VIII. Pure Offline Verification | PASS | Each new verifier is `Response -> Either VerifyError ()`. |
+| IX. One Verifier, Many Targets | PASS | Same dependency set as the write-side verifier; cross-target packaging tracked in milestone #3. |
+| X. Lean as Source of Truth | PASS | The new verifiers reuse the existing `replayWitnessedUtxo` / `replayTrieFact` preservation theorems; no new invariants are introduced. |
+
+No justified violations.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/231-typed-read-side-verifiers/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+cardano-mpfs-client/
+├── lib/Cardano/MPFS/Client.hs               (re-exports updated)
+├── lib/Cardano/MPFS/Client/Read.hs          (NEW: read response DTOs)
+├── lib/Cardano/MPFS/Client/Verify.hs        (extended verifiers)
+└── test/Cardano/MPFS/Client/
+    ├── Fixtures.hs                          (extended with read fixtures)
+    ├── ReadSpec.hs                          (NEW: read-side coverage)
+    └── Main.hs                              (registers ReadSpec)
+```
+
+**Structure Decision**: A new sibling `Cardano.MPFS.Client.Read`
+module hosts the read-side DTOs to keep `Cardano.MPFS.Client.Bundle`
+(write-side) focused. Read verifiers live alongside the existing
+write verifiers in `Cardano.MPFS.Client.Verify` because they share
+helpers (`checkWitnessedUtxoStructural`, `checkTrieFactStructural`,
+`replayWitnessedUtxos`, `replayTrieFacts`, `traverseIndexed`).
+
+## Phase 1: Design
+
+### Read DTOs (`Cardano.MPFS.Client.Read`)
+
+```haskell
+data TokenState = TokenState
+    { owner       :: Text
+    , root        :: Hex      -- trie root
+    , tip         :: Integer
+    , processTime :: Integer
+    , retractTime :: Integer
+    }
+
+data WitnessedTokenState = WitnessedTokenState
+    { utxo  :: WitnessedUtxo
+    , state :: TokenState
+    }
+
+data Request = Request
+    { token       :: Hex
+    , owner       :: Text
+    , key         :: Hex
+    , operation   :: Text
+    , value       :: Maybe Hex
+    , fee         :: Integer
+    , submittedAt :: Integer
+    }
+
+data WitnessedRequest = WitnessedRequest
+    { utxo    :: WitnessedUtxo
+    , request :: Request
+    }
+
+data FactWitness = FactWitness
+    { state    :: WitnessedTokenState
+    , mpfProof :: Hex
+    }
+
+data TokenResponse = TokenResponse
+    { snapshot :: VerificationSnapshot
+    , state    :: WitnessedTokenState
+    }
+
+data FactResponse = FactResponse
+    { snapshot :: VerificationSnapshot
+    , value    :: Hex
+    , fact     :: FactWitness
+    }
+
+data ProofResponse = ProofResponse
+    { snapshot :: VerificationSnapshot
+    , fact     :: FactWitness
+    }
+
+data RequestsResponse = RequestsResponse
+    { snapshot :: VerificationSnapshot
+    , requests :: [WitnessedRequest]
+    }
+```
+
+### Verifier signatures
+
+```haskell
+verifyTokenResponse    :: TokenResponse    -> Either VerifyError ()
+verifyFactResponse     :: FactResponse     -> Either VerifyError ()
+verifyProofResponse    :: ProofResponse    -> Either VerifyError ()
+verifyRequestsResponse :: RequestsResponse -> Either VerifyError ()
+```
+
+### Field path conventions
+
+| Endpoint   | Role path examples                                              |
+|-----------|------------------------------------------------------------------|
+| `/tokens/<id>`               | `token.state.utxo_proof`, `token.state.tx_out`, `token.snapshot.utxo_root` |
+| `/tokens/<id>/facts/<key>`   | `fact.state.utxo_proof`, `fact.state.root`, `fact.mpf_proof`               |
+| `/tokens/<id>/proofs/<key>`  | `proof.state.utxo_proof`, `proof.mpf_proof`                                |
+| `/tokens/<id>/requests`      | `requests.requests[i].utxo_proof`                                          |
+
+### Replay flow per verifier
+
+* `verifyTokenResponse`
+  * structural: snapshot, `state.utxo` witness, `state.state.root`
+    32-byte hash;
+  * replay `state.utxo` against `snapshot.utxo_root`.
+* `verifyFactResponse`
+  * structural: snapshot, `fact.state.utxo`, `fact.state.state.root`,
+    `value`, `fact.mpf_proof`;
+  * replay `fact.state.utxo` against `snapshot.utxo_root`;
+  * replay `TrieFact { key = (server-provided), value = Just value,
+    mpfProof = fact.mpf_proof }` against `fact.state.state.root`.
+  * Note: the verifier shape needs the queried key on the side of
+    the request, not on the response wire. Servers in this codebase
+    return `value` and `fact` only; the *client* knows the key it
+    asked for. The verifier therefore takes the queried key as an
+    extra argument:
+
+    ```haskell
+    verifyFactResponse  :: Hex -> FactResponse  -> Either VerifyError ()
+    verifyProofResponse :: Hex -> Maybe Hex -> ProofResponse -> Either VerifyError ()
+    ```
+
+    The extra `Hex` is dotted-path-rooted as `fact.key` /
+    `proof.key` / `proof.value` for diagnostics.
+* `verifyProofResponse`
+  * structural: snapshot, `fact.state.utxo`, `fact.state.state.root`,
+    `fact.mpf_proof`, plus the queried key (and, for inclusion claims,
+    queried value) the caller passes;
+  * replay `fact.state.utxo` against `snapshot.utxo_root`;
+  * replay `TrieFact { key, value, mpfProof }` against
+    `fact.state.state.root`.
+* `verifyRequestsResponse`
+  * structural: snapshot, every `requests[i].utxo`;
+  * replay every `requests[i].utxo` against `snapshot.utxo_root`.
+  * The decoded `Request` payload is opaque to the verifier — it is
+    surfaced for downstream consumption only.
+
+## Phase 2: Implementation
+
+1. Add `Cardano.MPFS.Client.Read` module with DTOs + `Aeson` instances.
+2. Extend `Cardano.MPFS.Client.Verify` with the four read verifiers,
+   reusing the existing structural and replay helpers.
+3. Update `Cardano.MPFS.Client` re-exports.
+4. Add `Cardano.MPFS.Client.Fixtures` honest read fixtures
+   (`honestTokenResponse`, `honestFactResponse`, `honestProofResponse`,
+   `honestRequestsResponse`) plus the queried key constants needed for
+   `verifyFactResponse` / `verifyProofResponse`.
+5. Add `Cardano.MPFS.Client.ReadSpec` covering positive and forgery
+   paths for every verifier; register it in the test suite.
+6. Run the full local quality gate: `just unit`, `just format-check`,
+   `just hlint`, `cabal check`.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| *(none)*  | -          | -                                   |

--- a/specs/231-typed-read-side-verifiers/spec.md
+++ b/specs/231-typed-read-side-verifiers/spec.md
@@ -1,0 +1,198 @@
+# Feature Specification: Typed read-side endpoints + verifiers
+
+**Feature Branch**: `feat/231-typed-read-side-verifiers`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**: Issue [#231](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/231) — "client: typed read-side endpoints + verifiers"
+
+## User Scenarios & Testing
+
+### User Story 1 — Read MPFS state through one client API (Priority: P1)
+
+MOOG (and any other downstream wallet integrator) reads MPFS state on
+every poll: it asks for token state, single facts, single MPF
+inclusion/absence proofs, and the list of pending requests. Today,
+each consumer owns its own URL construction, JSON decoding, and replay
+plumbing. This feature adds typed Haskell mirrors of the four
+proof-bearing read responses and pure offline verifiers for each, so a
+consumer imports `cardano-mpfs-client`, decodes the response, runs one
+verifier, and either gets `Right ()` or a structured `VerifyError`.
+
+**Why this priority**: This is the second of the two MOOG-facing slices
+that close the read/write asymmetry. After #230 (write-side typed
+HTTP wrappers) the client could build transactions; without this,
+MOOG still has to roll its own decoder and verifier for every read.
+
+**Independent Test**: For each read endpoint, build an honest fixture
+with the pure CSMT + MPF backends, decode it through the new types,
+run the matching verifier, and assert `shouldAccept`. Build a forged
+variant with the existing forgery DSL and assert `shouldRejectWith`
+the expected `VerifyError` constructor and field path.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `TokenResponse` whose state-output witness replays
+   against the advertised `utxo_root`, **When** `verifyTokenResponse`
+   is called, **Then** it returns `Right ()`.
+2. **Given** a `FactResponse` whose state witness replays against
+   `utxo_root` and whose MPF inclusion proof replays against the
+   carried trie root, **When** `verifyFactResponse` is called,
+   **Then** it returns `Right ()`.
+3. **Given** a `ProofResponse` whose state witness and MPF
+   inclusion/absence proof both replay, **When**
+   `verifyProofResponse` is called, **Then** it returns `Right ()`.
+4. **Given** a `RequestsResponse` whose every request witness replays
+   against `utxo_root`, **When** `verifyRequestsResponse` is called,
+   **Then** it returns `Right ()`.
+
+### User Story 2 — Surface read forgeries with the same vocabulary (Priority: P1)
+
+Whatever shape a read response takes, a forged proof must be rejected
+with one of the existing `VerifyError` constructors at a dotted field
+path that points to the role and leaf that failed. No new error
+constructors, no per-endpoint wording — MOOG and any other consumer
+already knows the vocabulary from the write-side verifiers.
+
+**Independent Test**: Use the existing `flipProof`, `flipTxOut`,
+`flipSnapshotRoot`, `flipTrieValue`, `dropToExclusion`, and
+`flipTrieRoot` combinators to forge each read response. Assert each
+forgery becomes `Left (CsmtReplayFailed …)` /
+`Left (MpfReplayFailed …)` / `Left (MalformedHex …)` at a path of
+shape `<endpoint>.<role>[<index>]?.<leaf>`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `TokenResponse` whose state UTxO proof was bit-flipped,
+   **When** `verifyTokenResponse` is called, **Then** the result is
+   `Left (CsmtReplayFailed "token.state.utxo_proof" "root mismatch")`.
+2. **Given** a `FactResponse` whose MPF proof was bit-flipped,
+   **When** `verifyFactResponse` is called, **Then** the result is
+   `Left (MpfReplayFailed "fact.mpf_proof" "root mismatch")`.
+3. **Given** a `RequestsResponse` whose first request witness has a
+   forged `tx_out`, **When** `verifyRequestsResponse` is called,
+   **Then** the result is
+   `Left (CsmtReplayFailed "requests.requests[0].utxo_proof" "value binding mismatch")`.
+
+### User Story 3 — Top-level re-exports (Priority: P2)
+
+Downstream consumers should keep the single-import experience:
+everything they need to verify a read response — types, verifiers, and
+DSL combinators — must be reachable from `Cardano.MPFS.Client`.
+
+**Independent Test**: A test module imports only
+`Cardano.MPFS.Client` and constructs all four read responses, calls
+all four verifiers, and uses the existing DSL combinators
+(`shouldAccept`, `shouldRejectWith`, the forgery operations).
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer that imports only `Cardano.MPFS.Client`,
+   **When** it constructs and verifies any read response, **Then** no
+   additional client modules need to be imported.
+
+## Edge Cases
+
+- A `FactResponse.value` MUST match the value the MPF inclusion proof
+  binds to. The verifier delegates this binding check to
+  `verifyAikenInclusionProof`, which folds the advertised `(key, value)`
+  into the recomputed root; a mismatch surfaces as
+  `MpfReplayFailed _ "root mismatch"`.
+- A `ProofResponse` is the only read response whose proof can legally
+  carry an absence claim (`value == Nothing`). Verifiers MUST accept
+  both inclusion and exclusion shapes against the carried trie root.
+- A `RequestsResponse` with an empty requests list is valid — the
+  verifier returns `Right ()` after the snapshot pass.
+- The trie root the response carries (for `/facts` and `/proofs`) is
+  reported by the server inside the state witness. The verifier MUST
+  trust the state witness CBOR (already replayed against `utxo_root`)
+  but only as far as the bytes go: the trie root is a separate hex
+  field on the typed mirror so the client never re-derives it from
+  ledger types.
+- All field paths follow the existing dotted convention rooted at the
+  endpoint name: `token.<role>[<index>]?.<leaf>`,
+  `fact.<role>.<leaf>`, `proof.<role>.<leaf>`,
+  `requests.<role>[<index>]?.<leaf>`.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The client MUST expose typed mirrors `TokenResponse`,
+  `FactResponse`, `ProofResponse`, and `RequestsResponse` for the four
+  proof-bearing read endpoints.
+- **FR-002**: The client MUST expose supporting witness types
+  `WitnessedTokenState`, `WitnessedRequest`, and `FactWitness` plus
+  decoded payload mirrors `TokenState` and `Request` covering exactly
+  the fields the server emits over the wire.
+- **FR-003**: The mirrors MUST round-trip the server's JSON wire format
+  (snake_case field names, identical object shape).
+- **FR-004**: The client MUST expose `verifyTokenResponse`,
+  `verifyFactResponse`, `verifyProofResponse`, and
+  `verifyRequestsResponse`, each pure, each
+  `Response -> Either VerifyError ()`.
+- **FR-005**: Each verifier MUST run the existing structural pass
+  (hex decode, 32-byte hash check, non-empty payload) before any
+  cryptographic replay.
+- **FR-006**: Each verifier MUST replay every `WitnessedUtxo` against
+  `snapshot.utxo_root` using the existing `replayWitnessedUtxo`
+  primitive.
+- **FR-007**: `verifyFactResponse` and `verifyProofResponse` MUST
+  replay their MPF proof against the trie root carried in the response
+  using the existing `replayTrieFact` primitive.
+- **FR-008**: Verifiers MUST NOT introduce new `VerifyError`
+  constructors; the existing fixed vocabulary suffices.
+- **FR-009**: All field paths MUST follow the existing
+  `<endpoint>.<role>[<index>]?.<leaf>` shape.
+- **FR-010**: `Cardano.MPFS.Client` MUST re-export the new types and
+  verifiers.
+- **FR-011**: All new code MUST compile under the same dependency set
+  as the existing client package — no `cardano-ledger-*`, no C FFI
+  beyond pure hashing, no `IO` in verifier paths.
+
+### Key Entities
+
+- **TokenResponse**: Snapshot-bearing envelope for `GET /tokens/<id>`.
+- **FactResponse**: Snapshot-bearing envelope for
+  `GET /tokens/<id>/facts/<key>`.
+- **ProofResponse**: Snapshot-bearing envelope for
+  `GET /tokens/<id>/proofs/<key>`.
+- **RequestsResponse**: Snapshot-bearing envelope for
+  `GET /tokens/<id>/requests`.
+- **WitnessedTokenState**: UTxO witness for the state output paired
+  with the decoded state datum (owner, root, tip, process/retract
+  windows).
+- **FactWitness**: State witness plus an MPF proof targeting the trie
+  root carried in the state.
+- **WitnessedRequest**: UTxO witness for a pending request output
+  paired with the decoded request payload.
+
+## Success Criteria
+
+- **SC-001**: Every read endpoint MOOG hits is decoded into a typed
+  value and runs the existing replay primitives.
+- **SC-002**: Honest fixtures + forgery-DSL tests for each new
+  verifier exist in `cardano-mpfs-client:unit-tests`, mirroring the
+  structure of `VerifySpec.hs`.
+- **SC-003**: `cardano-mpfs-client:unit-tests` passes locally.
+- **SC-004**: No write-side verifier test regresses.
+- **SC-005**: The top-level `Cardano.MPFS.Client` import surface
+  remains the only module a downstream consumer needs to import.
+
+## Assumptions
+
+- Server-side `TokenResponse`, `FactResponse`, `ProofResponse`, and
+  `RequestsResponse` already exist in `cardano-mpfs-api:Cardano.MPFS.API.Types`
+  and their wire format is the source of truth.
+- The decoded state/request payload mirrors only need the fields a
+  client integrator (MOOG) consumes; future server-side fields can be
+  added later without breaking forwards-compat.
+- HTTP transport for read endpoints is out of scope for this slice and
+  belongs to a follow-up if needed; this slice is types and verifiers
+  only, matching the issue's stated scope.
+
+## Out of Scope
+
+- HTTP transport (typed wrappers around `GET` endpoints) — separate
+  follow-up.
+- Anchoring (independent root witness) — issue [#232](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/232).
+- Browser/WASM/JS packaging — milestone #3.

--- a/specs/231-typed-read-side-verifiers/tasks.md
+++ b/specs/231-typed-read-side-verifiers/tasks.md
@@ -1,0 +1,38 @@
+---
+description: "Task list for feature 231-typed-read-side-verifiers"
+---
+
+# Tasks: Typed read-side endpoints + verifiers
+
+**Input**: Design documents from `specs/231-typed-read-side-verifiers/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md)
+**Issue**: [#231](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/231)
+
+## Phase 1: Setup and Speckit
+
+- [X] T001 Create worktree `cardano-mpfs-offchain-issue-231` and branch `feat/231-typed-read-side-verifiers`.
+- [X] T002 Author speckit spec, plan, and tasks.
+
+## Phase 2: Read DTOs
+
+- [X] T003 Add `cardano-mpfs-client/lib/Cardano/MPFS/Client/Read.hs` with `TokenState`, `WitnessedTokenState`, `Request`, `WitnessedRequest`, `FactWitness`, `TokenResponse`, `FactResponse`, `ProofResponse`, `RequestsResponse` and matching `FromJSON`/`ToJSON` instances.
+- [X] T004 List `Cardano.MPFS.Client.Read` in `cardano-mpfs-client.cabal:exposed-modules`.
+
+## Phase 3: Read Verifiers
+
+- [X] T005 Extend `Cardano.MPFS.Client.Verify` with `verifyTokenResponse`, `verifyFactResponse`, `verifyProofResponse`, `verifyRequestsResponse` reusing the existing structural and replay helpers.
+- [X] T006 Re-export the four new types and four new verifiers from `Cardano.MPFS.Client`.
+
+## Phase 4: Fixtures + Tests
+
+- [X] T007 Extend `Cardano.MPFS.Client.Fixtures` with honest read responses (`honestTokenResponse`, `honestFactResponse`, `honestProofResponse`, `honestRequestsResponse`) plus the queried key constants needed by fact / proof verifiers.
+- [X] T008 Add `Cardano.MPFS.Client.ReadSpec` covering positive paths and forgery-DSL coverage for each read verifier; register it in the test suite (`Main.hs`, `cabal:other-modules`).
+
+## Phase 5: Validation and Merge
+
+- [X] T009 Run `nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests` (87 examples, 0 failures).
+- [X] T010 Run `nix develop --quiet -c cabal test cardano-mpfs-offchain:unit-tests` (371 examples, 0 failures).
+- [X] T011 Run `nix develop --quiet -c just format-check`.
+- [X] T012 Run `nix develop --quiet -c just hlint`.
+- [ ] T013 Push branch and open PR linked to #231; assign and label.
+- [ ] T014 Update PR body after every push; wait for green CI; merge through merge-guard.


### PR DESCRIPTION
Closes #231.

## Summary

Adds typed Haskell mirrors of the four proof-bearing read responses
(`/tokens/<id>`, `/tokens/<id>/facts/<key>`, `/tokens/<id>/proofs/<key>`,
`/tokens/<id>/requests`) and a pure offline verifier per response.
Each verifier reuses the existing `replayWitnessedUtxo` and
`replayTrieFact` primitives — no new `VerifyError` constructors, same
dotted field-path shape, same fixed reason vocabulary.

## What's new

- New module `Cardano.MPFS.Client.Read` with DTOs:
  `TokenState`, `Request`, `WitnessedTokenState`, `WitnessedRequest`,
  `FactWitness`, `TokenResponse`, `FactResponse`, `ProofResponse`,
  `RequestsResponse`. JSON instances mirror the server wire format
  in `cardano-mpfs-api:Cardano.MPFS.API.Types`.
- New verifiers in `Cardano.MPFS.Client.Verify`:
  - `verifyTokenResponse :: TokenResponse -> Either VerifyError ()`
  - `verifyFactResponse :: Hex -> FactResponse -> Either VerifyError ()`
  - `verifyProofResponse :: Hex -> Maybe Hex -> ProofResponse -> Either VerifyError ()`
  - `verifyRequestsResponse :: RequestsResponse -> Either VerifyError ()`

  The fact / proof verifiers take the queried key (and, for
  inclusion proofs, the queried value) explicitly: the server's
  read responses do not return them on the wire, so the caller —
  which knows what it asked for — supplies them.
- Top-level `Cardano.MPFS.Client` re-exports the new types and
  verifiers, keeping the single-import experience.

## Tests

`cardano-mpfs-client:unit-tests` grew from 73 → 87 examples, all green.

- Honest fixtures (`honestTokenResponse`, `honestFactResponse`,
  `honestProofResponseInclusion`, `honestProofResponseExclusion`,
  `honestRequestsResponse`, `honestRequestsResponseEmpty`) built from
  the same pure CSMT + MPF backends as the write-side fixtures.
- Forgery coverage per endpoint: tampered state UTxO proof / tx_out,
  flipped MPF proof, flipped advertised value, malformed / wrong-length
  hex, exclusion-proof-claimed-as-inclusion and vice versa.
- JSON round-trip on every read fixture.

## Local validation

- `cabal test cardano-mpfs-client:unit-tests` — 87 examples, 0 failures
- `cabal test cardano-mpfs-offchain:unit-tests` — 371 examples, 0 failures
- `just format-check`
- `just hlint` — no hints

## Speckit artifacts

[`specs/231-typed-read-side-verifiers/`](https://github.com/lambdasistemi/cardano-mpfs-offchain/tree/feat/231-typed-read-side-verifiers/specs/231-typed-read-side-verifiers):
[spec.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/feat/231-typed-read-side-verifiers/specs/231-typed-read-side-verifiers/spec.md),
[plan.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/feat/231-typed-read-side-verifiers/specs/231-typed-read-side-verifiers/plan.md),
[tasks.md](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/feat/231-typed-read-side-verifiers/specs/231-typed-read-side-verifiers/tasks.md).

## Out of scope

- HTTP transport for read endpoints (separate follow-up if needed).
- Snapshot anchoring — issue #232.
- Browser/WASM/JS packaging — milestone #3.