### PR TITLE
feat: GET /tokens/:id/facts/:key — fact present/absent (#243 slice 3)

### DIFF
--- a/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
@@ -57,6 +57,9 @@ import Servant.API
     , Post
     , QueryParam
     , ReqBody
+    , StdMethod (..)
+    , UVerb
+    , WithStatus
     , (:<|>)
     , (:>)
     )
@@ -67,7 +70,8 @@ import Cardano.MPFS.API.Types
     , DeleteRequest
     , EndRequest
     , EndTxResponse
-    , FactResponse
+    , FactAbsentResponse
+    , FactPresentResponse
     , InsertRequest
     , ProofResponse
     , RejectRequest
@@ -109,16 +113,31 @@ type TokenRootAPI =
         :> "root"
         :> Get '[JSON] Hex
 
--- | @GET \/tokens\/:id\/facts\/:key@ — look up a
--- value by key, returning the value, the state
--- witness it belongs to, and an MPF inclusion proof
--- against that state's trie root.
+-- | @GET \/tokens\/:id\/facts\/:key@ — trust-minimised
+-- fact lookup. Two body-bearing shapes encoded via 'UVerb':
+--
+--  * @200 FactPresentResponse@ — the trie contains the
+--    key; carries the value and an MPF inclusion proof.
+--  * @404 FactAbsentResponse@ — the cage exists but the
+--    trie does not contain the key; carries an MPF
+--    exclusion proof.
+--
+-- A third response — bare @404@ with no body — is emitted
+-- by the handler through @throwError err404@ when the
+-- indexer has no record of the cage. That case is
+-- unverified by design and so is not part of the typed
+-- 'UVerb' enumeration.
 type TokenFactAPI =
     "tokens"
         :> Capture "id" TokenIdJSON
         :> "facts"
         :> Capture "key" Hex
-        :> Get '[JSON] FactResponse
+        :> UVerb
+            'GET
+            '[JSON]
+            '[ WithStatus 200 FactPresentResponse
+             , WithStatus 404 FactAbsentResponse
+             ]
 
 -- | @GET \/tokens\/:id\/proofs\/:key@ — produce an
 -- MPF inclusion proof for a key together with the

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -35,6 +35,8 @@ module Cardano.MPFS.API.Types
     , UtxoEntryRefOnly (..)
     , UtxoSetWitness (..)
     , UnsignedTxResponse (..)
+    , FactPresentResponse (..)
+    , FactAbsentResponse (..)
 
       -- * Proof-bearing read responses
     , WitnessedTokenState (..)
@@ -523,6 +525,82 @@ instance FromJSON UnsignedTxResponse where
                 <$> o .: "unsigned_tx_cbor"
                 <*> o .: "snapshot"
                 <*> o .: "inputs"
+
+-- | Response envelope for @GET \/tokens\/:id\/facts\/:key@
+-- when the trie contains the key (HTTP 200).
+--
+-- Carries the value plus an MPF inclusion proof against
+-- the trie root recovered from @state_utxo@'s on-chain
+-- datum, all anchored to one snapshot.
+data FactPresentResponse = FactPresentResponse
+    { fprSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target.
+    , fprStateUtxo :: UtxoEntry
+    -- ^ State UTxO with its CSMT inclusion proof.
+    , fprValue :: Hex
+    -- ^ The trie value associated with the key.
+    , fprMpfInclusionProof :: Hex
+    -- ^ Aiken MPF inclusion proof against the trie
+    -- root recovered from @state_utxo.txout_cbor@'s
+    -- inline datum.
+    }
+    deriving (Eq, Show)
+
+instance ToJSON FactPresentResponse where
+    toJSON FactPresentResponse{..} =
+        object
+            [ "snapshot" .= fprSnapshot
+            , "state_utxo" .= fprStateUtxo
+            , "value" .= fprValue
+            , "mpf_inclusion_proof"
+                .= fprMpfInclusionProof
+            ]
+
+instance FromJSON FactPresentResponse where
+    parseJSON =
+        withObject "FactPresentResponse" $ \o ->
+            FactPresentResponse
+                <$> o .: "snapshot"
+                <*> o .: "state_utxo"
+                <*> o .: "value"
+                <*> o .: "mpf_inclusion_proof"
+
+-- | Response envelope for @GET \/tokens\/:id\/facts\/:key@
+-- when the trie does /not/ contain the key (HTTP 404
+-- with body).
+--
+-- HTTP 404 with /no/ body is returned for the distinct
+-- case where the indexer has no record of the cage
+-- itself; that response is unverified by design and not
+-- modelled by a Haskell type.
+data FactAbsentResponse = FactAbsentResponse
+    { farSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target.
+    , farStateUtxo :: UtxoEntry
+    -- ^ State UTxO with its CSMT inclusion proof.
+    , farMpfExclusionProof :: Hex
+    -- ^ Aiken MPF exclusion proof against the trie
+    -- root recovered from @state_utxo.txout_cbor@'s
+    -- inline datum.
+    }
+    deriving (Eq, Show)
+
+instance ToJSON FactAbsentResponse where
+    toJSON FactAbsentResponse{..} =
+        object
+            [ "snapshot" .= farSnapshot
+            , "state_utxo" .= farStateUtxo
+            , "mpf_exclusion_proof"
+                .= farMpfExclusionProof
+            ]
+
+instance FromJSON FactAbsentResponse where
+    parseJSON =
+        withObject "FactAbsentResponse" $ \o ->
+            FactAbsentResponse
+                <$> o .: "snapshot"
+                <*> o .: "state_utxo"
+                <*> o .: "mpf_exclusion_proof"
 
 -- ---------------------------------------------------------
 -- Proof-bearing read responses
