### PR TITLE
feat(request): atomic POST /tx/request/{insert,delete,update} — apply boot pattern to the three request endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # cardano-mpfs-offchain Development Guidelines
 
 Auto-generated from active feature plans and maintained by hand where
-repo-wide guidance is stable. Last updated: 2026-05-02.
+repo-wide guidance is stable. Last updated: 2026-05-03.
 
 ## Source of Truth
 
@@ -18,6 +18,7 @@ after design.
 - Haskell GHC 9.10.1 (offchain server, verifier library); Lean 4 (formal model — `lean/` directory) + Servant (HTTP API), `cardano-mpfs-cage` (Aiken-derived on-chain types via PlutusV3 blueprint), `cardano-mpfs-client` (verifier package), `haskell-mts` (CSMT inclusion + prefix-completeness primitives, MPF inclusion + exclusion), `cardano-utxo-csmt` (CSMT runtime), `cardano-ledger-conway` (TxOut/Tx serialization), `cardano-node-clients` (N2C wiring), `chain-follower` (block stream) (243-proof-redesign)
 - RocksDB (existing CSMT + index column families) (243-proof-redesign)
 - RocksDB with 13 column families (6 UTxO from (249-atomic-boot-handler)
+- RocksDB with the existing 13-column-family unified (256-atomic-request-handlers)
 
 - Haskell with GHC 9.10.1 for native builds.
 - `cardano-mpfs-client` verifiers must remain compatible with native
@@ -77,10 +78,10 @@ Every issue starts with speckit artifacts before implementation:
 4. Implementation follows the task list, updating status as work lands.
 
 ## Recent Changes
+- 256-atomic-request-handlers: Added Haskell GHC 9.10.1
 - 249-atomic-boot-handler: Added Haskell GHC 9.10.1
 - 243-proof-redesign: Added Haskell GHC 9.10.1 (offchain server, verifier library); Lean 4 (formal model — `lean/` directory) + Servant (HTTP API), `cardano-mpfs-cage` (Aiken-derived on-chain types via PlutusV3 blueprint), `cardano-mpfs-client` (verifier package), `haskell-mts` (CSMT inclusion + prefix-completeness primitives, MPF inclusion + exclusion), `cardano-utxo-csmt` (CSMT runtime), `cardano-ledger-conway` (TxOut/Tx serialization), `cardano-node-clients` (N2C wiring), `chain-follower` (block stream)
 
-- `178-crypto-proof-replay`: added proof-bearing response verification,
   cryptographic replay constraints, and verifier portability principles.
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/256-atomic-request-handlers/checklists/requirements.md
+++ b/specs/256-atomic-request-handlers/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Atomic POST /tx/request/{insert,delete,update}
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — the spec talks about indexer, snapshot, atomic reads, wire contract, builder purity; no Haskell types, no module names that aren't already public, no record fields.
+- [x] Focused on user value and business needs — proof-bearing verifiability and operational viability under load are the headline outcomes; matches the boot slice's framing.
+- [x] Written for non-technical stakeholders — concepts are stated in plain prose; protocol-level terms (UTxO, CSMT, chain follower) are unavoidable for this domain.
+- [x] All mandatory sections completed — User Scenarios & Testing, Requirements, Success Criteria, Assumptions all present.
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — none introduced; the boot slice answered the architecturally-load-bearing questions.
+- [x] Requirements are testable and unambiguous — each FR specifies a check-able condition; FR-002 / SC-002 / FR-006 / SC-003 are greppable.
+- [x] Success criteria are measurable — verifier-acceptance rate, source-grep counts, suite pass/fail.
+- [x] Success criteria are technology-agnostic — they describe outcomes, not internals.
+- [x] All acceptance scenarios are defined — each user story carries Given/When/Then scenarios.
+- [x] Edge cases are identified — unfunded address, unwarmed indexer, block-during-build, unknown token, corrupted KV column.
+- [x] Scope is clearly bounded — the wire contracts are explicitly preserved; #254 (multi-band snapshots) and the remaining handlers are explicitly out of scope per Assumptions.
+- [x] Dependencies and assumptions identified — Assumptions section captures the IndexerTx primitives' sufficiency, the helper reuse, the DSL combinator coverage, and the out-of-scope items.
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria — every FR maps to at least one acceptance scenario or edge case.
+- [x] User scenarios cover primary flows — Story 1 (verifier-acceptance), Story 2 (no node UTxO query), Story 3 (pure builder modules), Story 4 (no-follower test fixtures).
+- [x] Feature meets measurable outcomes defined in Success Criteria — SC-001 through SC-005 each tie back to a story.
+- [x] No implementation details leak into specification — checked.
+
+## Notes
+
+- This spec is a direct extension of the #249-atomic-boot-handler slice (PR #253). It deliberately reuses the boot slice's proven shape: pure `*Core` constructors + IO orchestrator + DSL program. No new architectural decisions; only application of the same pattern to three more endpoints.
+- The wire contracts (`{ token, key, value, address }`, `{ token, key, value, address }`, `{ token, key, oldValue, newValue, address }` for insert/delete/update respectively) are intentionally preserved.

--- a/specs/256-atomic-request-handlers/contracts/request-core.md
+++ b/specs/256-atomic-request-handlers/contracts/request-core.md
@@ -1,0 +1,201 @@
+# Internal Contract: requestCore + runRequestBuilder
+
+## Purpose
+
+Exact application of the boot-slice contract
+(`specs/249-atomic-boot-handler/contracts/atomic-cage-reader.md`)
+to the three request endpoints. The transaction is described as a
+pure `TxBuild` program in
+`Cardano.MPFS.TxBuilder.Real.Request.requestCore`; the IO
+orchestration (fetch `pp`, run DSL `build`, assemble envelope)
+lives in `Cardano.MPFS.TxBuilder.Real.runRequestBuilder`.
+Handlers compose `IndexerTx` primitives at the HTTP boundary and
+hand the resulting (snapshot, inputs) to the orchestrator.
+
+This is an **internal** contract: there is no HTTP surface
+change. The three wire contracts
+(`POST /tx/request/{insert,delete,update}`) are preserved
+unchanged.
+
+## Signature
+
+```haskell
+-- Cardano.MPFS.TxBuilder.Real.Request
+
+data RequestCore = RequestCore
+    { rcProgram :: TxBuild (Const ()) Void ()
+    , rcInputs :: [(TxIn, TxOut ConwayEra)]
+    , rcAddr :: Addr
+    , rcFunding :: [WitnessedInput]
+    , rcSnapshot :: BundleSnapshot
+    }
+
+data RequestCoreError
+    = RequestCoreDecodeFailed DecoderError
+    | RequestCoreEmptyInputs
+    deriving (Show)
+
+requestCore
+    :: CageConfig
+    -> BundleSnapshot
+    -> [ResolvedWalletInput]
+    -> TokenId
+    -> ByteString
+    -> Operation
+    -> Addr
+    -> Either RequestCoreError RequestCore
+
+requestInsertCore
+    :: CageConfig -> BundleSnapshot
+    -> [ResolvedWalletInput] -> TokenId
+    -> ByteString -> ByteString -> Addr
+    -> Either RequestCoreError RequestCore
+
+requestDeleteCore
+    :: CageConfig -> BundleSnapshot
+    -> [ResolvedWalletInput] -> TokenId
+    -> ByteString -> ByteString -> Addr
+    -> Either RequestCoreError RequestCore
+
+requestUpdateCore
+    :: CageConfig -> BundleSnapshot
+    -> [ResolvedWalletInput] -> TokenId
+    -> ByteString -> ByteString -> ByteString -> Addr
+    -> Either RequestCoreError RequestCore
+```
+
+## Semantics
+
+The implementation MUST satisfy:
+
+1. **Pure construction.** `requestCore` and the three wrappers
+   MUST be pure values. Their module imports neither
+   `Cardano.MPFS.Provider` nor `IO`. (FR-006, SC-003.)
+
+2. **TxBuild program shape.** The `TxBuild` program in `rcProgram`
+   uses only `spend`, `payTo'`, and `collateral` from the DSL.
+   No `mint`, no `spendScript`, no `attachScript`. (Q0-4.)
+
+3. **Pending request output.** The `payTo'` call MUST emit a
+   single output at the per-token request address
+   (`requestAddrFromCfg cfg tid (network cfg)`) with the
+   request datum inline. Value is the requester's tip, computed
+   via `requestLockedAda` (or equivalent).
+
+4. **Input picking.** The first decoded `InputRow` is the
+   funding input (`spend` it). The collateral is the last one
+   (per the boot-slice convention; reused for symmetry).
+
+5. **No `queryUTxOs` reachable from the build path.** A grep of
+   `Cardano.MPFS.TxBuilder.Real.Request` MUST return zero
+   matches for `queryUTxOs`. The provider is not in scope here
+   at all. (FR-002, SC-002.)
+
+6. **Snapshot pass-through.** `rcSnapshot` is the
+   `BundleSnapshot` the caller obtained from
+   `readSnapshot`. The orchestrator places it in `envSnapshot`
+   verbatim.
+
+7. **Funding pass-through.** `rcFunding` is the list of
+   `WitnessedInput` rows emitted via
+   `Wallet.Inputs.rowToWitness`. Same shape as
+   `BootProof.bootFunding`.
+
+## IO orchestrator
+
+```haskell
+-- Cardano.MPFS.TxBuilder.Real
+
+runRequestBuilder
+    :: CageConfig
+    -> Provider IO
+    -> ( CageConfig -> BundleSnapshot
+         -> [ResolvedWalletInput] -> TokenId
+         -> ByteString -> Addr
+         -> Either RequestCoreError RequestCore
+       )
+    -- ^ The pre-applied core constructor (closes over the
+    --   operation kind via partial application from one of the
+    --   three wrappers).
+    -> BundleSnapshot
+    -> [ResolvedWalletInput]
+    -> TokenId
+    -> ByteString
+    -> Addr
+    -> IO (ProofEnvelope RequestProof)
+```
+
+**Behaviour**:
+
+```haskell
+runRequestBuilder cfg prov mkCore snap inputs tid k addr =
+    case mkCore cfg snap inputs tid k addr of
+        Left e -> error $ "requestBuilder: " <> show e
+        Right core -> do
+            pp <- queryProtocolParams prov
+            let evalAdapter tx =
+                    fmap (fmap (either (Left . show) Right))
+                        (evaluateTx prov tx)
+            result <-
+                build pp noCtxInterpretIO evalAdapter
+                    (rcInputs core) (rcAddr core)
+                    (rcProgram core)
+            case result of
+                Left e -> error $ "requestBuilder: DSL build \
+                                  \failed: " <> show e
+                Right tx ->
+                    pure ProofEnvelope
+                        { envTx = tx
+                        , envSnapshot = rcSnapshot core
+                        , envProof = RequestProof
+                            { requestFunding = rcFunding core }
+                        }
+```
+
+The orchestrator mirrors `runBootBuilder` exactly. The DSL's
+`build` is called once per request; the IO surface is one
+function.
+
+## Caller composition (HTTP handlers)
+
+```haskell
+txInsertHandler ctx req = do
+    addr <- requireAddr (irAddr req)
+    let tid = tokenIdFromJSON (irToken req)
+    (mSnap, inputs) <-
+        liftIO $ runIndexerTx ctx $ do
+            snap <- readSnapshot
+            ins <- readWalletInputsAt addr
+            pure (snap, ins)
+    case mSnap of
+        Nothing -> throwError err503 …
+        Just snap
+            | null inputs -> throwError err400 …
+            | otherwise -> do
+                bundle <- liftIO
+                    $ Tx.requestInsert (txBuilder ctx)
+                        snap inputs tid (k req) (v req) addr
+                pure (mkRequestTxResponse bundle)
+```
+
+Symmetric handlers for `txDeleteHandler` and
+`txUpdateValueHandler`. Every handler is one
+`runIndexerTx ctx $ do { … }` followed by one
+`Tx.requestX (txBuilder ctx) …` call.
+
+## Forbidden patterns
+
+These patterns MUST NOT appear after this slice:
+
+- Any call to `queryUTxOs` in
+  `Cardano.MPFS.TxBuilder.Real.Request*` or in the three
+  request handlers.
+- `requireBundleSnapshot` calls in any of the three request
+  handlers (the snapshot is now read inside the same
+  `runIndexerTx` as the wallet inputs — same fix as the boot
+  handler in PR #253).
+- A second `runIndexerTx` call inside one HTTP request.
+- `Provider` or `IO` imports inside the
+  `Cardano.MPFS.TxBuilder.Real.Request` module.
+
+These are the greppable acceptance criteria for the slice.

--- a/specs/256-atomic-request-handlers/data-model.md
+++ b/specs/256-atomic-request-handlers/data-model.md
@@ -1,0 +1,279 @@
+# Phase 1 Data Model: Atomic POST /tx/request/{insert,delete,update}
+
+## Scope
+
+This feature introduces one new pure record (`RequestCore`), one new
+error sum (`RequestCoreError`), one new public function with three
+thin operation-specific wrappers (`requestCore`, `requestInsertCore`,
+`requestDeleteCore`, `requestUpdateCore`), and one IO orchestrator
+(`runRequestBuilder`). It also moves the existing input-decoding
+helpers from `Boot/Inputs.hs` to a shared `Wallet/Inputs.hs`. Every
+other entity it touches already exists.
+
+## New entities
+
+### `RequestCore`
+
+```haskell
+data RequestCore = RequestCore
+    { rcProgram :: TxBuild (Const ()) Void ()
+    , rcInputs :: [(TxIn, TxOut ConwayEra)]
+    , rcAddr :: Addr
+    , rcFunding :: [WitnessedInput]
+    , rcSnapshot :: BundleSnapshot
+    }
+```
+
+**Location**: `Cardano.MPFS.TxBuilder.Real.Request` (existing
+module — replaces the imperative `requestImpl` body).
+
+**Purpose**: Mirrors `BootCore`. All the data the IO layer needs to
+drive the DSL's `build` loop and emit a proof-bearing
+`ProofEnvelope RequestProof`.
+
+### `RequestCoreError`
+
+```haskell
+data RequestCoreError
+    = RequestCoreDecodeFailed DecoderError
+    | RequestCoreEmptyInputs
+    deriving (Show)
+```
+
+**Location**: same module.
+
+**Purpose**: Mirrors `BootCoreError` — the two pre-IO failure modes
+the pure constructor surfaces.
+
+### `requestCore` (pure shared constructor)
+
+```haskell
+requestCore
+    :: CageConfig
+    -> BundleSnapshot
+    -> [ResolvedWalletInput]
+    -> TokenId
+    -> ByteString          -- key
+    -> Operation           -- insert / delete / update payload
+    -> Addr                -- requester
+    -> Either RequestCoreError RequestCore
+```
+
+**Behaviour**: Decode inputs → pick wallet UTxOs (one funding input
+plus one collateral, mirroring boot) → derive the per-token request
+address from `cfg + tid` (pure) → describe the tx as a
+`TxBuild (Const ()) Void ()` program (`spend` + `payTo'` for the
+pending-request output with inline datum + `collateral`) → return
+`RequestCore`.
+
+### `requestInsertCore`, `requestDeleteCore`, `requestUpdateCore`
+
+Three thin wrappers that pre-fill the operation discriminator:
+
+```haskell
+requestInsertCore cfg snap inputs tid key value addr =
+    requestCore cfg snap inputs tid key (OpInsert value) addr
+
+requestDeleteCore cfg snap inputs tid key oldVal addr =
+    requestCore cfg snap inputs tid key (OpDelete oldVal) addr
+
+requestUpdateCore cfg snap inputs tid key oldVal newVal addr =
+    requestCore cfg snap inputs tid key
+        (OpUpdate oldVal newVal) addr
+```
+
+These three are the public surface of the module.
+
+### `runRequestBuilder` (IO orchestrator)
+
+**Location**: `Cardano.MPFS.TxBuilder.Real` (alongside
+`runBootBuilder`).
+
+```haskell
+runRequestBuilder
+    :: CageConfig
+    -> Provider IO
+    -> ( CageConfig
+         -> BundleSnapshot
+         -> [ResolvedWalletInput]
+         -> TokenId
+         -> ByteString
+         -> Addr
+         -> Either RequestCoreError RequestCore
+       )
+    -- ^ One of the three *Core wrappers, partially applied
+    -> BundleSnapshot
+    -> [ResolvedWalletInput]
+    -> TokenId
+    -> ByteString
+    -> Addr
+    -> IO (ProofEnvelope RequestProof)
+```
+
+**Behaviour**: Call the supplied core constructor → on `Left`,
+`error` with the variant → on `Right`, fetch `pp`, run DSL `build`
+with the request's `evalAdapter` (same shape as boot) → return
+the envelope.
+
+## Changed entities
+
+### `Cardano.MPFS.TxBuilder.Real.Request`
+
+- Remove `requestImpl` (the imperative IO function).
+- Remove `requestInsertImpl`, `requestDeleteImpl`,
+  `requestUpdateImpl` (their wrappers around `requestImpl`).
+- Add `requestCore`, `requestInsertCore`, `requestDeleteCore`,
+  `requestUpdateCore` — pure functions returning
+  `Either RequestCoreError RequestCore`.
+- Drop imports of `Provider`, `State`, `IO`,
+  `evaluateAndBalance`, `mkBasicTxBody`, etc.
+- Module is structurally pure: no `IO`, no `Provider`.
+
+### `Cardano.MPFS.TxBuilder.Real.mkRealTxBuilder`
+
+Wire the three request fields to `runRequestBuilder` partial-
+applications (one per operation):
+
+```haskell
+{ requestInsert = \snap inputs tid k v addr ->
+    runRequestBuilder cfg prov
+        (\c s i t k' a -> requestInsertCore c s i t k' v a)
+        snap inputs tid k addr
+, requestDelete = \snap inputs tid k oldV addr ->
+    runRequestBuilder cfg prov
+        (\c s i t k' a -> requestDeleteCore c s i t k' oldV a)
+        snap inputs tid k addr
+, requestUpdate = \snap inputs tid k oldV newV addr ->
+    runRequestBuilder cfg prov
+        (\c s i t k' a -> requestUpdateCore c s i t k' oldV newV a)
+        snap inputs tid k addr
+}
+```
+
+Or, if cleaner, three small private orchestrators (one per
+operation) calling a common `runRequestBuilder'` that accepts a
+pre-built `RequestCore` builder. Both shapes equivalent;
+implementation chooses the less awkward.
+
+### `Cardano.MPFS.HTTP.Server.txInsertHandler` / `txDeleteHandler` / `txUpdateValueHandler`
+
+Each handler today reads the snapshot in the HTTP layer (separate
+from the per-input proofs read inside `requestImpl`). After this
+slice, each handler:
+
+```haskell
+txInsertHandler ctx req = do
+    addr <- requireAddr (irAddr req)
+    let tid = tokenIdFromJSON (irToken req)
+    (mSnap, inputs) <-
+        liftIO $ runIndexerTx ctx $ do
+            snap <- readSnapshot
+            ins <- readWalletInputsAt addr
+            pure (snap, ins)
+    case mSnap of
+        Nothing -> throwError err503 …
+        Just snap
+            | null inputs -> throwError err400 …
+            | otherwise -> do
+                bundle <-
+                    liftIO
+                        $ Tx.requestInsert
+                            (txBuilder ctx)
+                            snap
+                            inputs
+                            tid
+                            (k req)
+                            (v req)
+                            addr
+                pure (mkRequestTxResponse bundle)
+```
+
+The `Tx.requestInsert` field's signature gains a
+`[ResolvedWalletInput]` argument before the `TokenId`, mirroring
+the change `Tx.bootToken` got in PR #253. Same for the other two.
+
+### `Cardano.MPFS.TxBuilder.TxBuilder` (signature changes)
+
+```haskell
+data TxBuilder m = TxBuilder
+    { bootToken
+        :: BundleSnapshot -> [ResolvedWalletInput] -> Addr
+        -> m (ProofEnvelope BootProof)
+    , requestInsert
+        :: BundleSnapshot -> [ResolvedWalletInput] -> TokenId
+        -> ByteString -> ByteString -> Addr
+        -> m (ProofEnvelope RequestProof)
+    , requestDelete
+        :: BundleSnapshot -> [ResolvedWalletInput] -> TokenId
+        -> ByteString -> ByteString -> Addr
+        -> m (ProofEnvelope RequestProof)
+    , requestUpdate
+        :: BundleSnapshot -> [ResolvedWalletInput] -> TokenId
+        -> ByteString -> ByteString -> ByteString -> Addr
+        -> m (ProofEnvelope RequestProof)
+    , …  -- updateToken, retractRequest, rejectRequests, endToken
+        -- unchanged for this slice
+    }
+```
+
+The three request fields gain a `[ResolvedWalletInput]` argument
+in the same position boot already has (after `BundleSnapshot`).
+
+### `Cardano.MPFS.TxBuilder.Real.Boot.Inputs` → `Wallet.Inputs`
+
+Module move only. Same exports; importers in `Boot.hs` and
+`Request.hs` update.
+
+## Unchanged entities (used as-is)
+
+- `Cardano.MPFS.TxBuilder.BundleSnapshot` — produced by
+  `readSnapshot` (from PR #253).
+- `Cardano.MPFS.TxBuilder.WitnessedInput` — emitted by the
+  builder; constructed via `Wallet.Inputs.rowToWitness`.
+- `Cardano.MPFS.TxBuilder.RequestProof` — unchanged.
+- `Cardano.MPFS.TxBuilder.ResolvedWalletInput` — produced by
+  `readWalletInputsAt`.
+- `Cardano.MPFS.TxBuilder.Real.Internal.requestAddrFromCfg`,
+  `mkRequestDatum`, `toPlcData`, `mkInlineDatum`,
+  `requestLockedAda` — reused.
+- `Cardano.MPFS.HTTP.Types.InsertRequest` /
+  `DeleteRequest` / `UpdateRequest` — wire contracts unchanged
+  (FR-003).
+- `Cardano.MPFS.Provider.queryUTxOs` — kept for wallet-side test
+  use; zero call sites in `lib/` after this slice.
+
+## State transitions
+
+Each request endpoint is stateless on the server side (no DB write).
+The state observed is the indexer's snapshot at transaction-open
+time (one `runIndexerTx`).
+
+```text
+Request → runIndexerTx ctx (readSnapshot >>= readWalletInputsAt addr)
+                              ↓ one transaction, coherent reads
+                          (snap, inputs)
+                              ↓
+                          requestInsert / Delete / Update
+                              ↓
+                          ProofEnvelope RequestProof
+                              ↓
+                          UnsignedTxResponse → wallet
+```
+
+Errors map deterministically:
+
+- `mSnap == Nothing` → `503 Indexer not ready: snapshot unavailable`
+- `mSnap == Just _` && `null inputs` → `400 No wallet UTxOs at address`
+
+## Validation rules
+
+| Rule                                                                                                                                             | Source FR(s) |
+| ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| `runIndexerTx` opens exactly one underlying RocksDB transaction per HTTP request.                                                                | FR-001 |
+| Every `WitnessedInput` proof verifies against the response's snapshot's CSMT root.                                                               | FR-001, FR-007 |
+| The three request impl modules contain zero call sites of `queryUTxOs`.                                                                           | FR-002, SC-002 |
+| `InsertRequest`, `DeleteRequest`, `UpdateRequest` retain their existing fields exactly.                                                          | FR-003 |
+| Each handler emits the documented status codes deterministically per error case.                                                                  | FR-004 |
+| `readWalletInputsAt`'s wall-clock cost is bounded by the number of UTxOs at the address (already true after PR #253; reused unchanged).          | FR-005 |
+| The Request module imports neither `Provider` nor any IO-typed function; the transaction body is a `TxBuild` program.                            | FR-006, SC-003 |
+| The verifier accepts request responses purely offline.                                                                                           | FR-007, SC-001 |

--- a/specs/256-atomic-request-handlers/plan.md
+++ b/specs/256-atomic-request-handlers/plan.md
@@ -1,0 +1,286 @@
+# Implementation Plan: Atomic POST /tx/request/{insert,delete,update}
+
+**Branch**: `256-atomic-request-handlers` | **Date**: 2026-05-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/256-atomic-request-handlers/spec.md`
+
+## Summary
+
+Apply the proven boot-slice pattern (#249, PR #253) to the three
+request endpoints. Each handler reads its `BundleSnapshot` and the
+wallet inputs at the requester address inside one
+`runIndexerTx ctx $ do { … }` call composed from the existing
+`Cardano.MPFS.Indexer.Reads` primitives (`readSnapshot`,
+`readWalletInputsAt`). The three builder impls collapse into a single
+shared pure `requestCore` (mirroring `bootTokenCore`) that returns a
+`RequestCore` record (program + ledger pairs + funding + snapshot);
+`Cardano.MPFS.TxBuilder.Real` holds the IO orchestrator
+(`runRequestBuilder`) that fetches `pp`, runs the DSL `build` loop,
+and assembles the envelope. `Provider.queryUTxOs` is removed from the
+request build path entirely.
+
+The request transaction shape itself is unchanged — the on-chain
+validators in `cardano-mpfs-onchain` and the wire contracts are
+untouched. Only the server-side construction path is reshaped.
+
+## Technical Context
+
+**Language/Version**: Haskell GHC 9.10.1
+**Primary Dependencies**:
+
+- `cardano-mpfs-offchain` (this repo) — server, tx-builders, HTTP
+  layer, indexer reads.
+- `cardano-node-clients:Cardano.Node.Client.TxBuild` — the DSL we
+  migrated boot to in PR #253; reused verbatim here.
+- `cardano-mpfs-offchain:Cardano.MPFS.Indexer.Reads` — `IndexerTx`
+  monad and primitives (`readSnapshot`, `readWalletInputsAt`)
+  introduced in PR #253.
+- `cardano-ledger-conway` — `TxOut` CBOR (de)serialization (already
+  used by `Boot.Inputs.decodeAll`; either reuse or generalise to a
+  shared `Wallet.Inputs` module).
+- `servant-server` — the three `txInsertHandler`, `txDeleteHandler`,
+  `txUpdateValueHandler` Servant handlers.
+
+**Storage**: RocksDB with the existing 13-column-family unified
+schema. No schema change.
+
+**Testing**:
+
+- Unit tests in `cardano-mpfs-offchain` — new property tests for the
+  three pure `*Core` constructors using deterministic
+  `[(TxIn, TxOut bytes, proof)]` triples.
+- E2E tests in `cardano-mpfs-offchain` — extend `ProofsSpec` with
+  three churn-test variants (insert/delete/update); the existing
+  `HTTPLifecycleSpec` and `CageFlowSpec` already exercise the three
+  endpoints under `followerEnabled = True`, so they validate FR-001
+  end-to-end against the new shape.
+
+**Target Platform**: Linux server (amd64) inside `nix develop`.
+
+**Project Type**: Haskell multi-package web service.
+
+**Performance Goals**:
+
+- Same as boot slice: request endpoint median latency at K=2 wallet
+  UTxOs and 1M total chain UTxOs ≤ 2× the median at 1k total chain
+  UTxOs.
+
+**Constraints**:
+
+- Wire contracts MUST stay identical (FR-003).
+- No `Provider.queryUTxOs` on the build path (FR-002, SC-002).
+- Builder modules MUST be pure (FR-006, SC-003).
+- One indexer transaction per request (FR-001, SC-005).
+- Verifier purity preserved (FR-007).
+
+**Scale/Scope**:
+
+- ~3 modules touched in `cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/`
+  (`Request.hs` rewrites, `Real.hs` adds the IO orchestrator, the
+  `Internal.hs` helpers it reuses are unchanged).
+- ~3 HTTP handlers rewritten in `Cardano/MPFS/HTTP/Server.hs`.
+- Optional: `Boot/Inputs.hs` generalised to `Wallet/Inputs.hs` if
+  shared decode/projection helpers move out — to be decided in
+  Phase 0.
+- 1 new unit-test module covering the three `*Core` constructors.
+- E2E tests extended in-place (no new modules).
+- No wire-schema or migration changes.
+
+## Constitution Check
+
+The constitution at `.specify/memory/constitution.md` enumerates
+principles that govern architectural decisions. This slice's gates
+are identical in structure to the boot slice's (#249, PR #253).
+
+### Principle I — Ledger-Native Types
+
+**Gate**: PASS. The shared `InputRow` carries `TxOut ConwayEra`
+directly; the DSL's `build` returns `Tx ConwayEra`. No shadow types.
+
+### Principle II — Records of Functions
+
+**Gate**: PASS. No new typeclasses introduced. `RequestCore` is a
+pure data record; `Context` already exposes `runIndexerTx` from
+PR #253 and is reused as-is.
+
+### Principle III — Atomic Block Processing
+
+**Gate**: PASS. The chain follower's writer invariant is unchanged.
+The three request handlers add three new readers, each one a single
+`runIndexerTx ctx $ do { … }` block — exactly the discipline
+introduced by PR #253. No new column families, no new write paths.
+
+### Principle IV — External Signing
+
+**Gate**: PASS. Returned txs are unsigned. Unchanged.
+
+### Principle V — Aiken Compatibility
+
+**Gate**: PASS. Request datum, redeemer, output address, and
+on-chain reference shapes are unchanged from the existing
+`requestImpl`. Only the construction mechanism (DSL program vs.
+imperative lens updates) changes; the resulting `Tx` is byte-equal
+when fed identical inputs.
+
+### Principle VI — Test Locally First
+
+**Gate**: PASS. Full quality gate locally before each push,
+mirroring the boot slice's discipline:
+`nix build .#offchain-tests .#e2e-tests .#cardano-mpfs-offchain
+.#docker-image .#checks.x86_64-linux.swagger-up-to-date && just
+format-check && just hlint && nix run .#unit-tests && nix run
+.#e2e-tests`.
+
+### Principle VII — Nix Reproducibility
+
+**Gate**: PASS. No new system dependencies.
+
+### Principle VIII — Pure Offline Verification
+
+**Gate**: PASS. The verifier is unchanged. Producer-side fix is
+what makes verifier acceptance reach 100% under churn (SC-001) for
+the three request responses.
+
+### Principle IX — One Verifier, Many Targets
+
+**Gate**: PASS / not affected. No verifier changes; no new
+`cardano-mpfs-client` deps.
+
+### Principle X — Lean as Source of Truth
+
+**Gate**: NOT APPLICABLE for this slice. Same reasoning as PR #253
+— the Lean model formalizes verifier-side properties; producer-side
+read coherence is captured by FR-001/SC-001, not by a Lean theorem.
+
+**Re-check after Phase 1 design**: see end of this file.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/256-atomic-request-handlers/
+├── plan.md              # This file
+├── research.md          # Phase 0 — design decisions
+├── data-model.md        # Phase 1 — RequestCore + reuse map
+├── quickstart.md        # Phase 1 — exercise the three endpoints
+├── contracts/
+│   └── request-core.md  # Phase 1 — internal contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (already complete)
+└── tasks.md             # Phase 2 — generated by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+cardano-mpfs-offchain/
+├── lib/Cardano/MPFS/
+│   ├── HTTP/Server.hs                        # CHANGED — three request handlers rewritten
+│   ├── TxBuilder/Real.hs                     # CHANGED — adds runRequestBuilder
+│   ├── TxBuilder/Real/Request.hs             # CHANGED — collapses to pure requestCore + 3 wrappers
+│   ├── TxBuilder/Real/Boot/Inputs.hs         # MAYBE MOVED to Wallet/Inputs.hs (Phase 0)
+│   └── TxBuilder/Real/Internal.hs            # UNCHANGED — non-boot/request builders still use it
+└── test/Cardano/MPFS/TxBuilder/
+    └── RequestSpec.hs                        # NEW — unit tests for the three Cores
+```
+
+**Structure Decision**: The boot slice already established the
+shape: one pure `*Core` module + IO orchestrator in `Real.hs` + DSL
+program for the tx body. This slice repeats that shape for the
+three request endpoints, sharing one `requestCore` function across
+`requestInsertCore` / `requestDeleteCore` / `requestUpdateCore` —
+the three already funnel through a shared `requestImpl` today, so
+the parameterisation point already exists in the source.
+
+The only architectural question to resolve in Phase 0 is whether
+`Boot/Inputs.hs` (input decoding + `InputRow` + `decodeAll` +
+`ledgerPair` + `rowToWitness`) generalises to a shared
+`Wallet/Inputs.hs`, since the three request endpoints need exactly
+the same decoding shape as boot.
+
+## Phase 0: Outline & Research
+
+See `research.md` for the resolved design questions:
+
+- **Q0-1 — Share `Boot/Inputs.hs` or duplicate?** Resolved: rename
+  to `Wallet/Inputs.hs`. Both Boot and Request consume identical
+  data. No behaviour change — just a cross-handler home.
+- **Q0-2 — One `requestCore` parameterised on operation, or three
+  separate functions?** Resolved: keep one `requestCore` with an
+  operation-kind argument (mirrors today's `requestImpl`); export
+  three thin wrappers as the public API.
+- **Q0-3 — Where does `runRequestBuilder` live?** Resolved:
+  `Cardano.MPFS.TxBuilder.Real`, alongside `runBootBuilder`. Both
+  hold the `Provider` and the DSL `build` call; co-locating keeps
+  the IO surface searchable.
+- **Q0-4 — DSL combinator coverage.** Resolved: `spend` (per
+  wallet input), `payTo'` (request output with inline datum at the
+  per-token request address), `collateral`. No `mint`, no
+  `spendScript`. The existing DSL combinators are sufficient.
+- **Q0-5 — Where does the per-token request address come from?**
+  Resolved: looked up via `State.tokens` (an existing `State` field
+  on `Context`) inside the IO orchestrator. The pure
+  `requestCore` receives the resolved `requestAddr` as an argument
+  rather than the `tokenId`, so it does not depend on `State`.
+- **Q0-6 — Does `requestImpl` consult `Provider.queryUTxOs` only,
+  or anything else from `Provider`?** Resolved by source reading:
+  `requestImpl` calls `queryUTxOs prov addr` (the forbidden one)
+  and `queryProtocolParams prov` (kept, called from the IO
+  orchestrator) and `evaluateTx prov` (kept, called from the IO
+  orchestrator inside the DSL `build` evaluator). Only
+  `queryUTxOs` goes.
+
+**Output**: `research.md`.
+
+## Phase 1: Design & Contracts
+
+**Prerequisites**: research.md complete.
+
+### 1. Data model
+
+See `data-model.md`. Key entities:
+
+- `RequestCore` — record bundling `TxBuild` program + ledger
+  pairs + funding + snapshot + the per-token request output
+  destination address.
+- `RequestCoreError` — sum type for decode-failure and empty-
+  inputs cases (mirrors `BootCoreError`).
+- `RequestOp` — operation discriminator carrying insert / delete /
+  update payloads; reuses the existing `Operation` ADT in
+  `Cardano.MPFS.Core.Types` plus the on-chain `OpInsert` /
+  `OpDelete` / `OpUpdate` constructors in
+  `Cardano.MPFS.Core.OnChain`.
+
+### 2. Contracts
+
+See `contracts/request-core.md` — internal contract for the
+shared `requestCore` function and the three public wrappers.
+There are no new HTTP contracts: the three request wire
+contracts are unchanged (FR-003).
+
+### 3. Quickstart
+
+See `quickstart.md` — bring up devnet, exercise the three
+endpoints, observe the atomicity property.
+
+### 4. Agent context update
+
+`CLAUDE.md` already lists the technologies. This slice introduces
+no new tech.
+
+## Constitution Check (Re-evaluation, Post Phase 1 Design)
+
+I, II, III, IV, V, VI, VII, VIII, IX, X — unchanged from
+pre-Phase-0 evaluation. The shape is a strict pattern application
+of the boot slice; no new types, typeclasses, key handling, Aiken
+changes, system deps, verifier changes, or Lean changes.
+
+No violations. No entries needed in Complexity Tracking.
+
+## Complexity Tracking
+
+> No constitutional violations. Section intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none)    |            |                                     |

--- a/specs/256-atomic-request-handlers/quickstart.md
+++ b/specs/256-atomic-request-handlers/quickstart.md
@@ -1,0 +1,108 @@
+# Quickstart: Exercise the atomic POST /tx/request/{insert,delete,update}
+
+This walkthrough drives the three request endpoints end-to-end and
+verifies the atomic-read property. Boots from a fresh devnet plus a
+booted token.
+
+## 1. Enter dev shell + run the boot scenario first
+
+```bash
+cd /code/cardano-mpfs-offchain-atomic-requests
+nix develop
+```
+
+Run the boot quickstart from the previous slice
+(`specs/249-atomic-boot-handler/quickstart.md`) up to "boot a
+token", or use the e2e harness directly. The result: a
+`tokenId` whose state UTxO is indexed.
+
+## 2. Drive POST /tx/request/insert
+
+```bash
+TOKEN_ID=…                # from boot step
+ADDR=…                    # requester address (hex)
+KEY=$(printf 'hello' | xxd -p)
+VALUE=$(printf 'world' | xxd -p)
+
+curl -sS http://localhost:3000/tx/request/insert \
+    -H 'Content-Type: application/json' \
+    -d "{\"token\":\"$TOKEN_ID\",\"key\":\"$KEY\",\"value\":\"$VALUE\",\"address\":\"$ADDR\"}" \
+    | jq
+```
+
+Expected: an `UnsignedTxResponse` with the same shape as boot — a
+`transaction` field plus a `snapshot` and a `proof.request_funding`
+list of `WitnessedInput` triples (ref, txout, csmt_proof).
+
+Sign + submit (same script the boot quickstart uses) and observe
+the chain follower indexing the resulting pending-request UTxO at
+the per-token request address.
+
+## 3. Drive POST /tx/request/delete
+
+```bash
+curl -sS http://localhost:3000/tx/request/delete \
+    -H 'Content-Type: application/json' \
+    -d "{\"token\":\"$TOKEN_ID\",\"key\":\"$KEY\",\"value\":\"$VALUE\",\"address\":\"$ADDR\"}" \
+    | jq
+```
+
+Same response shape; the on-chain validators discriminate
+insert/delete/update via the request datum.
+
+## 4. Drive POST /tx/request/update
+
+```bash
+NEW_VALUE=$(printf 'monde' | xxd -p)
+curl -sS http://localhost:3000/tx/request/update \
+    -H 'Content-Type: application/json' \
+    -d "{\"token\":\"$TOKEN_ID\",\"key\":\"$KEY\",\"old_value\":\"$VALUE\",\"new_value\":\"$NEW_VALUE\",\"address\":\"$ADDR\"}" \
+    | jq
+```
+
+## 5. Verify each response offline
+
+```bash
+just verify-request-response /tmp/insert-response.json --trusted-root <utxo_root>
+just verify-request-response /tmp/delete-response.json --trusted-root <utxo_root>
+just verify-request-response /tmp/update-response.json --trusted-root <utxo_root>
+```
+
+All three MUST exit 0 (`accepted`). Tamper with `--trusted-root`
+and the verifier MUST exit non-zero with a snapshot mismatch.
+
+## 6. Atomicity under chain churn (SC-001)
+
+```bash
+just chain-churn-load &      # background: 1+ block per second
+sleep 60                     # let the chain churn
+
+# Hit each endpoint 50 times back-to-back; every response must
+# verify cleanly.
+for i in $(seq 1 50); do
+    just request-insert-and-verify "$TOKEN_ID" "$ADDR" "key$i" "val$i"
+    just request-delete-and-verify "$TOKEN_ID" "$ADDR" "key$i" "val$i"
+    just request-update-and-verify "$TOKEN_ID" "$ADDR" "key$i" "old$i" "new$i"
+done
+```
+
+All 150 invocations MUST exit 0.
+
+## 7. followerEnabled = False fixture path
+
+The harness used by `CageFlowSpec` already calls the three request
+builders directly via `Tx.requestX (txBuilder ctx) …`. After this
+slice, the call site adds `bootInputs` (or an analogous
+`requestInputs`) before the `tokenId`:
+
+```haskell
+inputs <- walletBootInputs (provider ctx) genesisAddr
+bundle <- Tx.requestInsert (txBuilder ctx) emptySnap inputs tid key value addr
+```
+
+Run with:
+
+```bash
+just unit-offchain --match "CageFlow"
+just e2e --match "Request"
+```

--- a/specs/256-atomic-request-handlers/research.md
+++ b/specs/256-atomic-request-handlers/research.md
@@ -1,0 +1,187 @@
+# Phase 0 Research: Atomic POST /tx/request/{insert,delete,update}
+
+This research log resolves the design questions raised by the spec.
+The slice carries no NEEDS CLARIFICATION markers — every decision
+below is grounded in code already in the repo (post-PR #253) or in
+the existing `requestImpl` body.
+
+## Q0-1 — Share `Boot/Inputs.hs` or duplicate?
+
+**Decision**: Rename
+`cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot/Inputs.hs`
+to
+`cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Wallet/Inputs.hs`.
+The module's exported types (`InputRow`, `decodeAll`, `ledgerPair`,
+`rowToWitness`) are domain-neutral — they describe how the indexer's
+raw bytes become ledger-typed pairs and witnessed-input rows.
+Importers update from
+`Cardano.MPFS.TxBuilder.Real.Boot.Inputs` to
+`Cardano.MPFS.TxBuilder.Real.Wallet.Inputs`. No behaviour change.
+
+**Rationale**: Both Boot and Request consume identical data. Two
+copies would drift; a shared module under a name that doesn't imply
+"boot-only" is the right home.
+
+**Alternatives considered**:
+
+- *Leave under Boot, import across handlers*: rejected. The name
+  lies — readers seeing
+  `Cardano.MPFS.TxBuilder.Real.Boot.Inputs.InputRow` in a Request
+  module would assume a Boot-specific dependency.
+- *Duplicate in Request*: rejected. Drift is guaranteed; the
+  decoder either matches the indexer's encoding or the response
+  is wrong, and we don't want two answers to that question.
+- *Defer until update/reject also need it*: rejected. Three
+  callers (boot, insert, delete, update — actually four including
+  the boot case) is enough to justify the shared home now.
+
+## Q0-2 — One `requestCore` parameterised, or three?
+
+**Decision**: One pure `requestCore` taking the operation kind as
+an argument; three thin public wrappers (`requestInsertCore`,
+`requestDeleteCore`, `requestUpdateCore`) parameterise the
+operation and call the shared core.
+
+**Rationale**: This matches today's source — `requestImpl` already
+takes an `Operation` parameter and is shared by the three impls. The
+DSL migration doesn't change that structure; it only replaces the
+imperative tx assembly inside `requestImpl` with a `TxBuild`
+program. Keeping three public wrappers preserves the
+`TxBuilder.requestInsert` / `requestDelete` / `requestUpdate` field
+shapes used by `mkRealTxBuilder` and the HTTP handlers.
+
+**Alternatives considered**:
+
+- *Three independent `*Core` functions, each ~60 lines*: rejected.
+  Triplicates the shared assembly (output construction, redeemer
+  derivation, etc.), opens room for divergence.
+- *No public wrappers; HTTP handlers call `requestCore` directly
+  with the operation tag*: rejected. The `TxBuilder` record-of-
+  functions interface is the project's service boundary
+  (Principle II); each endpoint has its own field there.
+
+## Q0-3 — Where does `runRequestBuilder` live?
+
+**Decision**: `Cardano.MPFS.TxBuilder.Real`, alongside the existing
+`runBootBuilder`. The two functions share the same shape (decode →
+fetch `pp` → run DSL `build` → assemble envelope) and both depend
+on `Provider IO`.
+
+**Rationale**: PR #253 established `Real.hs` as the IO surface for
+boot. Adding `runRequestBuilder` next to it keeps the IO call sites
+greppable in one file. The HTTP handler imports neither
+`Real.runRequestBuilder` nor `Real.runBootBuilder` directly — it
+calls through `txBuilder ctx`.
+
+**Alternatives considered**:
+
+- *Inline in HTTP handler*: rejected. Mixes wire-shape concerns
+  with tx-build IO and breaks the IO/handler separation the boot
+  slice established.
+- *New module
+  `Cardano.MPFS.TxBuilder.Real.Request.Build`*: rejected. The IO
+  surface is small (~40 lines per handler family); fragmenting
+  across modules costs more than co-location.
+
+## Q0-4 — DSL combinator coverage
+
+**Decision**: The three request transactions need:
+
+- `spend` per consumed wallet input,
+- `payTo'` to construct the pending-request output at the
+  per-token request address with the request datum inline,
+- `collateral` to designate the script-witness slot,
+
+… and nothing else. No `mint` (request txs don't mint), no
+`spendScript` (they don't consume any script UTxO; the state UTxO
+is consulted out-of-band via tip-checking), no `attachScript`
+(the script-witness is on the consumed wallet input only — no
+Plutus script attaches in the request tx body).
+
+**Rationale**: Read `requestImpl`'s body in
+`cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs`.
+It builds a tx body with one input (the seed wallet UTxO), one
+output (the pending request), one collateral. No mint, no script
+witnesses on the redeemer side. The DSL combinators above cover
+this exactly.
+
+**Alternatives considered**:
+
+- *Use `output`, not `payTo'`, and inline the datum manually*:
+  rejected. `payTo'` is the DSL idiom for "value + inline datum at
+  address"; matches the boot slice's `bootStateOutput`.
+
+## Q0-5 — Where does the per-token request address come from?
+
+**Decision**: Looked up via `State.tokens` (an existing `State`
+field on `Context`) inside the IO orchestrator
+`runRequestBuilder`. The pure `requestCore` receives the resolved
+`requestAddr` as an argument rather than the `TokenId`; it does
+not depend on `State`.
+
+**Rationale**: Today `requestImpl` does:
+
+```haskell
+requestImpl cfg prov st proofFn snap tid key op addr = do
+    pp <- queryProtocolParams prov
+    utxos <- queryUTxOs prov addr            -- ← removed
+    -- … look up the token's request address via cfg + tid …
+    -- … build the tx …
+```
+
+The "look up the token's request address" step is `pure` and uses
+only `cfg` + `tid` (no `State`). Looking at
+`requestAddrFromCfg cfg tid (network cfg)` in
+`TxBuilder/Real/Internal.hs` confirms this. So `requestCore` can
+either:
+
+a) take `tid` and call `requestAddrFromCfg` itself (still pure), or
+b) take the resolved `requestAddr` from the orchestrator.
+
+**Going with (a)** — the function takes `tid`. Keeps the
+orchestrator simple; `requestAddrFromCfg` is pure so this doesn't
+add IO to the core.
+
+## Q0-6 — Does `requestImpl` use anything else from `Provider`?
+
+**Decision** (by source reading): `requestImpl` calls:
+
+- `queryUTxOs prov addr` — FORBIDDEN, removed.
+- `queryProtocolParams prov` — kept; called from the IO
+  orchestrator (same as boot).
+- `evaluateTx prov` — kept; called from the IO orchestrator inside
+  the DSL `build` evaluator (same as boot).
+
+No `posixMsToSlot` / `posixMsCeilSlot` calls (request txs don't
+set validity intervals). Provider stays in `runRequestBuilder`,
+not in `requestCore`.
+
+## Q0-7 — Reuse boot's `noCtxInterpretIO` or define another?
+
+**Decision**: Promote `noCtxInterpretIO` from the local helper in
+`Cardano.MPFS.TxBuilder.Real` (where it lives after PR #253) to a
+shared helper in the same module — already there. Both boot and
+request orchestrators use it.
+
+## Pinned facts
+
+- `Cardano.MPFS.Indexer.Reads` exposes `readSnapshot` and
+  `readWalletInputsAt`. No new primitives are needed.
+- `Cardano.MPFS.TxBuilder.Real.Boot.Inputs` will be renamed to
+  `Cardano.MPFS.TxBuilder.Real.Wallet.Inputs` (only an import-path
+  change, no semantics).
+- `Cardano.MPFS.TxBuilder.Real.Internal` exposes
+  `requestAddrFromCfg`, `mkRequestDatum`, `toPlcData`,
+  `mkInlineDatum`, `requestLockedAda` — all the helpers we need.
+  No edits there.
+- The wire contracts in
+  `Cardano.MPFS.HTTP.Types` (`InsertRequest`, `DeleteRequest`,
+  `UpdateRequest`) are unchanged.
+- `Provider.queryUTxOs` is kept as a Provider field (test
+  fixtures still use it on the wallet side); after this slice
+  there are zero call sites of `queryUTxOs` in
+  `cardano-mpfs-offchain/lib/`.
+
+## Output
+
+`research.md` — this file.

--- a/specs/256-atomic-request-handlers/spec.md
+++ b/specs/256-atomic-request-handlers/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Atomic POST /tx/request/{insert,delete,update}
+
+**Feature Branch**: `256-atomic-request-handlers`
+**Created**: 2026-05-03
+**Status**: Draft
+**Input**: User description: "atomic-request-handlers — apply the same atomic-indexer-read pattern from #249 (PR #253) to the three request endpoints. Each handler MUST read its `BundleSnapshot` and the resolved `TxOut` bytes + CSMT inclusion proofs for every wallet UTxO at the requester address in ONE indexer transaction via `runIndexerTx ctx $ do { … }` composing the existing `Cardano.MPFS.Indexer.Reads` primitives. The boot pattern is the reference: `bootTokenCore` is pure, and `runBootBuilder` does the IO orchestration. The TxBuild DSL replaces the imperative builder bodies. Drop `Provider.queryUTxOs` from these three build paths entirely."
+
+## User Scenarios & Testing
+
+### User Story 1 — Honest request submission under realistic chain churn (Priority: P1)
+
+A wallet client sends `POST /tx/request/insert { token, key, value, address }` (or the `delete` / `update` variants) against an MPFS server whose chain follower is actively processing blocks. The server returns an unsigned request transaction together with a `VerificationSnapshot` and a CSMT inclusion proof for every wallet input the transaction spends. The wallet signs, submits, and the on-chain validator accepts the transaction. An offline verifier given the response and an independently-obtained trusted UTxO root checks the response without performing any further query: every proof verifies against the snapshot's `utxo_root`, and the snapshot's `utxo_root` equals the externally-supplied trusted root.
+
+**Why this priority**: This is the same proof-bearing promise the boot slice (#249, PR #253) delivers, extended to the request endpoints. Today the three request handlers carry the same race window the boot slice had before it was fixed: they read the snapshot in the HTTP layer separately from the per-input proof reads inside `requestInsertImpl` / `requestDeleteImpl` / `requestUpdateImpl`. Until that race is closed, the response cannot be reliably verified offline under churn.
+
+**Independent Test**: Run each request endpoint end-to-end against a devnet under load: submit `request/insert`, `request/delete`, `request/update` while the chain follower is processing concurrent blocks, then run the verifier on each response with the snapshot's own root as the trusted root. The verifier MUST accept on every attempt. Repeat with a tampered root and the verifier MUST reject with a snapshot mismatch. The test holds independently of the boot slice and independently of every other handler.
+
+**Acceptance Scenarios**:
+
+1. **Given** an MPFS server actively following the chain with multiple blocks per second, **When** a client sends `POST /tx/request/insert { token, key, value, address }` for an address that has wallet UTxOs in the indexer, **Then** the response carries a `VerificationSnapshot { utxo_root, chainpoint }` and a CSMT inclusion proof for every wallet input in the unsigned transaction; every proof verifies against `utxo_root`; and the response is accepted by the offline verifier.
+2. **Given** the same conditions, **When** the chain follower applies a new block while the server is building the request response, **Then** the snapshot, the resolved input bytes, and the proofs all reflect the same single point in chain history (no torn read).
+3. **Given** an offline verifier given the same response and a trusted root tampered with one byte, **When** the verifier runs, **Then** it rejects with a snapshot-root mismatch at the snapshot's `utxo_root` field.
+4. **Given** the same flow but with `POST /tx/request/delete` (then `POST /tx/request/update`), **When** the verifier runs against each response, **Then** acceptance and tamper-rejection behave identically to the `insert` case.
+
+---
+
+### User Story 2 — Server stops querying cardano-node for UTxO state on the request path (Priority: P1)
+
+The MPFS server's request tx-build path is fully self-sufficient: it does not consult cardano-node's `LocalStateQuery` for UTxO state at any point. All UTxO knowledge needed to build a request transaction comes from the local indexer.
+
+**Why this priority**: Same as the boot slice. cardano-node's `GetUTxOByAddress` is `O(total UTxOs on chain)`, not `O(UTxOs at the address)`. At production scale (millions of UTxOs on mainnet) the call is unusable on a hot path. Each of the three request endpoints today carries an identical `queryUTxOs prov addr` call in its impl module — three distinct copies of the same defect. They must all go.
+
+**Independent Test**: After all three request flows are exercised through the system, `grep` the request tx-builder source. The forbidden call MUST be absent from `requestInsertImpl`, `requestDeleteImpl`, `requestUpdateImpl`, and any helper they share on the build path. Operationally, run the three endpoints while disabling cardano-node's `GetUTxOByAddress` (or running against a node that rejects it) and confirm all three still succeed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the request tx-builder source, **When** a reviewer searches for `queryUTxOs` on the build path, **Then** the search returns zero matches in any of the three request impl modules and zero matches in the request handlers.
+2. **Given** an MPFS server whose connection to cardano-node has been configured to reject `GetUTxOByAddress`, **When** a client sends each of `POST /tx/request/insert`, `POST /tx/request/delete`, `POST /tx/request/update`, **Then** all three succeed because the indexer is the single source of UTxO state.
+
+---
+
+### User Story 3 — Builder modules are pure (Priority: P2)
+
+The three request builder modules follow the same shape the boot slice established: a pure `*Core` function returning a `*Core` record (program + inputs + funding + snapshot), with all IO orchestration confined to `Cardano.MPFS.TxBuilder.Real`. The TxBuild DSL replaces every imperative ledger-lens builder body.
+
+**Why this priority**: This is the operational-coupling fix of the boot slice extended to the request endpoints. Without it, each request module would be re-doing imperative tx assembly that the DSL has already absorbed; reviews would have to re-validate the same mechanical pieces three times. P2 because it is observable through code reading rather than through user-visible behavior.
+
+**Independent Test**: A reviewer opens the request builder module(s) and finds: no `IO` in any function signature, no `Provider` import, and the transaction body described as a `TxBuild` program (not as a sequence of lens updates on `mkBasicTxBody`).
+
+**Acceptance Scenarios**:
+
+1. **Given** the request builder module(s), **When** a reviewer searches for `Provider`, `IO`, or `evaluateAndBalance` imports, **Then** the search returns zero matches in those modules.
+2. **Given** the same modules, **When** a reviewer searches for `mkBasicTxBody`, `inputsTxBodyL`, or `mintTxBodyL` outside of comments and module-level documentation, **Then** the search returns zero matches.
+
+---
+
+### User Story 4 — Test fixtures keep working without a chain follower (Priority: P2)
+
+Test fixtures that drive the indexer manually (`followerEnabled = False`) and call the request builders directly continue to work without any new infrastructure. They use the existing `walletBootInputs` helper (or an equivalent) to obtain the wallet inputs they need, then feed them to the new pure `*Core` constructors. Tests with `followerEnabled = True` use the production HTTP path and observe the same proof-bearing acceptance.
+
+**Why this priority**: P2 because it preserves an existing test surface rather than introducing new behavior. Failure here would block the existing `CageSpec` / `CageFlowSpec` / `IndexerSpec` harnesses — the same harnesses already validated by the boot slice.
+
+**Independent Test**: Run the existing e2e suite end-to-end. The fixtures that exercise `requestInsert`, `requestDelete`, `requestUpdate` on `followerEnabled = False` build with the wallet helper and submit successfully; the fixtures on `followerEnabled = True` go through HTTP and verify against the response's snapshot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a test fixture with `followerEnabled = False` that calls `requestInsert` directly, **When** the fixture builds the transaction by feeding `walletBootInputs` (or an analogous helper) to the new pure constructor, **Then** the transaction is accepted on-chain and the indexer's manual application of the resulting block produces the expected events.
+2. **Given** a test fixture with `followerEnabled = True` that calls `POST /tx/request/insert` over HTTP, **When** the fixture submits the response and verifies it against the response's own snapshot, **Then** verification accepts.
+
+---
+
+### Edge Cases
+
+- The wallet address has zero UTxOs in the indexer (unfunded address): the server MUST fail with a deterministic 4xx error explicitly identifying "no wallet UTxOs at address" as the cause.
+- The chain follower has not yet written a checkpoint (server just started): the server MUST fail with a deterministic 503 explicitly identifying "indexer not ready: snapshot unavailable" as the cause.
+- A block lands during the request build: the response MUST reflect a single, coherent point in chain history.
+- The token referenced by the request does not exist in the indexer: the existing 404 behavior is unchanged.
+- The CSMT contains UTxOs at the requester address but their KV column is missing the resolved `TxOut` bytes (corrupted database): the server MUST fail loudly rather than emit a partial response — same loud-error semantics as the boot slice's `readWalletInputsAt`.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Each of the three request endpoints (`POST /tx/request/insert`, `POST /tx/request/delete`, `POST /tx/request/update`) MUST emit a response whose snapshot, resolved-input bytes, and CSMT inclusion proofs all reflect a single coherent point in the indexer's chain history. Block application by the chain follower MUST NOT be able to interleave between any two reads contributing to a single response.
+- **FR-002**: The three request tx-builders MUST source every UTxO they spend from the local indexer's CSMT, walked at the requester address's prefix. They MUST NOT call cardano-node's `LocalStateQuery` `GetUTxOByAddress` at any point on the build path.
+- **FR-003**: The wire contracts for `POST /tx/request/insert`, `POST /tx/request/delete`, `POST /tx/request/update` MUST remain unchanged.
+- **FR-004**: When the indexer cannot produce a coherent snapshot, the request endpoints MUST fail with a distinct, deterministic error that names the cause. They MUST NOT silently emit a partial or synthetic response.
+- **FR-005**: The request tx-builders' wallet-input lookup time MUST grow with the number of UTxOs at the requester address, not with the total number of UTxOs on the chain.
+- **FR-006**: The three request builder modules MUST be pure: their public function signatures MUST NOT mention `IO` or `Provider`; the transaction body MUST be expressed as a `TxBuild` program; the IO step that runs the DSL `build` loop MUST live in `Cardano.MPFS.TxBuilder.Real`.
+- **FR-007**: The verifier component, given a request response and a trusted root that matches the response's snapshot, MUST accept the response without making any further chain or indexer call.
+
+### Key Entities
+
+- **RequestCore (×3)**: One per request endpoint (`RequestInsertCore`, `RequestDeleteCore`, `RequestUpdateCore`) — pure record bundling the `TxBuild` program, the ledger-typed inputs, the requester address, the funding witnesses, and the snapshot. Mirrors the boot slice's `BootCore`.
+- **WalletInput**: A UTxO at the requester's address that the request transaction can spend. The indexer holds (input reference, transaction-output bytes, inclusion proof) for each one — same shape as the boot slice.
+- **BundleSnapshot**: The snapshot the response is anchored to; produced by the existing `readSnapshot` primitive. Unchanged.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Each of the three request endpoints accepts proof-bearing verification by the offline verifier (using the response's own snapshot as trusted root) on 100% of attempts under sustained chain churn (≥ 1 block per second sustained for ≥ 60 seconds before the call). On the previous racy implementation this rate is observably below 100%.
+- **SC-002**: A reviewer searching the request tx-builder source for `queryUTxOs` returns zero matches in any of the three request impl modules and zero matches in the request handlers.
+- **SC-003**: A reviewer searching the request builder modules for `IO` or `Provider` in function signatures returns zero matches; a search for `mkBasicTxBody` / `inputsTxBodyL` / `mintTxBodyL` outside comments returns zero matches.
+- **SC-004**: The full automated test suite — the standard build of all derivations the project ships, formatter and linter, unit tests, and the devnet-backed end-to-end suite — passes locally and in CI on the change.
+- **SC-005**: The atomicity claim per endpoint is visible in one place: each handler is a single `runIndexerTx ctx $ do { … }` block followed by a single call to the IO orchestrator that runs the DSL `build` loop. Reviews must not require chasing reads across multiple functions or modules.
+
+## Assumptions
+
+- The `IndexerTx` primitives library introduced in #249 (PR #253) — `readSnapshot` and `readWalletInputsAt` — is sufficient for the three request endpoints. They each need exactly the same indexer reads as boot: the snapshot and the wallet inputs at one address. No new primitives are needed.
+- The `walletBootInputs` e2e helper is reusable for request fixtures; if a request-specific helper is more convenient, it is a thin wrapper around the same `Provider.queryUTxOs` call.
+- The TxBuild DSL's existing combinators (`spend`, `payTo'`, `attachScript`, `mint`, `collateral`) plus the request-side `Cardano.MPFS.TxBuilder.Real.Internal` helpers are sufficient to express the three request transactions. No DSL extensions are needed for this slice.
+- The multi-band snapshot redesign (issue #254) is a separate, larger spec and is explicitly out of scope here. This slice ships the same single-snapshot-at-tip semantics the boot slice ships.
+- The remaining handlers (`retract`, `reject`, `update`, `end`) are out of scope for this spec; they need new indexer primitives (state-UTxO read, request-UTxO read, trie-fact read) and will be specced separately as the workstream progresses.


### PR DESCRIPTION
## Summary

Apply the proven boot-slice pattern (#249, https://github.com/lambdasistemi/cardano-mpfs-offchain/pull/253)
to the three request endpoints: `POST /tx/request/insert`,
`POST /tx/request/delete`, `POST /tx/request/update`. Each handler
reads its `BundleSnapshot` and the wallet inputs at the requester
address inside one `runIndexerTx ctx $ do { … }` call composed from
the existing `Cardano.MPFS.Indexer.Reads` primitives. The three
builder impls collapse into a single shared pure `requestCore`
(mirroring `bootTokenCore`); IO orchestration moves to
`Cardano.MPFS.TxBuilder.Real.runRequestBuilder`. The TxBuild DSL
replaces the imperative builder body. `Provider.queryUTxOs` is
removed from the request build path entirely.

Wire contracts unchanged — `POST /tx/request/insert
{ token, key, value, address }` etc. The server picks UTxOs at the
requester address from its own CSMT.

## Spec-driven design

This PR ships in lockstep with the speckit artifacts under
`specs/256-atomic-request-handlers/`:

- spec.md: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/256-atomic-request-handlers/specs/256-atomic-request-handlers/spec.md
- plan.md: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/256-atomic-request-handlers/specs/256-atomic-request-handlers/plan.md
- research.md: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/256-atomic-request-handlers/specs/256-atomic-request-handlers/research.md
- data-model.md: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/256-atomic-request-handlers/specs/256-atomic-request-handlers/data-model.md
- contracts/request-core.md: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/256-atomic-request-handlers/specs/256-atomic-request-handlers/contracts/request-core.md
- quickstart.md: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/256-atomic-request-handlers/specs/256-atomic-request-handlers/quickstart.md

## Stack layout (StGit)

The PR will land as a vertical, bisect-safe stack:

1. `docs(spec)`: speckit artifacts (this commit).
2. `refactor`: rename `Boot/Inputs.hs` → `Wallet/Inputs.hs`
   (shared decode/projection module).
3. `feat(request)`: pure `requestCore` + three thin
   `requestInsertCore` / `requestDeleteCore` /
   `requestUpdateCore` wrappers; DSL program replaces the
   imperative `requestImpl` body.
4. `feat(request)`: IO orchestrator `runRequestBuilder` in
   `Cardano.MPFS.TxBuilder.Real`; HTTP handlers rewritten to
   compose `IndexerTx` primitives at the boundary; `TxBuilder`
   field signatures gain `[ResolvedWalletInput]` for the three
   request methods.
5. `test(request)`: unit tests for the three Cores + churn
   coverage in ProofsSpec.

## Closes / refs

- Refs https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/250
- Refs https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/252
- Builds on https://github.com/lambdasistemi/cardano-mpfs-offchain/pull/253 (just merged)
- Defers https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/254

## Test plan

- [ ] Build Gate green (all five derivations)
- [ ] format-check + hlint
- [ ] `nix run .#unit-tests` (incl. new RequestSpec)
- [ ] `nix run .#e2e-tests` (incl. churn variants for the three endpoints)
- [ ] Walk every commit in the stack with `stg goto` and re-run the gate
- [ ] swagger.json diff empty (FR-003 — wire contracts unchanged)

## ⚠️ Blocker

This PR depends on https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/256 — a verifier-side gap in PR #253's boot envelope (verifier doesn't enforce cage-output destination, datum owner, or change-output address). The same gap would apply to the request envelopes if we shipped #255 without first fixing #256. Plan: land #256 first (fixes boot, exposes the shared `verifyConservation` helper); #255 then reuses the helper for the three request endpoints.