### PR TITLE
Pin onchain dependency to upstream main

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -76,11 +76,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/cardano-foundation/cardano-mpfs-onchain
-  -- Tracking PR cardano-foundation/cardano-mpfs-onchain#50 (split state
-  -- and request validators) during integration. Will rebump to the
-  -- main SHA before merging this downstream PR.
-  tag: cf3a8bdcd1414aa62d490c8fa51c2ef87336179f
-  --sha256: 1bwxf7n7xhbayhn1ln47nij4l58l61d7p34bs3i6hxa2calriqq7
+  tag: 023d352e850f866752927818da44861478ae99e5
+  --sha256: 1w1i4a00m08r0hf4bn6dwvmka1qibrchdz06l9bck8xzzvyn69k1
   subdir: haskell
 
 -- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API

--- a/flake.lock
+++ b/flake.lock
@@ -596,17 +596,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1777366109,
-        "narHash": "sha256-B+OYqWJCdWji0IuMe1owFBVKZLSHWBos9GrBfuxxna8=",
+        "lastModified": 1777468828,
+        "narHash": "sha256-YSZj/f6/o8lWogb8BlleEQc16+bN2EUcBBmBCoAiMfA=",
         "owner": "cardano-foundation",
         "repo": "cardano-mpfs-onchain",
-        "rev": "cf3a8bdcd1414aa62d490c8fa51c2ef87336179f",
+        "rev": "023d352e850f866752927818da44861478ae99e5",
         "type": "github"
       },
       "original": {
         "owner": "cardano-foundation",
         "repo": "cardano-mpfs-onchain",
-        "rev": "cf3a8bdcd1414aa62d490c8fa51c2ef87336179f",
+        "rev": "023d352e850f866752927818da44861478ae99e5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -24,10 +24,8 @@
     };
     cardano-node.follows = "cardano-node-clients/cardano-node";
     cardano-mpfs-onchain = {
-      # Tracking PR #50 (split state and request validators) during
-      # integration. Will rebump to main once #50 merges.
       url =
-        "github:cardano-foundation/cardano-mpfs-onchain/cf3a8bdcd1414aa62d490c8fa51c2ef87336179f";
+        "github:cardano-foundation/cardano-mpfs-onchain/023d352e850f866752927818da44861478ae99e5";
     };
   };
 


### PR DESCRIPTION
## Summary

Fixes the downstream dependency policy violation from PR #241 by moving `cardano-mpfs-onchain` off the pre-merge PR commit and onto the canonical upstream `main` commit.

Upstream PR #50 is now merged:
https://github.com/cardano-foundation/cardano-mpfs-onchain/pull/50

The new upstream `main` pin is:
https://github.com/cardano-foundation/cardano-mpfs-onchain/commit/023d352e850f866752927818da44861478ae99e5

## Changes

- `cabal.project`: replace the old PR-branch commit `cf3a8bdc...` with upstream-main commit `023d352...`.
- `cabal.project`: update the `--sha256:` nix32 hint to `1w1i4a00m08r0hf4bn6dwvmka1qibrchdz06l9bck8xzzvyn69k1`.
- `flake.nix`: point `cardano-mpfs-onchain` at the same upstream-main SHA and remove the stale “tracking PR #50” comment.
- `flake.lock`: update the locked rev and nar hash for `cardano-mpfs-onchain`.

## Verification

- Upstream PR #50 merge guard passed before merge: `build`, `lean`, `tests`, `e2e`, `lint`, and `deploy` were green.
- Upstream post-merge `main` CI is green on `023d352`.
- `git -C /code/cardano-mpfs-onchain branch --remote --contains 023d352e850f866752927818da44861478ae99e5` shows `origin/main`.
- Local downstream `just ci` passed: package/swagger build, unit 369/0, unit-offchain 369/0, format-check, hlint.
- `git diff --check` passed.