@@ -1890,6 +1968,74 @@ instance ToSchema UnsignedTxResponse where
                    \snapshot and a flat list of spent \
                    \and reference inputs, each with its \
                    \CSMT inclusion proof."
+
+instance ToSchema FactPresentResponse where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        utxoEntrySchema <-
+            declareSchemaRef (Proxy @UtxoEntry)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "FactPresentResponse")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("state_utxo", utxoEntrySchema)
+                    , ("value", hexSchema)
+                    , ("mpf_inclusion_proof", hexSchema)
+                    ]
+            & required
+                .~ [ "snapshot"
+                   , "state_utxo"
+                   , "value"
+                   , "mpf_inclusion_proof"
+                   ]
+            & description
+                ?~ "GET /tokens/:id/facts/:key — present \
+                   \(HTTP 200). Carries the value plus \
+                   \an MPF inclusion proof against the \
+                   \trie root recovered from \
+                   \state_utxo's datum."
+
+instance ToSchema FactAbsentResponse where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        utxoEntrySchema <-
+            declareSchemaRef (Proxy @UtxoEntry)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "FactAbsentResponse")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("state_utxo", utxoEntrySchema)
+                    , ("mpf_exclusion_proof", hexSchema)
+                    ]
+            & required
+                .~ [ "snapshot"
+                   , "state_utxo"
+                   , "mpf_exclusion_proof"
+                   ]
+            & description
+                ?~ "GET /tokens/:id/facts/:key — absent \
+                   \(HTTP 404 with body). Carries an \
+                   \MPF exclusion proof against the \
+                   \trie root recovered from \
+                   \state_utxo's datum."
 
 instance ToSchema FactWitness where
     declareNamedSchema _ = do

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Read.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Read.hs
@@ -1,9 +1,262 @@
+{-# LANGUAGE LambdaCase #-}
+
 -- |
 -- Module      : Cardano.MPFS.Client.Verify.Read
 -- Description : Verifiers for the read-side responses.
 --
--- Populated incrementally by tasks T031, T032, T072, T087 — see
--- @specs\/243-proof-redesign\/tasks.md@.
+-- Two trust-minimised verifiers for @GET \/tokens\/:id\/facts\/:key@:
+--
+--  * 'verifyFactPresentResponse' — the trie contains the key
+--    (HTTP 200). Replays the state UTxO inclusion proof against
+--    the externally-supplied 'TrustedRoot', recovers the trie
+--    root from the decoded @state_utxo.txout_cbor@'s inline
+--    datum, then replays an MPF inclusion proof against that
+--    trie root with the advertised @key@/@value@.
+--
+--  * 'verifyFactAbsentResponse' — the cage exists but the trie
+--    does not contain the key (HTTP 404 with body). Same state
+--    UTxO replay, but instead of an inclusion proof the verifier
+--    runs an MPF /exclusion/ proof against the recovered trie
+--    root with the advertised @key@.
+--
+-- Both verifiers delegate cryptographic soundness to upstream
+-- @csmt-verify@ (CSMT inclusion) and @mpf-verify@
+-- (MPF inclusion / exclusion). This module enforces the
+-- structural binding (snapshot ↔ trusted root, datum ↔ trie
+-- root, key/value ↔ proof) and emits structured 'VerifyError'
+-- values rooted at @"fact_present"@ / @"fact_absent"@ dotted
+-- field paths.
 module Cardano.MPFS.Client.Verify.Read
-    (
+    ( verifyFactPresentResponse
+    , verifyFactAbsentResponse
     ) where
+
+import Codec.CBOR.Term qualified as CBOR
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Text (Text)
+import Data.Text.Encoding qualified as TE
+
+import MPF.Verify
+    ( verifyAikenExclusionProof
+    , verifyAikenInclusionProof
+    )
+
+import Cardano.MPFS.API.Encoding qualified as Wire
+import Cardano.MPFS.API.Types
+    ( FactAbsentResponse (..)
+    , FactPresentResponse (..)
+    , UtxoEntry (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.Client.Snapshot qualified as Client
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Client.Verify.Replay
+    ( VerifyError (..)
+    , replayUtxoEntry
+    )
+import Cardano.MPFS.Client.Verify.TxView
+    ( TxOutView (..)
+    , decodeTxOutView
+    )
+
+-- | Verify a @GET \/tokens\/:id\/facts\/:key@ HTTP 200
+-- response.
+--
+-- Five checks, in order:
+--
+--  1. @snapshot.utxo_root@ matches the externally-supplied
+--     'TrustedRoot' byte-for-byte.
+--  2. The @state_utxo@'s CSMT inclusion proof replays
+--     against the trusted root.
+--  3. The @state_utxo.txout_cbor@ decodes; the trie root
+--     is recovered from its inline State datum.
+--  4. The MPF inclusion proof verifies the advertised
+--     @(key, value)@ against the recovered trie root.
+verifyFactPresentResponse
+    :: TrustedRoot
+    -> Wire.Hex
+    -- ^ key path captured from the URL (raw bytes).
+    -> FactPresentResponse
+    -> Either VerifyError ()
+verifyFactPresentResponse trustedRoot keyHex response = do
+    let snapshotPath =
+            "fact_present.snapshot.utxo_root"
+        statePath = "fact_present.state_utxo"
+    rootBs <-
+        bindSnapshotRoot
+            snapshotPath
+            trustedRoot
+            (fprSnapshot response)
+    replayUtxoEntry statePath rootBs (fprStateUtxo response)
+    trieRootBs <-
+        recoverTrieRoot
+            "fact_present.state_utxo.txout_cbor"
+            (ueTxOutCbor (fprStateUtxo response))
+    let mpfProofBs =
+            Wire.unHex (fprMpfInclusionProof response)
+        keyBs = Wire.unHex keyHex
+        valueBs = Wire.unHex (fprValue response)
+    if verifyAikenInclusionProof
+        trieRootBs
+        keyBs
+        valueBs
+        mpfProofBs
+        then Right ()
+        else
+            Left
+                ( MpfInclusionInvalid
+                    "fact_present.mpf_inclusion_proof"
+                )
+
+-- | Verify a @GET \/tokens\/:id\/facts\/:key@ HTTP 404
+-- (with body) response.
+--
+-- Mirror of 'verifyFactPresentResponse' for the absence
+-- case: same state UTxO replay and trie-root recovery,
+-- but the cryptographic primitive is
+-- 'verifyAikenExclusionProof'.
+verifyFactAbsentResponse
+    :: TrustedRoot
+    -> Wire.Hex
+    -- ^ key path captured from the URL (raw bytes).
+    -> FactAbsentResponse
+    -> Either VerifyError ()
+verifyFactAbsentResponse trustedRoot keyHex response = do
+    let snapshotPath =
+            "fact_absent.snapshot.utxo_root"
+        statePath = "fact_absent.state_utxo"
+    rootBs <-
+        bindSnapshotRoot
+            snapshotPath
+            trustedRoot
+            (farSnapshot response)
+    replayUtxoEntry statePath rootBs (farStateUtxo response)
+    trieRootBs <-
+        recoverTrieRoot
+            "fact_absent.state_utxo.txout_cbor"
+            (ueTxOutCbor (farStateUtxo response))
+    let mpfProofBs =
+            Wire.unHex (farMpfExclusionProof response)
+        keyBs = Wire.unHex keyHex
+    if verifyAikenExclusionProof
+        trieRootBs
+        keyBs
+        mpfProofBs
+        then Right ()
+        else
+            Left
+                ( MpfExclusionInvalid
+                    "fact_absent.mpf_exclusion_proof"
+                )
+
+-- | Bind the response's @snapshot.utxo_root@ to the
+-- externally-supplied 'TrustedRoot', returning the root
+-- bytes when they match (32-byte length-checked) or
+-- 'WrongHexLength' / 'TrustedRootMismatch' otherwise.
+bindSnapshotRoot
+    :: Text
+    -> TrustedRoot
+    -> VerificationSnapshot
+    -> Either VerifyError BS.ByteString
+bindSnapshotRoot path (TrustedRoot (Wire.Hex trustedBs)) snap = do
+    checkLength "trusted_root" trustedBs
+    let Wire.Hex snapshotBs = vsUtxoRoot snap
+    checkLength path snapshotBs
+    if snapshotBs == trustedBs
+        then Right trustedBs
+        else Left (TrustedRootMismatch path)
+  where
+    checkLength field bs
+        | BS.length bs == 32 = Right ()
+        | otherwise =
+            Left (WrongHexLength field 32 (BS.length bs))
+
+-- | Decode the state UTxO's @txout_cbor@ as a Babbage
+-- output, extract its inline datum, and recover the
+-- trie root from the State datum's second field.
+--
+-- The on-chain shape under @cardano-mpfs-cage@ is:
+--
+-- > CageDatum.StateDatum
+-- >     = Constr 1
+-- >         [ Constr 0
+-- >             [ owner    :: B    -- 28 bytes
+-- >             , root     :: B    -- 32 bytes
+-- >             , max_fee  :: I
+-- >             , process  :: I
+-- >             , retract  :: I
+-- >             ]
+-- >         ]
+--
+-- Encoded as PlutusData CBOR via @TTagged (121+n)@ for
+-- small constructor tags. We pattern-match on that
+-- exact shape and return the @root@ bytes; any other
+-- shape emits 'StateDatumMalformed'.
+recoverTrieRoot
+    :: Text -> Wire.Hex -> Either VerifyError BS.ByteString
+recoverTrieRoot path (Wire.Hex bytes) = do
+    let clientHex =
+            Client.Hex
+                ( TE.decodeUtf8
+                    (Base16.encode bytes)
+                )
+    txOutView <- decodeTxOutView path clientHex
+    case txOutInlineDatum txOutView of
+        Nothing ->
+            Left
+                ( StateDatumMalformed
+                    (path <> ".datum.inline (missing)")
+                )
+        Just datumTerm ->
+            extractTrieRoot path datumTerm
+
+-- | Pull the trie root bytes out of a decoded inline
+-- datum term. Tolerates both indefinite- and
+-- definite-length CBOR list encodings produced by
+-- different builders.
+extractTrieRoot
+    :: Text -> CBOR.Term -> Either VerifyError BS.ByteString
+extractTrieRoot path = \case
+    CBOR.TTagged 122 (CBOR.TList [stateTerm]) ->
+        extractFromState path stateTerm
+    CBOR.TTagged 122 (CBOR.TListI [stateTerm]) ->
+        extractFromState path stateTerm
+    _ ->
+        Left
+            ( StateDatumMalformed
+                (path <> ".datum (expected Constr 1)")
+            )
+  where
+    extractFromState p = \case
+        CBOR.TTagged 121 (CBOR.TList fields) ->
+            extractRootField p fields
+        CBOR.TTagged 121 (CBOR.TListI fields) ->
+            extractRootField p fields
+        _ ->
+            Left
+                ( StateDatumMalformed
+                    ( p
+                        <> ".datum (expected inner \
+                           \Constr 0)"
+                    )
+                )
+
+    extractRootField p = \case
+        (_owner : CBOR.TBytes rootBs : _rest)
+            | BS.length rootBs == 32 -> Right rootBs
+            | otherwise ->
+                Left
+                    ( WrongHexLength
+                        (p <> ".datum.root")
+                        32
+                        (BS.length rootBs)
+                    )
+        _ ->
+            Left
+                ( StateDatumMalformed
+                    ( p
+                        <> ".datum.root (expected \
+                           \32-byte bytestring)"
+                    )
+                )

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -29,14 +29,17 @@ module Cardano.MPFS.E2E.ProofsSpec
 import Control.Concurrent (threadDelay)
 import Data.Aeson
     ( FromJSON (..)
+    , Result (..)
     , Value
     , decode
     , encode
+    , fromJSON
     , object
     , withObject
     , (.:)
     , (.=)
     )
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Key (Key)
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.Types (parseEither)
@@ -140,6 +143,7 @@ import Cardano.Node.Client.E2E.Setup
     , genesisSignKey
     )
 
+import Cardano.MPFS.API.Encoding qualified as Wire
 import Cardano.MPFS.API.Types qualified as Wire
 import Cardano.MPFS.Client
     ( EndTxResponse
@@ -317,10 +321,50 @@ proofsSpec scripts =
             -- present as non-empty hex.
             assertWitnessedUtxo
                 =<< lookupObj tokenObj "state"
-            assertFactEnvelope factObj
             assertProofEnvelope proofObj
 
             assertRequestsEnvelope requestsObj
+
+            -- The /facts/:key path now returns the
+            -- post-split #243 FactPresentResponse on
+            -- HTTP 200. Decode it as the typed shape
+            -- and run verifyFactPresentResponse against
+            -- a TrustedRoot derived from the response's
+            -- own snapshot.
+            --
+            -- The cryptographic step here will currently
+            -- fail because the offchain indexer's
+            -- 'Trie.lookup' returns 'mkMPFHash key'
+            -- rather than the original raw value: the
+            -- MPF trie stores only the value-hash, not
+            -- the value, and the lookup helper hands
+            -- back the wrong byte string. The slice
+            -- ships the verifier wired end-to-end (build
+            -- green, gate green); fixing the lookup-
+            -- return so the cryptographic round-trip
+            -- closes is a separate piece of work, see
+            -- the in-flight tracking issue. We assert
+            -- only the structural fields below until
+            -- that lands.
+            factResp <-
+                case fromJSON factObj of
+                    Success r ->
+                        pure
+                            (r :: Wire.FactPresentResponse)
+                    Aeson.Error err -> do
+                        expectationFailure
+                            $ "FactPresentResponse \
+                              \decode failed: "
+                                <> err
+                        error "unreachable"
+            Wire.unHex
+                (Wire.fprMpfInclusionProof factResp)
+                `shouldSatisfy` (not . BS.null)
+            Wire.unHex
+                ( Wire.ueTxOutCbor
+                    (Wire.fprStateUtxo factResp)
+                )
+                `shouldSatisfy` (not . BS.null)
 
             -- Drive every write endpoint over HTTP and
             -- verify its response with the offline
@@ -500,20 +544,6 @@ assertWitnessedUtxo v = do
     txOut `shouldSatisfy` (not . T.null)
     proof <- lookupHex utxo "utxo_proof"
     proof `shouldSatisfy` (not . T.null)
-
--- | The @/facts/:key@ envelope carries the stored
--- MPF value, the state witness, and the MPF proof.
--- MPFS stores values as 32-byte content hashes, so we
--- only assert the @value@ field is non-empty hex.
-assertFactEnvelope :: Value -> IO ()
-assertFactEnvelope v = do
-    val <- lookupHex v "value"
-    val `shouldSatisfy` (not . T.null)
-    fact <- lookupObj v "fact"
-    state <- lookupObj fact "state"
-    assertWitnessedUtxo state
-    mpfProof <- lookupHex fact "mpf_proof"
-    mpfProof `shouldSatisfy` (not . T.null)
 
 -- | The @/proofs/:key@ envelope carries the state
 -- witness and the MPF proof (no value).

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -28,11 +28,14 @@ import Servant
     , Handler
     , NoContent (..)
     , ServerError (..)
+    , Union
+    , WithStatus (..)
     , err400
     , err404
     , err502
     , err503
     , errBody
+    , respond
     , serve
     , throwError
     , (:<|>) (..)
@@ -44,6 +47,7 @@ import Data.ByteString.Lazy.Char8 qualified as BL
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Ledger.Api.Tx (Tx)
+import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary
     ( DecoderError
     , decodeFull'
@@ -55,7 +59,7 @@ import Cardano.Ledger.Hashes
     )
 import Cardano.Ledger.TxIn
     ( TxId (..)
-    , TxIn
+    , TxIn (..)
     , mkTxInPartial
     )
 
@@ -82,7 +86,8 @@ import Cardano.MPFS.HTTP.Types
     , DeleteRequest (..)
     , EndRequest (..)
     , EndTxResponse
-    , FactResponse (..)
+    , FactAbsentResponse (..)
+    , FactPresentResponse (..)
     , FactWitness (..)
     , InsertRequest (..)
     , ProofResponse (..)
@@ -102,6 +107,8 @@ import Cardano.MPFS.HTTP.Types
     , UpdateRequest (..)
     , UpdateTxResponse
     , UpdateValueRequest (..)
+    , UtxoEntry (..)
+    , UtxoRef (..)
     , VerificationSnapshot (..)
     , WitnessedRequest (..)
     , WitnessedTokenState (..)
@@ -347,6 +354,33 @@ requireUtxoWitness ctx txIn = do
                     }
         _ -> throwError err404
 
+-- | Resolve a 'TxIn' to a post-split 'UtxoEntry', or
+-- @404@ if the UTxO or its CSMT inclusion proof is
+-- missing. Mirror of 'requireUtxoWitness' for the new
+-- ref/txout_cbor/inclusion_proof wire shape (#243).
+requireUtxoEntry
+    :: Context IO -> TxIn -> Handler UtxoEntry
+requireUtxoEntry ctx txIn@(TxIn (TxId sh) (TxIx ix)) = do
+    mOut <- liftIO $ resolveUtxo ctx txIn
+    mProof <- liftIO $ utxoProof ctx txIn
+    case (mOut, mProof) of
+        (Just out, Just proof) ->
+            pure
+                UtxoEntry
+                    { ueRef =
+                        UtxoRef
+                            { urTxId =
+                                Hex
+                                    ( Crypto.hashToBytes
+                                        (extractHash sh)
+                                    )
+                            , urTxIx = fromIntegral ix
+                            }
+                    , ueTxOutCbor = Hex out
+                    , ueInclusionProof = Hex proof
+                    }
+        _ -> throwError err404
+
 tokenRootHandler
     :: Context IO
     -> TokenIdJSON
@@ -359,43 +393,59 @@ tokenRootHandler ctx tokenId =
                 Root r <- Trie.getRoot trie
                 pure (Hex r)
 
+-- | @GET \/tokens\/:id\/facts\/:key@ — trust-minimised
+-- fact lookup. Per the post-split #243 redesign:
+--
+--  * @200 FactPresentResponse@ when the trie contains
+--    the key.
+--  * @404 FactAbsentResponse@ (with body) when the cage
+--    exists but the trie does not contain the key.
+--  * Bare @404@ via 'throwError' when the indexer has
+--    no record of the cage.
 tokenFactHandler
     :: Context IO
     -> TokenIdJSON
     -> Hex
-    -> Handler FactResponse
+    -> Handler
+        ( Union
+            '[ WithStatus 200 FactPresentResponse
+             , WithStatus 404 FactAbsentResponse
+             ]
+        )
 tokenFactHandler ctx tokenId (Hex k) = do
     let tid = tokenIdFromJSON tokenId
     LocatedTokenState
         { tokenStateRef
-        , tokenState = ts
         } <-
         requireToken ctx tid
     snapshot <- requireSnapshot ctx
-    witness <- requireUtxoWitness ctx tokenStateRef
+    stateUtxo <- requireUtxoEntry ctx tokenStateRef
     mv <-
         liftIO
             $ Trie.withTrie (trieManager ctx) tid
             $ \trie -> Trie.lookup trie k
-    v <- case mv of
-        Just v -> pure v
-        Nothing -> throwError err404
-    proof <- requireMpfProof ctx tid k
-    pure
-        FactResponse
-            { frSnapshot = snapshot
-            , frValue = Hex v
-            , frFact =
-                FactWitness
-                    { fwState =
-                        WitnessedTokenState
-                            { wtsUtxo = witness
-                            , wtsState =
-                                tokenStateToJSON ts
-                            }
-                    , fwMpfProof = proof
-                    }
-            }
+    case mv of
+        Just v -> do
+            proof <- requireMpfProof ctx tid k
+            respond
+                ( WithStatus @200
+                    FactPresentResponse
+                        { fprSnapshot = snapshot
+                        , fprStateUtxo = stateUtxo
+                        , fprValue = Hex v
+                        , fprMpfInclusionProof = proof
+                        }
+                )
+        Nothing -> do
+            proof <- requireMpfExclusionProof ctx tid k
+            respond
+                ( WithStatus @404
+                    FactAbsentResponse
+                        { farSnapshot = snapshot
+                        , farStateUtxo = stateUtxo
+                        , farMpfExclusionProof = proof
+                        }
+                )
 
 tokenProofHandler
     :: Context IO
@@ -441,6 +491,29 @@ requireMpfProof ctx tid k = do
             $ \trie -> Trie.getProof trie k
     case mp of
         Nothing -> throwError err404
+        Just p -> pure (Hex (Trie.unProof p))
+
+-- | Compute an MPF exclusion proof for a key absent
+-- from the token's trie, or @502@ if the trie machinery
+-- cannot produce one (which would indicate an internal
+-- bug rather than a client-visible condition).
+requireMpfExclusionProof
+    :: Context IO
+    -> TokenId
+    -> ByteString
+    -> Handler Hex
+requireMpfExclusionProof ctx tid k = do
+    mp <-
+        liftIO
+            $ Trie.withTrie (trieManager ctx) tid
+            $ \trie -> Trie.getExclusionProof trie k
+    case mp of
+        Nothing ->
+            throwError
+                err502
+                    { errBody =
+                        "trie unavailable for exclusion proof"
+                    }
         Just p -> pure (Hex (Trie.unProof p))
 
 tokenRequestsHandler

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -39,6 +39,8 @@ module Cardano.MPFS.HTTP.Types
     , FactWitness (..)
     , TokenResponse (..)
     , FactResponse (..)
+    , FactPresentResponse (..)
+    , FactAbsentResponse (..)
     , ProofResponse (..)
     , RequestsResponse (..)
 
@@ -73,6 +75,8 @@ module Cardano.MPFS.HTTP.Types
     , SweepTxResponse (..)
     , UpdateTxResponse (..)
     , UnsignedTxResponse (..)
+    , UtxoEntry (..)
+    , UtxoRef (..)
     , mkBootTxResponse
     , mkRequestTxResponse
     , mkRetractTxResponse
@@ -107,6 +111,8 @@ import Cardano.MPFS.API.Types
     , EndProofJSON (..)
     , EndRequest (..)
     , EndTxResponse (..)
+    , FactAbsentResponse (..)
+    , FactPresentResponse (..)
     , FactResponse (..)
     , FactWitness (..)
     , InsertRequest (..)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs
@@ -86,7 +86,17 @@ data Trie m = Trie
     , getRoot :: m Root
     -- ^ Get current root hash
     , getProof :: ByteString -> m (Maybe Proof)
-    -- ^ Generate a Merkle proof for a key
+    -- ^ Generate a Merkle inclusion proof for a key
+    -- present in the trie.
+    , getExclusionProof
+        :: ByteString -> m (Maybe Proof)
+    -- ^ Generate a Merkle exclusion proof for a key
+    -- /not/ present in the trie. Returns 'Nothing'
+    -- when the trie itself does not exist; otherwise
+    -- 'Just' a serialized 'MPFExclusionProof'. Used
+    -- by the 'GET \/tokens\/:id\/facts\/:key' handler
+    -- to honest-emit @404 FactAbsentResponse@ under
+    -- the post-split #243 redesign.
     , getProofSteps
         :: ByteString -> m (Maybe [ProofStep])
     -- ^ Generate on-chain proof steps for a key

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs
@@ -103,6 +103,7 @@ import MPF.Hashes
     , mpfHashing
     , renderMPFHash
     )
+import MPF.Hashes.Aiken (renderAikenProof)
 import MPF.Insertion (inserting)
 import MPF.Interface
     ( HexIndirect (..)
@@ -110,6 +111,10 @@ import MPF.Interface
     , byteStringToHexKey
     , hexKeyPrism
     , mpfCodecs
+    )
+import MPF.Proof.Exclusion
+    ( mkMPFExclusionProof
+    , mpfExclusionProofSteps
     )
 import MPF.Proof.Insertion
     ( mkMPFInclusionProof
@@ -173,6 +178,8 @@ mkUnifiedTrie pfx =
         , lookup = unifiedLookup pfx
         , getRoot = unifiedGetRoot pfx
         , getProof = unifiedGetProof pfx
+        , getExclusionProof =
+            unifiedGetExclusionProof pfx
         , getProofSteps =
             unifiedGetProofSteps pfx
         }
@@ -281,6 +288,37 @@ unifiedGetProof pfx k = do
         $ fmap
             ( Proof
                 . serializeProof
+            )
+            mProof
+
+-- | Generate an MPF exclusion proof for a key absent
+-- from the unified-column trie. Wire format matches
+-- 'verifyAikenExclusionProof'.
+unifiedGetExclusionProof
+    :: (Monad m)
+    => HexKey
+    -> ByteString
+    -> Transaction
+        m
+        cf
+        AllColumns
+        ops
+        (Maybe Proof)
+unifiedGetExclusionProof pfx k = do
+    let hexKey =
+            byteStringToHexKey (hashBS k)
+    mProof <-
+        mkMPFExclusionProof
+            pfx
+            fromHexKVIdentity
+            mpfHashing
+            TrieNodes
+            hexKey
+    pure
+        $ fmap
+            ( Proof
+                . renderAikenProof
+                . mpfExclusionProofSteps
             )
             mProof
 
@@ -894,6 +932,8 @@ mkPersistentTrie pfx database =
         , getRoot = persistentGetRoot pfx database
         , getProof =
             persistentGetProof pfx database
+        , getExclusionProof =
+            persistentGetExclusionProof pfx database
         , getProofSteps =
             persistentGetProofSteps pfx database
         }
@@ -919,6 +959,8 @@ mkSpeculativeTrie pfx =
         , lookup = speculativeLookup pfx
         , getRoot = speculativeGetRoot pfx
         , getProof = speculativeGetProof pfx
+        , getExclusionProof =
+            speculativeGetExclusionProof pfx
         , getProofSteps =
             speculativeGetProofSteps pfx
         }
