### PR TITLE
fix(boot): indexer-only POST /tx/boot — wallet supplies funding refs (closes parts of #250, #252)

### DIFF
--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -697,18 +697,34 @@ instance FromJSON RequestsResponse where
             <*> o .: "requests"
 
 -- | @POST \/tx\/boot@ request body.
-newtype BootRequest = BootRequest
+data BootRequest = BootRequest
     { brAddr :: Hex
-    -- ^ Address (hex-encoded serialized)
+    -- ^ Address (hex-encoded serialized).
+    , brFunding :: [UtxoRef]
+    -- ^ Wallet-supplied funding inputs. The first
+    -- entry is used as the seed for asset-name
+    -- derivation; the last entry is used as the
+    -- collateral input. The wallet selects these —
+    -- the server NEVER queries cardano-node's
+    -- 'GetUTxOByAddress' (an O(total UTxOs)
+    -- linear scan) to pick them. The server only
+    -- reads each ref's 'TxOut' and CSMT inclusion
+    -- proof from its local indexer, atomically
+    -- with the snapshot.
     }
 
 instance ToJSON BootRequest where
     toJSON BootRequest{..} =
-        object ["address" .= brAddr]
+        object
+            [ "address" .= brAddr
+            , "funding" .= brFunding
+            ]
 
 instance FromJSON BootRequest where
     parseJSON = withObject "BootRequest" $ \o ->
-        BootRequest <$> o .: "address"
+        BootRequest
+            <$> o .: "address"
+            <*> o .: "funding"
 
 -- | @POST \/tx\/request\/insert@ request body.
 data InsertRequest = InsertRequest
@@ -1438,6 +1454,8 @@ instance ToSchema BootRequest where
     declareNamedSchema _ = do
         hexSchema <-
             declareSchemaRef (Proxy @Hex)
+        fundingSchema <-
+            declareSchemaRef (Proxy @[UtxoRef])
         pure
             $ Swagger.NamedSchema
                 (Just "BootRequest")
@@ -1446,8 +1464,13 @@ instance ToSchema BootRequest where
                 ?~ Swagger.SwaggerObject
             & properties
                 .~ fromList
-                    [("address", hexSchema)]
-            & required .~ ["address"]
+                    [ ("address", hexSchema)
+                    , ("funding", fundingSchema)
+                    ]
+            & required
+                .~ [ "address"
+                   , "funding"
+                   ]
             & description
                 ?~ "Boot a new token"
 

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -257,6 +257,7 @@ test-suite unit-tests
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-babbage
+    , cardano-ledger-binary
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
@@ -364,3 +365,4 @@ test-suite e2e-tests
     Cardano.MPFS.E2E.ProofsSpec
     Cardano.MPFS.E2E.ProviderSpec
     Cardano.MPFS.E2E.SubmitterSpec
+    Cardano.MPFS.E2E.WalletSim

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -70,6 +70,7 @@ import Cardano.MPFS.Core.Types
     , TokenId (..)
     , TokenState (..)
     )
+import Cardano.MPFS.E2E.WalletSim (walletBoot)
 import Cardano.MPFS.Provider
     ( Provider (..)
     , SlotNo (..)
@@ -146,10 +147,7 @@ cageFlowSpec scripts =
             -- Step 1: Boot token
             signedBoot <-
                 buildAndSubmit ctx
-                    $ bootToken
-                        (txBuilder ctx)
-                        emptySnap
-                        genesisAddr
+                    $ walletBoot ctx genesisAddr
             let tokenId =
                     extractTokenId cfg signedBoot
 
@@ -276,10 +274,7 @@ deleteFlowSpec scripts =
                 -- Boot
                 signedBoot <-
                     buildAndSubmit ctx
-                        $ bootToken
-                            (txBuilder ctx)
-                            emptySnap
-                            genesisAddr
+                        $ walletBoot ctx genesisAddr
                 let tokenId =
                         extractTokenId cfg signedBoot
                 _ <-
@@ -539,10 +534,7 @@ rejectFlowSpec scripts =
                 -- Boot
                 signedBoot <-
                     buildAndSubmit ctx
-                        $ bootToken
-                            (txBuilder ctx)
-                            emptySnap
-                            genesisAddr
+                        $ walletBoot ctx genesisAddr
                 let tokenId =
                         extractTokenId cfg signedBoot
                 _ <-
@@ -657,6 +649,7 @@ withE2E scripts action = do
                                 Nothing
                             , followerEnabled =
                                 True
+                            , atomicCageReaderOverride = Nothing
                             , appTracer =
                                 nullTracer
                             }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -52,7 +52,7 @@ import Cardano.Ledger.BaseTypes
     ( Network (..)
     , TxIx (..)
     )
-import Cardano.Ledger.Binary (serialize)
+import Cardano.Ledger.Binary (natVersion, serialize)
 import Cardano.Ledger.Core (eraProtVerLow)
 import Cardano.Ledger.Mary.Value
     ( MultiAsset (..)
@@ -66,7 +66,10 @@ import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
     )
-import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Context
+    ( AtomicCageReader
+    , Context (..)
+    )
 import Cardano.MPFS.Core.Blueprint
     ( CageScripts
     , loadCageScripts
@@ -84,6 +87,7 @@ import Cardano.MPFS.Core.Types
     , TokenId (..)
     , TokenState (..)
     )
+import Cardano.MPFS.E2E.WalletSim (walletBoot)
 import Cardano.MPFS.Provider
     ( Provider (..)
     , SlotNo (..)
@@ -163,10 +167,7 @@ cageFlowSpec bpPath scripts =
 
             -- Step 1: Boot token
             bundleBoot <-
-                bootToken
-                    (txBuilder ctx)
-                    emptySnap
-                    genesisAddr
+                walletBoot ctx genesisAddr
             let unsignedBoot = envTx bundleBoot
                 signedBoot =
                     addKeyWitness
@@ -429,6 +430,8 @@ withE2E scripts action = do
                         Nothing
                     , followerEnabled =
                         False
+                    , atomicCageReaderOverride =
+                        Just stubAtomicReader
                     , appTracer =
                         nullTracer
                     }
@@ -480,6 +483,37 @@ extractTokenId cfg tx =
 -- (~50 devnet blocks at 0.1s slots).
 awaitTx :: IO ()
 awaitTx = threadDelay 5_000_000
