### PR TITLE
fix: GET /tokens/:id/facts/:key — serve actual values, not key-hashes (#248)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ after design.
 - Haskell GHC 9.10.1 (offchain server, verifier library); Lean 4 (formal model — `lean/` directory) + Servant (HTTP API), `cardano-mpfs-cage` (Aiken-derived on-chain types via PlutusV3 blueprint), `cardano-mpfs-client` (verifier package), `haskell-mts` (CSMT inclusion + prefix-completeness primitives, MPF inclusion + exclusion), `cardano-utxo-csmt` (CSMT runtime), `cardano-ledger-conway` (TxOut/Tx serialization), `cardano-node-clients` (N2C wiring), `chain-follower` (block stream) (243-proof-redesign)
 - RocksDB (existing CSMT + index column families) (243-proof-redesign)
 - RocksDB with 13 column families (6 UTxO from (249-atomic-boot-handler)
+- `rocksdb-kv-transactions` (atomic batch writes), `mts:mpf` (per-token MPF trie), `Cardano.MPFS.Indexer.Event` (`InvTrieInsert`/`InvTrieDelete` inverse-op machinery) (248-value-persistence)
+- RocksDB column families. Existing trie-related families: `TrieNodes` (`KV HexKey (HexIndirect MPFHash)`), `TrieKV` (`KV HexKey MPFHash`, the value-hash mirror the merkle layer queries), `TrieMeta` (token visibility registry). This feature adds a fourth family for raw values. (248-value-persistence)
 
 - Haskell with GHC 9.10.1 for native builds.
 - `cardano-mpfs-client` verifiers must remain compatible with native
@@ -80,6 +82,7 @@ Every issue starts with speckit artifacts before implementation:
 4. Implementation follows the task list, updating status as work lands.
 
 ## Recent Changes
+- 248-value-persistence: add `TrieRawValues` column family + fix `Trie.lookup` to return raw value bytes
 - 249-atomic-boot-handler: Added Haskell GHC 9.10.1
 - 243-proof-redesign: Added Haskell GHC 9.10.1 (offchain server, verifier library); Lean 4 (formal model — `lean/` directory) + Servant (HTTP API), `cardano-mpfs-cage` (Aiken-derived on-chain types via PlutusV3 blueprint), `cardano-mpfs-client` (verifier package), `haskell-mts` (CSMT inclusion + prefix-completeness primitives, MPF inclusion + exclusion), `cardano-utxo-csmt` (CSMT runtime), `cardano-ledger-conway` (TxOut/Tx serialization), `cardano-node-clients` (N2C wiring), `chain-follower` (block stream)
 

--- a/specs/248-value-persistence/checklists/requirements.md
+++ b/specs/248-value-persistence/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Value persistence for the fact lookup endpoint
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec deliberately keeps the postmortem framing in the input quote (so future readers see why this work exists) but the User Stories / Requirements / Success Criteria are written from the user's perspective without leaking the bug-cause story.
+- One narrow leak to flag for review: FR-001 / Assumptions reference `Cardano.MPFS.Indexer.Event` and the `InvTrieInsert`/`InvTrieDelete` machinery by name. This is an existing internal mechanism the spec relies on rather than designs; calling it out keeps the spec honest about the dependency without reaching into implementation. If the user prefers a stricter no-implementation-detail spec, those references move to `plan.md` and the spec talks only about "the existing atomic block-write mechanism."
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/248-value-persistence/contracts/trie-lookup.md
+++ b/specs/248-value-persistence/contracts/trie-lookup.md
@@ -1,0 +1,166 @@
+# Contract: `Cardano.MPFS.Trie.Trie.lookup` semantic change
+
+**Branch**: `248-value-persistence` | **Type**: internal record-of-functions boundary
+
+This contract describes the only externally-observable interface
+change introduced by this feature: the meaning of the `lookup` field
+on the `Trie m` record-of-functions.
+
+## Scope of this contract
+
+`Trie m` is an internal seam, not an HTTP/JSON contract. It is
+consumed by:
+
+- `Cardano.MPFS.HTTP.Server` (the fact-lookup handler)
+- `Cardano.MPFS.Indexer.Follower` (`applyRequestOp`,
+  `applyCageInverses`)
+- `Cardano.MPFS.TxBuilder.*` (speculative trie sessions for fee
+  estimation)
+- Unit tests in `test/Cardano/MPFS/`
+
+The HTTP wire shape (`FactResponse`'s JSON encoding, status codes,
+URL paths) is **not** changed by this work. See "HTTP wire shape" at
+the bottom of this file.
+
+## Interface
+
+```haskell
+data Trie m = Trie
+    { insert        :: ByteString -> ByteString -> m Root
+    , delete        :: ByteString -> m Root
+    , lookup        :: ByteString -> m (Maybe ByteString)
+    , getRoot       :: m Root
+    , getProof      :: ByteString -> m (Maybe Proof)
+    , getProofSteps :: ByteString -> m (Maybe [ProofStep])
+    }
+```
+
+The type signatures are unchanged. The change is in the meaning of
+`lookup`.
+
+## Semantic change
+
+### Before this feature
+
+```haskell
+lookup :: ByteString -> m (Maybe ByteString)
+-- For any key k:
+--   present in trie ⇒ Just (renderMPFHash (mkMPFHash k))
+--                     i.e. the hash of the *key*, not the value
+--   absent in trie  ⇒ Nothing
+```
+
+The pre-existing `lookup` returns 32 bytes of hash-of-key sentinel
+when the key exists. This is the bug postmortem #248 documents: a
+type-correct lie that satisfies `Maybe ByteString` and exists only
+because the MPF trie discards raw values at insert time.
+
+### After this feature
+
+```haskell
+lookup :: ByteString -> m (Maybe ByteString)
+-- For any key k:
+--   present in trie ⇒ Just v
+--                     where v is the exact bytes the requester
+--                     supplied as the `value` field of the most
+--                     recent Insert/Update request for k
+--   absent in trie  ⇒ Nothing
+```
+
+The new `lookup` returns the raw value bytes from the new
+`TrieRawValues` column family. Empty value (`BS.empty`) is a
+legitimate present result and is distinct from `Nothing`.
+
+## Behavioural requirements
+
+For all implementations of `Trie m` (transactional, persistent IO,
+speculative IO, pure in-memory):
+
+### LR-1 — Round-trip on insert
+
+```haskell
+trie.insert k v >> trie.lookup k = pure (Just v)
+```
+
+For all `k :: ByteString`, `v :: ByteString` (including
+`v = BS.empty`).
+
+### LR-2 — Round-trip on delete
+
+```haskell
+trie.insert k v >> trie.delete k >> trie.lookup k = pure Nothing
+```
+
+For all `k`, `v`.
+
+### LR-3 — Last-write-wins on update
+
+```haskell
+trie.insert k v1 >> trie.insert k v2 >> trie.lookup k = pure (Just v2)
+```
+
+Equivalently for an `Update` request operation (which `applyRequestOp`
+implements as `delete` then `insert`).
+
+### LR-4 — Independence across keys
+
+```haskell
+trie.insert k1 v1 >> trie.insert k2 v2 >> trie.lookup k1 = pure (Just v1)
+```
+
+For all distinct `k1`, `k2`. The token prefix in the storage layout
+guarantees this across tokens too.
+
+### LR-5 — Independence across tokens
+
+For tries `t_a` and `t_b` belonging to distinct `TokenId`s:
+
+```haskell
+t_a.insert k v1 >> t_b.insert k v2 >> t_a.lookup k = pure (Just v1)
+```
+
+The trie's prefix scoping (via `tokenHexPrefix` and `tokenPrefix`)
+guarantees this.
+
+### LR-6 — Atomicity with merkle root (transactional layer only)
+
+When `Trie m` is the transactional variant
+(`mkUnifiedTrie pfx`, used by the chain-follower's per-block
+transaction):
+
+```text
+After commit of a transaction containing trie.insert k v:
+  - getRoot returns the new merkle root incorporating k → hash(v)
+  - lookup k returns Just v
+  - both observations are simultaneous (no in-between window)
+```
+
+This is the storage-layer expression of FR-003 / INV-1. Mechanically
+guaranteed by both operations writing into the same RocksDB
+`Transaction`.
+
+## HTTP wire shape (unchanged)
+
+For reference, the fact-lookup endpoint that consumes this interface:
+
+- **Path:** `GET /tokens/:id/facts/:key`
+- **Response shape:** `FactResponse` envelope as defined in slice 3
+  (PR #246 / branch `243-proof-redesign`). This work changes which
+  bytes go into the `value` field, **not** the field's existence,
+  type, name, or JSON encoding.
+- **Status codes:** unchanged. 200 for present, 404 for absent.
+
+The wire-level acceptance test is in `e2e-test/Cardano/MPFS/E2E/
+ProofsSpec.hs` and asserts byte-equality between the inserted bytes
+and the bytes returned in the `value` field.
+
+## Implementation surface
+
+Each `Trie m` constructor must satisfy LR-1 through LR-6:
+
+| Constructor | Module | Backing store for raw values |
+|---|---|---|
+| `mkUnifiedTrie` | `Trie/Persistent.hs` | `TrieRawValues` CF inside the unified `Transaction` |
+| `mkPersistentTrie` | `Trie/Persistent.hs` | `TrieRawValues` CF via `mkPrefixedTrieDB` (4th CF arg) |
+| `mkSpeculativeTrie` | `Trie/Persistent.hs` | Same `TrieRawValues` CF, wrapped in `runSpeculation` |
+| `mkPureTrie` / `mkPureTrieFromRef` | `Trie/Pure.hs` | New sibling `IORef (Map ByteString ByteString)` |

--- a/specs/248-value-persistence/data-model.md
+++ b/specs/248-value-persistence/data-model.md
@@ -1,0 +1,193 @@
+# Phase 1 Data Model: Value persistence for the fact lookup endpoint
+
+**Branch**: `248-value-persistence` | **Plan**: [plan.md](./plan.md)
+| **Spec**: [spec.md](./spec.md) | **Research**: [research.md](./research.md)
+
+## Entities
+
+### `RawFactValue` (storage-level)
+
+The bytes a requester originally supplied as the `value` of an
+Insert or Update request, scoped to a single `(token, key)` pair.
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| token | `TokenId` | request datum's `requestToken` | Namespace key |
+| key | `ByteString` | request datum's `requestKey` (raw) | The exact bytes the requester sent — no normalisation |
+| value | `ByteString` | request datum's `requestValue` payload | The exact bytes the requester sent — no normalisation, no re-encoding |
+
+This entity is not a domain object exposed via Haskell types. It is
+the abstract content of the new RocksDB column family `TrieRawValues`,
+described below.
+
+## Storage layout
+
+### New RocksDB column family: `TrieRawValues`
+
+| Property | Value |
+|---|---|
+| Name (in `cageColumnFamilies`) | `"trie-raw-values"` |
+| Position in `allColumnFamilies` | 7th cage CF (after `trie-meta`), 13th overall (before `composed-rollbacks`) |
+| GADT constructor | `TrieRawValues :: AllColumns (KV ByteString ByteString)` |
+| Key codec | `identityPrism :: Prism' ByteString ByteString` (passthrough) |
+| Value codec | `identityPrism :: Prism' ByteString ByteString` (passthrough) |
+| Key shape | `tokenPrefix tid <> requestKey` (concatenation, no separator) |
+| Value shape | The raw value bytes the requester supplied |
+
+`tokenPrefix tid` is the existing length-prefixed encoding from
+`Cardano.MPFS.Trie.Persistent`:
+
+```haskell
+tokenPrefix :: TokenId -> ByteString
+tokenPrefix (TokenId (AssetName sbs)) =
+    let raw = SBS.fromShort sbs
+        len = BS.length raw
+    in  BS.singleton (fromIntegral len) <> raw
+```
+
+The 1-byte length prefix gives a parseable boundary between the token
+namespace and the user-supplied key suffix, so prefix iteration over
+a token's raw values is deterministic.
+
+### Existing column families (unchanged)
+
+| CF name | GADT | Purpose | This feature's relationship |
+|---|---|---|---|
+| `trie-nodes` | `TrieNodes` | MPF node store (`KV HexKey (HexIndirect MPFHash)`) | Untouched. Merkle layer continues to retain only the value-hash. |
+| `trie-kv` | `TrieKV` | MPF leaf hashes (`KV HexKey MPFHash`) | Untouched. Mirror of value-hashes the merkle layer queries. |
+| `trie-meta` | `TrieMeta` | Per-token visibility (`KV TokenId TrieStatus`) | Untouched. Visibility check still gates `withTrie`. |
+
+### CF ordering invariant
+
+```text
+allColumnFamilies =
+    utxoColumnFamilies                  -- 6 CFs (UTxO/CSMT, including journal & runner rollbacks)
+        <> cageColumnFamilies            -- 7 CFs (was 6, +1 for TrieRawValues)
+        <> [("composed-rollbacks", _)]   -- 1 CF (chain-follower)
+                                         -- = 14 total (was 13)
+```
+
+The destructuring sites in `Cardano.MPFS.Application` and any test
+that opens a cage-only DB pattern-match positionally on this list;
+they all extend by one slot.
+
+## Lifecycle / state transitions
+
+### Per `(token, key)` pair
+
+```text
+                                  ┌───────────────────────────────┐
+                                  │     [absent in storage]       │
+                                  └───────────┬───────────────────┘
+                                              │
+              ┌───────────────────────────────┤
+              │ Insert (k, v) processed       │
+              ▼                               │
+   ┌────────────────────┐                     │
+   │  raw value = v     │◀───────────────┐    │
+   │  in TrieRawValues  │                │    │
+   └─────┬──────────────┘                │    │
+         │                               │    │
+         │ Update (k, v')                │    │
+         ▼                               │    │
+   ┌────────────────────┐                │    │
+   │  raw value = v'    │                │    │
+   │  in TrieRawValues  │                │    │
+   └─────┬──────────────┘                │    │
+         │                               │    │
+         │ Delete k                      │    │
+         ▼                               │    │
+              ┌───────────────────────────────┤
+              │ Rollback of any of the above  │
+              │  → restored to immediately    │
+              │    prior state                │
+              └───────────────────────────────┘
+```
+
+Transitions are produced by the chain-follower's `applyRequestOp`
+inside the same `Transaction m cf AllColumns ops` that mutates
+`TrieNodes` / `TrieKV`. Rollback is produced by the existing
+`applyCageInverses` replaying through the same `Trie.insert` /
+`Trie.delete` interface.
+
+### Sequencing rule
+
+For a single block containing operations `op1, op2, ...` against the
+same `(token, key)`, the final state of `TrieRawValues` after the
+block commits is the state after the last operation:
+
+| Within a block | Final raw value state |
+|---|---|
+| Insert v | present, v |
+| Insert v then Delete | absent |
+| Insert v then Update v' | present, v' |
+| Insert v then Delete then Insert v'' | present, v'' |
+
+This matches the spec Edge Case "Insert then delete in the same
+block": after the block commits, the lookup returns absent.
+
+## Invariants
+
+### INV-1 — Atomicity with merkle state
+
+For every committed block N and every `(token, key)`:
+
+```text
+(present in TrieRawValues at block N) ⇔ (present in TrieKV at block N)
+```
+
+Mechanically enforced by routing every raw-value mutation through
+the same `Transaction` as the corresponding `TrieKV` / `TrieNodes`
+mutation. Violation would be visible to clients as one of:
+
+- Lookup returns absent for a key whose merkle proof is present.
+- Lookup returns present bytes for a key whose merkle proof is absent.
+
+INV-1 is the storage-layer expression of FR-003.
+
+### INV-2 — Rollback equivalence
+
+For any block sequence ending in a rollback to chain tip T:
+
+```text
+∀ (token, key). lookup_after_rollback(token, key)
+            ≡ lookup_at_tip_T_in_alternate_world(token, key)
+```
+
+where the "alternate world" is the storage state in which the
+rolled-back blocks had never been observed. INV-2 is the storage-layer
+expression of FR-004.
+
+INV-2 holds inductively: each `applyCageInverses` call replays the
+inverse op via `Trie.insert` / `Trie.delete`, which write to both the
+merkle columns and `TrieRawValues` atomically; therefore the state
+after rollback matches the state at tip T.
+
+### INV-3 — Codec passthrough
+
+The key and value codecs for `TrieRawValues` are
+`prism' id Just`. No CBOR wrapping, no length prefix on the value, no
+escape encoding. The bytes the requester supplied land in RocksDB
+verbatim, and `Trie.lookup` returns them verbatim.
+
+INV-3 is the storage-layer expression of the spec's "no re-encoding,
+no normalisation" assumption.
+
+## Non-entities (out of scope here)
+
+- **Migration from pre-#248 databases.** Per spec Clarification
+  2026-04-30, existing devnet/preprod databases are wiped and
+  re-synced. No on-disk schema-version field, no detection logic, no
+  guided migration step.
+
+- **`Request` / `Operation` / `LocatedTokenState`.** These are
+  unchanged. The on-chain wire format is unchanged. The `requestKey`
+  / `requestValue` fields are already raw `ByteString` in
+  `Cardano.MPFS.Core.Types`; the codec in `requestPrism` already
+  carries them through verbatim (Codecs.hs:269).
+
+- **`CageInverseOp`.** The `InvTrieInsert` / `InvTrieDelete`
+  constructors and their CBOR encoding are unchanged. See research.md
+  §1.
+
+- **`FactResponse` / HTTP wire shape.** Unchanged. See contracts/.

--- a/specs/248-value-persistence/plan.md
+++ b/specs/248-value-persistence/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Value persistence for the fact lookup endpoint
+
+**Branch**: `248-value-persistence` | **Date**: 2026-05-01 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/248-value-persistence/spec.md`
+
+## Summary
+
+`GET /tokens/:id/facts/:key` must return the bytes the requester originally inserted in its `value` field, instead of `mkMPFHash key`. The fix persists raw value bytes in a new RocksDB column family that lives alongside the existing trie state, written and rolled back inside the chain-follower's existing atomic-block + inverse-op machinery so the new state stays in lockstep with the merkle tree. The HTTP read path keeps its single `Trie.lookup` interface, with the new column threaded through the existing trie manager.
+
+## Technical Context
+
+**Language/Version**: Haskell GHC 9.10.1 (existing toolchain)
+**Primary Dependencies**: `cardano-ledger-*` (domain types), `chain-follower` (block stream + rollback), `rocksdb-kv-transactions` (atomic batch writes), `mts:mpf` (per-token MPF trie), `mts:csmt` (UTxO CSMT — orthogonal to this feature but shares the same RocksDB), `Cardano.MPFS.Indexer.Event` (`InvTrieInsert`/`InvTrieDelete` inverse-op machinery)
+**Storage**: RocksDB column families. Existing trie-related families: `TrieNodes` (`KV HexKey (HexIndirect MPFHash)`), `TrieKV` (`KV HexKey MPFHash`, the value-hash mirror the merkle layer queries), `TrieMeta` (token visibility registry). This feature adds a fourth family for raw values.
+**Testing**: hspec unit suite (`just unit`), devnet-subprocess e2e (`just e2e`) per Principle VI. The e2e fixture already inserts known `(key, value)` pairs through the request → process flow; the byte-equality assertion plugs into that.
+**Target Platform**: Linux server (offchain). Verifier code paths (cardano-mpfs-client) untouched by this work, so GHC-WASM / GHC-JS cross-target obligations are not exercised here.
+**Project Type**: web-service backend, single project (the existing `cardano-mpfs-offchain` library + `mpfs-serve` executable + e2e devnet harness).
+**Performance Goals**: correctness, not throughput. No SLA on lookup latency; large-value performance does not need to match small-value performance per spec Edge Cases. Block-processing throughput must not regress meaningfully — the new write is one extra `KV.insert`/`KV.delete` inside the existing batch.
+**Constraints**: Principle III (atomic block processing) is the load-bearing one. Every mutation introduced by this feature must land in the same RocksDB write batch as the corresponding trie mutation, or the rollback story collapses.
+**Scale/Scope**: existing devnet/preprod scale. Storage growth is bounded by the on-chain protocol's accepted request value sizes; no new growth model.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Applies? | Compliance |
+|---|---|---|
+| I. Ledger-Native Types | Neutral | This feature lives in the storage layer; no domain-type changes. |
+| II. Records of Functions | Yes | `Trie m` is already a record-of-functions and stays that way. The `lookup` field's semantics change (returns raw value, not the bug-compatible sentinel) but the boundary shape is unchanged. No new typeclass introduced. |
+| III. Atomic Block Processing | Yes — load-bearing | FR-003 / FR-004 explicitly reuse the existing atomic-block + inverse-op machinery. Every raw-value mutation rides inside the same `Transaction` the chain-follower already opens for the block. The existing `InvTrieInsert` / `InvTrieDelete` carriers stay byte-shape-identical: they already pass raw value bytes, and rollback already replays through `Trie.insert` / `Trie.delete` — once those mirror to the new column, restoration is automatic. See research.md §1. |
+| IV. External Signing | Neutral | No tx-building or signing changes. |
+| V. Aiken Compatibility | Neutral | Trie hashing, proof encoding, and datum construction are unchanged. The merkle tree continues to store the value-hash exactly as it does today; the new column is purely an offchain mirror. |
+| VI. Test Locally First | Yes | The byte-equality e2e test (FR-005 / SC-001) runs against the existing devnet-subprocess harness. No CI-only checks. Unit-level coverage of the inverse-op machinery exists today; we extend it rather than introduce a new test runner. |
+| VII. Nix Reproducibility | Neutral | Standard `nix develop` + `just ci` flow. |
+| VIII. Pure Offline Verification | Neutral, with downstream effect | This feature does not touch the verifier. It does fix a bug that made the verifier reject honest responses (the lookup returning the wrong bytes blocked `verifyFactPresentResponse` in slice 3). The verifier stays pure; the input it receives stops lying. |
+| IX. One Verifier, Many Targets | Neutral | No verifier code edited; cross-target matrix obligations unchanged. |
+| X. Lean as Source of Truth | Neutral | The Lean model in `lean/Phase4` deliberately covers verifier state machines (the trust-replay envelope), not server-side storage. The Haskell predicates relevant to this fix (`replayFactPresent_*` in slice 3) stay valid because the wire shape they describe is unchanged; this work makes the server's `value` field finally match what those predicates always assumed. No Lean amendments required. |
+
+**Result**: PASS. No principle violated, no Complexity Tracking entries needed.
+
+**Post-design re-check (after Phase 1)**: PASS, unchanged. The Phase 0
+research reduced the planned blast radius by demonstrating that
+`InvTrieInsert` / `InvTrieDelete` carriers do not need extension
+(research.md §1) — the existing wire format and rollback decoder stay
+byte-shape-identical, which strengthens compliance with Principle III.
+Phase 1 contracts (`contracts/trie-lookup.md`) document the only
+boundary change: the meaning of `Trie.lookup`'s return value, with the
+record-of-functions shape itself unchanged (Principle II preserved).
+No new dependencies, no new typeclasses, no verifier-side changes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/248-value-persistence/
+├── plan.md              # This file (/speckit.plan output)
+├── spec.md              # Feature spec (/speckit.specify + /speckit.clarify output)
+├── research.md          # Phase 0 output — inverse-op extension, read-path bridge wiring
+├── data-model.md        # Phase 1 output — TrieRawValues column + key derivation
+├── contracts/           # Phase 1 output — Trie.lookup semantic change, HTTP wire shape unchanged
+├── quickstart.md        # Phase 1 output — developer/operator quickstart
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+
+checklists/
+└── requirements.md      # Spec quality checklist (/speckit.specify output)
+```
+
+### Source Code (repository root)
+
+```text
+cardano-mpfs-offchain/
+├── lib/
+│   └── Cardano/
+│       └── MPFS/
+│           ├── Indexer/
+│           │   ├── Columns.hs       # ADD: TrieRawValues constructor on AllColumns
+│           │   ├── Codecs.hs        # ADD: identity prism for the new column (raw passthrough)
+│           │   └── Event.hs         # UNCHANGED: InvTrieInsert/Delete carriers already pass raw bytes; semantics are corrected upstream by Trie.lookup returning the real value
+│           ├── Trie.hs              # MODIFY: lookup semantics — returns the raw value, not Just (hashBS k)
+│           ├── Trie/
+│           │   ├── Persistent.hs    # MODIFY: unifiedInsert/Delete/Lookup + persistent/speculative variants mirror to the new column; mkPersistentTrieManager / withPersistentTrieManager grow a 4th CF parameter
+│           │   └── Pure.hs          # MODIFY: in-memory pure implementation returns the inserted raw bytes from lookup (mirror via separate IORef map)
+│           └── Application.hs       # MODIFY: cageColumnFamilies grows by one entry; CF index pattern updated
+├── e2e-test/
+│   └── Cardano/MPFS/E2E/
+│       └── ProofsSpec.hs            # MODIFY: replace assertFactEnvelope's "non-empty hex" check with byte-equality on the inserted value
+└── test/
+    └── Cardano/MPFS/Indexer/
+        └── RollbackSpec.hs          # ADD/MODIFY: rollback fixture covers Insert/Update/Delete × single-block / multi-block reorgs leaving raw values byte-identical to the rolled-back tip's view
+```
+
+**Structure Decision**: single Haskell project, modifying the existing `cardano-mpfs-offchain` library plus its e2e test suite. No new packages. The fact endpoint's wire shape is unchanged so `cardano-mpfs-api` and `cardano-mpfs-client` are untouched.
+
+## Complexity Tracking
+
+> Constitution Check passed with no violations; this section intentionally empty.

--- a/specs/248-value-persistence/quickstart.md
+++ b/specs/248-value-persistence/quickstart.md
@@ -1,0 +1,152 @@
+# Quickstart: Value persistence for the fact lookup endpoint
+
+**Branch**: `248-value-persistence` | **Plan**: [plan.md](./plan.md)
+| **Spec**: [spec.md](./spec.md) | **Data Model**: [data-model.md](./data-model.md)
+
+This document is the developer/operator on-ramp for the value
+persistence work. It does **not** repeat content from spec, plan, or
+research — those are linked above. It tells you what to do once the
+work has landed.
+
+## What changed for users of the offchain
+
+`GET /tokens/:id/facts/:key` now returns the bytes the requester
+originally inserted in the response's `value` field. Previously it
+returned `mkMPFHash key` (a hash of the *key*) — see postmortem #248.
+
+The HTTP wire shape (`FactResponse` envelope, JSON encoding, status
+codes) is **unchanged**. Existing clients that did not depend on the
+broken `value` field semantics keep working. Clients that took the
+broken value at face value now get correct bytes — which may be a
+breaking change in the sense that "garbage you trusted" becomes
+"truth that doesn't match the garbage you persisted."
+
+## What changed for operators
+
+### Database
+
+The RocksDB schema gains one column family: `trie-raw-values`. It is
+appended to the cage CF list, so it is the 7th cage CF and the 13th
+overall (before `composed-rollbacks`).
+
+**No migration is provided.** Existing devnet/preprod databases must
+be wiped and resynced as part of normal upgrade hygiene (per spec
+Clarification 2026-04-30). Concretely:
+
+```bash
+# Stop the offchain
+just stop                    # or systemctl stop, etc.
+
+# Wipe the database directory
+rm -rf path/to/rocksdb/dir
+
+# Restart — the offchain will sync from genesis (or your configured
+# starting point) and populate trie-raw-values as it processes blocks.
+just run                     # or systemctl start, etc.
+```
+
+A pre-#248 database opened by post-#248 code will fail at CF-open
+time because the new CF doesn't exist on disk; the error will name
+`trie-raw-values`. That is the intended detection — not a guided
+migration step, just a clear failure mode.
+
+### Disk usage
+
+Storage growth is bounded by the size of values the on-chain
+protocol accepts in request datums. There is no new growth model
+beyond what already exists for processed requests.
+
+## What changed for developers
+
+### Reading raw values from code
+
+Use the existing `Trie.lookup` interface — its semantics are now
+correct. Example:
+
+```haskell
+withTrie trieMgr tokenId $ \trie -> do
+    mValue <- lookup trie key
+    case mValue of
+        Just v  -> -- v is the exact bytes the requester supplied
+                   handlePresent v
+        Nothing -> -- key was never inserted, or was deleted
+                   handleAbsent
+```
+
+There is no sibling primitive on `Context` for raw value lookup. If
+you find yourself wanting one, re-read the §2 of research.md — the
+single read seam is intentional.
+
+### Reading raw values from a checked-out RocksDB
+
+The `mpfs-inspect-db` executable should be able to dump the new
+column. Composite key shape: `tokenPrefix tid <> requestKey`, where
+`tokenPrefix` is `BS.singleton (length asset_name) <> asset_name`.
+Strip the first byte and the next `length` bytes from any key in
+`trie-raw-values` to recover the requester-supplied key bytes.
+
+### Adding a new `Trie m` implementation
+
+Any new `Trie m` constructor must satisfy LR-1 through LR-6 in
+`contracts/trie-lookup.md`. The simplest way to verify is to plug
+the new constructor into `Cardano.MPFS.TrieSpec` and re-run the unit
+suite — the round-trip cases there exercise all six requirements.
+
+## How to verify the fix locally
+
+### E2E — the byte-equality acceptance test
+
+The fact-lookup E2E in `e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs`
+inserts a known `(key, value)` pair through the live request →
+process flow and asserts byte-equality on the response's `value`
+field.
+
+```bash
+just e2e
+```
+
+A passing run is the primary acceptance signal for SC-001.
+
+### Unit — rollback fixtures
+
+The rollback unit suite covers Insert / Update / Delete under
+single-block and multi-block reorgs (SC-002):
+
+```bash
+just unit
+# or, scoped:
+cabal test unit-tests --test-options="--match \"RollbackSpec\""
+```
+
+### Inspecting state after a sync
+
+After running the offchain against a known fixture, you can confirm
+the new column is populated using `mpfs-inspect-db` (already shipped):
+
+```bash
+cabal run mpfs-inspect-db -- /path/to/db
+```
+
+Expect to see entries under `trie-raw-values` for every `(token, key)`
+present in the corresponding token's MPF trie.
+
+## What does NOT need verification
+
+- The HTTP wire shape — there are no schema changes, so swagger /
+  contract tests pass without intervention.
+- The merkle proof construction — the `TrieNodes` / `TrieKV` columns
+  are byte-identical to before. Existing proof-replay tests
+  (`Cardano.MPFS.ProofSpec`, `Cardano.MPFS.E2E.ProofsSpec`'s
+  proof-cryptography assertions) keep passing.
+- Verifier code paths in `cardano-mpfs-client` — untouched. No
+  GHC-WASM / GHC-JS rebuild needed for this work.
+
+## Where this fix unblocks downstream work
+
+The slice 3 work in PR #246 (branch `243-proof-redesign`) was
+blocked because `verifyFactPresentResponse` rejected honest oracle
+responses — the `value` field carried `mkMPFHash key` which did not
+match the value-hash on the merkle proof path. Once #248 merges and
+slice 3 rebases on top, the verifier sees correct bytes and passes
+the cryptographic round-trip end-to-end. Issue #247 tracks closing
+that loop.

--- a/specs/248-value-persistence/research.md
+++ b/specs/248-value-persistence/research.md
@@ -1,0 +1,244 @@
+# Phase 0 Research: Value persistence for the fact lookup endpoint
+
+**Branch**: `248-value-persistence` | **Plan**: [plan.md](./plan.md) | **Spec**: [spec.md](./spec.md)
+
+This document resolves the technical unknowns flagged in the Technical
+Context section of the plan. Each section below pairs a question with
+the chosen path, the reasoning, and the alternatives considered.
+
+## §1 — Inverse-op carrier extension
+
+**Question.** Do the `InvTrieInsert` / `InvTrieDelete` carriers in
+`Cardano.MPFS.Indexer.Event` need to grow a field for the prior raw
+value, so rollback can restore it?
+
+**Decision.** **No carrier changes.** The carriers already pass raw
+value bytes (`InvTrieInsert !TokenId !ByteString !ByteString`); their
+on-disk CBOR shape stays identical. The fix is purely in `Trie.lookup`
+semantics and in `Trie.insert` / `Trie.delete` mirroring writes to the
+new column.
+
+**Rationale.** Tracing the existing flow in
+`Cardano.MPFS.Indexer.Follower.applyRequestOp` (Follower.hs:391):
+
+```haskell
+Insert v -> do
+    oldVal <- trieLookup requestKey
+    void $ trieInsert requestKey v
+    pure $ case oldVal of
+        Nothing  -> [InvTrieDelete tid requestKey]
+        Just old -> [InvTrieInsert tid requestKey old]
+```
+
+The carrier already holds whatever `trieLookup` returned. Today that
+return is `Just (hashBS k)` (Trie/Persistent.hs:234), so the rollback
+is byte-compatible-but-meaningless. Once `trieLookup` returns the real
+prior value bytes from the new `TrieRawValues` column, `old` becomes
+the actual prior value, and `applyCageInverses` (Follower.hs:493) —
+which already replays via `withTrie tm tid $ \trie -> insert trie key
+val` — restores both the merkle layer and the raw-value mirror in one
+call, because the underlying `insert` writes to both columns.
+
+This is the smallest intervention that satisfies FR-004: it leaves the
+existing rollback carrier wire format and decoder untouched, which is
+important because rollback points are persisted on disk.
+
+**Alternatives considered.**
+
+- **Carrier extension (`InvTrieInsert tid k oldHash oldRawValue`).**
+  Rejected. Forces a CBOR tag bump in `encodeInvOp` /
+  `decodeInvOp` (Codecs.hs:562), breaks any in-flight rollback points
+  in existing devnet databases (we wipe-and-resync per spec
+  Clarification 2026-04-30, but compounds the disruption),
+  and duplicates information already implied by the trie state.
+
+- **Two-step rollback (replay old root, then re-derive raw value).**
+  Rejected. There's no inverse map from value-hash to raw bytes; the
+  whole point of this work is that the raw value was discarded.
+
+## §2 — Read-path bridge wiring
+
+**Question.** How does the HTTP fact-lookup handler reach the new
+raw-value storage, given that the existing `Trie.lookup` is the only
+read interface and `mkPersistentTrieManager` (used by the HTTP path)
+is wired to its own RocksDB column-family handles?
+
+**Decision.** **Thread one extra `ColumnFamily` argument through
+`mkPersistentTrieManager` / `withPersistentTrieManager` and through
+`mkPrefixedTrieDB`.** `Trie.lookup` (and its IO/speculative variants)
+queries the new column; the HTTP handler reads through the same
+`Trie.lookup` it already uses. No new sibling primitive on `Context`,
+no parallel read path. (Confirmed by spec Clarification 2026-05-01.)
+
+**Rationale.** The HTTP handler's call site is
+`withTrie trieMgr tid $ \trie -> lookup trie key`. Every variant of
+`Trie` (transactional `mkUnifiedTrie`, IO `mkPersistentTrie`,
+speculative `mkSpeculativeTrie`, pure `mkPureTrieFromRef`) already has
+a `lookup` field. Changing the field's implementation in each variant
+to query the raw-value store is a focused, type-checked change. The
+chain-follower path uses `mkUnifiedTrieManager` over `AllColumns`, so
+the `TrieRawValues` selector reaches it for free once added to the
+GADT.
+
+`withPersistentTrieManager` currently opens 3 CFs (`nodes`, `kv`,
+`meta`) and pattern-matches `case columnFamilies of [nodesCF, kvCF,
+metaCF] -> ...` (Trie/Persistent.hs:456). It grows by one entry to
+`[nodesCF, kvCF, metaCF, rawValuesCF]`. `mkPersistentTrieManager`'s
+arity grows by one `ColumnFamily` parameter and threads it through
+each persistent helper.
+
+**Alternatives considered.**
+
+- **Sibling primitive on `Context`** (e.g.
+  `lookupRawValue :: TokenId -> ByteString -> IO (Maybe ByteString)`).
+  Rejected by spec clarification — splits the read interface, requires
+  every consumer (HTTP handler, future verifier wiring, CLI inspect
+  tool) to pick the right primitive, and decouples the raw-value
+  storage from the trie's visibility/hidden checks.
+
+- **Encode the raw value into the existing `TrieKV` value column**
+  (e.g. CBOR-pack `(MPFHash, ByteString)`).
+  Rejected. The MPF library reads `TrieKV` directly via its own codec
+  (`mpfHashCodecs`); changing the value shape breaks the merkle layer
+  or forces an MPF library change. Keeping a separate column also
+  isolates the raw-value bytes from MPF iteration logic.
+
+## §3 — Key derivation in `TrieRawValues`
+
+**Question.** What's the on-disk key shape for the new column? The
+existing trie columns use `HexKey` (nibble-split MPF paths); does
+`TrieRawValues` need to match?
+
+**Decision.** **Composite raw-byte key
+`tokenPrefix tid <> requestKey`**, where `tokenPrefix` is the existing
+length-prefixed token serialization
+(`BS.singleton (length raw) <> raw`, Trie/Persistent.hs:151). Value:
+the raw value bytes as the requester supplied them. Codecs are
+identity prisms (no CBOR wrapping).
+
+**Rationale.** The new column is a flat KV store, not a trie. There's
+no merkle structure to maintain over it, no proofs derived from it,
+no iteration order requirement. The token prefix gives us the same
+namespace isolation the MPF columns already get; reusing `tokenPrefix`
+(not `tokenHexPrefix`) keeps the key space dense and avoids the 2×
+expansion of nibble encoding.
+
+The request key is used directly. The MPF layer hashes keys for path
+construction (`byteStringToHexKey (hashBS k)`) so that the merkle tree
+is balanced; the raw-value column has no such constraint, so no
+hashing is applied — the request key bytes go in verbatim. This means
+a future operator inspecting RocksDB can grep raw keys directly.
+
+**Alternatives considered.**
+
+- **Hash the key to match the MPF column's key derivation** (i.e.
+  `tokenPrefix tid <> hashBS requestKey`).
+  Rejected. Adds work without benefit — the raw-value column is never
+  joined to the MPF nodes column at the storage layer, so the key
+  shapes don't need to align. Keeping raw keys also makes
+  `mpfs-inspect-db` output human-readable.
+
+- **Per-token sub-database / separate CF per token.**
+  Rejected. Existing trie columns are single shared CFs with prefix
+  isolation; this work follows the established pattern. Per-token CFs
+  would also force schema migration on every mint.
+
+## §4 — Pure implementation parity
+
+**Question.** Where does `Cardano.MPFS.Trie.Pure` keep the raw value
+bytes, given it's an in-memory `IORef` over `MPFInMemoryDB`?
+
+**Decision.** **Add a sibling `IORef (Map ByteString ByteString)` for
+raw values**, threaded into `mkPureTrieFromRef` alongside the existing
+MPF database ref. `pureLookup` reads from this map; `pureInsert` /
+`pureDelete` mutate it.
+
+**Rationale.** `MPFInMemoryDB` is owned by the `mts:mpf` library and
+its shape is fixed. Wedging raw values inside it would require an
+upstream library change — out of scope. A sibling IORef is the
+simplest, locally-owned mirror that keeps `Trie IO` honest in unit
+tests (`TrieSpec`, `TrieManagerSpec`) and in any test that uses
+`mkPureTrie` as a stand-in for the persistent backend.
+
+The pair (`MPF database ref`, `raw-value map ref`) gets passed
+together by the trie manager (`PureManager`) so the two stay in
+lockstep within a single `Trie`.
+
+**Alternatives considered.**
+
+- **Skip the pure backend update; only fix the persistent backend.**
+  Rejected. Unit tests rely on the pure backend matching persistent
+  semantics; diverging them re-introduces the same class of bug
+  this work fixes (test theatre that only checks structural shape).
+
+## §5 — Test surface
+
+**Question.** Where do the new tests live and what do they cover?
+
+**Decision.** Three test surfaces:
+
+1. **E2E (`e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs`).** The existing
+   fixture inserts known `(key, value)` pairs through the live
+   request → process flow. Replace `assertFactEnvelope`'s
+   `not . T.null` check with a byte-equality assertion against the
+   inserted value (FR-005 / SC-001 / SC-003).
+
+2. **Unit rollback fixtures (`test/Cardano/MPFS/Indexer/RollbackSpec.hs`).**
+   Cover Insert / Update / Delete under single-block and multi-block
+   reorgs. Each scenario asserts that `Trie.lookup` after rollback
+   returns byte-identical results to the lookup that would have run
+   at the rolled-back tip (SC-002).
+
+3. **Trie unit suite (`test/Cardano/MPFS/Trie/PersistentSpec.hs`,
+   `Cardano.MPFS.TrieSpec`, `Cardano.MPFS.TrieManagerSpec`).** Add
+   round-trip cases: insert raw value → lookup returns the same bytes
+   (including empty `BS.empty` and a moderately large blob to
+   exercise the size axis from spec Edge Cases).
+
+The pre-existing `assertFactEnvelope` helper is removed entirely
+(SC-003); its only callers are in `ProofsSpec.hs`.
+
+**Rationale.** Three layers, three failure modes:
+
+- E2E catches "the bug we shipped" (postmortem #248) by exercising
+  the wire-level contract.
+- Rollback unit tests catch "we broke the atomicity invariant" by
+  driving the inverse-op machinery directly without the chain-sync
+  setup.
+- Trie unit tests catch "we broke the storage layer" without the
+  follower or HTTP layers in the loop.
+
+**Alternatives considered.**
+
+- **E2E only.** Rejected. E2E doesn't exercise rollback paths
+  end-to-end (no devnet reorg fixture); SC-002 needs unit-level
+  reorg drivers.
+
+## §6 — `cageColumnFamilies` ordering
+
+**Question.** Where in the existing 6-CF cage list does the new
+column go, and does ordering matter?
+
+**Decision.** Append `("trie-raw-values", dbConfig)` as the 7th
+entry, after `trie-meta`. The corresponding GADT constructor
+`TrieRawValues` goes last in `AllColumns`, after `TrieMeta`.
+
+**Rationale.** RocksDB CF ordering must match between
+`allColumnFamilies` (Application.hs:256) and the destructuring sites
+(Application.hs and the test fixtures). Appending preserves the
+existing positional unpacking for the 6 prior columns; the new
+position consumes the new last slot. The `GEq` / `GCompare` instances
+extend with the standard lexicographic-by-constructor pattern.
+
+`UnifiedColumns` doesn't need changes — it's parametric over
+`AllColumns x`, so the new constructor reaches it for free via
+`InCage`. `allUnifiedCodecs` similarly inherits the new entry from
+`allCodecs` via `DMap.mapKeysMonotonic InCage allCodecs`.
+
+**Alternatives considered.**
+
+- **Insert between `TrieKV` and `TrieMeta`** (so all "trie data"
+  columns are contiguous before "trie metadata").
+  Rejected. Forces re-pinning of every positional unpack site and
+  the on-disk CF order. Append is the boring choice with the
+  smallest blast radius.

--- a/specs/248-value-persistence/spec.md
+++ b/specs/248-value-persistence/spec.md
@@ -3,7 +3,17 @@
 **Feature Branch**: `248-value-persistence`
 **Created**: 2026-04-30
 **Status**: Draft
-**Input**: User description: "248 — `GET /tokens/:id/facts/:key` returns the wrong byte string in its `value` field. Today the endpoint returns `mkMPFHash key` (a hash of the request's key) in the `value` field of `FactResponse`, instead of the bytes the requester originally inserted. Root cause: the per-token MPF trie is content-addressed and stores only the value-hash; the raw value is discarded at insert time, and the lookup helper was wired to return any 32 bytes that satisfied the type signature. The endpoint's e2e test only asserts \"non-empty hex\" on `value` and so missed it for the endpoint's entire life (postmortem: lambdasistemi/cardano-mpfs-offchain#248). Scope: make the endpoint return the actual inserted bytes. Persist raw value bytes inside the offchain so lookup can recover them. The chain-follower's \"one block = one DB transaction\" invariant must still hold; rollbacks must restore prior raw-value state via the existing inverse-op machinery (`InvTrieInsert`/`InvTrieDelete` in `Cardano.MPFS.Indexer.Event`). Migration story for existing devnet/preprod databases included. Acceptance: the e2e for the endpoint inserts a (key, value) pair and asserts the GET response's `value` field equals the inserted bytes byte-for-byte."
+**Input**: User description: "248 — `GET /tokens/:id/facts/:key` returns the wrong byte string in its `value` field. Today the endpoint returns `mkMPFHash key` (a hash of the request's key) in the `value` field of `FactResponse`, instead of the bytes the requester originally inserted. Root cause: the per-token MPF trie is content-addressed and stores only the value-hash; the raw value is discarded at insert time, and the lookup helper was wired to return any 32 bytes that satisfied the type signature. The endpoint's e2e test only asserts \"non-empty hex\" on `value` and so missed it for the endpoint's entire life (postmortem: lambdasistemi/cardano-mpfs-offchain#248). Scope: make the endpoint return the actual inserted bytes. Persist raw value bytes inside the offchain so lookup can recover them. The chain-follower's \"one block = one DB transaction\" invariant must still hold; rollbacks must restore prior raw-value state via the existing inverse-op machinery (`InvTrieInsert`/`InvTrieDelete` in `Cardano.MPFS.Indexer.Event`). Acceptance: the e2e for the endpoint inserts a (key, value) pair and asserts the GET response's `value` field equals the inserted bytes byte-for-byte."
+
+## Clarifications
+
+### Session 2026-04-30
+
+- Q: How does the offchain handle a pre-change database directory at startup? → A: No migration concerns; existing deployments are wiped and resynced as part of normal upgrade hygiene, no explicit detection or guided migration step is required.
+
+### Session 2026-05-01
+
+- Q: How does the HTTP fact-lookup handler reach the new raw-value storage? → A: `Trie.lookup` stays the single read interface for both transactional and IO consumers; the new column is threaded through the existing trie manager so `Trie.lookup` returns the actual value bytes. No sibling primitive on `Context`.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -39,21 +49,6 @@ The chain-follower processes blocks atomically: every mutation a block produces 
 
 ---
 
-### User Story 3 - Existing operators have a migration path (Priority: P2)
-
-Operators running this offchain on devnets, preprod, or any other deployment have an existing database on disk built before this change. The release notes for the version that ships value persistence document, in plain language, what those operators need to do when upgrading.
-
-**Why this priority**: Real deployments exist (devnet stack, preprod indexer reachable at `umpfs.plutimus.com`). Shipping a storage-shape change without operator-facing instructions creates an outage even if the code is correct. Lower priority than the fix and the rollback story because the technical risk is contained — failed startup is loud and recoverable — but it's still required for the feature to be operationally correct.
-
-**Independent Test**: take a database snapshot from a deployment running the pre-change version, attempt to start the new version against it, and verify that the documented migration procedure (whatever it is) is sufficient to bring the deployment up to a state where User Story 1 passes.
-
-**Acceptance Scenarios**:
-
-1. **Given** a database directory produced by a pre-change version of the offchain, **When** an operator follows the documented upgrade procedure, **Then** the new version starts successfully and `GET /tokens/:id/facts/:key` returns correct values for every fact inserted after the upgrade completes.
-2. **Given** a database directory produced by a pre-change version, **When** an operator runs the new version without following the documented procedure, **Then** the offchain refuses to start with an error message that points the operator at the migration documentation. (Failure is loud; never silent corruption.)
-
----
-
 ### Edge Cases
 
 - **Empty value insert.** A requester inserts `(k, "")` (zero-byte value). The lookup returns a present response with `value = ""`. Empty is a legitimate value, distinct from "key absent."
@@ -70,14 +65,11 @@ Operators running this offchain on devnets, preprod, or any other deployment hav
 - **FR-002**: When a request that deletes a key is observed and processed, the offchain MUST remove the previously persisted raw value for that key from storage. A subsequent fact lookup MUST report the key as absent.
 - **FR-003**: Every storage mutation introduced by FR-001 and FR-002 MUST happen within the same atomic write boundary as the existing trie-node and KV-hash mutations the follower already performs for the same block. There is no observable storage state in which the trie reflects block N while raw values reflect block N-1, or vice versa.
 - **FR-004**: When the chain-follower rolls back a block that previously applied an Insert, Update, or Delete to a token's trie, the offchain MUST restore the raw-value storage to the state it had immediately before that block was applied. After the rollback completes, fact lookups MUST return the values that were correct at the new chain tip.
-- **FR-005**: When the offchain starts against a database directory whose schema does not include the storage required by FR-001, the offchain MUST refuse to start and emit an error pointing the operator at the migration documentation. The offchain MUST NOT silently corrupt, partially upgrade, or otherwise mutate such a database.
-- **FR-006**: The end-to-end test for `GET /tokens/:id/facts/:key` MUST exercise FR-001 by inserting a known `(key, value)` pair through the request → process flow and asserting the response's `value` field equals the inserted bytes byte-for-byte. The pre-existing `assertFactEnvelope` structural-only check (whose only test on `value` was `not . T.null`) MUST be removed.
-- **FR-007**: The migration documentation produced by FR-005 MUST cover, at minimum: which deployments need migration (devnet, preprod, mainnet); what the operator must do (e.g., wipe-and-resync vs explicit migration step); and the expected downtime for each affected deployment class.
+- **FR-005**: The end-to-end test for `GET /tokens/:id/facts/:key` MUST exercise FR-001 by inserting a known `(key, value)` pair through the request → process flow and asserting the response's `value` field equals the inserted bytes byte-for-byte. The pre-existing `assertFactEnvelope` structural-only check (whose only test on `value` was `not . T.null`) MUST be removed.
 
 ### Key Entities *(include if feature involves data)*
 
 - **Raw fact value**: the bytes a requester originally supplied as the `value` of an Insert or Update request, scoped to a single `(token, key)` pair. Distinct from the value-hash that the merkle tree retains for proof construction. Lifecycle: created when the corresponding request is processed; replaced when an Update for the same `(token, key)` is processed; removed when a Delete is processed; restored to its prior state when any of those operations is rolled back.
-- **Storage upgrade boundary**: the schema version distinction between "database produced by the pre-change offchain" and "database produced by the post-change offchain." Detection of this boundary by the offchain at startup is what gates FR-005.
 
 ## Success Criteria *(mandatory)*
 
@@ -85,13 +77,11 @@ Operators running this offchain on devnets, preprod, or any other deployment hav
 
 - **SC-001**: 100% of `GET /tokens/:id/facts/:key` calls following a successful Insert/Update return the requester's exact value bytes, verified by an end-to-end test that compares response bytes to inserted bytes byte-for-byte. (Today: 0%.)
 - **SC-002**: Rollback fixtures exercising Insert, Update, and Delete operations across single-block and multi-block reorgs leave fact-lookup responses byte-identical to the lookup responses that would be observed if the rolled-back blocks had never been seen. Measured by automated test, no manual inspection.
-- **SC-003**: Operator-facing release notes for the version that ships this change include a migration section. Reviewed by a person who has run the offchain in deployment but did not write the change.
-- **SC-004**: The pre-existing `assertFactEnvelope` structural-only check (`val \`shouldSatisfy\` (not . T.null)`) no longer appears in the test suite as the sole verification of the fact endpoint's `value` field. Replaced by the byte-equality test from SC-001.
+- **SC-003**: The pre-existing `assertFactEnvelope` structural-only check (`val \`shouldSatisfy\` (not . T.null)`) no longer appears in the test suite as the sole verification of the fact endpoint's `value` field. Replaced by the byte-equality test from SC-001.
 
 ## Assumptions
 
 - The offchain's chain-follower already implements atomic block writes (`InvTrieInsert`/`InvTrieDelete` and the rest of the inverse-op machinery in `Cardano.MPFS.Indexer.Event`). FR-003 and FR-004 reuse that mechanism rather than introducing a parallel one.
-- Wipe-and-resync is acceptable for devnet and preprod deployments. Resync time on preprod is roughly 70 minutes based on the most recent measurement during the dependency-bump work; that's the order of magnitude expected, not a guarantee. Mainnet has not yet shipped this offchain, so no mainnet migration is in scope.
+- Existing deployments are wiped and resynced as part of normal upgrade hygiene; no in-place migration path is offered or required by this feature. (See clarification 2026-04-30.)
 - The current wire shape of `GET /tokens/:id/facts/:key` (the `FactResponse` envelope, including the `value` field's existence and JSON encoding) is unchanged by this feature. A separate concurrent change (#243) replaces the wire shape; that work is out of scope here.
 - "Raw value" means the byte string the requester originally placed in the request datum's value field, exactly as it arrived in the indexed transaction's CBOR. No re-encoding, no normalisation.
-- Operators reading the migration documentation are technically competent with the offchain's deployment story (Docker, RocksDB on disk). The documentation does not need to teach them what RocksDB is.

--- a/specs/248-value-persistence/spec.md
+++ b/specs/248-value-persistence/spec.md
@@ -1,0 +1,97 @@
+# Feature Specification: Value persistence for the fact lookup endpoint
+
+**Feature Branch**: `248-value-persistence`
+**Created**: 2026-04-30
+**Status**: Draft
+**Input**: User description: "248 — `GET /tokens/:id/facts/:key` returns the wrong byte string in its `value` field. Today the endpoint returns `mkMPFHash key` (a hash of the request's key) in the `value` field of `FactResponse`, instead of the bytes the requester originally inserted. Root cause: the per-token MPF trie is content-addressed and stores only the value-hash; the raw value is discarded at insert time, and the lookup helper was wired to return any 32 bytes that satisfied the type signature. The endpoint's e2e test only asserts \"non-empty hex\" on `value` and so missed it for the endpoint's entire life (postmortem: lambdasistemi/cardano-mpfs-offchain#248). Scope: make the endpoint return the actual inserted bytes. Persist raw value bytes inside the offchain so lookup can recover them. The chain-follower's \"one block = one DB transaction\" invariant must still hold; rollbacks must restore prior raw-value state via the existing inverse-op machinery (`InvTrieInsert`/`InvTrieDelete` in `Cardano.MPFS.Indexer.Event`). Migration story for existing devnet/preprod databases included. Acceptance: the e2e for the endpoint inserts a (key, value) pair and asserts the GET response's `value` field equals the inserted bytes byte-for-byte."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Fact lookup returns the inserted value (Priority: P1)
+
+A requester submits an Insert request that pairs a key with a value. After the request is processed by the oracle, an oracle or external client calls `GET /tokens/:id/facts/:key`. The response's `value` field carries the same bytes the requester originally inserted, byte-for-byte.
+
+**Why this priority**: This is the entire feature. The endpoint exists to serve values; today it does not. Every consumer that takes its `value` output at face value gets garbage. Without this, the endpoint is misleading by construction.
+
+**Independent Test**: insert a (key, value) pair through the live request → process flow on a devnet, then call `GET /tokens/:id/facts/:key`, decode the response's `value` field, and assert it equals the original value bytes. No other endpoint or feature is required for this slice to be demonstrable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a token whose trie contains the pair `(k, v)` produced by a successful Insert, **When** an HTTP client calls `GET /tokens/:id/facts/:key` with `:key = k`, **Then** the response's `value` field decodes to `v` byte-for-byte.
+2. **Given** the same token where an Update has overwritten `v` with `v'`, **When** the same lookup runs, **Then** the response's `value` field decodes to `v'` (not `v`, not `mkMPFHash k`, not any other byte string).
+3. **Given** a token whose trie does not contain `:key`, **When** the lookup runs, **Then** the endpoint preserves its existing absent-key response semantics (HTTP 404 today). No `value` field is fabricated.
+
+---
+
+### User Story 2 - Rollback restores prior values (Priority: P1)
+
+The chain-follower processes blocks atomically: every mutation a block produces is part of one all-or-nothing storage write. When a rollback unwinds a block whose application inserted/updated/deleted entries in a token's trie, the raw value bytes a subsequent fact lookup observes must reflect the state at the new chain tip — never a value that only existed in the rolled-back block.
+
+**Why this priority**: Without this, the endpoint becomes a window onto inconsistent state during rollbacks. Any client that polls during a re-org could read a value that no longer "exists" on chain. This is the same correctness bar the rest of the indexer already meets for trie roots, requests, and cage state; raw value persistence cannot be the one drawer that escapes it.
+
+**Independent Test**: drive a block-by-block reorg fixture in the existing follower test suite — apply a block that inserts `(k, v)`, then roll back to before that block. After the rollback, calling `GET /tokens/:id/facts/:key` returns the same response shape as it would have at the rolled-back tip (404 if `(k, v)` was the first-ever insert; the prior value if `(k, v)` overwrote one).
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh token with no prior trie state, **When** block N applies an Insert of `(k, v)` and the follower then rolls back to block N-1, **Then** the lookup at `:key = k` returns the same response it would return for an absent key.
+2. **Given** a token whose trie already contained `(k, v_old)` at block N-1, **When** block N applies an Update that overwrites it with `(k, v_new)` and the follower rolls back to N-1, **Then** the lookup at `:key = k` returns `v_old`, not `v_new`.
+3. **Given** any block sequence ending in a rollback, **When** the follower has finished applying the rollback, **Then** the storage state of raw values is identical to what it would have been if the rolled-back blocks had never been observed.
+
+---
+
+### User Story 3 - Existing operators have a migration path (Priority: P2)
+
+Operators running this offchain on devnets, preprod, or any other deployment have an existing database on disk built before this change. The release notes for the version that ships value persistence document, in plain language, what those operators need to do when upgrading.
+
+**Why this priority**: Real deployments exist (devnet stack, preprod indexer reachable at `umpfs.plutimus.com`). Shipping a storage-shape change without operator-facing instructions creates an outage even if the code is correct. Lower priority than the fix and the rollback story because the technical risk is contained — failed startup is loud and recoverable — but it's still required for the feature to be operationally correct.
+
+**Independent Test**: take a database snapshot from a deployment running the pre-change version, attempt to start the new version against it, and verify that the documented migration procedure (whatever it is) is sufficient to bring the deployment up to a state where User Story 1 passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a database directory produced by a pre-change version of the offchain, **When** an operator follows the documented upgrade procedure, **Then** the new version starts successfully and `GET /tokens/:id/facts/:key` returns correct values for every fact inserted after the upgrade completes.
+2. **Given** a database directory produced by a pre-change version, **When** an operator runs the new version without following the documented procedure, **Then** the offchain refuses to start with an error message that points the operator at the migration documentation. (Failure is loud; never silent corruption.)
+
+---
+
+### Edge Cases
+
+- **Empty value insert.** A requester inserts `(k, "")` (zero-byte value). The lookup returns a present response with `value = ""`. Empty is a legitimate value, distinct from "key absent."
+- **Insert then delete in the same block.** The follower applies Insert `(k, v)` and then Delete `k` inside one block. After the block commits, the lookup at `k` returns the absent response, the same as if neither operation had been observed. Rollback of this block also returns to the prior state.
+- **Concurrent reads during chain sync.** An HTTP client calls `GET /tokens/:id/facts/:key` while the follower is mid-block. The client sees only states that correspond to a committed block — never a partial view where the trie root has moved but the raw value bytes haven't, or vice versa.
+- **Large value.** The size of an inserted value is bounded only by what the on-chain protocol accepts in a request datum. The endpoint serves any value the trie accepts an insert for; performance for very large values does not need to match small-value performance, but correctness does.
+- **Database upgraded once, downgraded.** Operator upgrades, then for any reason re-runs the prior version against the upgraded database. Behaviour is undefined for now and not specified here; the only requirement is that the forward upgrade path is supported.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When a request that inserts or updates a key-value pair is observed and processed by the chain-follower, the offchain MUST persist the requester's raw value bytes such that a subsequent fact lookup for the same key returns those exact bytes.
+- **FR-002**: When a request that deletes a key is observed and processed, the offchain MUST remove the previously persisted raw value for that key from storage. A subsequent fact lookup MUST report the key as absent.
+- **FR-003**: Every storage mutation introduced by FR-001 and FR-002 MUST happen within the same atomic write boundary as the existing trie-node and KV-hash mutations the follower already performs for the same block. There is no observable storage state in which the trie reflects block N while raw values reflect block N-1, or vice versa.
+- **FR-004**: When the chain-follower rolls back a block that previously applied an Insert, Update, or Delete to a token's trie, the offchain MUST restore the raw-value storage to the state it had immediately before that block was applied. After the rollback completes, fact lookups MUST return the values that were correct at the new chain tip.
+- **FR-005**: When the offchain starts against a database directory whose schema does not include the storage required by FR-001, the offchain MUST refuse to start and emit an error pointing the operator at the migration documentation. The offchain MUST NOT silently corrupt, partially upgrade, or otherwise mutate such a database.
+- **FR-006**: The end-to-end test for `GET /tokens/:id/facts/:key` MUST exercise FR-001 by inserting a known `(key, value)` pair through the request → process flow and asserting the response's `value` field equals the inserted bytes byte-for-byte. The pre-existing `assertFactEnvelope` structural-only check (whose only test on `value` was `not . T.null`) MUST be removed.
+- **FR-007**: The migration documentation produced by FR-005 MUST cover, at minimum: which deployments need migration (devnet, preprod, mainnet); what the operator must do (e.g., wipe-and-resync vs explicit migration step); and the expected downtime for each affected deployment class.
+
+### Key Entities *(include if feature involves data)*
+
+- **Raw fact value**: the bytes a requester originally supplied as the `value` of an Insert or Update request, scoped to a single `(token, key)` pair. Distinct from the value-hash that the merkle tree retains for proof construction. Lifecycle: created when the corresponding request is processed; replaced when an Update for the same `(token, key)` is processed; removed when a Delete is processed; restored to its prior state when any of those operations is rolled back.
+- **Storage upgrade boundary**: the schema version distinction between "database produced by the pre-change offchain" and "database produced by the post-change offchain." Detection of this boundary by the offchain at startup is what gates FR-005.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of `GET /tokens/:id/facts/:key` calls following a successful Insert/Update return the requester's exact value bytes, verified by an end-to-end test that compares response bytes to inserted bytes byte-for-byte. (Today: 0%.)
+- **SC-002**: Rollback fixtures exercising Insert, Update, and Delete operations across single-block and multi-block reorgs leave fact-lookup responses byte-identical to the lookup responses that would be observed if the rolled-back blocks had never been seen. Measured by automated test, no manual inspection.
+- **SC-003**: Operator-facing release notes for the version that ships this change include a migration section. Reviewed by a person who has run the offchain in deployment but did not write the change.
+- **SC-004**: The pre-existing `assertFactEnvelope` structural-only check (`val \`shouldSatisfy\` (not . T.null)`) no longer appears in the test suite as the sole verification of the fact endpoint's `value` field. Replaced by the byte-equality test from SC-001.
+
+## Assumptions
+
+- The offchain's chain-follower already implements atomic block writes (`InvTrieInsert`/`InvTrieDelete` and the rest of the inverse-op machinery in `Cardano.MPFS.Indexer.Event`). FR-003 and FR-004 reuse that mechanism rather than introducing a parallel one.
+- Wipe-and-resync is acceptable for devnet and preprod deployments. Resync time on preprod is roughly 70 minutes based on the most recent measurement during the dependency-bump work; that's the order of magnitude expected, not a guarantee. Mainnet has not yet shipped this offchain, so no mainnet migration is in scope.
+- The current wire shape of `GET /tokens/:id/facts/:key` (the `FactResponse` envelope, including the `value` field's existence and JSON encoding) is unchanged by this feature. A separate concurrent change (#243) replaces the wire shape; that work is out of scope here.
+- "Raw value" means the byte string the requester originally placed in the request datum's value field, exactly as it arrived in the indexed transaction's CBOR. No re-encoding, no normalisation.
+- Operators reading the migration documentation are technically competent with the offchain's deployment story (Docker, RocksDB on disk). The documentation does not need to teach them what RocksDB is.


### PR DESCRIPTION
Closes https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/248

Stacked on https://github.com/lambdasistemi/cardano-mpfs-offchain/pull/244 (boot-slice tip of `243-proof-redesign`). Unblocks https://github.com/lambdasistemi/cardano-mpfs-offchain/pull/246 and https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/247 once merged.

## What

`GET /tokens/:id/facts/:key` returns `mkMPFHash(key)` in its `value` field instead of the bytes the requester originally inserted. The MPF trie is content-addressed and only retains the value-hash; the raw value is discarded at insert time and the lookup helper was wired to return any 32 bytes that satisfied the type signature. The endpoint's e2e test asserted only "non-empty hex" on `value`, so the bug shipped and stayed shipped — see https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/248 for the full postmortem (schema gap × test theatre).

## Spec-driven, not freehand

The schema and rollback semantics needed real specification, not a freehand patch. This PR follows the speckit workflow:

- [x] `/speckit.specify` — `specs/248-value-persistence/spec.md`: two P1 user stories (lookup correctness, rollback correctness), five functional requirements, three measurable success criteria
- [x] `/speckit.clarify` — two clarifications recorded:
  - **Migration**: no in-place migration. Existing devnet/preprod databases are wiped and re-synced as part of normal upgrade hygiene.
  - **Read-path bridge**: `Trie.lookup` stays the single read interface for both transactional and IO consumers. The new column is threaded through the existing trie manager so `Trie.lookup` returns the actual value bytes. No sibling primitive on `Context`.
- [x] `/speckit.plan` — Constitution Check **PASS** pre- and post-design. Six unknowns resolved in `research.md`. Key finding: `InvTrieInsert` / `InvTrieDelete` carriers stay byte-shape-identical — fixing `Trie.lookup` semantics propagates correctness through the existing rollback machinery, so no carrier extension or CBOR tag bump is needed. See `specs/248-value-persistence/research.md` §1.
- [ ] `/speckit.tasks` — next: ordered, bisect-safe implementation breakdown (stgit stack)
- [ ] `/speckit.implement` — patches land here, gate-clean per commit

## Plan artifacts

All under `specs/248-value-persistence/`:

- `spec.md` — user-visible requirement and acceptance criteria
- `plan.md` — technical approach + Constitution Check (PASS, no Complexity Tracking entries)
- `research.md` — six design unknowns resolved with rationale + alternatives
- `data-model.md` — `TrieRawValues` column shape (composite raw key, identity codecs), three storage invariants (atomicity / rollback equivalence / codec passthrough)
- `contracts/trie-lookup.md` — internal record-of-functions boundary change (six behavioural requirements LR-1..LR-6); HTTP wire shape unchanged
- `quickstart.md` — operator wipe-and-resync recipe, developer usage of the corrected `Trie.lookup`, verification recipes
- `checklists/requirements.md` — quality checklist (passed)

## Implementation surface (from plan)

8 source files + 2 test files in `cardano-mpfs-offchain/`:

- `lib/Cardano/MPFS/Indexer/Columns.hs` — add `TrieRawValues` constructor on `AllColumns`
- `lib/Cardano/MPFS/Indexer/Codecs.hs` — add identity prism for the new column
- `lib/Cardano/MPFS/Trie.hs` — `lookup` semantics: returns the raw value, not `Just (hashBS k)`
- `lib/Cardano/MPFS/Trie/Persistent.hs` — `unifiedInsert/Delete/Lookup` + persistent/speculative variants mirror to the new column; `mkPersistentTrieManager` / `withPersistentTrieManager` grow a 4th CF parameter
- `lib/Cardano/MPFS/Trie/Pure.hs` — in-memory pure implementation matches (sibling `IORef (Map ByteString ByteString)`)
- `lib/Cardano/MPFS/Application.hs` — `cageColumnFamilies` grows by one entry; CF index pattern updated
- `lib/Cardano/MPFS/Indexer/Event.hs` — **unchanged** (carriers already pass raw bytes)
- `lib/Cardano/MPFS/Indexer/Follower.hs` — **unchanged** (`applyRequestOp`'s `oldVal` becomes correct automatically once `Trie.lookup` is fixed)
- `e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs` — replace `assertFactEnvelope`'s `not . T.null` check with byte-equality on the inserted value
- `test/Cardano/MPFS/Indexer/RollbackSpec.hs` — Insert/Update/Delete × single-block / multi-block reorg fixtures

## Test plan

- [ ] `just format-check`, `just hlint`, `just unit` clean per commit
- [ ] `just e2e` proofs spec exercises FR-001 (byte-equality on `value` field of `GET /tokens/:id/facts/:key` after a known Insert)
- [ ] Rollback unit fixtures exercise FR-004 (Insert / Update / Delete × single-block / multi-block reorgs leave fact lookups byte-identical to the rolled-back tip's view) — SC-002
- [ ] `assertFactEnvelope` (the structural-only "non-empty hex" check) removed from the test suite — SC-003