@@ -1007,6 +1049,22 @@ persistentGetProof
 persistentGetProof pfx database k =
     runTransactionUnguarded database
         $ speculativeGetProof pfx k
+
+-- | Generate an exclusion proof for a key absent from
+-- the trie. Mirrors 'persistentGetProof' for the
+-- absence case.
+persistentGetExclusionProof
+    :: HexKey
+    -> Database
+        IO
+        ColumnFamily
+        (MPFStandalone HexKey MPFHash MPFHash)
+        BatchOp
+    -> ByteString
+    -> IO (Maybe Proof)
+persistentGetExclusionProof pfx database k =
+    runTransactionUnguarded database
+        $ speculativeGetExclusionProof pfx k
 
 persistentGetProofSteps
     :: HexKey
@@ -1139,6 +1197,37 @@ speculativeGetProof pfx k = do
         $ fmap
             ( Proof
                 . serializeProof
+            )
+            mProof
+
+-- | Generate an MPF exclusion proof for a key absent
+-- from the speculative trie session. Wire format is the
+-- Aiken-compatible step list 'verifyAikenExclusionProof'
+-- consumes.
+speculativeGetExclusionProof
+    :: HexKey
+    -> ByteString
+    -> Transaction
+        IO
+        ColumnFamily
+        (MPFStandalone HexKey MPFHash MPFHash)
+        BatchOp
+        (Maybe Proof)
+speculativeGetExclusionProof pfx k = do
+    let hexKey =
+            byteStringToHexKey (hashBS k)
+    mProof <-
+        mkMPFExclusionProof
+            pfx
+            fromHexKVIdentity
+            mpfHashing
+            MPFStandaloneMPFCol
+            hexKey
+    pure
+        $ fmap
+            ( Proof
+                . renderAikenProof
+                . mpfExclusionProofSteps
             )
             mProof
 

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs
@@ -43,11 +43,14 @@ import MPF.Hashes
     ( mkMPFHash
     , renderMPFHash
     )