+
+-- | Wallet-backed 'AtomicCageReader' stub for
+-- @followerEnabled = False@ fixtures. See
+-- 'IndexerSpec.stubAtomicReader'.
+stubAtomicReader
+    :: Provider IO -> AtomicCageReader IO
+stubAtomicReader prov refs = do
+    utxos <- queryUTxOs prov genesisAddr
+    let utxoMap = Map.fromList utxos
+        encode txOut =
+            BSL.toStrict
+                $ serialize
+                    (natVersion @11)
+                    txOut
+        triples =
+            [ (r, encode txOut, BS.empty)
+            | r <- refs
+            , Just txOut <-
+                [Map.lookup r utxoMap]
+            ]
+    pure
+        $ Just
+            ( BundleSnapshot
+                { snapshotUtxoRoot =
+                    BS.replicate 32 0
+                , snapshotSlot = SlotNo 0
+                , snapshotBlockId =
+                    BlockId (BS.replicate 32 0)
+                }
+            , triples
+            )
 
 -- | Optionally dump and simulate a signed transaction with Aiken.
 --

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -63,6 +63,7 @@ import Cardano.MPFS.Core.Types
     , TokenId (..)
     , TokenState (..)
     )
+import Cardano.MPFS.E2E.WalletSim (walletBoot)
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.State
     ( Checkpoints (..)
@@ -133,10 +134,7 @@ chainsyncSpecs scripts = do
             -- Submit boot tx
             signedBoot <-
                 buildAndSubmit ctx
-                    $ bootToken
-                        (txBuilder ctx)
-                        emptySnap
-                        genesisAddr
+                    $ walletBoot ctx genesisAddr
             let tokenId =
                     extractTokenId cfg signedBoot
 
@@ -165,10 +163,7 @@ chainsyncSpecs scripts = do
             -- Submit boot tx
             signedBoot <-
                 buildAndSubmit ctx
-                    $ bootToken
-                        (txBuilder ctx)
-                        emptySnap
-                        genesisAddr
+                    $ walletBoot ctx genesisAddr
             let tokenId =
                     extractTokenId cfg signedBoot
 
@@ -233,10 +228,7 @@ chainsyncSpecs scripts = do
             -- are being processed
             signedBoot <-
                 buildAndSubmit ctx
-                    $ bootToken
-                        (txBuilder ctx)
-                        emptySnap
-                        genesisAddr
+                    $ walletBoot ctx genesisAddr
             let tokenId =
                     extractTokenId cfg signedBoot
 
@@ -305,6 +297,7 @@ withE2E scripts action = do
                                 Nothing
                             , followerEnabled =
                                 True
+                            , atomicCageReaderOverride = Nothing
                             , appTracer =
                                 nullTracer
                             }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
@@ -27,10 +27,9 @@ import Cardano.MPFS.Core.Blueprint
     , loadCageScripts
     )
 import Cardano.MPFS.Core.Types
-    ( BlockId (..)
-    , SlotNo (..)
-    , TokenId
+    ( TokenId
     )
+import Cardano.MPFS.E2E.WalletSim (walletBoot)
 import Cardano.MPFS.State
     ( State (..)
     , Tokens (..)
@@ -41,9 +40,7 @@ import Cardano.MPFS.Submitter
     )
 import Cardano.MPFS.Trace (AppTrace (..))
 import Cardano.MPFS.TxBuilder
-    ( BundleSnapshot (..)
-    , ProofEnvelope (..)
-    , TxBuilder (..)
+    ( ProofEnvelope (..)
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -79,7 +76,6 @@ import Control.Tracer
     ( Tracer (..)
     , traceWith
     )
-import Data.ByteString qualified as BS
 import Data.Foldable (for_)
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
@@ -319,6 +315,7 @@ mkAppConfig socketPath cfg tracer dbPath = do
             , cageConfig = cfg
             , byronGenesisPath = Nothing
             , followerEnabled = True
+            , atomicCageReaderOverride = Nothing
             , appTracer = tracer
             }
 
@@ -327,7 +324,7 @@ mkAppConfig socketPath cfg tracer dbPath = do
 bootAndAwait :: Context IO -> IO TokenId
 bootAndAwait ctx = do
     bundle <-
-        bootToken (txBuilder ctx) emptySnap genesisAddr
+        walletBoot ctx genesisAddr
     let unsignedBoot = envTx bundle
         signed =
             addKeyWitness genesisSignKey unsignedBoot
@@ -348,17 +345,6 @@ bootAndAwait ctx = do
             error
                 $ "boot rejected: "
                     ++ show reason
-
--- | Placeholder snapshot used by e2e tests. The
--- builder embeds it verbatim but does not yet use
--- it to drive tx construction.
-emptySnap :: BundleSnapshot
-emptySnap =
-    BundleSnapshot
-        { snapshotUtxoRoot = BS.replicate 32 0
-        , snapshotSlot = SlotNo 0
-        , snapshotBlockId = BlockId (BS.replicate 32 0)
-        }
 
 -- * Config
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -87,6 +87,7 @@ import Cardano.MPFS.Core.Types
     , ConwayEra
     , TokenId (..)
     )
+import Cardano.MPFS.E2E.WalletSim (walletBoot)
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.Provider
     ( Provider (..)
@@ -166,7 +167,7 @@ lifecycleSpec scripts =
             -- Boot
             bootTx <-
                 submit
-                    $ bootToken tb emptySnap genesisAddr
+                    $ walletBoot ctx genesisAddr
             let tid =
                     extractTokenId cfg bootTx
 
@@ -414,6 +415,7 @@ withE2E scripts action = do
                                 Nothing
                             , followerEnabled =
                                 True
+                            , atomicCageReaderOverride = Nothing
                             , appTracer =
                                 nullTracer
                             }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -14,6 +14,7 @@ module Cardano.MPFS.E2E.IndexerSpec (spec) where
 
 import Control.Concurrent (threadDelay)
 import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
 import Data.Map.Strict qualified as Map
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
@@ -34,6 +35,7 @@ import Cardano.Ledger.BaseTypes
     ( Network (..)
     , TxIx (..)
     )
+import Cardano.Ledger.Binary (natVersion, serialize)
 import Cardano.Ledger.TxIn (TxIn (..))
 
 import Cardano.Chain.Slotting (EpochSlots (..))
@@ -43,7 +45,10 @@ import Cardano.MPFS.Application
     ( AppConfig (..)
     , withApplication
     )
-import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Context
+    ( AtomicCageReader
+    , Context (..)
+    )
 import Cardano.MPFS.Core.Blueprint
     ( CageScripts
     , loadCageScripts
@@ -60,6 +65,7 @@ import Cardano.MPFS.Core.Types
     , Root (..)
     , TokenState (..)
     )
+import Cardano.MPFS.E2E.WalletSim (walletBoot)
 import Cardano.MPFS.Indexer.Event
     ( CageEvent (..)
     , inversesOf
@@ -156,7 +162,7 @@ indexerSpecs scripts = do
             -- Submit boot tx
             signedBoot <-
                 buildAndSubmit ctx
-                    $ bootToken (txBuilder ctx) emptySnap genesisAddr
+                    $ walletBoot ctx genesisAddr
             let resolver =
                     mkResolver preUtxos []
 
@@ -698,10 +704,7 @@ indexerSpecs scripts = do
             -- Submit boot tx
             signedBoot <-
                 buildAndSubmit ctx
-                    $ bootToken
-                        (txBuilder ctx)
-                        emptySnap
-                        genesisAddr
+                    $ walletBoot ctx genesisAddr
             let resolver =
                     mkResolver preUtxos []
             events <-
@@ -886,10 +889,7 @@ indexerSpecs scripts = do
                     scriptAddr
             signedBoot <-
                 buildAndSubmit ctx
-                    $ bootToken
-                        (txBuilder ctx)
-                        emptySnap
-                        genesisAddr
+                    $ walletBoot ctx genesisAddr
             let resolver =
                     mkResolver preUtxos []
             events <-
@@ -964,6 +964,8 @@ withE2E scripts action = do
                                 Nothing
                             , followerEnabled =
                                 False
+                            , atomicCageReaderOverride =
+                                Just stubAtomicReader
                             , appTracer =
                                 nullTracer
                             }
@@ -1016,6 +1018,41 @@ assertSubmitted (Rejected reason) =
 awaitTx :: IO ()
 awaitTx = threadDelay 5_000_000
 
+-- | Wallet-backed 'AtomicCageReader' stub for
+-- fixtures that run with @followerEnabled = False@.
+-- Looks up resolved @TxOut@ bytes via cardano-node
+-- 'queryUTxOs' at the wallet address so the
+-- tx-builder can balance, but emits placeholder
+-- 'BundleSnapshot' and zero-length proofs — these
+-- specs do not exercise the proof-bearing verifier.
+stubAtomicReader
+    :: Provider IO -> AtomicCageReader IO
+stubAtomicReader prov refs = do
+    utxos <- queryUTxOs prov genesisAddr
+    let utxoMap = Map.fromList utxos
+        encode txOut =
+            BSL.toStrict
+                $ serialize
+                    (natVersion @11)
+                    txOut
+        triples =
+            [ (r, encode txOut, BS.empty)
+            | r <- refs
+            , Just txOut <-
+                [Map.lookup r utxoMap]
+            ]
+    pure
+        $ Just
+            ( BundleSnapshot
+                { snapshotUtxoRoot =
+                    BS.replicate 32 0
+                , snapshotSlot = SlotNo 0
+                , snapshotBlockId =
+                    BlockId (BS.replicate 32 0)
+                }
+            , triples
+            )
+
 -- | Snapshot UTxOs at the cage script address for
 -- building a resolver. Must be called BEFORE
 -- submitting a transaction (spent UTxOs disappear).
@@ -1055,7 +1092,7 @@ bootAndRegister cfg ctx = do
     -- Build + submit boot tx
     signedBoot <-
         buildAndSubmit ctx
-            $ bootToken (txBuilder ctx) emptySnap genesisAddr
+            $ walletBoot ctx genesisAddr
 
     -- Detect and apply
     let resolver =

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -110,6 +110,7 @@ import Cardano.MPFS.Core.Types
     , ConwayEra
     , TokenId (..)
     )
