### PR TITLE
feat: GET /tokens — trust-minimised cage discovery (#243 slice 2)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,8 +46,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: f6f0ee24593bc20244afbc8899687a3fb73f4d88
-  --sha256: 0yvbnmbqfiichkw2qskj4b82kmk44f8483fvvh2gmibvda10229i
+  tag: 13264a52b47e3a1f43a6ebeebd424a10f9e4466a
+  --sha256: 1bqgpxdy79ncsz8hyg2qyd7jnm8hqj4q8rq8mhr3iirix66c77fb
 
 source-repository-package
   type: git

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
@@ -82,6 +82,7 @@ import Cardano.MPFS.API.Types
     , SweepTxResponse
     , TokenIdJSON
     , TokenResponse
+    , TokensListResponse
     , UnsignedTxResponse
     , UpdateRequest
     , UpdateTxResponse
@@ -91,8 +92,15 @@ import Cardano.MPFS.API.Types
 -- | @GET \/status@ — indexer chain tip and checkpoint.
 type StatusAPI = "status" :> Get '[JSON] StatusResponse
 
--- | @GET \/tokens@ — list all known token IDs.
-type TokensAPI = "tokens" :> Get '[JSON] [TokenIdJSON]
+-- | @GET \/tokens@ — trust-minimised cage discovery.
+--
+-- Returns one snapshot plus a 'UtxoSetWitness' over every
+-- UTxO at the global state validator address: a flat
+-- list of @{ref, txout_cbor}@ entries with a single CSMT
+-- prefix-completeness proof outside the list. The address
+-- itself is not carried — clients derive it locally from
+-- the trusted blueprint.
+type TokensAPI = "tokens" :> Get '[JSON] TokensListResponse
 
 -- | @GET \/tokens\/:id@ — get a token's state
 -- together with its UTxO witness and the

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -35,6 +35,7 @@ module Cardano.MPFS.API.Types
     , UtxoEntryRefOnly (..)
     , UtxoSetWitness (..)
     , UnsignedTxResponse (..)
+    , TokensListResponse (..)
 
       -- * Proof-bearing read responses
     , WitnessedTokenState (..)
@@ -523,6 +524,38 @@ instance FromJSON UnsignedTxResponse where
                 <$> o .: "unsigned_tx_cbor"
                 <*> o .: "snapshot"
                 <*> o .: "inputs"
+
+-- | Response envelope for @GET \/tokens@.
+--
+-- The trust-minimised oracle-discovery shape under #243:
+-- one snapshot, one 'UtxoSetWitness' (every UTxO at the
+-- global state validator address with a single CSMT
+-- prefix-completeness proof). The address itself is not
+-- carried — the verifier derives it locally from the
+-- trusted blueprint and cross-checks the wire entries
+-- against the proof.
+data TokensListResponse = TokensListResponse
+    { tlrSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled completeness proof targets.
+    , tlrTokens :: UtxoSetWitness
+    -- ^ Enumerated UTxOs at the global state validator
+    -- address with a single completeness proof.
+    }
+    deriving (Eq, Show)
+
+instance ToJSON TokensListResponse where
+    toJSON TokensListResponse{..} =
+        object
+            [ "snapshot" .= tlrSnapshot
+            , "tokens" .= tlrTokens
+            ]
+
+instance FromJSON TokensListResponse where
+    parseJSON =
+        withObject "TokensListResponse" $ \o ->
+            TokensListResponse
+                <$> o .: "snapshot"
+                <*> o .: "tokens"
 
 -- ---------------------------------------------------------
 -- Proof-bearing read responses
@@ -1890,6 +1923,33 @@ instance ToSchema UnsignedTxResponse where
                    \snapshot and a flat list of spent \
                    \and reference inputs, each with its \
                    \CSMT inclusion proof."
+
+instance ToSchema TokensListResponse where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        tokensSchema <-
+            declareSchemaRef (Proxy @UtxoSetWitness)
+        pure
+            $ Swagger.NamedSchema
+                (Just "TokensListResponse")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("tokens", tokensSchema)
+                    ]
+            & required
+                .~ [ "snapshot"
+                   , "tokens"
+                   ]
+            & description
+                ?~ "Trust-minimised cage discovery: one \
+                   \snapshot plus a UtxoSetWitness over \
+                   \the global state validator address."
 
 instance ToSchema FactWitness where
     declareNamedSchema _ = do

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
@@ -28,7 +28,7 @@ import CSMT.Core.Hash
     ( Hash (..)
     , byteStringToKey
     )
-import CSMT.Core.Types (Indirect (..))
+import CSMT.Core.Types (Indirect (..), Key)
 import CSMT.Verify (verifyCompletenessProof)
 import CSMT.Verify.Blake2b (blake2b256)
 
@@ -82,7 +82,7 @@ verifyCompleteness path trustedRoot address witness = do
                 Wire.Hex proofBs
             } = witness
         prefix = byteStringToKey (blake2b256 addressBs)
-        leaves = map entryToIndirect entries
+        leaves = map (entryToIndirect prefix) entries
     if verifyCompletenessProof rootBs prefix leaves proofBs
         then Right ()
         else Left (CompletenessProofInvalid path)
@@ -124,17 +124,21 @@ verifyCompletenessEmpty path trustedRoot address witness =
 -- @addressPrefix(A) ++ encodeTxIn(ref)@ where
 -- @addressPrefix(A) = byteStringToKey (blake2b256 A)@. The
 -- 'Indirect' presented to 'verifyCompletenessProof' carries
--- only the post-prefix portion as its @jump@ — the prefix is
--- supplied separately. The 'Hash' value is the leaf's stored
+-- the *absolute* path bits as its @jump@ — i.e. the
+-- @addressPrefix(A) ++ byteStringToKey(encodeTxIn ref)@
+-- concatenation — per the @csmt-verify@ contract since
+-- @haskell-mts#158@. The 'Hash' value is the leaf's stored
 -- hash, which is @blake2b256@ of the @TxOut@ CBOR.
-entryToIndirect :: UtxoEntryRefOnly -> Indirect Hash
-entryToIndirect UtxoEntryRefOnly{uerRef, uerTxOutCbor} =
+entryToIndirect
+    :: Key -> UtxoEntryRefOnly -> Indirect Hash
+entryToIndirect prefix UtxoEntryRefOnly{uerRef, uerTxOutCbor} =
     let txInBytes :: ByteString
         txInBytes =
             encodeTxIn
                 (Wire.unHex (urTxId uerRef))
                 (urTxIx uerRef)
     in  Indirect