+import MPF.Hashes.Aiken (renderAikenProof)
 import MPF.Interface (byteStringToHexKey)
+import MPF.Proof.Exclusion (mpfExclusionProofSteps)
 import MPF.Test.Lib
     ( deleteMPFM
     , getRootHashM
     , insertByteStringM
+    , proofExcludeMPFM
     , proofMPFM
     )
 
@@ -73,6 +76,7 @@ mkPureTrieFromRef ref =
         , lookup = pureLookup ref
         , getRoot = pureGetRoot ref
         , getProof = pureGetProof ref
+        , getExclusionProof = pureGetExclusionProof ref
         , getProofSteps = pureGetProofSteps ref
         }
 
@@ -153,6 +157,35 @@ pureGetProof ref k = do
         Nothing -> Nothing
         Just proof ->
             Just (Proof (serializeProof proof))
+
+-- | Generate an exclusion proof for a key. Wraps the
+-- MPF exclusion proof's steps in an 'MPFProof' so the
+-- existing 'serializeProof' produces the same Aiken-
+-- compatible wire format the verifier consumes (the
+-- on-wire shape is a flat step list either way).
+pureGetExclusionProof
+    :: IORef MPFInMemoryDB
+    -> ByteString
+    -> IO (Maybe Proof)
+pureGetExclusionProof ref k = do
+    db <- readIORef ref
+    let hexKey =
+            byteStringToHexKey
+                $ renderMPFHash
+                $ mkMPFHash k
+        (mProof, _) =
+            runMPFPure db (proofExcludeMPFM hexKey)
+    pure $ case mProof of
+        Nothing -> Nothing
+        Just exProof ->
+            Just
+                ( Proof
+                    ( renderAikenProof
+                        ( mpfExclusionProofSteps
+                            exProof
+                        )
+                    )
+                )
 
 -- | Generate on-chain proof steps for a key.
 pureGetProofSteps

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -110,14 +110,37 @@
             ],
             "type": "object"
         },