+import Cardano.MPFS.E2E.WalletSim (walletBoot)
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.Provider
     ( Provider (..)
@@ -231,7 +232,7 @@ proofsSpec scripts =
 
             -- Boot → insert → update to land the fact
             bootTx <-
-                submit $ bootToken tb emptySnap genesisAddr
+                submit $ walletBoot ctx genesisAddr
             let tid = extractTokenId cfg bootTx
                 tidHex = tokenIdHex tid
                 keyHex = B16.encode factKey
@@ -337,9 +338,33 @@ proofsSpec scripts =
             -- in e2e we read it from the response's own
             -- snapshot for the honest path, then forge a
             -- different one for the rejection path.
+            -- Discover wallet UTxOs and pass their
+            -- refs in the request body. Server-side
+            -- 'queryUTxOs' is forbidden (#252).
+            walletUtxos <-
+                queryUTxOs (provider ctx) genesisAddr
+            let walletFunding =
+                    map
+                        ( \(TxIn (TxId txid) (TxIx ix), _) ->
+                            object
+                                [ "tx_id"
+                                    .= Hex
+                                        ( TE.decodeUtf8
+                                            $ B16.encode
+                                                ( Crypto.hashToBytes
+                                                    (extractHash txid)
+                                                )
+                                        )
+                                , "tx_ix" .= ix
+                                ]
+                        )
+                        walletUtxos
             bootResp <-
                 postJSON app "/tx/boot"
-                    $ object ["address" .= addrHex]
+                    $ object
+                        [ "address" .= addrHex
+                        , "funding" .= walletFunding
+                        ]
             let bootResp' = bootResp :: Wire.UnsignedTxResponse
                 bootSnapRoot =
                     Wire.vsUtxoRoot
@@ -731,6 +756,7 @@ withE2E scripts action = do
                             , byronGenesisPath =
                                 Nothing
                             , followerEnabled = True
+                            , atomicCageReaderOverride = Nothing
                             , appTracer = nullTracer
                             }
                 withApplication appCfg $ \ctx -> do

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WalletSim.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WalletSim.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Module      : Cardano.MPFS.E2E.WalletSim
+-- Description : Test-only wallet simulator
+-- License     : Apache-2.0
+--
+-- E2E test fixtures act as the wallet from the
+-- server's perspective: they discover their own
+-- UTxOs by querying cardano-node's
+-- 'LocalStateQuery' and pass the chosen refs to
+-- proof-bearing endpoints in the request body.
+--
+-- This module isolates that wallet-side query
+-- behind a single helper. The server's tx-build
+-- path NEVER calls 'queryUTxOs' (#252):
+-- cardano-node implements 'GetUTxOByAddress' as a
+-- linear scan over the entire ledger UTxO set,
+-- so it is unfit for any hot-path use. Wallets
+-- can use it because each wallet's call is rare;
+-- the server cannot, because it would amplify
+-- one HTTP request into a full ledger scan.
+--
+-- Any new e2e fixture that needs to simulate a
+-- wallet picking inputs MUST go through this
+-- helper rather than calling 'queryUTxOs'
+-- directly, so the next time we audit the
+-- codebase the test-only uses are easy to find
+-- and the production-side ban remains
+-- enforceable.
+module Cardano.MPFS.E2E.WalletSim
+    ( walletBoot
+    ) where
+
+import Cardano.Ledger.Address (Addr)
+
+import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.TxBuilder
+    ( BootProof
+    , ProofEnvelope
+    , TxBuilder (..)
+    )
+
+-- | Simulate a wallet building a boot tx: query
+-- the node-side UTxO state at @addr@, hand those
+-- refs to the server's 'bootToken'. Test-only.
+walletBoot
+    :: Context IO
+    -> Addr
+    -> IO (ProofEnvelope BootProof)
+walletBoot ctx addr = do
+    utxos <- queryUTxOs (provider ctx) addr
+    bootToken
+        (txBuilder ctx)
+        addr
+        (map fst utxos)

--- a/cardano-mpfs-offchain/exe/DevnetServer.hs
+++ b/cardano-mpfs-offchain/exe/DevnetServer.hs
@@ -92,6 +92,7 @@ main = do
                             , byronGenesisPath =
                                 Nothing
                             , followerEnabled = True
+                            , atomicCageReaderOverride = Nothing
                             , appTracer = nullTracer
                             }
                 withApplication appCfg $ \ctx -> do

--- a/cardano-mpfs-offchain/exe/RunPreprod.hs
+++ b/cardano-mpfs-offchain/exe/RunPreprod.hs
@@ -46,6 +46,7 @@ preprodConfig sock dbDir =
                 "/tmp/cardano-preprod/config\
                 \/byron-genesis.json"
         , followerEnabled = True
+        , atomicCageReaderOverride = Nothing
         , appTracer = jsonLinesTracer
         }
 