-            { jump = byteStringToKey txInBytes
+            { jump =
+                prefix <> byteStringToKey txInBytes
             , value = Hash (blake2b256 (Wire.unHex uerTxOutCbor))
             }

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
@@ -7,8 +7,134 @@
 -- supported and is the load-bearing primitive for
 -- @POST \/tx\/oracle\/end@.
 --
--- Populated by tasks T013 + T014 — see
--- @specs\/243-proof-redesign\/tasks.md@.
+-- Mirrors the Lean 'Phase4.Completeness.replayLeaf' /
+-- 'empty_witness_records_no_leaves' theorems: the verifier
+-- replays each advertised leaf into a 'CompletenessEnvelope'
+-- anchored at @trustedRoot@ with 'scriptPrefix' derived
+-- locally from the trusted blueprint, then runs the
+-- cryptographic 'verifyCompletenessProof' from
+-- @csmt-verify@. Cryptographic soundness is delegated to
+-- the upstream primitive; this module only enforces the
+-- structural recordkeeping and emits structured errors.
 module Cardano.MPFS.Client.Verify.Completeness
-    (
+    ( verifyCompleteness
+    , verifyCompletenessEmpty
     ) where
+
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+
+import CSMT.Core.Hash
+    ( Hash (..)
+    , byteStringToKey
+    )
+import CSMT.Core.Types (Indirect (..))
+import CSMT.Verify (verifyCompletenessProof)
+import CSMT.Verify.Blake2b (blake2b256)
+
+import Cardano.MPFS.API.Encoding qualified as Wire
+import Cardano.MPFS.API.Types
+    ( UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    )
+import Cardano.MPFS.Client.TrustedRoot
+    ( Address (..)
+    , TrustedRoot (..)
+    )
+import Cardano.MPFS.Client.Verify.Replay
+    ( VerifyError (..)
+    , encodeTxIn
+    )
+
+-- | Verify a 'UtxoSetWitness' is a complete enumeration of
+-- the leaves under the locally-derived script-address prefix
+-- in the trusted CSMT root.
+--
+-- Three checks:
+--
+--  1. The trusted root and the supplied address bytes are
+--     32-byte hashes (length check, 'WrongHexLength' on
+--     mismatch).
+--  2. Each entry's @inclusion_proof@ is /not/ replayed here
+--     — the wire shape carries no per-entry inclusion
+--     proof; soundness comes from the single completeness
+--     proof.
+--  3. The completeness proof bytes plus the leaves
+--     reconstructed from the entry list verify against
+--     @trustedRoot@ under @byteStringToKey
+--     (blake2b256 addressBytes)@. On failure emits
+--     'CompletenessProofInvalid' at the supplied dotted
+--     field path.
+verifyCompleteness
+    :: Text
+    -- ^ dotted field path, e.g. @"tokens.requests"@.
+    -> TrustedRoot
+    -> Address
+    -> UtxoSetWitness
+    -> Either VerifyError ()
+verifyCompleteness path trustedRoot address witness = do
+    let TrustedRoot (Wire.Hex rootBs) = trustedRoot
+        Address (Wire.Hex addressBs) = address
+        UtxoSetWitness
+            { uswEntries = entries
+            , uswCompletenessProof =
+                Wire.Hex proofBs
+            } = witness
+        prefix = byteStringToKey (blake2b256 addressBs)
+        leaves = map entryToIndirect entries
+    if verifyCompletenessProof rootBs prefix leaves proofBs
+        then Right ()
+        else Left (CompletenessProofInvalid path)
+
+-- | Verify that a 'UtxoSetWitness' attests an /empty/
+-- leaf-set under the given script-address prefix. The
+-- entries list MUST be empty — any leaf is a contract
+-- violation and emits 'CompletenessExtraLeaf' at the
+-- supplied path with the offending ref.
+--
+-- Otherwise delegates to 'verifyCompleteness': the
+-- completeness proof must validate against an empty leaf
+-- list under the locally-derived prefix.
+--
+-- Load-bearing primitive for @POST \/tx\/oracle\/end@:
+-- the oracle's signature must not be obtainable while
+-- pending requests still sit at the per-cage request
+-- address.
+verifyCompletenessEmpty
+    :: Text
+    -> TrustedRoot
+    -> Address
+    -> UtxoSetWitness
+    -> Either VerifyError ()
+verifyCompletenessEmpty path trustedRoot address witness =
+    case uswEntries witness of
+        [] -> verifyCompleteness path trustedRoot address witness
+        (entry : _) ->
+            Left
+                ( CompletenessExtraLeaf
+                    path
+                    (uerRef entry)
+                )
+
+-- | Convert a wire 'UtxoEntryRefOnly' to the 'Indirect Hash'
+-- shape the cryptographic verifier expects.
+--
+-- The CSMT key for a UTxO under address @A@ is
+-- @addressPrefix(A) ++ encodeTxIn(ref)@ where
+-- @addressPrefix(A) = byteStringToKey (blake2b256 A)@. The
+-- 'Indirect' presented to 'verifyCompletenessProof' carries
+-- only the post-prefix portion as its @jump@ — the prefix is
+-- supplied separately. The 'Hash' value is the leaf's stored
+-- hash, which is @blake2b256@ of the @TxOut@ CBOR.
+entryToIndirect :: UtxoEntryRefOnly -> Indirect Hash
+entryToIndirect UtxoEntryRefOnly{uerRef, uerTxOutCbor} =
+    let txInBytes :: ByteString
+        txInBytes =
+            encodeTxIn
+                (Wire.unHex (urTxId uerRef))
+                (urTxIx uerRef)
+    in  Indirect
+            { jump = byteStringToKey txInBytes
+            , value = Hash (blake2b256 (Wire.unHex uerTxOutCbor))
+            }

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Read.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Read.hs
@@ -2,8 +2,83 @@
 -- Module      : Cardano.MPFS.Client.Verify.Read
 -- Description : Verifiers for the read-side responses.
 --
--- Populated incrementally by tasks T031, T032, T072, T087 — see
--- @specs\/243-proof-redesign\/tasks.md@.
+-- Mirror of the Lean 'Phase4.ProofRedesign.TokensListEnvelope'
+-- state machine: each verifier threads an externally-supplied
+-- 'TrustedRoot' through every cryptographic check, and locally
+-- derives the validator addresses it cross-checks against from
+-- the trusted 'Blueprint'. Soundness of the cryptographic
+-- primitives is delegated to upstream
+-- @csmt-verify@ / @mpf-verify@; this module only enforces the
+-- structural binding (snapshot ↔ trusted root, address ↔
+-- blueprint).
 module Cardano.MPFS.Client.Verify.Read
-    (
+    ( verifyTokensListResponse
     ) where
+
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+
+import Cardano.MPFS.API.Encoding qualified as Wire
+import Cardano.MPFS.API.Types
+    ( TokensListResponse (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.Client.TrustedRoot
+    ( Blueprint (..)
+    , TrustedRoot (..)
+    )
+import Cardano.MPFS.Client.Verify.Completeness
+    ( verifyCompleteness
+    )
+import Cardano.MPFS.Client.Verify.Replay
+    ( VerifyError (..)
+    )
+
+-- | Verify a @GET \/tokens@ response.
+--
+-- Two checks:
+--
+--  1. @snapshot.utxo_root@ matches the externally-supplied
+--     'TrustedRoot' byte-for-byte
+--     ('TrustedRootMismatch' otherwise).
+--  2. The 'UtxoSetWitness' inside @tokens@ is a complete
+--     enumeration of the leaves under the locally-derived
+--     global state script address (from the trusted
+--     'Blueprint') against the trusted root, via
+--     'verifyCompleteness'.
+--
+-- Per-entry classification (legitimate state UTxO vs
+-- sweepable garbage, NFT policy / asset-name checks, datum
+-- well-formedness) is intentionally /not/ part of this
+-- verifier — those are the wrapping application's
+-- concern. The trust-minimised guarantee here is that
+-- the entries list is exactly what sits at the global
+-- state validator address in the trusted snapshot.
+verifyTokensListResponse
+    :: TrustedRoot
+    -> Blueprint
+    -> TokensListResponse
+    -> Either VerifyError ()
+verifyTokensListResponse trustedRoot blueprint response = do
+    let TrustedRoot (Wire.Hex trustedBs) = trustedRoot
+        snapshotPath = "tokens.snapshot.utxo_root"
+        Wire.Hex snapshotBs =
+            vsUtxoRoot (tlrSnapshot response)
+    checkLength
+        "tokens.trusted_root"
+        trustedBs
+    checkLength snapshotPath snapshotBs
+    if snapshotBs == trustedBs
+        then Right ()
+        else Left (TrustedRootMismatch snapshotPath)
+    verifyCompleteness
+        "tokens"
+        trustedRoot
+        (bpStateScriptAddress blueprint)
+        (tlrTokens response)
+  where
+    checkLength :: Text -> BS.ByteString -> Either VerifyError ()
+    checkLength field bs
+        | BS.length bs == 32 = Right ()
+        | otherwise =
+            Left (WrongHexLength field 32 (BS.length bs))

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Replay.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Replay.hs
@@ -19,6 +19,7 @@ module Cardano.MPFS.Client.Verify.Replay
     , replayWitnessedUtxo
     , replayUtxoEntry
     , replayTrieFact
+    , encodeTxIn
     ) where
 
 import Codec.CBOR.Encoding qualified as CBOR

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -67,6 +67,7 @@ library
     , mts
     , mts:csmt
     , mts:csmt-core
+    , mts:csmt-verify
     , mts:mpf
     , mts:mpf-test-lib
     , mts:rollbacks

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -16,7 +16,7 @@ module Cardano.MPFS.E2E.HTTPLifecycleSpec
     ) where
 
 import Control.Concurrent (threadDelay)
-import Data.Aeson (decode)
+import Data.Aeson (decode, eitherDecode)
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.Types (Value (..))
 import Data.ByteString (ByteString)
@@ -72,6 +72,10 @@ import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
 
+import Cardano.MPFS.API.Types
+    ( TokensListResponse (..)
+    , UtxoSetWitness (..)
+    )
 import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
@@ -334,12 +338,15 @@ tokenCount :: Application -> IO Int
 tokenCount app = do
     resp <- get app "/tokens"
     simpleStatus resp `shouldBe` status200
-    case decode (simpleBody resp) of
-        Just (Array arr) ->
-            pure (V.length arr)
-        _ -> do
+    case eitherDecode (simpleBody resp) of
+        Right (TokensListResponse{tlrTokens}) ->
+            pure
+                (length (uswEntries tlrTokens))
+        Left e -> do
             expectationFailure
-                "Expected JSON array"
+                ( "Expected TokensListResponse: "
+                    <> e
+                )
             pure 0
 
 -- | Low-level GET helper.

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -144,6 +144,7 @@ import Cardano.Node.Client.E2E.Setup
     , genesisSignKey
     )
 
+import Cardano.MPFS.API.Encoding qualified as ApiHex
 import Cardano.MPFS.API.Types qualified as Wire
 import Cardano.MPFS.Client
     ( EndTxResponse
@@ -326,16 +327,16 @@ proofsSpec scripts =
                 tokensBlueprint =
                     Blueprint
                         { bpStatePolicyId =
-                            Wire.Hex BS.empty
+                            ApiHex.Hex BS.empty
                         , bpStateScriptAddress =
                             Address
-                                ( Wire.Hex
+                                ( ApiHex.Hex
                                     stateAddrBytes
                                 )
                         , bpRequestScriptAddress =
                             \_ ->
                                 Address
-                                    ( Wire.Hex
+                                    ( ApiHex.Hex
                                         BS.empty
                                     )
                         }
@@ -345,7 +346,7 @@ proofsSpec scripts =
                     tokensBlueprint
             let forgedTokensRoot =
                     TrustedRoot
-                        (flipMidByte tokensSnapRoot)
+                        (flipApiHexMidByte tokensSnapRoot)
             tokensListResp'
                 `shouldRejectWith` verifyTokensListResponse
                     forgedTokensRoot

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -29,14 +29,17 @@ module Cardano.MPFS.E2E.ProofsSpec
 import Control.Concurrent (threadDelay)
 import Data.Aeson
     ( FromJSON (..)
+    , Result (..)
     , Value
     , decode
     , encode
+    , fromJSON
     , object
     , withObject
     , (.:)
     , (.=)
     )
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Key (Key)
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.Types (parseEither)
@@ -129,7 +132,8 @@ import Cardano.MPFS.TxBuilder
     )
 import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
 import Cardano.MPFS.TxBuilder.Real.Internal
-    ( cagePolicyIdFromCfg
+    ( cageAddrFromCfg
+    , cagePolicyIdFromCfg
     , computeScriptHash
     )
 import Cardano.Node.Client.E2E.Devnet (withCardanoNode)
@@ -170,7 +174,14 @@ import Cardano.MPFS.Client
     , verifyVerificationSnapshot
     , withReason
     )
-import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Client.TrustedRoot
+    ( Address (..)
+    , Blueprint (..)
+    , TrustedRoot (..)
+    )
+import Cardano.MPFS.Client.Verify.Read
+    ( verifyTokensListResponse
+    )
 import Cardano.MPFS.Client.Verify.Write
     ( verifyUnsignedTxResponse
     )
@@ -279,6 +290,68 @@ proofsSpec scripts =
                         genesisAddr
             let reqTxIn =
                     TxIn (txIdTx reqTx) (TxIx 0)
+
+            -- GET /tokens — trust-minimised cage discovery
+            -- (post-split #243). Decode as the new
+            -- `TokensListResponse`, then verify with the
+            -- externally-supplied trusted root and a
+            -- locally-derived blueprint mock. The forgery
+            -- tampers the trusted root — verifier emits
+            -- TrustedRootMismatch.
+            tokensListVal <- getJSON app "/tokens"
+            tokensListResp' <-
+                case fromJSON tokensListVal of
+                    Success r ->
+                        pure
+                            (r :: Wire.TokensListResponse)
+                    Aeson.Error err -> do
+                        expectationFailure
+                            $ "TokensListResponse \
+                              \decode failed: "
+                                <> err
+                        error "unreachable"
+            let tokensSnapRoot =
+                    Wire.vsUtxoRoot
+                        ( Wire.tlrSnapshot
+                            tokensListResp'
+                        )
+                tokensTrustedRoot =
+                    TrustedRoot tokensSnapRoot
+                stateAddrBytes =
+                    serialiseAddr
+                        ( cageAddrFromCfg
+                            cfg
+                            (network cfg)
+                        )
+                tokensBlueprint =
+                    Blueprint
+                        { bpStatePolicyId =
+                            Wire.Hex BS.empty
+                        , bpStateScriptAddress =
+                            Address
+                                ( Wire.Hex
+                                    stateAddrBytes
+                                )
+                        , bpRequestScriptAddress =
+                            \_ ->
+                                Address
+                                    ( Wire.Hex
+                                        BS.empty
+                                    )
+                        }
+            tokensListResp'
+                `shouldAccept` verifyTokensListResponse
+                    tokensTrustedRoot
+                    tokensBlueprint
+            let forgedTokensRoot =
+                    TrustedRoot
+                        (flipMidByte tokensSnapRoot)
+            tokensListResp'
+                `shouldRejectWith` verifyTokensListResponse
+                    forgedTokensRoot
+                    tokensBlueprint
+                $ trustedRootMismatchAt
+                    "tokens.snapshot.utxo_root"
 
             -- Pull every proof-bearing read.
             tokenObj <- getJSON app ("/tokens/" <> tidHex)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -64,6 +64,7 @@ import Control.Concurrent.STM
 import Control.Exception (finally, throwIO)
 import Control.Monad (when)
 import Control.Tracer (Tracer (..), contramap, traceWith)
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short (toShort)
 import Data.IORef (newIORef, readIORef, writeIORef)
@@ -100,12 +101,18 @@ import Ouroboros.Network.Point
     )
 
 import CSMT.Core.CBOR (renderCompletenessProof)
+import CSMT.Core.Hash (Hash (..), byteStringToKey)
+import CSMT.Core.Types (Indirect (..))
 import CSMT.Hashes
     ( generateInclusionProof
+    , mkHash
     , renderHash
     )
 import CSMT.Proof.Completeness qualified as CSMT.Completeness
     ( generateProof
+    )
+import CSMT.Verify qualified as CSMT.Verify
+    ( verifyCompletenessProof
     )
 import Cardano.Ledger.Shelley.Genesis
     ( ShelleyGenesis
@@ -175,7 +182,6 @@ import Cardano.Ledger.Binary
     , serialize
     )
 
-import CSMT.Hashes.Types (Hash)
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
@@ -632,20 +638,87 @@ withApplication cfg action = do
                                         CSMTCol
                                         []
                                         targetPrefix
-                                pure
-                                    $ fmap
-                                        ( \p ->
-                                            ( map
-                                                ( \(k, v) ->
-                                                    ( BSL.toStrict k
-                                                    , BSL.toStrict v
-                                                    )
-                                                )
-                                                entries
-                                            , renderCompletenessProof p
-                                            )
+                                mRoot <-
+                                    queryMerkleRoot
+                                        ( hashing
+                                            context
                                         )
-                                        mProof
+                                pure
+                                    $ case (mProof, mRoot) of
+                                        (Just p, Just r) ->
+                                            let strictEntries =
+                                                    map
+                                                        ( \(k, v) ->
+                                                            ( BSL.toStrict k
+                                                            , BSL.toStrict v
+                                                            )
+                                                        )
+                                                        entries
+                                                proofBs =
+                                                    renderCompletenessProof
+                                                        p
+                                                rootBs =
+                                                    renderHash
+                                                        r
+                                                leaves =
+                                                    map
+                                                        ( \(k, v) ->
+                                                            Indirect
+                                                                ( byteStringToKey
+                                                                    ( BSL.toStrict
+                                                                        k
+                                                                    )
+                                                                )
+                                                                ( mkHash
+                                                                    ( BSL.toStrict
+                                                                        v
+                                                                    )
+                                                                )
+                                                        )
+                                                        entries
+                                                ok =
+                                                    CSMT.Verify.verifyCompletenessProof
+                                                        rootBs
+                                                        targetPrefix
+                                                        leaves
+                                                        proofBs
+                                            in  if ok
+                                                    then
+                                                        Just
+                                                            ( strictEntries
+                                                            , proofBs
+                                                            )
+                                                    else
+                                                        error
+                                                            ( "setWitness self-check failed:\n"
+                                                                <> "  rootBs len = "
+                                                                <> show
+                                                                    ( BS.length
+                                                                        rootBs
+                                                                    )
+                                                                <> "\n  prefix len (bits) = "
+                                                                <> show
+                                                                    ( length
+                                                                        targetPrefix
+                                                                    )
+                                                                <> "\n  proofBs len = "
+                                                                <> show
+                                                                    ( BS.length
+                                                                        proofBs
+                                                                    )
+                                                                <> "\n  leaves count = "
+                                                                <> show
+                                                                    ( length
+                                                                        leaves
+                                                                    )
+                                                                <> "\n  leaves = "
+                                                                <> show leaves
+                                                                <> "\n  rootBs = "
+                                                                <> show rootBs
+                                                                <> "\n  proofBs = "
+                                                                <> show proofBs
+                                                            )
+                                        _ -> Nothing
                         ctx =
                             Context
                                 { provider = prov

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -64,12 +64,11 @@ import Control.Concurrent.STM
 import Control.Exception (finally, throwIO)
 import Control.Monad (when)
 import Control.Tracer (Tracer (..), contramap, traceWith)
-import Data.Bifunctor (bimap)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short (toShort)
 import Data.IORef (newIORef, readIORef, writeIORef)
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing)
 import Ouroboros.Consensus.HardFork.Combinator
     ( OneEraHash (..)
     )
@@ -102,15 +101,15 @@ import Ouroboros.Network.Point
     )
 
 import CSMT.Core.CBOR (renderCompletenessProof)
-import CSMT.Core.Hash (Hash (..), byteStringToKey)
+import CSMT.Core.Hash (Hash, keyToByteString)
 import CSMT.Core.Types (Indirect (..))
 import CSMT.Hashes
     ( generateInclusionProof
-    , mkHash
     , renderHash
     )
 import CSMT.Proof.Completeness qualified as CSMT.Completeness
-    ( generateProof
+    ( collectValues
+    , generateProof
     )
 import CSMT.Verify qualified
     ( verifyCompletenessProof
@@ -138,7 +137,6 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , ReadyState (..)
     , mkCSMTOps
     , openCSMTOps
-    , queryByAddress
     , queryMerkleRoot
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction qualified as CSMT
@@ -625,14 +623,13 @@ withApplication cfg action = do
                                     $ fmap snd result
                         setWitness addressBs =
                             CSMT.transact utxoRt $ do
-                                let fkv =
-                                        fromKV context
-                                    targetPrefix =
+                                let targetPrefix =
                                         hashAddressKey
                                             addressBs
-                                entries <-
-                                    queryByAddress
-                                        fkv
+                                indirects <-
+                                    CSMT.Completeness.collectValues
+                                        CSMTCol
+                                        []
                                         targetPrefix
                                 mProof <-
                                     CSMT.Completeness.generateProof
@@ -644,80 +641,75 @@ withApplication cfg action = do
                                         ( hashing
                                             context
                                         )
-                                pure
-                                    $ case (mProof, mRoot) of
-                                        (Just p, Just r) ->
-                                            let strictEntries =
-                                                    map
-                                                        ( bimap
-                                                            BSL.toStrict
-                                                            BSL.toStrict
-                                                        )
-                                                        entries
-                                                proofBs =
-                                                    renderCompletenessProof
-                                                        p
-                                                rootBs =
-                                                    renderHash
-                                                        r
-                                                leaves =
-                                                    map
-                                                        ( \(k, v) ->
-                                                            Indirect
-                                                                ( byteStringToKey
-                                                                    ( BSL.toStrict
-                                                                        k
-                                                                    )
+                                let
+                                    -- Each absolute leaf jump
+                                    -- is @targetPrefix ++ kvBits@.
+                                    -- Strip the prefix to recover
+                                    -- the kvKey bytes.
+                                    stripList
+                                        :: Eq x
+                                        => [x]
+                                        -> [x]
+                                        -> Maybe [x]
+                                    stripList [] xs = Just xs
+                                    stripList (a : as) (b : bs)
+                                        | a == b =
+                                            stripList as bs
+                                    stripList _ _ = Nothing
+                                    kvKeyOf
+                                        :: Indirect a
+                                        -> Maybe BS.ByteString
+                                    kvKeyOf Indirect{jump} =
+                                        keyToByteString
+                                            <$> stripList
+                                                targetPrefix
+                                                jump
+                                rawEntries <-
+                                    catMaybes
+                                        <$> traverse
+                                            ( \ind ->
+                                                case kvKeyOf ind of
+                                                    Nothing ->
+                                                        pure Nothing
+                                                    Just k -> do
+                                                        mv <-
+                                                            query
+                                                                KVCol
+                                                                ( BSL.fromStrict
+                                                                    k
                                                                 )
-                                                                ( mkHash
-                                                                    ( BSL.toStrict
+                                                        pure
+                                                            $ fmap
+                                                                ( \v ->
+                                                                    ( k
+                                                                    , BSL.toStrict
                                                                         v
                                                                     )
                                                                 )
-                                                        )
-                                                        entries
+                                                                mv
+                                            )
+                                            indirects
+                                pure
+                                    $ case (mProof, mRoot) of
+                                        (Just p, Just r) ->
+                                            let proofBs =
+                                                    renderCompletenessProof
+                                                        p
+                                                rootBs =
+                                                    renderHash r
                                                 ok =
                                                     CSMT.Verify.verifyCompletenessProof
                                                         rootBs
                                                         targetPrefix
-                                                        leaves
+                                                        indirects
                                                         proofBs
                                             in  if ok
                                                     then
                                                         Just
-                                                            ( strictEntries
+                                                            ( rawEntries
                                                             , proofBs
                                                             )
-                                                    else
-                                                        error
-                                                            ( "setWitness self-check failed:\n"
-                                                                <> "  rootBs len = "
-                                                                <> show
-                                                                    ( BS.length
-                                                                        rootBs
-                                                                    )
-                                                                <> "\n  prefix len (bits) = "
-                                                                <> show
-                                                                    ( length
-                                                                        targetPrefix
-                                                                    )
-                                                                <> "\n  proofBs len = "
-                                                                <> show
-                                                                    ( BS.length
-                                                                        proofBs
-                                                                    )
-                                                                <> "\n  leaves count = "
-                                                                <> show
-                                                                    ( length
-                                                                        leaves
-                                                                    )
-                                                                <> "\n  leaves = "
-                                                                <> show leaves
-                                                                <> "\n  rootBs = "
-                                                                <> show rootBs
-                                                                <> "\n  proofBs = "
-                                                                <> show proofBs
-                                                            )
+                                                    else Nothing
                                         _ -> Nothing
                         ctx =
                             Context

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -64,6 +64,7 @@ import Control.Concurrent.STM
 import Control.Exception (finally, throwIO)
 import Control.Monad (when)
 import Control.Tracer (Tracer (..), contramap, traceWith)
+import Data.Bifunctor (bimap)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short (toShort)
@@ -111,7 +112,7 @@ import CSMT.Hashes
 import CSMT.Proof.Completeness qualified as CSMT.Completeness
     ( generateProof
     )
-import CSMT.Verify qualified as CSMT.Verify
+import CSMT.Verify qualified
     ( verifyCompletenessProof
     )
 import Cardano.Ledger.Shelley.Genesis
@@ -648,10 +649,9 @@ withApplication cfg action = do
                                         (Just p, Just r) ->
                                             let strictEntries =
                                                     map
-                                                        ( \(k, v) ->
-                                                            ( BSL.toStrict k
-                                                            , BSL.toStrict v
-                                                            )
+                                                        ( bimap
+                                                            BSL.toStrict
+                                                            BSL.toStrict
                                                         )
                                                         entries
                                                 proofBs =

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -99,9 +99,13 @@ import Ouroboros.Network.Point
     , WithOrigin (..)
     )
 
+import CSMT.Core.CBOR (renderCompletenessProof)
 import CSMT.Hashes
     ( generateInclusionProof
     , renderHash
+    )
+import CSMT.Proof.Completeness qualified as CSMT.Completeness
+    ( generateProof
     )
 import Cardano.Ledger.Shelley.Genesis
     ( ShelleyGenesis
@@ -126,6 +130,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , ReadyState (..)
     , mkCSMTOps
     , openCSMTOps
+    , queryByAddress
     , queryMerkleRoot
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction qualified as CSMT
@@ -138,6 +143,7 @@ import Cardano.UTxOCSMT.Application.Metrics
 import Cardano.UTxOCSMT.Application.Run.Config
     ( armageddonParams
     , context
+    , hashAddressKey
     , prisms
     )
 import Cardano.UTxOCSMT.Bootstrap.Genesis
@@ -610,6 +616,36 @@ withApplication cfg action = do
                                         )
                                 pure
                                     $ fmap snd result
+                        setWitness addressBs =
+                            CSMT.transact utxoRt $ do
+                                let fkv =
+                                        fromKV context
+                                    targetPrefix =
+                                        hashAddressKey
+                                            addressBs
+                                entries <-
+                                    queryByAddress
+                                        fkv
+                                        targetPrefix
+                                mProof <-
+                                    CSMT.Completeness.generateProof
+                                        CSMTCol
+                                        []
+                                        targetPrefix
+                                pure
+                                    $ fmap
+                                        ( \p ->
+                                            ( map
+                                                ( \(k, v) ->
+                                                    ( BSL.toStrict k
+                                                    , BSL.toStrict v
+                                                    )
+                                                )
+                                                entries
+                                            , renderCompletenessProof p
+                                            )
+                                        )
+                                        mProof
                         ctx =
                             Context
                                 { provider = prov
@@ -640,6 +676,8 @@ withApplication cfg action = do
                                 , runIndexerTx =
                                     \(IndexerTx body) ->
                                         run body
+                                , utxoSetWitness =
+                                    setWitness
                                 , readMetrics =
                                     readIORef metricsRef
                                 }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
@@ -75,6 +75,23 @@ data Context m = Context
     -- composition follows from there being a single
     -- @run@. See spec
     -- @specs\/249-atomic-boot-handler@.
+    , utxoSetWitness
+        :: ByteString
+        -> m
+            ( Maybe
+                ( [(ByteString, ByteString)]
+                , ByteString
+                )
+            )
+    -- ^ Enumerate UTxOs at a given on-chain address
+    -- (raw serialized bytes) and return them with a
+    -- single CSMT prefix-completeness proof against
+    -- the current root. The first 'ByteString' in
+    -- each pair is the canonical 'TxIn' CBOR (the
+    -- KV key); the second is the @TxOut@ CBOR
+    -- (value). The trailing 'ByteString' is the
+    -- CompletenessProof CBOR. Returns 'Nothing' when
+    -- the CSMT is not yet available.
     , readMetrics :: m (Maybe Metrics)
     -- ^ Current metrics snapshot (if available)
     }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -44,6 +44,7 @@ import Data.ByteString.Lazy.Char8 qualified as BL
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Ledger.Api.Tx (Tx)
+import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary
     ( DecoderError
     , decodeFull'
@@ -53,7 +54,6 @@ import Cardano.Ledger.Hashes
     ( extractHash
     , unsafeMakeSafeHash
     )
-import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.TxIn
     ( TxId (..)
     , TxIn (..)
@@ -101,12 +101,12 @@ import Cardano.MPFS.HTTP.Types
     , TokenResponse (..)
     , TokensListResponse (..)
     , UnsignedTxResponse
-    , UtxoEntryRefOnly (..)
-    , UtxoRef (..)
-    , UtxoSetWitness (..)
     , UpdateRequest (..)
     , UpdateTxResponse
     , UpdateValueRequest (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
     , VerificationSnapshot (..)
     , WitnessedRequest (..)
     , WitnessedTokenState (..)
@@ -133,10 +133,10 @@ import Cardano.UTxOCSMT.Application.Metrics
     , renderPrometheus
     )
 
+import Cardano.Ledger.Address (serialiseAddr)
 import Cardano.MPFS.State qualified as St
 import Cardano.MPFS.Submitter qualified as Sub
 import Cardano.MPFS.Trie qualified as Trie
-import Cardano.Ledger.Address (serialiseAddr)
 import Cardano.MPFS.TxBuilder (BundleSnapshot (..))
 import Cardano.MPFS.TxBuilder qualified as Tx
 import Cardano.MPFS.TxBuilder.Config (CageConfig (..))

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -53,9 +53,10 @@ import Cardano.Ledger.Hashes
     ( extractHash
     , unsafeMakeSafeHash
     )
+import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.TxIn
     ( TxId (..)
-    , TxIn
+    , TxIn (..)
     , mkTxInPartial
     )
 
@@ -98,7 +99,11 @@ import Cardano.MPFS.HTTP.Types
     , SweepTxResponse (..)
     , TokenIdJSON
     , TokenResponse (..)
+    , TokensListResponse (..)
     , UnsignedTxResponse
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
     , UpdateRequest (..)
     , UpdateTxResponse
     , UpdateValueRequest (..)
@@ -116,7 +121,6 @@ import Cardano.MPFS.HTTP.Types
     , parseAddr
     , requestToJSON
     , tokenIdFromJSON
-    , tokenIdToJSON
     , tokenStateToJSON
     , txInToJSON
     )
@@ -132,9 +136,12 @@ import Cardano.UTxOCSMT.Application.Metrics
 import Cardano.MPFS.State qualified as St
 import Cardano.MPFS.Submitter qualified as Sub
 import Cardano.MPFS.Trie qualified as Trie
+import Cardano.Ledger.Address (serialiseAddr)
 import Cardano.MPFS.TxBuilder (BundleSnapshot (..))
 import Cardano.MPFS.TxBuilder qualified as Tx
+import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
 import Cardano.MPFS.TxBuilder.Real (sweepUtxoImpl)
+import Cardano.MPFS.TxBuilder.Real.Internal (cageAddrFromCfg)
 
 -- | Combined API with Swagger UI.
 type FullAPI = SwaggerAPI :<|> API
@@ -222,13 +229,70 @@ statusHandler ctx = do
             , currentUtxoRoot = fmap Hex mRoot
             }
 
+-- | @GET \/tokens@ — return the trust-minimised
+-- listing: every UTxO at the global state validator
+-- address with a single CSMT prefix-completeness
+-- proof, anchored to one snapshot.
+--
+-- Emits @503@ when the indexer has no CSMT root yet
+-- (still bootstrapping), or when the
+-- 'utxoSetWitness' primitive returns 'Nothing'.
 tokensHandler
-    :: Context IO -> Handler [TokenIdJSON]
+    :: Context IO -> Handler TokensListResponse
 tokensHandler ctx = do
-    tids <-
-        liftIO
-            $ St.listTokens (St.tokens (state ctx))
-    pure (map tokenIdToJSON tids)
+    snapshot <- requireSnapshot ctx
+    let cfg = cfgCage ctx
+        net = network cfg
+        addr = cageAddrFromCfg cfg net
+        addrBytes = serialiseAddr addr
+    mWitness <- liftIO $ utxoSetWitness ctx addrBytes
+    case mWitness of
+        Nothing ->
+            throwError
+                $ err503
+                    { errBody =
+                        "csmt not available yet"
+                    }
+        Just (entries, completenessBs) ->
+            pure
+                TokensListResponse
+                    { tlrSnapshot = snapshot
+                    , tlrTokens =
+                        UtxoSetWitness
+                            { uswEntries =
+                                map
+                                    txInPairToEntry
+                                    entries
+                            , uswCompletenessProof =
+                                Hex completenessBs
+                            }
+                    }
+  where
+    txInPairToEntry (txInBs, txOutBs) =
+        UtxoEntryRefOnly
+            { uerRef = txInBytesToRef txInBs
+            , uerTxOutCbor = Hex txOutBs
+            }
+    -- The CSMT KV-key is the canonical Shelley TxIn
+    -- CBOR layout: @[bytestring tx_id, uint tx_ix]@.
+    -- Decode it into a 'UtxoRef' for the wire.
+    txInBytesToRef bs =
+        case decodeFull' (natVersion @11) bs of
+            Right (TxIn (TxId sh) (TxIx ix)) ->
+                UtxoRef
+                    { urTxId =
+                        Hex
+                            ( Crypto.hashToBytes
+                                ( extractHash
+                                    sh
+                                )
+                            )
+                    , urTxIx = fromIntegral ix
+                    }
+            Left _ ->
+                error
+                    "tokensHandler: TxIn CBOR \
+                    \decode failed"
 
 tokenHandler
     :: Context IO

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -73,6 +73,10 @@ module Cardano.MPFS.HTTP.Types
     , SweepTxResponse (..)
     , UpdateTxResponse (..)
     , UnsignedTxResponse (..)
+    , TokensListResponse (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
     , mkBootTxResponse
     , mkRequestTxResponse
     , mkRetractTxResponse
@@ -128,6 +132,7 @@ import Cardano.MPFS.API.Types
     , TokenIdJSON (..)
     , TokenResponse (..)
     , TokenStateJSON (..)
+    , TokensListResponse (..)
     , TrieFactJSON (..)
     , TxInJSON (..)
     , UnsignedTxResponse (..)
@@ -136,7 +141,9 @@ import Cardano.MPFS.API.Types
     , UpdateTxResponse (..)
     , UpdateValueRequest (..)
     , UtxoEntry (..)
+    , UtxoEntryRefOnly (..)
     , UtxoRef (..)
+    , UtxoSetWitness (..)
     , VerificationSnapshot (..)
     , WitnessedRequest (..)
     , WitnessedTokenState (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
@@ -58,5 +58,6 @@ mkMockContext = do
                         "mkMockContext: runIndexerTx \
                         \not implemented (mock context \
                         \does not exercise tx-build paths)"
+            , utxoSetWitness = \_ -> pure Nothing
             , readMetrics = pure Nothing
             }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
@@ -83,6 +83,7 @@ mkTestContext = do
                         \implemented (HTTP unit \
                         \tests do not exercise \
                         \tx-build paths)"
+            , utxoSetWitness = \_ -> pure Nothing
             , readMetrics = pure Nothing
             }
 

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
@@ -1,18 +1,27 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      : Cardano.MPFS.HTTP.TokensSpec
 -- Description : Tests for GET /tokens endpoint
 -- License     : Apache-2.0
+--
+-- The endpoint returns a 'TokensListResponse' carrying a
+-- 'VerificationSnapshot' and a 'UtxoSetWitness' (the proof-bearing
+-- shape introduced in 243-tokens-list). The unit tests below
+-- exercise the response *shape* — not cryptographic validity of the
+-- completeness proof, which is the e2e suite's job.
 module Cardano.MPFS.HTTP.TokensSpec
     ( spec
     , mkDummyTokenState
     ) where
 
-import Data.Aeson (decode)
-import Data.Aeson.Types (Value (..))
+import Data.Aeson (Value (..), decode)
+import Data.Aeson.KeyMap qualified as KM
 import Data.ByteString qualified as BS
-import Data.ByteString.Short qualified as SBS
+import Data.ByteString.Lazy (ByteString)
+import Data.ByteString.Lazy qualified as BSL
 import Network.HTTP.Types (status200)
 import Network.Wai.Test
     ( SResponse (..)
@@ -29,14 +38,14 @@ import Test.Hspec
     , shouldBe
     )
 
-import Cardano.Ledger.Mary.Value (AssetName (..))
-
+import Cardano.Ledger.Binary (natVersion, serialize)
+import Cardano.Ledger.TxIn (TxIn)
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
-    ( Coin (..)
-    , LocatedTokenState (..)
+    ( BlockId (..)
+    , Coin (..)
     , Root (..)
-    , TokenId (..)
+    , SlotNo (..)
     , TokenState (..)
     )
 import Cardano.MPFS.Generators (genKeyHash, genTxIn)
@@ -45,6 +54,7 @@ import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.State qualified as St
 import Test.QuickCheck (generate)
 
+-- | Hit @GET /tokens@ on the supplied context.
 getTokens :: Context IO -> IO SResponse
 getTokens ctx =
     runSession
@@ -53,7 +63,7 @@ getTokens ctx =
         )
         (mkApp ctx)
 
--- | A dummy token state for testing.
+-- | A dummy token state for callers that still need one.
 mkDummyTokenState :: IO TokenState
 mkDummyTokenState = do
     kh <- generate genKeyHash
@@ -66,35 +76,82 @@ mkDummyTokenState = do
             , retractTime = 30_000
             }
 
+-- | Seed the snapshot precondition: the handler 503s unless the
+-- mock context has a CSMT root and a chain checkpoint. Returns a
+-- context with both filled in plus a caller-supplied
+-- @utxoSetWitness@ stub.
+withSnapshot
+    :: ( BS.ByteString
+         -> IO
+                ( Maybe
+                    ([(BS.ByteString, BS.ByteString)], BS.ByteString)
+                )
+       )
+    -> IO (Context IO)
+withSnapshot stubWitness = do
+    ctx <- mkTestContext
+    let rootBs = BS.replicate 32 0
+        ctx' =
+            ctx
+                { utxoRoot = pure (Just rootBs)
+                , utxoSetWitness = stubWitness
+                }
+    St.putCheckpoint
+        (St.checkpoints (state ctx'))
+        (SlotNo 1)
+        (BlockId (BS.replicate 32 0))
+    pure ctx'
+
+-- | Decode the response body and look up @tokens.entries@.
+tokensEntries :: ByteString -> Maybe Value
+tokensEntries body = do
+    Object root <- decode body
+    Object tokens <- KM.lookup "tokens" root
+    KM.lookup "entries" tokens
+
 spec :: Spec
 spec = describe "GET /tokens" $ do
-    it "returns empty list on fresh state" $ do
-        ctx <- mkTestContext
-        resp <- getTokens ctx
-        simpleStatus resp `shouldBe` status200
-        case decode (simpleBody resp) of
-            Just (Array arr) ->
-                length arr `shouldBe` 0
-            _ ->
-                expectationFailure
-                    "Expected JSON array"
+    it "returns 200 with empty entries when the witness is empty"
+        $ do
+            ctx <-
+                withSnapshot
+                    ( \_ ->
+                        pure (Just ([], BS.empty))
+                    )
+            resp <- getTokens ctx
+            simpleStatus resp `shouldBe` status200
+            case tokensEntries (simpleBody resp) of
+                Just (Array arr) ->
+                    length arr `shouldBe` 0
+                _ ->
+                    expectationFailure
+                        "Expected JSON object with \
+                        \tokens.entries array"
 
-    it "returns token after insertion" $ do
-        ctx <- mkTestContext
-        ts <- mkDummyTokenState
-        txIn <- generate genTxIn
-        let tid =
-                TokenId
-                    (AssetName (SBS.toShort "deadbeef"))
-        St.putToken
-            (St.tokens (state ctx))
-            tid
-            (LocatedTokenState txIn ts)
-        resp <- getTokens ctx
-        simpleStatus resp `shouldBe` status200
-        case decode (simpleBody resp) of
-            Just (Array arr) ->
-                length arr `shouldBe` 1
-            _ ->
-                expectationFailure
-                    "Expected JSON array with 1 element"
+    it "returns 200 with one entry when the witness has one"
+        $ do
+            txIn <- generate genTxIn
+            let txInBs =
+                    BSL.toStrict
+                        ( serialize
+                            (natVersion @11)
+                            (txIn :: TxIn)
+                        )
+                txOutBs = BS.replicate 16 0xbb
+            ctx <-
+                withSnapshot
+                    ( \_ ->
+                        pure
+                            ( Just
+                                ([(txInBs, txOutBs)], BS.empty)
+                            )
+                    )
+            resp <- getTokens ctx
+            simpleStatus resp `shouldBe` status200
+            case tokensEntries (simpleBody resp) of
+                Just (Array arr) ->
+                    length arr `shouldBe` 1
+                _ ->
+                    expectationFailure
+                        "Expected JSON object with \
+                        \tokens.entries array"

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -679,6 +679,22 @@
             ],
             "type": "object"
         },
+        "TokensListResponse": {
+            "description": "Trust-minimised cage discovery: one snapshot plus a UtxoSetWitness over the global state validator address.",
+            "properties": {
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "tokens": {
+                    "$ref": "#/definitions/UtxoSetWitness"
+                }
+            },
+            "required": [
+                "snapshot",
+                "tokens"
+            ],
+            "type": "object"
+        },
         "TrieFactJSON": {
             "description": "Trie read: key, optional value, and MPF proof against a trie root",
             "properties": {
@@ -862,6 +878,22 @@
             ],
             "type": "object"
         },
+        "UtxoEntryRefOnly": {
+            "description": "UTxO ref and CBOR body, without a per-entry inclusion proof. Used inside a UtxoSetWitness.",
+            "properties": {
+                "ref": {
+                    "$ref": "#/definitions/UtxoRef"
+                },
+                "txout_cbor": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "ref",
+                "txout_cbor"
+            ],
+            "type": "object"
+        },
         "UtxoRef": {
             "description": "UTxO reference",
             "properties": {
@@ -878,6 +910,25 @@
             "required": [
                 "tx_id",
                 "tx_ix"
+            ],
+            "type": "object"
+        },
+        "UtxoSetWitness": {
+            "description": "Enumerated UTxOs at a known script-hash prefix, with a single CSMT prefix-completeness proof attesting the set is exactly the leaves under that prefix.",
+            "properties": {
+                "completeness_proof": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "entries": {
+                    "items": {
+                        "$ref": "#/definitions/UtxoEntryRefOnly"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "entries",
+                "completeness_proof"
             ],
             "type": "object"
         },
@@ -1013,10 +1064,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "items": {
-                                "$ref": "#/definitions/TokenIdJSON"
-                            },
-                            "type": "array"
+                            "$ref": "#/definitions/TokensListResponse"
                         }
                     }
                 }

--- a/lean/Phase4/ProofRedesign.lean
+++ b/lean/Phase4/ProofRedesign.lean
@@ -276,4 +276,100 @@ theorem forge_boot_input_breaks_validity
       mem_replayInputs_acceptedWitnesses]
   simp [VerifiedEnvelope.init, h]
 
+-- =========================================================
+-- GET /tokens (US5) — trust-minimised cage discovery
+-- =========================================================
+
+/-- Replay state for the `GET /tokens` response: a single
+    `CompletenessEnvelope` anchored at the externally-supplied
+    `trustedRoot` and the locally-derived global state script
+    address as `scriptPrefix`. The cryptographic verifier is
+    delegated to the upstream `verifyCompletenessProof`; the
+    structural invariants captured here are exactly those of
+    `Phase4.Completeness.CompletenessEnvelope`. -/
+abbrev TokensListEnvelope (Root Prefix Key Value : Type) :=
+  CompletenessEnvelope Root Prefix Key Value
+
+namespace TokensListEnvelope
+
+variable {Root Prefix Key Value : Type}
+
+/-- Initial envelope for a `GET /tokens` response. -/
+def init
+    (r : Root) (pfx : Prefix)
+    : TokensListEnvelope Root Prefix Key Value :=
+  CompletenessEnvelope.init r pfx
+
+/-- Replay one advertised entry into the listing. -/
+def replayEntry
+    (env : TokensListEnvelope Root Prefix Key Value)
+    (k : Key) (v : Value)
+    : TokensListEnvelope Root Prefix Key Value :=
+  CompletenessEnvelope.replayLeaf env k v
+
+end TokensListEnvelope
+
+variable {Root Prefix Key Value : Type}
+
+/-- The replay never rewrites the trusted root supplied at
+    initialisation. Specialisation of
+    `Phase4.Completeness.replayLeaf_preserves_root_trust` to
+    the `GET /tokens` envelope. -/
+theorem tokensList_replayEntry_preserves_root_trust
+    (env : TokensListEnvelope Root Prefix Key Value)
+    (k : Key) (v : Value) :
+    (TokensListEnvelope.replayEntry env k v).trustedRoot
+      = env.trustedRoot := by
+  simp [TokensListEnvelope.replayEntry,
+        CompletenessEnvelope.replayLeaf]
+
+/-- The replay never rewrites the script-address prefix.
+    Specialisation of
+    `Phase4.Completeness.replayLeaf_preserves_script_prefix`. -/
+theorem tokensList_replayEntry_preserves_script_prefix
+    (env : TokensListEnvelope Root Prefix Key Value)
+    (k : Key) (v : Value) :
+    (TokensListEnvelope.replayEntry env k v).scriptPrefix
+      = env.scriptPrefix := by
+  simp [TokensListEnvelope.replayEntry,
+        CompletenessEnvelope.replayLeaf]
+
+/-- Folding `replayEntry` over an entries list preserves the
+    trusted root anchor — generalisation across the whole
+    listing of
+    `tokensList_replayEntry_preserves_root_trust`. -/
+theorem tokensList_fold_preserves_root_trust
+    (env : TokensListEnvelope Root Prefix Key Value)
+    (entries : List (Key × Value)) :
+    (entries.foldl
+        (fun e kv =>
+          TokensListEnvelope.replayEntry e kv.1 kv.2)
+        env).trustedRoot
+      = env.trustedRoot := by
+  induction entries generalizing env with
+  | nil => rfl
+  | cons _ rest ih =>
+      simp [TokensListEnvelope.replayEntry,
+            CompletenessEnvelope.replayLeaf]
+      exact ih _
+
+/-- Folding `replayEntry` over an entries list preserves the
+    script-address prefix — generalisation across the whole
+    listing of
+    `tokensList_replayEntry_preserves_script_prefix`. -/
+theorem tokensList_fold_preserves_script_prefix
+    (env : TokensListEnvelope Root Prefix Key Value)
+    (entries : List (Key × Value)) :
+    (entries.foldl
+        (fun e kv =>
+          TokensListEnvelope.replayEntry e kv.1 kv.2)
+        env).scriptPrefix
+      = env.scriptPrefix := by
+  induction entries generalizing env with
+  | nil => rfl
+  | cons _ rest ih =>
+      simp [TokensListEnvelope.replayEntry,
+            CompletenessEnvelope.replayLeaf]
+      exact ih _
+
 end Phase4.ProofRedesign


### PR DESCRIPTION
Tracking issue: #243. Stacked on top of #244 (boot slice).

Trust-minimised oracle discovery: `GET /tokens` returns every UTxO
under the global state validator address with a single CSMT
prefix-completeness proof outside the list, anchored to one
verification snapshot. Client derives the global state address
locally from the trusted blueprint and verifies completeness against
an externally-supplied trusted root.

Was blocked on
[lambdasistemi/haskell-mts#153](https://github.com/lambdasistemi/haskell-mts/issues/153)
(CompletenessProof CBOR + verifier in `csmt-verify`); upstream landed
at `f6f0ee2` and this PR consumes it.

## Already on this branch

- `deps`: bump haskell-mts to `f6f0ee2`
- `feat(client)`: `verifyCompleteness` + `verifyCompletenessEmpty`
  against the new `csmt-verify` primitive

## Outstanding (in flight)

- Lean `tokensListResponseValid` + 2 forgery theorems
- Indexer `enumerateAtScriptPrefix` extension
- `TokensListResponse` wire type
- `GET /tokens` route returning the new shape
- `tokensHandler` enumerating with completeness
- `verifyTokensListResponse :: TrustedRoot -> Blueprint -> _ -> Either VerifyError ()`
- Honest fixture + forgery corpus (extra leaf, missing leaf, address mismatch)
- E2E spec on devnet

## Test plan

- [ ] `just format-check`, `just hlint`, `just unit`
- [ ] `just e2e` covers the GET /tokens flow on devnet
- [ ] Lean `lake build` clean (no `sorry`, only `propext`-class axioms)
- [ ] swagger regenerated when read shapes are settled