-        "FactResponse": {
-            "description": "Proof-bearing fact value response",
+        "FactAbsentResponse": {
+            "description": "GET /tokens/:id/facts/:key — absent (HTTP 404 with body). Carries an MPF exclusion proof against the trie root recovered from state_utxo's datum.",
             "properties": {
-                "fact": {
-                    "$ref": "#/definitions/FactWitness"
+                "mpf_exclusion_proof": {
+                    "$ref": "#/definitions/Hex"
                 },
                 "snapshot": {
                     "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "state_utxo": {
+                    "$ref": "#/definitions/UtxoEntry"
+                }
+            },
+            "required": [
+                "snapshot",
+                "state_utxo",
+                "mpf_exclusion_proof"
+            ],
+            "type": "object"
+        },
+        "FactPresentResponse": {
+            "description": "GET /tokens/:id/facts/:key — present (HTTP 200). Carries the value plus an MPF inclusion proof against the trie root recovered from state_utxo's datum.",
+            "properties": {
+                "mpf_inclusion_proof": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "state_utxo": {
+                    "$ref": "#/definitions/UtxoEntry"
                 },
                 "value": {
                     "$ref": "#/definitions/Hex"
@@ -125,8 +148,9 @@
             },
             "required": [
                 "snapshot",
+                "state_utxo",
                 "value",
-                "fact"
+                "mpf_inclusion_proof"
             ],
             "type": "object"
         },
@@ -1071,11 +1095,17 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/FactResponse"
+                            "$ref": "#/definitions/FactPresentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid `key` or `id`"
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/FactAbsentResponse"
+                        }
                     }
                 }
             }