--- a/cardano-mpfs-offchain/exe/Serve.hs
+++ b/cardano-mpfs-offchain/exe/Serve.hs
@@ -203,6 +203,7 @@ mkAppConfig args cfg =
         , byronGenesisPath =
             argByronGenesis args
         , followerEnabled = True
+        , atomicCageReaderOverride = Nothing
         , appTracer = jsonLinesTracer
         }
 

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -166,7 +166,10 @@ import Ouroboros.Network.Block qualified as Network
 import Cardano.Ledger.Binary (EncCBOR, natVersion, serialize)
 
 import CSMT.Hashes.Types (Hash)
-import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Context
+    ( AtomicCageReader
+    , Context (..)
+    )
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
     , SlotNo (..)
@@ -177,6 +180,7 @@ import Cardano.MPFS.Indexer.Backend
 import Cardano.MPFS.Indexer.CageFollower
     ( mkCageIntersector
     )
+import Cardano.MPFS.TxBuilder (BundleSnapshot (..))
 import Data.Dependent.Map (DMap)
 
 import Cardano.MPFS.Indexer.Codecs (allUnifiedCodecs)
@@ -184,6 +188,7 @@ import Cardano.MPFS.Indexer.Columns (UnifiedColumns (..))
 import Cardano.MPFS.Indexer.Persistent
     ( mkPersistentState
     )
+import Cardano.MPFS.Provider (Provider)
 import Cardano.MPFS.Provider.NodeClient
     ( mkNodeClientProvider
     )
@@ -230,6 +235,22 @@ data AppConfig = AppConfig
     -- alongside Shelley initial funds on fresh DB.
     , followerEnabled :: !Bool
     -- ^ Start CageFollower ChainSync processing
+    , atomicCageReaderOverride
+        :: !( Maybe
+                (Provider IO -> AtomicCageReader IO)
+            )
+    -- ^ Override the indexer-backed
+    -- 'AtomicCageReader' with a test stub.
+    -- 'withApplication' applies the override (if
+    -- 'Just') to the constructed 'Provider' and
+    -- wires the resulting reader into
+    -- 'mkRealTxBuilder' and 'Context.atomicCageReader'
+    -- instead of the real one. Production code
+    -- always passes 'Nothing'; tests with
+    -- @followerEnabled = False@ supply a wallet-
+    -- backed stub that pulls @TxOut@ bytes via
+    -- 'queryUTxOs' so the boot tx-builder can
+    -- balance without a real indexer.
     , appTracer :: Tracer IO AppTrace
     -- ^ Application event tracer
     }
@@ -603,6 +624,94 @@ withApplication cfg action = do
                                         )
                                 pure
                                     $ fmap snd result
+                        -- Atomic indexer reader: opens ONE
+                        -- 'run' transaction over
+                        -- 'UnifiedColumns' and reads, in this
+                        -- order, the CSMT root, the chain
+                        -- checkpoint, and (TxOut bytes,
+                        -- inclusion proof) for every supplied
+                        -- 'TxIn'. RocksDB snapshot isolation
+                        -- guarantees the resulting
+                        -- 'BundleSnapshot', resolved values,
+                        -- and proofs are coherent regardless
+                        -- of concurrent chain-follower writes.
+                        --
+                        -- Returning the @TxOut@ bytes here is
+                        -- what lets bootTokenImpl and any
+                        -- future tx-builder avoid
+                        -- 'queryUTxOs prov addr' on the
+                        -- tx-build hot path — see #252 for
+                        -- the cost (cardano-node implements
+                        -- @GetUTxOByAddress@ as a linear
+                        -- scan over the entire ledger UTxO
+                        -- set) and #250 for the atomicity
+                        -- contract.
+                        atomicReader refs = run $ do
+                            let fkv = fromKV context
+                            mRoot <-
+                                mapColumns InUtxo
+                                    $ fmap renderHash
+                                        <$> queryMerkleRoot
+                                            ( hashing
+                                                context
+                                            )
+                            hist <-
+                                CFStore.queryHistory
+                                    InRollbacks
+                            mResolved <-
+                                traverse
+                                    ( mapColumns
+                                        InUtxo
+                                        . generateInclusionProof
+                                            fkv
+                                            KVCol
+                                            CSMTCol
+                                        . cborEncode
+                                    )
+                                    refs
+                            pure
+                                $ case (mRoot, hist) of
+                                    (Just rootBs, pts@(_ : _))
+                                        | Just resolved <-
+                                            sequence
+                                                mResolved ->
+                                            let (slot, rp) =
+                                                    last pts
+                                                blkId =
+                                                    fromMaybe
+                                                        ( BlockId
+                                                            mempty
+                                                        )
+                                                        (rpMeta rp)
+                                                snap =
+                                                    BundleSnapshot
+                                                        { snapshotUtxoRoot =
+                                                            rootBs
+                                                        , snapshotSlot =
+                                                            slot
+                                                        , snapshotBlockId =
+                                                            blkId
+                                                        }
+                                                triples =
+                                                    zipWith
+                                                        ( \r (v, p) ->
+                                                            ( r
+                                                            , BSL.toStrict
+                                                                v
+                                                            , p
+                                                            )
+                                                        )
+                                                        refs
+                                                        resolved
+                                            in  Just
+                                                    (snap, triples)
+                                    _ -> Nothing
+                        effectiveReader =
+                            case atomicCageReaderOverride
+                                cfg of
+                                Just mk -> mk prov
+                                Nothing ->
+                                    atomicReader
                         ctx =
                             Context
                                 { provider = prov
@@ -620,6 +729,7 @@ withApplication cfg action = do
                                         st
                                         tm
                                         proof
+                                        effectiveReader
                                 , cfgCage =
                                     cageConfig cfg
                                 , utxoExists = exists
@@ -630,6 +740,8 @@ withApplication cfg action = do
                                         resolve
                                 , utxoRoot = root
                                 , utxoProof = proof
+                                , atomicCageReader =
+                                    effectiveReader
                                 , readMetrics =
                                     readIORef metricsRef
                                 }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs
@@ -13,6 +13,9 @@
 module Cardano.MPFS.Context
     ( -- * Context
       Context (..)
+
+      -- * Atomic cage reader
+    , AtomicCageReader
     ) where
 
 import Data.ByteString (ByteString)
@@ -22,9 +25,46 @@ import Cardano.MPFS.Provider (Provider)
 import Cardano.MPFS.State (State)
 import Cardano.MPFS.Submitter (Submitter)
 import Cardano.MPFS.Trie (TrieManager)
-import Cardano.MPFS.TxBuilder (TxBuilder)
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot
+    , TxBuilder
+    )
 import Cardano.MPFS.TxBuilder.Config (CageConfig)
 import Cardano.UTxOCSMT.Application.Metrics (Metrics)
+
+-- | Read a 'BundleSnapshot' (CSMT root + chain
+-- checkpoint), the resolved @TxOut@ bytes, and the
+-- CSMT inclusion proof for each supplied 'TxIn' in
+-- ONE database transaction. Proof-bearing handlers
+-- MUST use this — never combine a separately-fetched
+-- snapshot with separately-fetched proofs or
+-- separately-fetched UTxO state.
+--
+-- Returning the @TxOut@ bytes here is what lets the
+-- server avoid cardano-node's @LocalStateQuery@
+-- @GetUTxOByAddress@ entirely on the tx-build hot
+-- path. That node-side query is a linear scan over
+-- the entire ledger UTxO set; calling it from a
+-- proof-bearing endpoint is forbidden (#252) both
+-- on cost and on torn-read grounds — the indexer is
+-- the single source of truth, and one transaction
+-- against it gives a coherent view.
+--
+-- Returns 'Nothing' if the indexer is not ready
+-- (no checkpoint or no root yet) or any input is
+-- not present in the current snapshot.
+type AtomicCageReader m =
+    [TxIn]
+    -> m
+        ( Maybe
+            ( BundleSnapshot
+            , [ ( TxIn
+                , ByteString
+                , ByteString
+                )
+              ]
+            )
+        )
 
 -- | Top-level context bundling all service
 -- interfaces. Parametric in the effect @m@.
@@ -58,10 +98,18 @@ data Context m = Context
         :: TxIn -> Maybe Int -> m (Maybe ByteString)
     -- ^ Block until a UTxO appears or timeout expires
     , utxoRoot :: m (Maybe ByteString)
-    -- ^ Current CSMT Merkle root hash (raw bytes)
+    -- ^ Current CSMT Merkle root hash (raw bytes).
+    -- Use only for non-proof-bearing /status reads.
     , utxoProof
         :: TxIn -> m (Maybe ByteString)
-    -- ^ CSMT inclusion proof for a TxIn (raw bytes)
+    -- ^ CSMT inclusion proof for a TxIn. NOT atomic
+    -- with a separately-fetched snapshot — kept for
+    -- handlers that have not yet been migrated to
+    -- 'atomicCageReader' (#250). New code must use
+    -- 'atomicCageReader'.
+    , atomicCageReader :: AtomicCageReader m
+    -- ^ Atomic snapshot + proofs reader for
+    -- proof-bearing handlers (see 'AtomicCageReader').
     , readMetrics :: m (Maybe Metrics)
     -- ^ Current metrics snapshot (if available)
     }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -102,6 +102,7 @@ import Cardano.MPFS.HTTP.Types
     , UpdateRequest (..)
     , UpdateTxResponse
     , UpdateValueRequest (..)
+    , UtxoRef (..)
     , VerificationSnapshot (..)
     , WitnessedRequest (..)
     , WitnessedTokenState (..)
@@ -596,12 +597,29 @@ txBootHandler
     :: Context IO
     -> BootRequest
     -> Handler UnsignedTxResponse
-txBootHandler ctx (BootRequest addrHex) = do
-    addr <- requireAddr addrHex
-    snap <- requireBundleSnapshot ctx
+txBootHandler ctx BootRequest{brAddr, brFunding} = do
+    addr <- requireAddr brAddr
+    -- The wallet supplies the funding inputs in
+    -- the request body (Principle IV — server does
+    -- not pick wallet UTxOs). 'bootToken' reads
+    -- the snapshot, the resolved @TxOut@ bytes,
+    -- and the inclusion proof for each ref from
+    -- the local indexer in ONE database
+    -- transaction. cardano-node's
+    -- @GetUTxOByAddress@ is never called on this
+    -- path (#252).
+    fundingRefs <-
+        traverse
+            ( \UtxoRef{urTxId, urTxIx} ->
+                requireTxIn urTxId urTxIx
+            )
+            brFunding
     bundle <-
         liftIO
-            $ Tx.bootToken (txBuilder ctx) snap addr
+            $ Tx.bootToken
+                (txBuilder ctx)
+                addr
+                fundingRefs
     pure (mkBootTxResponse bundle)
 
 txInsertHandler

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -31,6 +31,7 @@ module Cardano.MPFS.HTTP.Types
       -- * UTxO witnesses
     , TxInJSON (..)
     , txInToJSON
+    , UtxoRef (..)
     , WitnessedUtxo (..)
 
       -- * Proof-bearing read responses

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
@@ -52,5 +52,6 @@ mkMockContext = do
             , awaitUtxo = \_ _ -> pure Nothing
             , utxoRoot = pure Nothing
             , utxoProof = \_ -> pure Nothing
+            , atomicCageReader = \_ -> pure Nothing
             , readMetrics = pure Nothing
             }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
@@ -55,7 +55,21 @@ data Provider m = Provider
     { queryUTxOs
         :: Addr
         -> m [(TxIn, TxOut ConwayEra)]
-    -- ^ Look up UTxOs at an address
+    -- ^ FORBIDDEN IN ANY TX-BUILD PATH.
+    --
+    -- This call routes to cardano-node's
+    -- @LocalStateQuery@ @GetUTxOByAddress@, whose
+    -- implementation IS A LINEAR SCAN OVER THE
+    -- ENTIRE LEDGER UTXO SET. Cost is O(total
+    -- UTxOs on chain), not O(UTxOs at the
+    -- address). On mainnet that is millions of
+    -- entries per call.
+    --
+    -- Use the local indexer's atomic
+    -- @AtomicCageReader@ instead — it is O(M)
+    -- where M = UTxOs at the address. This field
+    -- is retained only for legacy callers that
+    -- have not yet been migrated.
     , queryProtocolParams
         :: m (PParams ConwayEra)
     -- ^ Fetch current protocol parameters

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
@@ -66,10 +66,19 @@ import Cardano.MPFS.Core.Types
 -- 'witnessedRef's covers every @txIn@ of 'envTx'.
 data TxBuilder m = TxBuilder
     { bootToken
-        :: BundleSnapshot
-        -> Addr
+        :: Addr
+        -> [TxIn]
         -> m (ProofEnvelope BootProof)
-    -- ^ Create a new MPFS token
+    -- ^ Create a new MPFS token at the owner
+    -- address using the wallet-supplied funding
+    -- inputs. The implementation reads its
+    -- 'BundleSnapshot', the resolved @TxOut@ bytes,
+    -- and the inclusion proof for each input from
+    -- the local indexer in ONE database transaction
+    -- — never via cardano-node's @GetUTxOByAddress@
+    -- (#252). The first input is the seed for
+    -- asset-name derivation; the last is the
+    -- collateral input.
     , requestInsert
         :: BundleSnapshot
         -> TokenId

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs
@@ -38,6 +38,7 @@ module Cardano.MPFS.TxBuilder.Real
     , spendingIndex
     ) where
 
+import Cardano.MPFS.Context (AtomicCageReader)
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.State (State (..))
 import Cardano.MPFS.Trie (TrieManager (..))
@@ -96,11 +97,19 @@ mkRealTxBuilder
     -> TrieManager IO
     -- ^ Per-token trie manager
     -> UtxoProofFn
-    -- ^ CSMT inclusion proof lookup
+    -- ^ CSMT inclusion proof lookup (legacy, used
+    -- by handlers that have not yet been migrated
+    -- to atomic snapshot+proof reads — #250).
+    -> AtomicCageReader IO
+    -- ^ Atomic snapshot + proofs reader; used by
+    -- 'bootToken' to read its 'BundleSnapshot' and
+    -- inclusion proofs in ONE database transaction.
+    -- Other operations still use 'proofFn' until
+    -- they are migrated.
     -> TxBuilder IO
-mkRealTxBuilder cfg prov st tm proofFn =
+mkRealTxBuilder cfg prov st tm proofFn atomicReader =
     TxBuilder
-        { bootToken = bootTokenImpl cfg prov proofFn
+        { bootToken = bootTokenImpl cfg prov atomicReader
         , requestInsert =
             requestInsertImpl cfg prov st proofFn
         , requestDelete =

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      : Cardano.MPFS.TxBuilder.Real.Boot
@@ -14,6 +16,7 @@ module Cardano.MPFS.TxBuilder.Real.Boot
     ( bootTokenImpl
     ) where
 
+import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short qualified as SBS
 import Data.Map.Strict qualified as Map
 import Data.Sequence.Strict qualified as StrictSeq
@@ -45,6 +48,10 @@ import Cardano.Ledger.Api.Tx.Wits
     , rdmrsTxWitsL
     , scriptTxWitsL
     )
+import Cardano.Ledger.Binary
+    ( decodeFull
+    , natVersion
+    )
 import Cardano.Ledger.Conway.Scripts
     ( ConwayPlutusPurpose (..)
     )
@@ -57,6 +64,7 @@ import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
 
+import Cardano.MPFS.Context (AtomicCageReader)
 import Cardano.MPFS.Core.OnChain
     ( CageDatum (..)
     , MintRedeemer (..)
@@ -67,13 +75,12 @@ import Cardano.MPFS.Core.OnChain
 import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , Coin (..)
+    , TxIn
     )
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder
     ( BootProof (..)
-    , BundleSnapshot
     , ProofEnvelope (..)
-    , UtxoProofFn
     )
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -89,24 +96,89 @@ bootTokenImpl
     :: CageConfig
     -- ^ Cage script config
     -> Provider IO
-    -- ^ Blockchain query interface
-    -> UtxoProofFn
-    -- ^ CSMT inclusion proof lookup
-    -> BundleSnapshot
-    -- ^ Snapshot this bundle will be anchored to
+    -- ^ Blockchain query interface (used only for
+    -- 'queryProtocolParams' and 'evaluateTx' /
+    -- 'evaluateAndBalance', never for UTxO state).
+    -> AtomicCageReader IO
+    -- ^ Atomic indexer reader. Returns the
+    -- 'BundleSnapshot' together with the resolved
+    -- @TxOut@ bytes and CSMT inclusion proof for
+    -- every supplied 'TxIn', all read in ONE
+    -- database transaction. This is the only
+    -- source of UTxO state on the tx-build hot
+    -- path (#250 / #252).
     -> Addr
     -- ^ Owner address (receives change, owns the token)
+    -> [TxIn]
+    -- ^ Wallet-supplied funding inputs. The wallet
+    -- selects which UTxOs to spend; the server does
+    -- not pick them itself (per Principle IV —
+    -- External Signing — and #252: cardano-node's
+    -- @GetUTxOByAddress@ is forbidden because it
+    -- is O(total UTxOs on chain)). The first ref
+    -- becomes the seed for asset-name derivation
+    -- and the spending input; the last ref becomes
+    -- the collateral input. At least one ref is
+    -- required.
     -> IO (ProofEnvelope BootProof)
-bootTokenImpl cfg prov proofFn snap addr = do
+bootTokenImpl cfg prov atomicReader addr fundingRefs = do
     pp <- queryProtocolParams prov
-    utxos <- queryUTxOs prov addr
-    case utxos of
-        [] -> error "bootToken: no UTxOs"
-        (seedUtxo : rest) -> do
-            let (seedRef, _seedOut) = seedUtxo
-                allInputUtxos = case rest of
-                    [] -> [seedUtxo]
-                    (u : _) -> [seedUtxo, u]
+    case fundingRefs of
+        [] ->
+            error
+                "bootToken: empty funding inputs \
+                \(wallet must supply at least one)"
+        (seedRef : _) -> do
+            let collateralRef =
+                    last fundingRefs
+            -- ATOMIC INDEXER READ: snapshot +
+            -- (TxOut bytes, inclusion proof) for
+            -- every supplied input, all in one DB
+            -- transaction. No cardano-node UTxO
+            -- query is involved: the indexer is the
+            -- single source of truth on the
+            -- tx-build path (#250, #252).
+            mAtomic <-
+                atomicReader fundingRefs
+            (snap, triples) <-
+                case mAtomic of
+                    Nothing ->
+                        error
+                            "bootToken: snapshot or \
+                            \input data unavailable \
+                            \in indexer (chain \
+                            \follower behind, or \
+                            \input not indexed)"
+                    Just (s, ts) -> pure (s, ts)
+            -- Decode the resolved 'TxOut' bytes
+            -- once, here, for tx balancing.
+            let decodeTxOut bs =
+                    case decodeFull
+                        (natVersion @11)
+                        ( BSL.fromStrict
+                            bs
+                        ) of
+                        Left e ->
+                            error
+                                $ "bootToken: \
+                                  \TxOut CBOR \
+                                  \decode failed: "
+                                    <> show e
+                        Right t -> t
+                allInputUtxos =
+                    [ (r, decodeTxOut v)
+                    | (r, v, _) <- triples
+                    ]
+                proofMap =
+                    Map.fromList
+                        [ (r, p)
+                        | (r, _, p) <- triples
+                        ]
+                proofFn ref =
+                    pure
+                        $ Map.lookup
+                            ref
+                            proofMap
             -- 1. Derive asset name from seed
             let onChainRef = txInToRef seedRef
                 assetNameBs =
@@ -189,9 +261,7 @@ bootTokenImpl cfg prov proofFn snap addr = do
                         & mintTxBodyL .~ mintMA
                         & collateralInputsTxBodyL
                             .~ Set.singleton
-                                ( fst
-                                    $ last allInputUtxos
-                                )
+                                collateralRef
                         & scriptIntegrityHashTxBodyL
                             .~ integrity
                 tx =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/StatusSpec.hs
@@ -75,6 +75,7 @@ mkTestContext = do
             , awaitUtxo = \_ _ -> pure Nothing
             , utxoRoot = pure Nothing
             , utxoProof = \_ -> pure Nothing
+            , atomicCageReader = \_ -> pure Nothing
             , readMetrics = pure Nothing
             }
 

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -8,6 +8,7 @@ module Cardano.MPFS.TxBuilderSpec (spec) where
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short qualified as SBS
 import Data.Foldable (for_)
 import Data.List (sort)
@@ -84,6 +85,7 @@ import Cardano.Ledger.BaseTypes
     , Network (..)
     , StrictMaybe (..)
     )
+import Cardano.Ledger.Binary (natVersion, serialize)
 import Cardano.Ledger.Credential
     ( Credential (..)
     , StakeReference (..)
@@ -100,6 +102,7 @@ import Cardano.Ledger.Mary.Value
     )
 import Cardano.Ledger.TxIn (TxIn)
 
+import Cardano.MPFS.Context (AtomicCageReader)
 import Cardano.MPFS.Core.Blueprint
     ( extractCompiledCode
     , loadBlueprint
@@ -319,6 +322,40 @@ mkTestProvider utxos =
 -- exercise proof content; they only verify tx shape.
 dummyProofFn :: TxIn -> IO (Maybe ByteString)
 dummyProofFn _ = pure Nothing
+
+-- | Build a dummy 'AtomicCageReader' from a set of
+-- known @(TxIn, TxOut)@ pairs. The reader returns a
+-- constant 'testSnap', the serialized @TxOut@ bytes
+-- for any matching ref (so the tx-builder can
+-- balance), and a zero-byte proof. Tests only
+-- verify tx shape; concrete proof bytes aren't
+-- validated.
+mkDummyAtomicReader
+    :: [(TxIn, TxOut ConwayEra)]
+    -> AtomicCageReader IO
+mkDummyAtomicReader utxos refs =
+    let utxoMap = Map.fromList utxos
+        encode txOut =
+            BSL.toStrict
+                $ serialize
+                    (natVersion @11)
+                    txOut
+        triples =
+            [ (r, encode txOut, mempty)
+            | r <- refs
+            , Just txOut <-
+                [Map.lookup r utxoMap]
+            ]
+    in  pure $ Just (testSnap, triples)
+
+-- | Empty 'AtomicCageReader' for tests that build
+-- tx-builders for non-boot operations (which never
+-- invoke the reader). The boot-related tests must
+-- use 'mkDummyAtomicReader' with real
+-- @(TxIn, TxOut)@ pairs so the tx-builder can
+-- decode the resolved 'TxOut' bytes for balancing.
+dummyAtomicReader :: AtomicCageReader IO
+dummyAtomicReader = mkDummyAtomicReader []
 
 -- | Dummy TrieManager that errors on use.
 dummyTrieManager :: TrieManager IO
@@ -1915,6 +1952,7 @@ runRetractRequestWith = do
                 st
                 dummyTrieManager
                 dummyProofFn
+                dummyAtomicReader
     bundle <-
         retractRequest builder testSnap reqIn feeAddr
     pure (envTx bundle, reqIn, stateIn)
@@ -1978,6 +2016,7 @@ runUpdateTokenWith = do
                 st
                 trieManager
                 dummyProofFn
+                dummyAtomicReader
     bundle <-
         updateToken builder testSnap testTid feeAddr
     pure (envTx bundle, stateIn, reqIn)
@@ -2026,6 +2065,7 @@ runEndTokenWith = do
                 st
                 dummyTrieManager
                 dummyProofFn
+                dummyAtomicReader
     bundle <- endToken builder testSnap testTid feeAddr
     pure (envTx bundle, stateIn)
 
@@ -2054,7 +2094,12 @@ runBootToken cfg = do
                 st
                 dummyTrieManager
                 dummyProofFn
-    envTx <$> bootToken builder testSnap feeAddr
+                ( mkDummyAtomicReader
+                    [ (txIn1, utxo1)
+                    , (txIn2, utxo2)
+                    ]
+                )
+    envTx <$> bootToken builder feeAddr [txIn1, txIn2]
 
 -- | Token ID used across tests.
 testTid :: TokenId
@@ -2097,6 +2142,7 @@ mkTestFixture = do
                 st
                 dummyTrieManager
                 dummyProofFn
+                dummyAtomicReader
     pure (st, prov, builder, txIn)
 
 -- ---------------------------------------------------------
@@ -2138,6 +2184,7 @@ mkRealisticFixture = do
                 st
                 dummyTrieManager
                 dummyProofFn
+                dummyAtomicReader
     pure (st, prov, builder, txIn)
 
 -- | Run requestInsert with realistic PParams.
@@ -2220,6 +2267,7 @@ runRealisticUpdateWith = do
                 st
                 trieManager
                 dummyProofFn
+                dummyAtomicReader
     bundle <-
         updateToken builder testSnap testTid feeAddr
     pure (envTx bundle, stateIn, reqIn)
@@ -2280,6 +2328,7 @@ runTightUpdate = do
                 st
                 trieManager
                 dummyProofFn
+                dummyAtomicReader
     envTx
         <$> updateToken builder testSnap testTid feeAddr
 
@@ -2338,6 +2387,7 @@ runRealisticRetractWith = do
                 st
                 dummyTrieManager
                 dummyProofFn
+                dummyAtomicReader
     bundle <-
         retractRequest builder testSnap reqIn feeAddr
     pure (envTx bundle, reqIn, stateIn)
@@ -2388,6 +2438,7 @@ runRealisticEndWith = do
                 st
                 dummyTrieManager
                 dummyProofFn
+                dummyAtomicReader
     bundle <- endToken builder testSnap testTid feeAddr
     pure (envTx bundle, stateIn)
 
@@ -2417,7 +2468,12 @@ runRealisticBootToken cfg = do
                 st
                 dummyTrieManager
                 dummyProofFn
-    envTx <$> bootToken builder testSnap feeAddr
+                ( mkDummyAtomicReader
+                    [ (txIn1, utxo1)
+                    , (txIn2, utxo2)
+                    ]
+                )
+    envTx <$> bootToken builder feeAddr [txIn1, txIn2]
 
 -- | Run rejectRequests with mock expired request.
 -- The request has submittedAt=0, processTime=300s,
@@ -2463,5 +2519,6 @@ runRejectRequests = do
                 st
                 trieManager
                 dummyProofFn
+                dummyAtomicReader
     envTx
         <$> rejectRequests builder testSnap testTid feeAddr

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -5,10 +5,17 @@
             "properties": {
                 "address": {
                     "$ref": "#/definitions/Hex"
+                },
+                "funding": {
+                    "items": {
+                        "$ref": "#/definitions/UtxoRef"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
-                "address"
+                "address",
+                "funding"
             ],
             "type": "object"
         },


### PR DESCRIPTION
Closes part of #250 (atomicity for the boot slice).
Closes the boot slice of #252 (no `queryUTxOs` on the boot tx-build path).

## What's wrong on `main`

The boot endpoint torn three reads at once:

1. **Separate snapshot read.** `requireBundleSnapshot` opened one DB transaction for `utxoRoot` and another (via `getCheckpoint`) for the chain checkpoint.
2. **`queryUTxOs prov addr` for input selection.** `bootTokenImpl` reached out to cardano-node's `LocalStateQuery` `GetUTxOByAddress` to pick the wallet's funding inputs. **That node-side query is a LINEAR SCAN OVER THE ENTIRE LEDGER UTXO SET** (see #252) — at production scale it both kills latency and risks DoSing the local node.
3. **Per-input inclusion proofs read in further separate DB transactions** inside `witnesses` via `utxoProof`.

The two reads in (1) tear; the read in (2) is at a different chain tip than (1) and (3); (3) tears against (1). The wire envelope mixes pieces from three different points in time and the verifier rightly rejects.

## What lands

`BootRequest` carries `funding :: [UtxoRef]`. **The wallet picks its own input UTxOs** (Principle IV — External Signing) and hands the refs to the server in the request body. The server never selects them.

The `AtomicCageReader` seam is widened to return everything `bootTokenImpl` needs, all from ONE indexer transaction:

```haskell
type AtomicCageReader m =
    [TxIn]
    -> m (Maybe (BundleSnapshot, [(TxIn, ByteString, ByteString)]))
    --                            ref     txOutCbor   proofBs
```

`bootTokenImpl` calls it once with the wallet's refs and gets back the snapshot, the resolved `TxOut` bytes (decoded once and used for tx balancing), and the per-input inclusion proofs. cardano-node is no longer consulted for state on this path.

`TxBuilder.bootToken`'s signature collapses to `Addr -> [TxIn] -> m (ProofEnvelope BootProof)` — no `BundleSnapshot` argument any more.

## Surface

- New: `BootRequest.brFunding :: [UtxoRef]` (wire-shape, JSON `funding` field).
- New: `AppConfig.atomicCageReaderOverride :: Maybe (Provider IO -> AtomicCageReader IO)` — test seam. Production passes `Nothing`. Fixtures with `followerEnabled = False` (`IndexerSpec`, `CageSpec`) supply a wallet-backed stub that pulls `TxOut` bytes via `queryUTxOs` so the tx-builder can balance without a real indexer.
- New: `Cardano.MPFS.E2E.WalletSim.walletBoot` — e2e fixture helper that simulates the wallet (it is allowed to call `queryUTxOs` because that is the wallet's job; the ban is on the *server*).
- Removed (from the boot path): `queryUTxOs prov addr` in `bootTokenImpl`. Other handlers still use it — they migrate in their own slices per #250.
- swagger.json regenerated.
- `Cardano.MPFS.Provider.queryUTxOs` haddock keeps the forbidden-in-tx-build warning that points at #252.

## Per-slice acceptance (#250)

This slice satisfies the rule that every atomic-handler migration MUST also remove `queryUTxOs` from its handler's path:

```
$ grep -n "queryUTxOs" cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs
(no output)
```

The field stays on `Provider` until the remaining six tx-builder modules (Request, Update, Retract, Reject, End, Sweep) are migrated; #252 closes when those are done and the field is deleted.

## Test plan (all run locally on this branch)

- [x] `nix build .#offchain-tests .#e2e-tests .#cardano-mpfs-offchain .#docker-image .#checks.x86_64-linux.swagger-up-to-date` — green
- [x] `nix run .#format-check` — clean
- [x] `nix run .#hlint` — no hints
- [x] `nix develop -c just e2e` — **22/22 pass**, including HTTPLifecycle, ProofsSpec proof-bearing scenarios, and the IndexerSpec/CageSpec no-follower fixtures backed by `stubAtomicReader`.

## Follow-ups (next slices)

- GET /tokens/:id (`tokenHandler`) and the other proof-bearing read handlers.
- POST /tx/{request/insert, request/delete, update-value, update, retract, reject, sweep, end} — each migration also removes `queryUTxOs` (#252).