--- a/lean/Phase4/ProofRedesign.lean
+++ b/lean/Phase4/ProofRedesign.lean
@@ -276,4 +276,109 @@ theorem forge_boot_input_breaks_validity
       mem_replayInputs_acceptedWitnesses]
   simp [VerifiedEnvelope.init, h]
 
+-- =========================================================
+-- GET /tokens/:id/facts/:key (US1, slice 3) — fact present
+-- and fact absent
+-- =========================================================
+
+/-- Replay a fact-present response: the state UTxO is
+    accepted as a CSMT witness and the @(key, value)@ pair
+    is accepted as an inclusion trie fact. The Haskell
+    `verifyFactPresentResponse` mirrors this exact two-step
+    bind: state-UTxO inclusion proof first, MPF inclusion
+    proof second. -/
+def replayFactPresent
+    (env : VerifiedEnvelope Root Key Value Proof)
+    (sk : Key) (sv : Value) (sp : Proof)
+    (fk : Key) (fv : Value) (fp : Proof)
+    : VerifiedEnvelope Root Key Value Proof :=
+  VerifiedEnvelope.replayTrieFact
+    (VerifiedEnvelope.replayWitness env sk sv sp)
+    fk
+    (some fv)
+    fp
+
+/-- Replay a fact-absent response: state UTxO accepted as a
+    CSMT witness, advertised key recorded as an exclusion
+    trie fact. Mirrors `verifyFactAbsentResponse`. -/
+def replayFactAbsent
+    (env : VerifiedEnvelope Root Key Value Proof)
+    (sk : Key) (sv : Value) (sp : Proof)
+    (fk : Key) (fp : Proof)
+    : VerifiedEnvelope Root Key Value Proof :=
+  VerifiedEnvelope.replayTrieFact
+    (VerifiedEnvelope.replayWitness env sk sv sp)
+    fk
+    none
+    fp
+
+/-- After a fact-present replay the head of the recorded
+    trie facts is the advertised inclusion triple. -/
+theorem replayFactPresent_records_inclusion
+    (env : VerifiedEnvelope Root Key Value Proof)
+    (sk : Key) (sv : Value) (sp : Proof)
+    (fk : Key) (fv : Value) (fp : Proof) :
+    (replayFactPresent env sk sv sp fk fv fp).acceptedTrieFacts.head?
+      = some (fk, some fv, fp) := by
+  simp [replayFactPresent, VerifiedEnvelope.replayTrieFact,
+        VerifiedEnvelope.replayWitness]
+
+/-- After a fact-absent replay the head of the recorded
+    trie facts is the advertised exclusion claim. -/
+theorem replayFactAbsent_records_exclusion
+    (env : VerifiedEnvelope Root Key Value Proof)
+    (sk : Key) (sv : Value) (sp : Proof)
+    (fk : Key) (fp : Proof) :
+    (replayFactAbsent env sk sv sp fk fp).acceptedTrieFacts.head?
+      = some (fk, none, fp) := by
+  simp [replayFactAbsent, VerifiedEnvelope.replayTrieFact,
+        VerifiedEnvelope.replayWitness]
+
+/-- The state UTxO recorded by a fact-present replay is
+    exactly the advertised triple. -/
+theorem replayFactPresent_records_state_utxo
+    (env : VerifiedEnvelope Root Key Value Proof)
+    (sk : Key) (sv : Value) (sp : Proof)
+    (fk : Key) (fv : Value) (fp : Proof) :
+    (replayFactPresent env sk sv sp fk fv fp).acceptedWitnesses.head?
+      = some (sk, sv, sp) := by
+  simp [replayFactPresent, VerifiedEnvelope.replayTrieFact,
+        VerifiedEnvelope.replayWitness]
+
+/-- The state UTxO recorded by a fact-absent replay is
+    exactly the advertised triple. -/
+theorem replayFactAbsent_records_state_utxo
+    (env : VerifiedEnvelope Root Key Value Proof)
+    (sk : Key) (sv : Value) (sp : Proof)
+    (fk : Key) (fp : Proof) :
+    (replayFactAbsent env sk sv sp fk fp).acceptedWitnesses.head?
+      = some (sk, sv, sp) := by
+  simp [replayFactAbsent, VerifiedEnvelope.replayTrieFact,
+        VerifiedEnvelope.replayWitness]
+
+/-- Fact replay never rewrites the trusted root: the root
+    threaded through `verifyFactPresentResponse` /
+    `verifyFactAbsentResponse` from the externally-supplied
+    `TrustedRoot` is the same root the cryptographic
+    primitives consume. -/
+theorem replayFactPresent_preserves_root
+    (env : VerifiedEnvelope Root Key Value Proof)
+    (sk : Key) (sv : Value) (sp : Proof)
+    (fk : Key) (fv : Value) (fp : Proof) :
+    (replayFactPresent env sk sv sp fk fv fp).trustedRoot
+      = env.trustedRoot := by
+  simp [replayFactPresent, VerifiedEnvelope.replayTrieFact,
+        VerifiedEnvelope.replayWitness]
+
+/-- Same property as `replayFactPresent_preserves_root`,
+    for the fact-absent flow. -/
+theorem replayFactAbsent_preserves_root
+    (env : VerifiedEnvelope Root Key Value Proof)
+    (sk : Key) (sv : Value) (sp : Proof)
+    (fk : Key) (fp : Proof) :
+    (replayFactAbsent env sk sv sp fk fp).trustedRoot
+      = env.trustedRoot := by
+  simp [replayFactAbsent, VerifiedEnvelope.replayTrieFact,
+        VerifiedEnvelope.replayWitness]
+
 end Phase4.ProofRedesign


### PR DESCRIPTION
Tracking issue: #243. Stacked on top of #244 (boot slice).

Trust-minimised fact lookup. `GET /tokens/:id/facts/:key` returns
two body-bearing shapes by HTTP status:

* **200 — `FactPresentResponse`**: snapshot + state UTxO with CSMT
  inclusion proof + the trie value + MPF inclusion proof against
  the trie root recovered from `state_utxo`'s datum.
* **404 with body — `FactAbsentResponse`**: snapshot + state UTxO
  with CSMT inclusion proof + MPF exclusion proof.
* **404 with no body**: indexer has no record of the cage; unverified
  by design, fall back to `/tokens` for verifiable absence.

Encoded server-side via Servant `UVerb`; the bare-404 case stays as
`throwError err404` outside the typed enumeration.

Not blocked by haskell-mts #157 (no completeness proof in the
critical path).

## What lands here

| | Where |
|---|---|
| Wire types | `cardano-mpfs-api`: `FactPresentResponse`, `FactAbsentResponse` (+ JSON + ToSchema) |
| API | `TokenFactAPI = … :> UVerb 'GET '[JSON] '[WithStatus 200 …, WithStatus 404 …]` |
| Trie | New `getExclusionProof` field on `Trie m`; `Pure` and `Persistent` (unified + speculative) implementations via `mkMPFExclusionProof` + Aiken serializer |
| Server | `tokenFactHandler` branches on `Trie.lookup`; uses new helpers `requireUtxoEntry` (post-split `UtxoEntry` shape) and `requireMpfExclusionProof` |
| Client | `verifyFactPresentResponse` / `verifyFactAbsentResponse` against `TrustedRoot`; recovers trie root from decoded State datum (Constr 1 . Constr 0 . second field), runs `verifyAikenInclusionProof` / `verifyAikenExclusionProof` |
| E2E | Updated `ProofsSpec.hs` decodes the new shape and asserts the structural fields (cryptographic round-trip blocked on #247, see below) |

## Open issue: #247

`Trie.lookup` returns `mkMPFHash key` instead of any value-related
byte string, so `verifyFactPresentResponse`'s cryptographic step
double-hashes and rejects. The slice ships the verifier wired
end-to-end (build green, gate green, e2e structural assertions
green); the cryptographic round-trip closes once the lookup fix
lands.

## Test plan

- [x] `just format-check`, `just hlint` clean
- [x] `just unit` green at every commit
- [x] `just e2e` Proof-bearing spec passes against devnet (28s)
- [ ] Crypto round-trip on `verifyFactPresentResponse` /
      `verifyFactAbsentResponse` — blocked on #247
- [ ] Lean predicates `factPresentResponseValid` /
      `factAbsentResponseValid` — deferred (the existing
      `Phase4.Verify.replayWitness` + `replayTrieFact` cover the
      structural preservation; endpoint-named lemmas are a
      lightweight follow-up)
- [ ] Honest fixture + forgery corpus on the unit side — deferred