### PR TITLE
feat(end): fact-provider pivot - POST /facts/end + endCageTx + verifyEndFacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ transactions; the client signs and submits via `POST /tx/submit`.
 | GET | `/tokens/:id/proofs/:key` | Merkle proof |
 | GET | `/tokens/:id/requests` | Pending requests |
 | GET | `/tx/:txId?timeout=30` | Block until tx is indexed |
-| POST | `/tx/boot` | Build boot transaction |
+| POST | `/facts/boot` | Return boot facts for wallet-side transaction construction |
+| POST | `/facts/end` | Return end facts for wallet-side transaction construction |
 | POST | `/tx/request/insert` | Build insert request |
 | POST | `/tx/request/delete` | Build delete request |
 | POST | `/tx/update` | Build update transaction |
 | POST | `/tx/retract` | Build retract transaction |
-| POST | `/tx/end` | Build end transaction |
 | POST | `/tx/submit` | Submit signed transaction |
 
 Swagger UI is served at `/swagger-ui`.

--- a/cabal.project
+++ b/cabal.project
@@ -46,8 +46,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: f6f0ee24593bc20244afbc8899687a3fb73f4d88
-  --sha256: 0yvbnmbqfiichkw2qskj4b82kmk44f8483fvvh2gmibvda10229i
+  tag: 13264a52b47e3a1f43a6ebeebd424a10f9e4466a
+  --sha256: 1bqgpxdy79ncsz8hyg2qyd7jnm8hqj4q8rq8mhr3iirix66c77fb
 
 source-repository-package
   type: git

--- a/cardano-mpfs-api/cardano-mpfs-api.cabal
+++ b/cardano-mpfs-api/cardano-mpfs-api.cabal
@@ -45,3 +45,5 @@ library
     Cardano.MPFS.API
     Cardano.MPFS.API.Encoding
     Cardano.MPFS.API.Types
+    Cardano.MPFS.API.Types.Common
+    Cardano.MPFS.API.Types.Facts

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
@@ -45,7 +45,6 @@ module Cardano.MPFS.API
     , TxUpdateAPI
     , TxRetractAPI
     , TxSweepAPI
-    , TxEndAPI
     , TxWriteAPI
     , TxSubmitAPI
     ) where
@@ -69,7 +68,6 @@ import Cardano.MPFS.API.Types
     ( BootRequest
     , DeleteRequest
     , EndRequest
-    , EndTxResponse
     , FactResponse
     , InsertRequest
     , ProofResponse
@@ -258,13 +256,6 @@ type TxSweepAPI =
         :> ReqBody '[JSON] SweepRequest
         :> Post '[JSON] SweepTxResponse
 
--- | @POST \/tx\/end@ — build an end transaction.
-type TxEndAPI =
-    "tx"
-        :> "end"
-        :> ReqBody '[JSON] EndRequest
-        :> Post '[JSON] EndTxResponse
-
 -- | MPFS write endpoints that construct unsigned
 -- transactions. This subset is used by native clients
 -- deriving a Servant client without depending on the
@@ -277,7 +268,6 @@ type TxWriteAPI =
         :<|> TxUpdateAPI
         :<|> TxRetractAPI
         :<|> TxSweepAPI
-        :<|> TxEndAPI
 
 -- | @POST \/tx\/submit@ — submit a signed
 -- transaction.
@@ -313,5 +303,4 @@ type API =
         :<|> TxUpdateAPI
         :<|> TxRetractAPI
         :<|> TxSweepAPI
-        :<|> TxEndAPI
         :<|> TxSubmitAPI

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
@@ -65,8 +65,7 @@ import Servant.API
 
 import Cardano.MPFS.API.Encoding (Hex)
 import Cardano.MPFS.API.Types
-    ( BootFacts
-    , BootRequest
+    ( BootRequest
     , DeleteRequest
     , EndRequest
     , EndTxResponse
@@ -83,12 +82,13 @@ import Cardano.MPFS.API.Types
     , SubmitRequest
     , SweepRequest
     , SweepTxResponse
-    , TokenIdJSON
     , TokenResponse
     , UpdateRequest
     , UpdateTxResponse
     , UpdateValueRequest
     )
+import Cardano.MPFS.API.Types.Common (TokenIdJSON)
+import Cardano.MPFS.API.Types.Facts (BootFacts)
 
 -- | @GET \/status@ — indexer chain tip and checkpoint.
 type StatusAPI = "status" :> Get '[JSON] StatusResponse

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
@@ -35,6 +35,7 @@ module Cardano.MPFS.API
 
       -- * Facts endpoints
     , FactsBootAPI
+    , FactsEndAPI
 
       -- * Transaction endpoints
     , TxInsertAPI
@@ -88,7 +89,10 @@ import Cardano.MPFS.API.Types
     , UpdateValueRequest
     )
 import Cardano.MPFS.API.Types.Common (TokenIdJSON)
-import Cardano.MPFS.API.Types.Facts (BootFacts)
+import Cardano.MPFS.API.Types.Facts
+    ( BootFacts
+    , EndFacts
+    )
 
 -- | @GET \/status@ — indexer chain tip and checkpoint.
 type StatusAPI = "status" :> Get '[JSON] StatusResponse
@@ -184,6 +188,15 @@ type FactsBootAPI =
         :> "boot"
         :> ReqBody '[JSON] BootRequest
         :> Post '[JSON] BootFacts
+
+-- | @POST \/facts\/end@ — return indexed facts
+-- required by wallet-side end transaction
+-- construction.
+type FactsEndAPI =
+    "facts"
+        :> "end"
+        :> ReqBody '[JSON] EndRequest
+        :> Post '[JSON] EndFacts
 
 -- | @POST \/tx\/request\/insert@ — build an insert
 -- request transaction.
@@ -292,6 +305,7 @@ type API =
         :<|> UtxoRootAPI
         :<|> TxAwaitAPI
         :<|> FactsBootAPI
+        :<|> FactsEndAPI
         :<|> TxInsertAPI
         :<|> TxDeleteAPI
         :<|> TxRequestUpdateAPI

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -37,6 +37,7 @@ module Cardano.MPFS.API.Types
     , UnsignedTxResponse (..)
     , UnverifiedPParams (..)
     , BootFacts (..)
+    , EndFacts (..)
 
       -- * Proof-bearing read responses
     , WitnessedTokenState (..)
@@ -110,7 +111,10 @@ import Cardano.MPFS.API.Types.Common
     , UtxoSetWitness (..)
     , VerificationSnapshot (..)
     )
-import Cardano.MPFS.API.Types.Facts (BootFacts (..))
+import Cardano.MPFS.API.Types.Facts
+    ( BootFacts (..)
+    , EndFacts (..)
+    )
 
 -- | Response for @GET \/status@.
 data StatusResponse = StatusResponse

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -85,12 +85,9 @@ import Data.Aeson
     , (.:)
     , (.=)
     )
-import Data.ByteString (ByteString)
-import Data.ByteString.Base16 qualified as B16
 import Data.Proxy (Proxy (..))
 import Data.Swagger
-    ( ToParamSchema (..)
-    , ToSchema (..)
+    ( ToSchema (..)
     , declareSchemaRef
     , description
     , properties
@@ -99,13 +96,21 @@ import Data.Swagger
 import Data.Swagger qualified as Swagger
 import Data.Swagger.Declare (Declare)
 import Data.Text (Text)
-import Data.Text qualified as T
-import Data.Text.Encoding qualified as TE
 import Data.Word (Word64)
 import GHC.IsList (IsList (..))
-import Servant.API (FromHttpApiData (..))
 
 import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts (BootFacts (..))
 
 -- | Response for @GET \/status@.
 data StatusResponse = StatusResponse
@@ -145,79 +150,6 @@ instance FromJSON StatusResponse where
             <*> o .: "checkpoint_slot"
             <*> o .: "checkpoint_block_id"
             <*> o .: "utxo_root"
-
--- | Indexed chain point baked into proof-bearing
--- responses. Identifies the exact block at which
--- the bundled proofs are valid.
-data ChainPointJSON = ChainPointJSON
-    { cpSlot :: Word64
-    -- ^ Slot of the indexed chain point
-    , cpBlockId :: Hex
-    -- ^ Block hash at that slot (hex)
-    }
-    deriving (Eq, Show)
-
-instance ToJSON ChainPointJSON where
-    toJSON ChainPointJSON{..} =
-        object
-            [ "slot" .= cpSlot
-            , "block_id" .= cpBlockId
-            ]
-
-instance FromJSON ChainPointJSON where
-    parseJSON = withObject "ChainPointJSON" $ \o ->
-        ChainPointJSON
-            <$> o .: "slot"
-            <*> o .: "block_id"
-
--- | Verification snapshot: the exact UTxO-CSMT root
--- plus indexed chain point against which a
--- proof-bearing response's bundled proofs are valid.
--- Every proof-bearing response embeds one of these so
--- clients can verify offline without a separate
--- @GET \/status@ call.
-data VerificationSnapshot = VerificationSnapshot
-    { vsUtxoRoot :: Hex
-    -- ^ UTxO-CSMT root hash
-    , vsChainPoint :: ChainPointJSON
-    -- ^ Indexed chain point
-    }
-    deriving (Eq, Show)
-
-instance ToJSON VerificationSnapshot where
-    toJSON VerificationSnapshot{..} =
-        object
-            [ "utxo_root" .= vsUtxoRoot
-            , "chainpoint" .= vsChainPoint
-            ]
-
-instance FromJSON VerificationSnapshot where
-    parseJSON =
-        withObject "VerificationSnapshot" $ \o ->
-            VerificationSnapshot
-                <$> o .: "utxo_root"
-                <*> o .: "chainpoint"
-
--- | Hex-encoded token identifier for JSON transport.
-newtype TokenIdJSON = TokenIdJSON
-    { unTokenIdJSON :: ByteString
-    }
-    deriving (Eq, Show)
-
-instance ToJSON TokenIdJSON where
-    toJSON (TokenIdJSON bs) =
-        toJSON (Hex bs)
-
-instance FromJSON TokenIdJSON where
-    parseJSON value = do
-        Hex bs <- parseJSON value
-        pure (TokenIdJSON bs)
-
-instance FromHttpApiData TokenIdJSON where
-    parseUrlPiece t =
-        case B16.decode (TE.encodeUtf8 t) of
-            Right bs -> Right (TokenIdJSON bs)
-            Left err -> Left (T.pack err)
 
 -- | JSON representation of on-chain token state.
 data TokenStateJSON = TokenStateJSON
@@ -371,112 +303,6 @@ instance FromJSON WitnessedUtxo where
 -- Old types stay until every endpoint is migrated; they
 -- will be removed in the polish slice of #243.
 
--- | UTxO reference (@{ tx_id, tx_ix }@).
-data UtxoRef = UtxoRef
-    { urTxId :: Hex
-    -- ^ Transaction id (32-byte blake2b, hex)
-    , urTxIx :: Word64
-    -- ^ Output index within the transaction
-    }
-    deriving (Eq, Show)
-
-instance ToJSON UtxoRef where
-    toJSON UtxoRef{..} =
-        object
-            [ "tx_id" .= urTxId
-            , "tx_ix" .= urTxIx
-            ]
-
-instance FromJSON UtxoRef where
-    parseJSON = withObject "UtxoRef" $ \o ->
-        UtxoRef
-            <$> o .: "tx_id"
-            <*> o .: "tx_ix"
-
--- | A single attested UTxO: reference, resolved
--- @TxOut@, and a CSMT inclusion proof against the
--- enclosing response's @snapshot.utxo_root@.
-data UtxoEntry = UtxoEntry
-    { ueRef :: UtxoRef
-    -- ^ UTxO reference (@ref@)
-    , ueTxOutCbor :: Hex
-    -- ^ CBOR-encoded @TxOut@ (@txout_cbor@)
-    , ueInclusionProof :: Hex
-    -- ^ CSMT inclusion proof (@inclusion_proof@)
-    }
-    deriving (Eq, Show)
-
-instance ToJSON UtxoEntry where
-    toJSON UtxoEntry{..} =
-        object
-            [ "ref" .= ueRef
-            , "txout_cbor" .= ueTxOutCbor
-            , "inclusion_proof" .= ueInclusionProof
-            ]
-
-instance FromJSON UtxoEntry where
-    parseJSON = withObject "UtxoEntry" $ \o ->
-        UtxoEntry
-            <$> o .: "ref"
-            <*> o .: "txout_cbor"
-            <*> o .: "inclusion_proof"
-
--- | A UTxO entry without a per-entry inclusion proof.
--- Appears inside a 'UtxoSetWitness' where the
--- enclosing 'uswCompletenessProof' attests the whole
--- set at once.
-data UtxoEntryRefOnly = UtxoEntryRefOnly
-    { uerRef :: UtxoRef
-    , uerTxOutCbor :: Hex
-    }
-    deriving (Eq, Show)
-
-instance ToJSON UtxoEntryRefOnly where
-    toJSON UtxoEntryRefOnly{..} =
-        object
-            [ "ref" .= uerRef
-            , "txout_cbor" .= uerTxOutCbor
-            ]
-
-instance FromJSON UtxoEntryRefOnly where
-    parseJSON =
-        withObject "UtxoEntryRefOnly" $ \o ->
-            UtxoEntryRefOnly
-                <$> o .: "ref"
-                <*> o .: "txout_cbor"
-
--- | An enumerated set of UTxOs at a known script-hash
--- prefix together with a single CSMT prefix-completeness
--- proof attesting the set is exactly the leaves under
--- that prefix in the snapshot's CSMT.
---
--- The script-hash prefix itself is not part of the
--- witness — the verifier derives it locally from the
--- trusted blueprint.
-data UtxoSetWitness = UtxoSetWitness
-    { uswEntries :: [UtxoEntryRefOnly]
-    -- ^ Enumerated entries (@entries@)
-    , uswCompletenessProof :: Hex
-    -- ^ CSMT prefix-completeness proof
-    -- (@completeness_proof@)
-    }
-    deriving (Eq, Show)
-
-instance ToJSON UtxoSetWitness where
-    toJSON UtxoSetWitness{..} =
-        object
-            [ "entries" .= uswEntries
-            , "completeness_proof"
-                .= uswCompletenessProof
-            ]
-
-instance FromJSON UtxoSetWitness where
-    parseJSON =
-        withObject "UtxoSetWitness" $ \o ->
-            UtxoSetWitness
-                <$> o .: "entries"
-                <*> o .: "completeness_proof"
-
 -- | Uniform response envelope for proof-bearing write
 -- endpoints under #243.
 --
@@ -525,67 +351,6 @@ instance FromJSON UnsignedTxResponse where
                 <$> o .: "unsigned_tx_cbor"
                 <*> o .: "snapshot"
                 <*> o .: "inputs"
-
--- | Protocol parameters carried by a facts-only boot response.
---
--- The offchain service can report these bytes to downstream
--- tooling, but this slice does not verify their ledger-level
--- meaning. The @verified@ flag is therefore part of the wire
--- contract and must be @false@ for the dummy/test values used
--- by the boot facts verifier.
-data UnverifiedPParams = UnverifiedPParams
-    { uppVerified :: Bool
-    -- ^ Whether the protocol parameters have been verified.
-    , uppCbor :: Hex
-    -- ^ CBOR-encoded protocol parameters (@cbor@).
-    }
-    deriving (Eq, Show)
-
-instance ToJSON UnverifiedPParams where
-    toJSON UnverifiedPParams{..} =
-        object
-            [ "verified" .= uppVerified
-            , "cbor" .= uppCbor
-            ]
-
-instance FromJSON UnverifiedPParams where
-    parseJSON =
-        withObject "UnverifiedPParams" $ \o ->
-            UnverifiedPParams
-                <$> o .: "verified"
-                <*> o .: "cbor"
-
--- | Facts-only boot response.
---
--- Unlike 'UnsignedTxResponse', this envelope carries no
--- transaction CBOR. Its verifier proves only that the
--- advertised wallet UTxOs are included in the trusted
--- snapshot root.
-data BootFacts = BootFacts
-    { bfSnapshot :: VerificationSnapshot
-    -- ^ Snapshot the bundled inclusion proofs target.
-    , bfWalletUtxos :: [UtxoEntry]
-    -- ^ Wallet UTxOs with CSMT inclusion proofs.
-    , bfProtocolParameters :: UnverifiedPParams
-    -- ^ Unverified protocol parameter bytes.
-    }
-    deriving (Eq, Show)
-
-instance ToJSON BootFacts where
-    toJSON BootFacts{..} =
-        object
-            [ "snapshot" .= bfSnapshot
-            , "wallet_utxos" .= bfWalletUtxos
-            , "protocol_parameters" .= bfProtocolParameters
-            ]
-
-instance FromJSON BootFacts where
-    parseJSON =
-        withObject "BootFacts" $ \o ->
-            BootFacts
-                <$> o .: "snapshot"
-                <*> o .: "wallet_utxos"
-                <*> o .: "protocol_parameters"
 
 -- ---------------------------------------------------------
 -- Proof-bearing read responses
@@ -1367,65 +1132,6 @@ instance ToSchema StatusResponse where
                 ?~ "Indexer chain tip, checkpoint, \
                    \and current UTxO-CSMT root"
 
-instance ToSchema ChainPointJSON where
-    declareNamedSchema _ = do
-        word64Schema <-
-            declareSchemaRef (Proxy @Word64)
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        pure
-            $ Swagger.NamedSchema
-                (Just "ChainPointJSON")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("slot", word64Schema)
-                    , ("block_id", hexSchema)
-                    ]
-            & required .~ ["slot", "block_id"]
-            & description
-                ?~ "Indexed chain point baked into \
-                   \proof-bearing responses"
-
-instance ToSchema VerificationSnapshot where
-    declareNamedSchema _ = do
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        chainPointSchema <-
-            declareSchemaRef (Proxy @ChainPointJSON)
-        pure
-            $ Swagger.NamedSchema
-                (Just "VerificationSnapshot")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("utxo_root", hexSchema)
-                    , ("chainpoint", chainPointSchema)
-                    ]
-            & required
-                .~ ["utxo_root", "chainpoint"]
-            & description
-                ?~ "UTxO-CSMT root and indexed chain \
-                   \point against which bundled \
-                   \proofs are valid"
-
-instance ToSchema TokenIdJSON where
-    declareNamedSchema _ =
-        pure
-            $ Swagger.NamedSchema
-                (Just "TokenIdJSON")
-            $ Swagger.toSchema (Proxy @String)
-            & description
-                ?~ "Hex-encoded token identifier"
-
-instance ToParamSchema TokenIdJSON where
-    toParamSchema _ =
-        Swagger.toParamSchema (Proxy @String)
-
 instance ToSchema TokenStateJSON where
     declareNamedSchema _ = do
         textSchema <-
@@ -1820,106 +1526,6 @@ instance ToSchema WitnessedRequest where
             & description
                 ?~ "Pending request plus UTxO witness"
 
--- Post-split (#243) primitives.
-
-instance ToSchema UtxoRef where
-    declareNamedSchema _ = do
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        word64Schema <-
-            declareSchemaRef (Proxy @Word64)
-        pure
-            $ Swagger.NamedSchema (Just "UtxoRef")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("tx_id", hexSchema)
-                    , ("tx_ix", word64Schema)
-                    ]
-            & required .~ ["tx_id", "tx_ix"]
-            & description ?~ "UTxO reference"
-
-instance ToSchema UtxoEntry where
-    declareNamedSchema _ = do
-        refSchema <-
-            declareSchemaRef (Proxy @UtxoRef)
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        pure
-            $ Swagger.NamedSchema (Just "UtxoEntry")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("ref", refSchema)
-                    , ("txout_cbor", hexSchema)
-                    , ("inclusion_proof", hexSchema)
-                    ]
-            & required
-                .~ [ "ref"
-                   , "txout_cbor"
-                   , "inclusion_proof"
-                   ]
-            & description
-                ?~ "UTxO ref, CBOR body, and CSMT \
-                   \inclusion proof against the \
-                   \enclosing snapshot's utxo_root"
-
-instance ToSchema UtxoEntryRefOnly where
-    declareNamedSchema _ = do
-        refSchema <-
-            declareSchemaRef (Proxy @UtxoRef)
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        pure
-            $ Swagger.NamedSchema
-                (Just "UtxoEntryRefOnly")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("ref", refSchema)
-                    , ("txout_cbor", hexSchema)
-                    ]
-            & required .~ ["ref", "txout_cbor"]
-            & description
-                ?~ "UTxO ref and CBOR body, without a \
-                   \per-entry inclusion proof. Used \
-                   \inside a UtxoSetWitness."
-
-instance ToSchema UtxoSetWitness where
-    declareNamedSchema _ = do
-        entrySchema <-
-            declareSchemaRef
-                (Proxy @[UtxoEntryRefOnly])
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        pure
-            $ Swagger.NamedSchema
-                (Just "UtxoSetWitness")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("entries", entrySchema)
-                    , ("completeness_proof", hexSchema)
-                    ]
-            & required
-                .~ [ "entries"
-                   , "completeness_proof"
-                   ]
-            & description
-                ?~ "Enumerated UTxOs at a known \
-                   \script-hash prefix, with a single \
-                   \CSMT prefix-completeness proof \
-                   \attesting the set is exactly the \
-                   \leaves under that prefix."
-
 instance ToSchema UnsignedTxResponse where
     declareNamedSchema _ = do
         hexSchema <-
@@ -1953,59 +1559,6 @@ instance ToSchema UnsignedTxResponse where
                    \snapshot and a flat list of spent \
                    \and reference inputs, each with its \
                    \CSMT inclusion proof."
-
-instance ToSchema UnverifiedPParams where
-    declareNamedSchema _ = do
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        boolSchema <-
-            declareSchemaRef (Proxy @Bool)
-        pure
-            $ Swagger.NamedSchema
-                (Just "UnverifiedPParams")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("verified", boolSchema)
-                    , ("cbor", hexSchema)
-                    ]
-            & required .~ ["verified", "cbor"]
-            & description
-                ?~ "CBOR-encoded protocol parameters \
-                   \reported as unverified facts."
-
-instance ToSchema BootFacts where
-    declareNamedSchema _ = do
-        snapshotSchema <-
-            declareSchemaRef
-                (Proxy @VerificationSnapshot)
-        walletSchema <-
-            declareSchemaRef (Proxy @[UtxoEntry])
-        ppSchema <-
-            declareSchemaRef (Proxy @UnverifiedPParams)
-        pure
-            $ Swagger.NamedSchema (Just "BootFacts")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("snapshot", snapshotSchema)
-                    , ("wallet_utxos", walletSchema)
-                    , ("protocol_parameters", ppSchema)
-                    ]
-            & required
-                .~ [ "snapshot"
-                   , "wallet_utxos"
-                   , "protocol_parameters"
-                   ]
-            & description
-                ?~ "Facts-only boot response. Carries \
-                   \wallet UTxO witnesses and \
-                   \unverified protocol parameters, \
-                   \with no unsigned transaction CBOR."
 
 instance ToSchema FactWitness where
     declareNamedSchema _ = do

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs
@@ -1,0 +1,441 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.API.Types.Common
+-- Description : Shared facts/proof JSON DTO primitives.
+-- License     : Apache-2.0
+--
+-- Shared wire primitives used by facts endpoints and the
+-- compatibility API DTO surface.
+module Cardano.MPFS.API.Types.Common
+    ( -- * Proof-bearing snapshot
+      ChainPointJSON (..)
+    , VerificationSnapshot (..)
+
+      -- * Tokens
+    , TokenIdJSON (..)
+
+      -- * Facts/proof UTxO witnesses
+    , UtxoRef (..)
+    , UtxoEntry (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoSetWitness (..)
+    , UnverifiedPParams (..)
+    ) where
+
+import Control.Lens ((&), (.~), (?~))
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , object
+    , withObject
+    , (.:)
+    , (.=)
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString.Base16 qualified as B16
+import Data.Proxy (Proxy (..))
+import Data.Swagger
+    ( ToParamSchema (..)
+    , ToSchema (..)
+    , declareSchemaRef
+    , description
+    , properties
+    , required
+    )
+import Data.Swagger qualified as Swagger
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Data.Word (Word64)
+import GHC.IsList (IsList (..))
+import Servant.API (FromHttpApiData (..))
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+
+-- | Indexed chain point baked into proof-bearing
+-- responses. Identifies the exact block at which
+-- the bundled proofs are valid.
+data ChainPointJSON = ChainPointJSON
+    { cpSlot :: Word64
+    -- ^ Slot of the indexed chain point
+    , cpBlockId :: Hex
+    -- ^ Block hash at that slot (hex)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON ChainPointJSON where
+    toJSON ChainPointJSON{..} =
+        object
+            [ "slot" .= cpSlot
+            , "block_id" .= cpBlockId
+            ]
+
+instance FromJSON ChainPointJSON where
+    parseJSON = withObject "ChainPointJSON" $ \o ->
+        ChainPointJSON
+            <$> o .: "slot"
+            <*> o .: "block_id"
+
+-- | Verification snapshot: the exact UTxO-CSMT root
+-- plus indexed chain point against which a
+-- proof-bearing response's bundled proofs are valid.
+-- Every proof-bearing response embeds one of these so
+-- clients can verify offline without a separate
+-- @GET \/status@ call.
+data VerificationSnapshot = VerificationSnapshot
+    { vsUtxoRoot :: Hex
+    -- ^ UTxO-CSMT root hash
+    , vsChainPoint :: ChainPointJSON
+    -- ^ Indexed chain point
+    }
+    deriving (Eq, Show)
+
+instance ToJSON VerificationSnapshot where
+    toJSON VerificationSnapshot{..} =
+        object
+            [ "utxo_root" .= vsUtxoRoot
+            , "chainpoint" .= vsChainPoint
+            ]
+
+instance FromJSON VerificationSnapshot where
+    parseJSON =
+        withObject "VerificationSnapshot" $ \o ->
+            VerificationSnapshot
+                <$> o .: "utxo_root"
+                <*> o .: "chainpoint"
+
+-- | Hex-encoded token identifier for JSON transport.
+newtype TokenIdJSON = TokenIdJSON
+    { unTokenIdJSON :: ByteString
+    }
+    deriving (Eq, Show)
+
+instance ToJSON TokenIdJSON where
+    toJSON (TokenIdJSON bs) =
+        toJSON (Hex bs)
+
+instance FromJSON TokenIdJSON where
+    parseJSON value = do
+        Hex bs <- parseJSON value
+        pure (TokenIdJSON bs)
+
+instance FromHttpApiData TokenIdJSON where
+    parseUrlPiece t =
+        case B16.decode (TE.encodeUtf8 t) of
+            Right bs -> Right (TokenIdJSON bs)
+            Left err -> Left (T.pack err)
+
+-- | UTxO reference (@{ tx_id, tx_ix }@).
+data UtxoRef = UtxoRef
+    { urTxId :: Hex
+    -- ^ Transaction id (32-byte blake2b, hex)
+    , urTxIx :: Word64
+    -- ^ Output index within the transaction
+    }
+    deriving (Eq, Show)
+
+instance ToJSON UtxoRef where
+    toJSON UtxoRef{..} =
+        object
+            [ "tx_id" .= urTxId
+            , "tx_ix" .= urTxIx
+            ]
+
+instance FromJSON UtxoRef where
+    parseJSON = withObject "UtxoRef" $ \o ->
+        UtxoRef
+            <$> o .: "tx_id"
+            <*> o .: "tx_ix"
+
+-- | A single attested UTxO: reference, resolved
+-- @TxOut@, and a CSMT inclusion proof against the
+-- enclosing response's @snapshot.utxo_root@.
+data UtxoEntry = UtxoEntry
+    { ueRef :: UtxoRef
+    -- ^ UTxO reference (@ref@)
+    , ueTxOutCbor :: Hex
+    -- ^ CBOR-encoded @TxOut@ (@txout_cbor@)
+    , ueInclusionProof :: Hex
+    -- ^ CSMT inclusion proof (@inclusion_proof@)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON UtxoEntry where
+    toJSON UtxoEntry{..} =
+        object
+            [ "ref" .= ueRef
+            , "txout_cbor" .= ueTxOutCbor
+            , "inclusion_proof" .= ueInclusionProof
+            ]
+
+instance FromJSON UtxoEntry where
+    parseJSON = withObject "UtxoEntry" $ \o ->
+        UtxoEntry
+            <$> o .: "ref"
+            <*> o .: "txout_cbor"
+            <*> o .: "inclusion_proof"
+
+-- | A UTxO entry without a per-entry inclusion proof.
+-- Appears inside a 'UtxoSetWitness' where the
+-- enclosing 'uswCompletenessProof' attests the whole
+-- set at once.
+data UtxoEntryRefOnly = UtxoEntryRefOnly
+    { uerRef :: UtxoRef
+    , uerTxOutCbor :: Hex
+    }
+    deriving (Eq, Show)
+
+instance ToJSON UtxoEntryRefOnly where
+    toJSON UtxoEntryRefOnly{..} =
+        object
+            [ "ref" .= uerRef
+            , "txout_cbor" .= uerTxOutCbor
+            ]
+
+instance FromJSON UtxoEntryRefOnly where
+    parseJSON =
+        withObject "UtxoEntryRefOnly" $ \o ->
+            UtxoEntryRefOnly
+                <$> o .: "ref"
+                <*> o .: "txout_cbor"
+
+-- | An enumerated set of UTxOs at a known script-hash
+-- prefix together with a single CSMT prefix-completeness
+-- proof attesting the set is exactly the leaves under
+-- that prefix in the snapshot's CSMT.
+--
+-- The script-hash prefix itself is not part of the
+-- witness — the verifier derives it locally from the
+-- trusted blueprint.
+data UtxoSetWitness = UtxoSetWitness
+    { uswEntries :: [UtxoEntryRefOnly]
+    -- ^ Enumerated entries (@entries@)
+    , uswCompletenessProof :: Hex
+    -- ^ CSMT prefix-completeness proof
+    -- (@completeness_proof@)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON UtxoSetWitness where
+    toJSON UtxoSetWitness{..} =
+        object
+            [ "entries" .= uswEntries
+            , "completeness_proof"
+                .= uswCompletenessProof
+            ]
+
+instance FromJSON UtxoSetWitness where
+    parseJSON =
+        withObject "UtxoSetWitness" $ \o ->
+            UtxoSetWitness
+                <$> o .: "entries"
+                <*> o .: "completeness_proof"
+
+-- | Protocol parameters carried by a facts-only boot response.
+--
+-- The offchain service can report these bytes to downstream
+-- tooling, but this slice does not verify their ledger-level
+-- meaning. The @verified@ flag is therefore part of the wire
+-- contract and must be @false@ for the dummy/test values used
+-- by the boot facts verifier.
+data UnverifiedPParams = UnverifiedPParams
+    { uppVerified :: Bool
+    -- ^ Whether the protocol parameters have been verified.
+    , uppCbor :: Hex
+    -- ^ CBOR-encoded protocol parameters (@cbor@).
+    }
+    deriving (Eq, Show)
+
+instance ToJSON UnverifiedPParams where
+    toJSON UnverifiedPParams{..} =
+        object
+            [ "verified" .= uppVerified
+            , "cbor" .= uppCbor
+            ]
+
+instance FromJSON UnverifiedPParams where
+    parseJSON =
+        withObject "UnverifiedPParams" $ \o ->
+            UnverifiedPParams
+                <$> o .: "verified"
+                <*> o .: "cbor"
+
+instance ToSchema ChainPointJSON where
+    declareNamedSchema _ = do
+        word64Schema <-
+            declareSchemaRef (Proxy @Word64)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "ChainPointJSON")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("slot", word64Schema)
+                    , ("block_id", hexSchema)
+                    ]
+            & required .~ ["slot", "block_id"]
+            & description
+                ?~ "Indexed chain point baked into \
+                   \proof-bearing responses"
+
+instance ToSchema VerificationSnapshot where
+    declareNamedSchema _ = do
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        chainPointSchema <-
+            declareSchemaRef (Proxy @ChainPointJSON)
+        pure
+            $ Swagger.NamedSchema
+                (Just "VerificationSnapshot")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("utxo_root", hexSchema)
+                    , ("chainpoint", chainPointSchema)
+                    ]
+            & required
+                .~ ["utxo_root", "chainpoint"]
+            & description
+                ?~ "UTxO-CSMT root and indexed chain \
+                   \point against which bundled \
+                   \proofs are valid"
+
+instance ToSchema TokenIdJSON where
+    declareNamedSchema _ =
+        pure
+            $ Swagger.NamedSchema
+                (Just "TokenIdJSON")
+            $ Swagger.toSchema (Proxy @String)
+            & description
+                ?~ "Hex-encoded token identifier"
+
+instance ToParamSchema TokenIdJSON where
+    toParamSchema _ =
+        Swagger.toParamSchema (Proxy @String)
+
+instance ToSchema UtxoRef where
+    declareNamedSchema _ = do
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        word64Schema <-
+            declareSchemaRef (Proxy @Word64)
+        pure
+            $ Swagger.NamedSchema (Just "UtxoRef")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("tx_id", hexSchema)
+                    , ("tx_ix", word64Schema)
+                    ]
+            & required .~ ["tx_id", "tx_ix"]
+            & description ?~ "UTxO reference"
+
+instance ToSchema UtxoEntry where
+    declareNamedSchema _ = do
+        refSchema <-
+            declareSchemaRef (Proxy @UtxoRef)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema (Just "UtxoEntry")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("ref", refSchema)
+                    , ("txout_cbor", hexSchema)
+                    , ("inclusion_proof", hexSchema)
+                    ]
+            & required
+                .~ [ "ref"
+                   , "txout_cbor"
+                   , "inclusion_proof"
+                   ]
+            & description
+                ?~ "UTxO ref, CBOR body, and CSMT \
+                   \inclusion proof against the \
+                   \enclosing snapshot's utxo_root"
+
+instance ToSchema UtxoEntryRefOnly where
+    declareNamedSchema _ = do
+        refSchema <-
+            declareSchemaRef (Proxy @UtxoRef)
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "UtxoEntryRefOnly")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("ref", refSchema)
+                    , ("txout_cbor", hexSchema)
+                    ]
+            & required .~ ["ref", "txout_cbor"]
+            & description
+                ?~ "UTxO ref and CBOR body, without a \
+                   \per-entry inclusion proof. Used \
+                   \inside a UtxoSetWitness."
+
+instance ToSchema UtxoSetWitness where
+    declareNamedSchema _ = do
+        entrySchema <-
+            declareSchemaRef
+                (Proxy @[UtxoEntryRefOnly])
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "UtxoSetWitness")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("entries", entrySchema)
+                    , ("completeness_proof", hexSchema)
+                    ]
+            & required
+                .~ [ "entries"
+                   , "completeness_proof"
+                   ]
+            & description
+                ?~ "Enumerated UTxOs at a known \
+                   \script-hash prefix, with a single \
+                   \CSMT prefix-completeness proof \
+                   \attesting the set is exactly the \
+                   \leaves under that prefix."
+
+instance ToSchema UnverifiedPParams where
+    declareNamedSchema _ = do
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        boolSchema <-
+            declareSchemaRef (Proxy @Bool)
+        pure
+            $ Swagger.NamedSchema
+                (Just "UnverifiedPParams")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("verified", boolSchema)
+                    , ("cbor", hexSchema)
+                    ]
+            & required .~ ["verified", "cbor"]
+            & description
+                ?~ "CBOR-encoded protocol parameters \
+                   \reported as unverified facts."

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.API.Types.Facts
+-- Description : Facts endpoint JSON DTOs.
+-- License     : Apache-2.0
+--
+-- Wire types owned by facts endpoints. The module re-exports the
+-- common facts/proof primitives needed by facts clients.
+module Cardano.MPFS.API.Types.Facts
+    ( -- * Facts responses
+      BootFacts (..)
+
+      -- * Common facts/proof primitives
+    , ChainPointJSON (..)
+    , VerificationSnapshot (..)
+    , TokenIdJSON (..)
+    , UtxoRef (..)
+    , UtxoEntry (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoSetWitness (..)
+    , UnverifiedPParams (..)
+    ) where
+
+import Control.Lens ((&), (.~), (?~))
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , object
+    , withObject
+    , (.:)
+    , (.=)
+    )
+import Data.Proxy (Proxy (..))
+import Data.Swagger
+    ( ToSchema (..)
+    , declareSchemaRef
+    , description
+    , properties
+    , required
+    )
+import Data.Swagger qualified as Swagger
+import GHC.IsList (IsList (..))
+
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    , VerificationSnapshot (..)
+    )
+
+-- | Facts-only boot response.
+--
+-- Unlike 'Cardano.MPFS.API.Types.UnsignedTxResponse', this envelope
+-- carries no transaction CBOR. Its verifier proves only that the
+-- advertised wallet UTxOs are included in the trusted snapshot root.
+data BootFacts = BootFacts
+    { bfSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled inclusion proofs target.
+    , bfWalletUtxos :: [UtxoEntry]
+    -- ^ Wallet UTxOs with CSMT inclusion proofs.
+    , bfProtocolParameters :: UnverifiedPParams
+    -- ^ Unverified protocol parameter bytes.
+    }
+    deriving (Eq, Show)
+
+instance ToJSON BootFacts where
+    toJSON BootFacts{..} =
+        object
+            [ "snapshot" .= bfSnapshot
+            , "wallet_utxos" .= bfWalletUtxos
+            , "protocol_parameters" .= bfProtocolParameters
+            ]
+
+instance FromJSON BootFacts where
+    parseJSON =
+        withObject "BootFacts" $ \o ->
+            BootFacts
+                <$> o .: "snapshot"
+                <*> o .: "wallet_utxos"
+                <*> o .: "protocol_parameters"
+
+instance ToSchema BootFacts where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        walletSchema <-
+            declareSchemaRef (Proxy @[UtxoEntry])
+        ppSchema <-
+            declareSchemaRef (Proxy @UnverifiedPParams)
+        pure
+            $ Swagger.NamedSchema (Just "BootFacts")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("wallet_utxos", walletSchema)
+                    , ("protocol_parameters", ppSchema)
+                    ]
+            & required
+                .~ [ "snapshot"
+                   , "wallet_utxos"
+                   , "protocol_parameters"
+                   ]
+            & description
+                ?~ "Facts-only boot response. Carries \
+                   \wallet UTxO witnesses and \
+                   \unverified protocol parameters, \
+                   \with no unsigned transaction CBOR."

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs
@@ -11,6 +11,7 @@
 module Cardano.MPFS.API.Types.Facts
     ( -- * Facts responses
       BootFacts (..)
+    , EndFacts (..)
 
       -- * Common facts/proof primitives
     , ChainPointJSON (..)
@@ -115,3 +116,90 @@ instance ToSchema BootFacts where
                    \wallet UTxO witnesses and \
                    \unverified protocol parameters, \
                    \with no unsigned transaction CBOR."
+
+-- | Facts-only end response.
+--
+-- Carries the current token state UTxO, wallet funding UTxOs,
+-- and a request-set completeness witness. The verifier proves
+-- these facts against the trusted snapshot before a client-side
+-- transaction builder may consume them.
+data EndFacts = EndFacts
+    { efSnapshot :: VerificationSnapshot
+    -- ^ Snapshot the bundled proofs target.
+    , efToken :: TokenIdJSON
+    -- ^ Cage token being ended.
+    , efStateUtxo :: UtxoEntry
+    -- ^ State UTxO with a CSMT inclusion proof.
+    , efWalletUtxos :: [UtxoEntry]
+    -- ^ Wallet UTxOs with CSMT inclusion proofs.
+    , efRequestSet :: UtxoSetWitness
+    -- ^ Request-address completeness witness.
+    , efProtocolParameters :: UnverifiedPParams
+    -- ^ Unverified protocol parameter bytes.
+    }
+    deriving (Eq, Show)
+
+instance ToJSON EndFacts where
+    toJSON EndFacts{..} =
+        object
+            [ "snapshot" .= efSnapshot
+            , "token" .= efToken
+            , "state_utxo" .= efStateUtxo
+            , "wallet_utxos" .= efWalletUtxos
+            , "request_set" .= efRequestSet
+            , "protocol_parameters" .= efProtocolParameters
+            ]
+
+instance FromJSON EndFacts where
+    parseJSON =
+        withObject "EndFacts" $ \o ->
+            EndFacts
+                <$> o .: "snapshot"
+                <*> o .: "token"
+                <*> o .: "state_utxo"
+                <*> o .: "wallet_utxos"
+                <*> o .: "request_set"
+                <*> o .: "protocol_parameters"
+
+instance ToSchema EndFacts where
+    declareNamedSchema _ = do
+        snapshotSchema <-
+            declareSchemaRef
+                (Proxy @VerificationSnapshot)
+        tokenSchema <-
+            declareSchemaRef (Proxy @TokenIdJSON)
+        stateSchema <-
+            declareSchemaRef (Proxy @UtxoEntry)
+        walletSchema <-
+            declareSchemaRef (Proxy @[UtxoEntry])
+        requestSetSchema <-
+            declareSchemaRef (Proxy @UtxoSetWitness)
+        ppSchema <-
+            declareSchemaRef (Proxy @UnverifiedPParams)
+        pure
+            $ Swagger.NamedSchema (Just "EndFacts")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("snapshot", snapshotSchema)
+                    , ("token", tokenSchema)
+                    , ("state_utxo", stateSchema)
+                    , ("wallet_utxos", walletSchema)
+                    , ("request_set", requestSetSchema)
+                    , ("protocol_parameters", ppSchema)
+                    ]
+            & required
+                .~ [ "snapshot"
+                   , "token"
+                   , "state_utxo"
+                   , "wallet_utxos"
+                   , "request_set"
+                   , "protocol_parameters"
+                   ]
+            & description
+                ?~ "Facts-only end response. Carries state and \
+                   \wallet UTxO witnesses plus a request-set \
+                   \completeness proof, with no unsigned \
+                   \transaction CBOR."

--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -140,6 +140,7 @@ test-suite unit-tests
     , warp                    >=3.4  && <3.5
 
   other-modules:
+    Cardano.MPFS.Client.APITypeSplitSpec
     Cardano.MPFS.Client.BootFactsSpec
     Cardano.MPFS.Client.BundleSpec
     Cardano.MPFS.Client.Cage.BootSpec

--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -44,6 +44,7 @@ library
     , cardano-ledger-api
     , cardano-ledger-babbage
     , cardano-ledger-binary
+    , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-mpfs-api
@@ -72,6 +73,7 @@ library
     Cardano.MPFS.Client.Cage.Boot
     Cardano.MPFS.Client.Cage.BuildError
     Cardano.MPFS.Client.Cage.Config
+    Cardano.MPFS.Client.Cage.End
     Cardano.MPFS.Client.Cage.Identity
     Cardano.MPFS.Client.Cage.Policy
     Cardano.MPFS.Client.Facts
@@ -119,6 +121,7 @@ test-suite unit-tests
     , cardano-ledger-babbage
     , cardano-ledger-binary
     , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-mpfs-api
     , cardano-mpfs-cage
     , cardano-mpfs-client
@@ -136,6 +139,7 @@ test-suite unit-tests
     , mts:csmt-write
     , mts:mpf-test-lib
     , mts:mpf-write
+    , plutus-tx
     , text
     , wai                     >=3.2  && <3.3
     , warp                    >=3.4  && <3.5
@@ -145,6 +149,7 @@ test-suite unit-tests
     Cardano.MPFS.Client.BootFactsSpec
     Cardano.MPFS.Client.BundleSpec
     Cardano.MPFS.Client.Cage.BootSpec
+    Cardano.MPFS.Client.Cage.EndSpec
     Cardano.MPFS.Client.EndFactsSpec
     Cardano.MPFS.Client.Fixtures
     Cardano.MPFS.Client.HttpSpec

--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -72,6 +72,7 @@ library
     Cardano.MPFS.Client.Cage.Boot
     Cardano.MPFS.Client.Cage.BuildError
     Cardano.MPFS.Client.Cage.Config
+    Cardano.MPFS.Client.Cage.Identity
     Cardano.MPFS.Client.Cage.Policy
     Cardano.MPFS.Client.Facts
     Cardano.MPFS.Client.Http
@@ -144,6 +145,7 @@ test-suite unit-tests
     Cardano.MPFS.Client.BootFactsSpec
     Cardano.MPFS.Client.BundleSpec
     Cardano.MPFS.Client.Cage.BootSpec
+    Cardano.MPFS.Client.EndFactsSpec
     Cardano.MPFS.Client.Fixtures
     Cardano.MPFS.Client.HttpSpec
     Cardano.MPFS.Client.SnapshotSpec

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
@@ -50,9 +50,12 @@ module Cardano.MPFS.Client
     , UpdateProof (..)
     , BootTxResponse (..)
     , BootFacts (..)
+    , EndFacts (..)
     , UnverifiedPParams (..)
     , VerifiedBootFacts
+    , VerifiedEndFacts
     , verifiedBootFacts
+    , verifiedEndFacts
     , RequestTxResponse (..)
     , RetractTxResponse (..)
     , RejectTxResponse (..)
@@ -63,6 +66,7 @@ module Cardano.MPFS.Client
     , VerifyError (..)
     , verifyVerificationSnapshot
     , verifyBootFacts
+    , verifyEndFacts
     , verifyBootTxResponse
     , verifyRequestTxResponse
     , verifyRetractTxResponse
@@ -129,9 +133,12 @@ import Cardano.MPFS.Client.Bundle
     )
 import Cardano.MPFS.Client.Facts
     ( BootFacts (..)
+    , EndFacts (..)
     , UnverifiedPParams (..)
     , VerifiedBootFacts
+    , VerifiedEndFacts
     , verifiedBootFacts
+    , verifiedEndFacts
     )
 import Cardano.MPFS.Client.Http
     ( BaseUrl (..)
@@ -166,6 +173,7 @@ import Cardano.MPFS.Client.Verify
     ( VerifyError (..)
     , verifyBootFacts
     , verifyBootTxResponse
+    , verifyEndFacts
     , verifyEndTxResponse
     , verifyRejectTxResponse
     , verifyRequestTxResponse

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client.hs
@@ -28,7 +28,6 @@ module Cardano.MPFS.Client
     , RetractParams (..)
     , RejectParams (..)
     , UpdateParams (..)
-    , EndParams (..)
     , bootFacts
     , requestInsertTx
     , requestDeleteTx
@@ -36,7 +35,6 @@ module Cardano.MPFS.Client
     , retractTx
     , rejectTx
     , updateTx
-    , endTx
 
       -- * Response envelopes
     , TxIn (..)
@@ -144,7 +142,6 @@ import Cardano.MPFS.Client.Http
     ( BaseUrl (..)
     , BootFactsParams (..)
     , ClientError (..)
-    , EndParams (..)
     , MpfsHttp (..)
     , RejectParams (..)
     , RequestDeleteParams (..)
@@ -155,7 +152,6 @@ import Cardano.MPFS.Client.Http
     , UpdateParams (..)
     , VerifierMode (..)
     , bootFacts
-    , endTx
     , rejectTx
     , requestDeleteTx
     , requestInsertTx

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Boot.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Boot.hs
@@ -85,12 +85,12 @@ import Cardano.Ledger.Plutus.Language
     )
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.MPFS.API.Encoding (Hex (..))
-import Cardano.MPFS.API.Types
-    ( BootFacts (..)
-    , UnverifiedPParams (..)
+import Cardano.MPFS.API.Types.Common
+    ( UnverifiedPParams (..)
     , UtxoEntry (..)
     , UtxoRef (..)
     )
+import Cardano.MPFS.API.Types.Facts (BootFacts (..))
 import Cardano.MPFS.Cage.AssetName (deriveAssetName)
 import Cardano.MPFS.Cage.Ledger
     ( ConwayEra

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/End.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/End.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Alonzo.TxBody
     )
 import Cardano.Ledger.Api.PParams
     ( ppCoinsPerUTxOByteL
+    , ppMaxTxExUnitsL
     , ppPricesL
     )
 import Cardano.Ledger.Api.Scripts.Data
@@ -94,6 +95,9 @@ import Cardano.Ledger.Keys
     )
 import Cardano.Ledger.Mary.Value
     ( MultiAsset (..)
+    )
+import Cardano.Ledger.Plutus.ExUnits
+    ( ExUnits (..)
     )
 import Cardano.Ledger.Plutus.Language
     ( Language (..)
@@ -356,6 +360,8 @@ buildEndTx
             Set.fromList (map rowRef allRows)
         stateIx =
             spendingIndex stateRef allInputs
+        endBudget =
+            endRedeemerBudget pp
         redeemers =
             Redeemers
                 $ Map.fromList
@@ -363,7 +369,7 @@ buildEndTx
                         ( ConwaySpending (AsIx stateIx)
                         ,
                             ( toLedgerData End
-                            , evalBudgetExUnits
+                            , endBudget
                             )
                         )
                     ,
@@ -371,7 +377,7 @@ buildEndTx
                         ,
                             ( toLedgerData
                                 (Burning $ onChainTokenId token)
-                            , evalBudgetExUnits
+                            , endBudget
                             )
                         )
                     ]
@@ -402,6 +408,20 @@ toLedgerData :: (ToData a) => a -> Data ConwayEra
 toLedgerData value =
     let BuiltinData d = toBuiltinData value
     in  Data d
+
+endRedeemerBudget :: PParams ConwayEra -> ExUnits
+endRedeemerBudget pp =
+    capExUnits evalBudgetExUnits
+        $ halfExUnits
+        $ pp ^. ppMaxTxExUnitsL
+
+capExUnits :: ExUnits -> ExUnits -> ExUnits
+capExUnits (ExUnits mem steps) (ExUnits maxMem maxSteps) =
+    ExUnits (min mem maxMem) (min steps maxSteps)
+
+halfExUnits :: ExUnits -> ExUnits
+halfExUnits (ExUnits mem steps) =
+    ExUnits (mem `div` 2) (steps `div` 2)
 
 spendingIndex :: TxIn -> Set.Set TxIn -> Word32
 spendingIndex needle inputs =

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/End.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/End.hs
@@ -1,0 +1,462 @@
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Module      : Cardano.MPFS.Client.Cage.End
+-- Description : Client-side end cage transaction builder.
+module Cardano.MPFS.Client.Cage.End
+    ( endCageTx
+    ) where
+
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BSL
+import Data.Coerce (coerce)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Word (Word16, Word32, Word64)
+import Lens.Micro ((&), (.~), (^.))
+
+import Cardano.Crypto.Hash
+    ( Blake2b_224
+    , Blake2b_256
+    , hashFromBytes
+    )
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Allegra.Scripts
+    ( ValidityInterval (..)
+    )
+import Cardano.Ledger.Alonzo.Scripts
+    ( AsIx (..)
+    )
+import Cardano.Ledger.Alonzo.TxBody
+    ( reqSignerHashesTxBodyL
+    , scriptIntegrityHashTxBodyL
+    )
+import Cardano.Ledger.Api.PParams
+    ( ppCoinsPerUTxOByteL
+    , ppPricesL
+    )
+import Cardano.Ledger.Api.Scripts.Data
+    ( Data (..)
+    , Datum (..)
+    , binaryDataToData
+    )
+import Cardano.Ledger.Api.Tx
+    ( Tx
+    , bodyTxL
+    , mkBasicTx
+    , witsTxL
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( collateralInputsTxBodyL
+    , feeTxBodyL
+    , inputsTxBodyL
+    , mintTxBodyL
+    , mkBasicTxBody
+    , vldtTxBodyL
+    )
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , addrTxOutL
+    , datumTxOutL
+    )
+import Cardano.Ledger.Api.Tx.Wits
+    ( Redeemers (..)
+    , rdmrsTxWitsL
+    , scriptTxWitsL
+    )
+import Cardano.Ledger.Babbage.PParams
+    ( CoinPerByte (..)
+    )
+import Cardano.Ledger.BaseTypes
+    ( StrictMaybe (..)
+    , TxIx (..)
+    )
+import Cardano.Ledger.Binary
+    ( DecoderError
+    , decodeFull
+    , natVersion
+    )
+import Cardano.Ledger.Conway.Scripts
+    ( ConwayPlutusPurpose (..)
+    )
+import Cardano.Ledger.Core
+    ( PParams
+    , hashScript
+    )
+import Cardano.Ledger.Hashes
+    ( unsafeMakeSafeHash
+    )
+import Cardano.Ledger.Keys
+    ( KeyHash (..)
+    , KeyRole (..)
+    )
+import Cardano.Ledger.Mary.Value
+    ( MultiAsset (..)
+    )
+import Cardano.Ledger.Plutus.Language
+    ( Language (..)
+    )
+import Cardano.Ledger.TxIn
+    ( TxId (..)
+    , TxIn (..)
+    )
+import Cardano.MPFS.API.Encoding
+    ( Hex (..)
+    )
+import Cardano.MPFS.API.Types.Common
+    ( UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoRef (..)
+    )
+import Cardano.MPFS.API.Types.Facts
+    ( EndFacts (..)
+    )
+import Cardano.MPFS.Cage.Ledger
+    ( ConwayEra
+    , TokenId (..)
+    )
+import Cardano.MPFS.Cage.Types
+    ( CageDatum (..)
+    , MintRedeemer (..)
+    , OnChainTokenState (..)
+    , UpdateRedeemer (..)
+    )
+import Cardano.MPFS.Client.Cage.BuildError
+    ( BuildError (..)
+    )
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , cagePolicyIdFromCfg
+    , mkCageScript
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( onChainTokenId
+    , tokenIdFromJSON
+    )
+import Cardano.MPFS.Client.Cage.Policy
+    ( PolicyViolationDetail (..)
+    , WalletPolicy (..)
+    )
+import Cardano.MPFS.Client.Facts
+    ( VerifiedEndFacts
+    , verifiedEndFacts
+    )
+import Cardano.Node.Client.Balance
+    ( BalanceResult (..)
+    , balanceTx
+    , computeScriptIntegrity
+    , evalBudgetExUnits
+    )
+import Cardano.Slotting.Slot
+    ( SlotNo (..)
+    )
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    , BuiltinData (..)
+    )
+import PlutusTx.IsData.Class
+    ( FromData (..)
+    , ToData (..)
+    )
+
+-- | Build an unsigned end transaction from already-verified end
+-- facts. The function decodes the supplied ledger facts, enforces
+-- wallet caps, and returns a transaction ready for owner signing.
+endCageTx
+    :: CageConfig
+    -> WalletPolicy
+    -> VerifiedEndFacts
+    -> Either BuildError (Tx ConwayEra)
+endCageTx cfg policy verified = do
+    let facts = verifiedEndFacts verified
+    pp <- decodePParams (efProtocolParameters facts)
+    enforcePParamsPolicy policy pp
+    stateRow <- decodeStateUtxo (efStateUtxo facts)
+    fundingRows <- decodeWalletUtxos (efWalletUtxos facts)
+    collateralRow <-
+        case fundingRows of
+            [] -> Left EmptyFunding
+            row : _ -> Right row
+    ownerBytes <- stateOwnerBytes stateRow
+    ownerSigner <- ownerWitnessKeyHash ownerBytes
+    let changeAddr = rowAddress collateralRow
+    tx <-
+        buildEndTx
+            cfg
+            pp
+            stateRow
+            fundingRows
+            collateralRow
+            changeAddr
+            ownerSigner
+            (tokenIdFromJSON $ efToken facts)
+    enforceTxPolicy policy tx
+    pure tx
+
+data InputRow = InputRow
+    { rowRef :: !TxIn
+    , rowOut :: !(TxOut ConwayEra)
+    }
+
+rowAddress :: InputRow -> Addr
+rowAddress row =
+    rowOut row ^. addrTxOutL
+
+decodePParams
+    :: UnverifiedPParams -> Either BuildError (PParams ConwayEra)
+decodePParams UnverifiedPParams{uppCbor = Hex ppBytes} =
+    case decodeFull (natVersion @11) (BSL.fromStrict ppBytes) of
+        Left err ->
+            Left
+                $ MalformedPParams
+                $ T.pack
+                $ show err
+        Right pp -> Right pp
+
+decodeStateUtxo :: UtxoEntry -> Either BuildError InputRow
+decodeStateUtxo UtxoEntry{ueRef, ueTxOutCbor = Hex outBytes} =
+    InputRow
+        <$> decodeRef "end.state_utxo.ref" ueRef
+        <*> decodeTxOut "end.state_utxo.tx_out_cbor" outBytes
+
+decodeWalletUtxos
+    :: [UtxoEntry] -> Either BuildError [InputRow]
+decodeWalletUtxos =
+    traverse (uncurry decodeWalletUtxo) . zip [0 :: Int ..]
+
+decodeWalletUtxo
+    :: Int -> UtxoEntry -> Either BuildError InputRow
+decodeWalletUtxo ix UtxoEntry{ueRef, ueTxOutCbor = Hex outBytes} =
+    InputRow
+        <$> decodeRef (walletField ix "ref") ueRef
+        <*> decodeTxOut (walletField ix "tx_out_cbor") outBytes
+
+decodeRef :: Text -> UtxoRef -> Either BuildError TxIn
+decodeRef path UtxoRef{urTxId = Hex txIdBytes, urTxIx} = do
+    txId <- decodeTxId (path <> ".tx_id") txIdBytes
+    txIx <- decodeTxIx (path <> ".tx_ix") urTxIx
+    Right (TxIn txId txIx)
+
+decodeTxId :: Text -> ByteString -> Either BuildError TxId
+decodeTxId path txIdBytes =
+    case hashFromBytes @Blake2b_256 txIdBytes of
+        Just hash ->
+            Right (TxId $ unsafeMakeSafeHash hash)
+        Nothing ->
+            Left
+                $ MalformedTxOut
+                $ path <> " must be 32 bytes"
+
+decodeTxIx :: Text -> Word64 -> Either BuildError TxIx
+decodeTxIx path txIx
+    | txIx <= fromIntegral (maxBound :: Word16) =
+        Right (TxIx $ fromIntegral txIx)
+    | otherwise =
+        Left
+            $ MalformedTxOut
+            $ path <> " exceeds Word16"
+
+decodeTxOut
+    :: Text -> ByteString -> Either BuildError (TxOut ConwayEra)
+decodeTxOut path outBytes =
+    case decodeFull (natVersion @11) (BSL.fromStrict outBytes) of
+        Left err ->
+            Left
+                $ MalformedTxOut
+                $ path <> ": " <> showDecoder err
+        Right out -> Right out
+
+showDecoder :: DecoderError -> Text
+showDecoder =
+    T.pack . show
+
+walletField :: Int -> Text -> Text
+walletField ix name =
+    "end.wallet_utxos[" <> T.pack (show ix) <> "]." <> name
+
+stateOwnerBytes :: InputRow -> Either BuildError ByteString
+stateOwnerBytes row =
+    case extractCageDatum (rowOut row) of
+        Just
+            ( StateDatum
+                    OnChainTokenState
+                        { stateOwner =
+                            BuiltinByteString ownerBytes
+                        }
+                ) ->
+                Right ownerBytes
+        _ ->
+            Left
+                $ MalformedTxOut
+                    "end.state_utxo.tx_out_cbor missing state datum"
+
+ownerWitnessKeyHash
+    :: ByteString -> Either BuildError (KeyHash 'Witness)
+ownerWitnessKeyHash ownerBytes =
+    coerce <$> ownerPaymentKeyHash ownerBytes
+
+ownerPaymentKeyHash
+    :: ByteString -> Either BuildError (KeyHash 'Payment)
+ownerPaymentKeyHash ownerBytes =
+    case hashFromBytes @Blake2b_224 ownerBytes of
+        Just hash -> Right (KeyHash hash)
+        Nothing ->
+            Left
+                $ MalformedTxOut
+                    "end.state_utxo.datum.owner must be 28 bytes"
+
+extractCageDatum :: TxOut ConwayEra -> Maybe CageDatum
+extractCageDatum txOut =
+    case txOut ^. datumTxOutL of
+        Datum bd ->
+            let Data plcData =
+                    binaryDataToData bd
+            in  fromBuiltinData (BuiltinData plcData)
+        _ -> Nothing
+
+buildEndTx
+    :: CageConfig
+    -> PParams ConwayEra
+    -> InputRow
+    -> [InputRow]
+    -> InputRow
+    -> Addr
+    -> KeyHash 'Witness
+    -> TokenId
+    -> Either BuildError (Tx ConwayEra)
+buildEndTx
+    cfg
+    pp
+    stateRow
+    fundingRows
+    collateralRow
+    ownerAddr
+    ownerSigner
+    token =
+        case balanceTx pp ledgerPairs ownerAddr draft of
+            Left err ->
+                Left (DSLBuildFailed $ T.pack $ show err)
+            Right BalanceResult{balancedTx} ->
+                Right balancedTx
+      where
+        stateRef = rowRef stateRow
+        collateralRef = rowRef collateralRow
+        policyId = cagePolicyIdFromCfg cfg
+        script = mkCageScript cfg
+        scriptHash = hashScript script
+        tokenAsset = unTokenId token
+        burnValue =
+            MultiAsset
+                $ Map.singleton policyId
+                $ Map.singleton tokenAsset (-1)
+        allRows = stateRow : fundingRows
+        allInputs =
+            Set.fromList (map rowRef allRows)
+        stateIx =
+            spendingIndex stateRef allInputs
+        redeemers =
+            Redeemers
+                $ Map.fromList
+                    [
+                        ( ConwaySpending (AsIx stateIx)
+                        ,
+                            ( toLedgerData End
+                            , evalBudgetExUnits
+                            )
+                        )
+                    ,
+                        ( ConwayMinting (AsIx 0)
+                        ,
+                            ( toLedgerData
+                                (Burning $ onChainTokenId token)
+                            , evalBudgetExUnits
+                            )
+                        )
+                    ]
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL .~ allInputs
+                & mintTxBodyL .~ burnValue
+                & collateralInputsTxBodyL
+                    .~ Set.singleton collateralRef
+                & reqSignerHashesTxBodyL
+                    .~ Set.singleton ownerSigner
+                & scriptIntegrityHashTxBodyL
+                    .~ computeScriptIntegrity
+                        PlutusV3
+                        pp
+                        redeemers
+        draft =
+            mkBasicTx body
+                & witsTxL . scriptTxWitsL
+                    .~ Map.singleton scriptHash script
+                & witsTxL . rdmrsTxWitsL .~ redeemers
+        ledgerPairs =
+            [ (rowRef row, rowOut row)
+            | row <- allRows
+            ]
+
+toLedgerData :: (ToData a) => a -> Data ConwayEra
+toLedgerData value =
+    let BuiltinData d = toBuiltinData value
+    in  Data d
+
+spendingIndex :: TxIn -> Set.Set TxIn -> Word32
+spendingIndex needle inputs =
+    go 0 (Set.toAscList inputs)
+  where
+    go _ [] =
+        error "spendingIndex: TxIn not in input set"
+    go n (x : xs)
+        | x == needle = n
+        | otherwise = go (n + 1) xs
+
+enforcePParamsPolicy
+    :: WalletPolicy
+    -> PParams ConwayEra
+    -> Either BuildError ()
+enforcePParamsPolicy WalletPolicy{..} pp = do
+    let CoinPerByte minUtxo = pp ^. ppCoinsPerUTxOByteL
+        prices = pp ^. ppPricesL
+    if minUtxo <= wpMaxMinUtxoCoinPerByte
+        then Right ()
+        else
+            Left
+                $ PolicyViolation
+                $ MinUtxoCoinPerByteTooHigh
+                    minUtxo
+                    wpMaxMinUtxoCoinPerByte
+    if prices <= wpMaxExUnitPrices
+        then Right ()
+        else
+            Left
+                $ PolicyViolation
+                $ ExUnitPricesTooHigh prices wpMaxExUnitPrices
+
+enforceTxPolicy
+    :: WalletPolicy -> Tx ConwayEra -> Either BuildError ()
+enforceTxPolicy WalletPolicy{..} tx = do
+    let fee = tx ^. bodyTxL . feeTxBodyL
+        width = validityWindow (tx ^. bodyTxL . vldtTxBodyL)
+    if fee <= wpMaxFee
+        then Right ()
+        else
+            Left
+                $ PolicyViolation
+                $ FeeTooHigh fee wpMaxFee
+    if width <= wpMaxValidityWindow
+        then Right ()
+        else
+            Left
+                $ PolicyViolation
+                $ ValidityWindowTooWide width wpMaxValidityWindow
+
+validityWindow :: ValidityInterval -> SlotNo
+validityWindow ValidityInterval{invalidBefore, invalidHereafter} =
+    case (invalidBefore, invalidHereafter) of
+        (SJust lo, SJust hi)
+            | hi >= lo ->
+                SlotNo (unSlotNo hi - unSlotNo lo)
+        _ -> SlotNo maxBound

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Identity.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Identity.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Module      : Cardano.MPFS.Client.Cage.Identity
+-- Description : Client-owned cage identity helpers.
+--
+-- Derives per-token request validator identity from the client
+-- cage configuration. These helpers mirror the offchain builder
+-- identity calculation without depending on the server package.
+module Cardano.MPFS.Client.Cage.Identity
+    ( onChainTokenId
+    , requestAddrFromCfg
+    , requestScriptBytesFromCfg
+    , requestSetPrefixFromCfg
+    , tokenIdFromJSON
+    ) where
+
+import Data.ByteString.Short qualified as SBS
+
+import Cardano.Crypto.Hash
+    ( hashToBytes
+    )
+import Cardano.Ledger.Address
+    ( Addr (..)
+    , serialiseAddr
+    )
+import Cardano.Ledger.BaseTypes
+    ( Network
+    )
+import Cardano.Ledger.Credential
+    ( Credential (..)
+    , StakeReference (..)
+    )
+import Cardano.Ledger.Hashes
+    ( ScriptHash (..)
+    )
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    )
+
+import CSMT.Core.Hash
+    ( byteStringToKey
+    )
+import CSMT.Core.Types
+    ( Key
+    )
+import CSMT.Verify.Blake2b
+    ( blake2b256
+    )
+
+import Cardano.MPFS.API.Types.Common
+    ( TokenIdJSON (..)
+    )
+import Cardano.MPFS.Cage.Blueprint
+    ( applyRequestParams
+    )
+import Cardano.MPFS.Cage.Ledger
+    ( AssetName (..)
+    , TokenId (..)
+    )
+import Cardano.MPFS.Cage.Types
+    ( OnChainTokenId (..)
+    )
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , computeScriptHash
+    )
+
+-- | Convert a wire token id to the ledger-side token id.
+tokenIdFromJSON :: TokenIdJSON -> TokenId
+tokenIdFromJSON (TokenIdJSON bs) =
+    TokenId (AssetName (SBS.toShort bs))
+
+-- | Convert a ledger-side token id to its on-chain bytes.
+onChainTokenId :: TokenId -> OnChainTokenId
+onChainTokenId tid =
+    OnChainTokenId
+        $ BuiltinByteString
+        $ SBS.fromShort
+        $ let AssetName sbs = unTokenId tid
+          in  sbs
+
+-- | Apply the request validator parameters for a token.
+requestScriptBytesFromCfg
+    :: CageConfig -> TokenId -> SBS.ShortByteString
+requestScriptBytesFromCfg cfg tid =
+    let ScriptHash h = cfgScriptHash cfg
+    in  applyRequestParams
+            (hashToBytes h)
+            (onChainTokenId tid)
+            (requestScriptBytes cfg)
+
+-- | Compute the per-cage request validator address.
+requestAddrFromCfg :: CageConfig -> TokenId -> Network -> Addr
+requestAddrFromCfg cfg tid net =
+    Addr
+        net
+        ( ScriptHashObj
+            $ computeScriptHash
+                (requestScriptBytesFromCfg cfg tid)
+        )
+        StakeRefNull
+
+-- | Derive the request-set CSMT prefix locally from config and
+-- token. Matches offchain @hashAddressKey (serialiseAddr addr)@.
+requestSetPrefixFromCfg :: CageConfig -> TokenIdJSON -> Key
+requestSetPrefixFromCfg cfg token =
+    byteStringToKey
+        $ blake2b256
+        $ serialiseAddr
+        $ requestAddrFromCfg
+            cfg
+            (tokenIdFromJSON token)
+            (network cfg)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs
@@ -16,10 +16,12 @@ import Data.ByteString qualified as BS
 import Data.Text qualified as T
 
 import Cardano.MPFS.API.Encoding (Hex (..))
-import Cardano.MPFS.API.Types
-    ( BootFacts (..)
-    , UnverifiedPParams (..)
+import Cardano.MPFS.API.Types.Common
+    ( UnverifiedPParams (..)
     , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts
+    ( BootFacts (..)
     )
 import Cardano.MPFS.Client.TrustedRoot
     ( TrustedRoot (..)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs
@@ -6,10 +6,14 @@
 -- post-verification witness returned by facts-only verifiers.
 module Cardano.MPFS.Client.Facts
     ( BootFacts (..)
+    , EndFacts (..)
     , UnverifiedPParams (..)
     , VerifiedBootFacts
+    , VerifiedEndFacts
     , verifiedBootFacts
+    , verifiedEndFacts
     , verifyBootFacts
+    , verifyEndFacts
     ) where
 
 import Data.ByteString qualified as BS
@@ -18,13 +22,25 @@ import Data.Text qualified as T
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types.Common
     ( UnverifiedPParams (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoSetWitness (..)
     , VerificationSnapshot (..)
     )
 import Cardano.MPFS.API.Types.Facts
     ( BootFacts (..)
+    , EndFacts (..)
+    )
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( requestSetPrefixFromCfg
     )
 import Cardano.MPFS.Client.TrustedRoot
     ( TrustedRoot (..)
+    )
+import Cardano.MPFS.Client.Verify.Completeness
+    ( verifyUtxoSetCompleteness
     )
 import Cardano.MPFS.Client.Verify.Replay
     ( VerifyError (..)
@@ -37,10 +53,21 @@ import Cardano.MPFS.Client.Verify.Replay
 newtype VerifiedBootFacts = VerifiedBootFacts BootFacts
     deriving stock (Eq, Show)
 
+-- | Opaque witness that end facts have been checked against the
+-- caller-supplied trusted root and locally-derived request prefix.
+newtype VerifiedEndFacts = VerifiedEndFacts EndFacts
+    deriving stock (Eq, Show)
+
 -- | Extract the verified facts after 'verifyBootFacts' has
 -- established the trusted-root and CSMT proof checks.
 verifiedBootFacts :: VerifiedBootFacts -> BootFacts
 verifiedBootFacts (VerifiedBootFacts facts) = facts
+
+-- | Extract the verified facts after 'verifyEndFacts' has
+-- established the trusted-root, inclusion proof, and
+-- request-set completeness checks.
+verifiedEndFacts :: VerifiedEndFacts -> EndFacts
+verifiedEndFacts (VerifiedEndFacts facts) = facts
 
 -- | Verify a facts-only boot response against an externally-supplied
 -- trusted UTxO-CSMT root.
@@ -77,3 +104,55 @@ verifyBootFacts
                         entry
                 )
                 (zip [0 ..] entries)
+
+-- | Verify a facts-only end response against an externally-supplied
+-- trusted UTxO-CSMT root and a client-owned cage configuration.
+verifyEndFacts
+    :: CageConfig
+    -> TrustedRoot
+    -> EndFacts
+    -> Either VerifyError VerifiedEndFacts
+verifyEndFacts
+    cfg
+    (TrustedRoot (Hex trustedBs))
+    facts@EndFacts{..} = do
+        checkLength "end.trusted_root" trustedBs
+        let snapshotPath = "end.snapshot.utxo_root"
+            Hex snapshotBs = vsUtxoRoot efSnapshot
+        checkLength snapshotPath snapshotBs
+        if snapshotBs == trustedBs
+            then Right ()
+            else Left (TrustedRootMismatch snapshotPath)
+        replayUtxoEntry "end.state_utxo" trustedBs efStateUtxo
+        replayWalletUtxos trustedBs efWalletUtxos
+        rejectRequestEntries (uswEntries efRequestSet)
+        verifyUtxoSetCompleteness
+            "end.request_set"
+            trustedBs
+            (requestSetPrefixFromCfg cfg efToken)
+            efRequestSet
+        Right (VerifiedEndFacts facts)
+      where
+        checkLength field bs
+            | BS.length bs == 32 = Right ()
+            | otherwise =
+                Left (WrongHexLength field 32 (BS.length bs))
+        replayWalletUtxos root entries =
+            mapM_
+                ( \(ix, entry) ->
+                    replayUtxoEntry
+                        ( "end.wallet_utxos["
+                            <> T.pack (show (ix :: Int))
+                            <> "]"
+                        )
+                        root
+                        entry
+                )
+                (zip [0 ..] entries)
+        rejectRequestEntries [] = Right ()
+        rejectRequestEntries (entry : _) =
+            Left
+                ( CompletenessExtraLeaf
+                    "end.request_set.entries[0]"
+                    (uerRef entry)
+                )

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Http.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Http.hs
@@ -74,6 +74,7 @@ import Cardano.MPFS.API
     , TxWriteAPI
     )
 import Cardano.MPFS.API.Types qualified as Wire
+import Cardano.MPFS.API.Types.Facts qualified as FactsWire
 import Cardano.MPFS.Client.Bundle
     ( EndTxResponse
     , RejectTxResponse
@@ -246,7 +247,7 @@ bootFacts
     :: MpfsHttp
     -> TrustedRoot
     -> BootFactsParams
-    -> IO (Either ClientError Wire.BootFacts)
+    -> IO (Either ClientError FactsWire.BootFacts)
 bootFacts http trustedRoot params =
     runWriteEndpoint
         http
@@ -377,7 +378,7 @@ fromServantError err =
             TransportError err
 
 factsBootClient
-    :: Wire.BootRequest -> ClientM Wire.BootFacts
+    :: Wire.BootRequest -> ClientM FactsWire.BootFacts
 txInsertClient
     :: Wire.InsertRequest -> ClientM Wire.RequestTxResponse
 txDeleteClient

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Http.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Http.hs
@@ -24,7 +24,6 @@ module Cardano.MPFS.Client.Http
     , RetractParams (..)
     , RejectParams (..)
     , UpdateParams (..)
-    , EndParams (..)
 
       -- * Write endpoints
     , bootFacts
@@ -36,7 +35,6 @@ module Cardano.MPFS.Client.Http
     , updateTx
     , sweepTx
     , SweepParams (..)
-    , endTx
     ) where
 
 import Data.Aeson
@@ -76,8 +74,7 @@ import Cardano.MPFS.API
 import Cardano.MPFS.API.Types qualified as Wire
 import Cardano.MPFS.API.Types.Facts qualified as FactsWire
 import Cardano.MPFS.Client.Bundle
-    ( EndTxResponse
-    , RejectTxResponse
+    ( RejectTxResponse
     , RequestTxResponse
     , RetractTxResponse
     , UpdateTxResponse
@@ -87,7 +84,6 @@ import Cardano.MPFS.Client.TrustedRoot (TrustedRoot)
 import Cardano.MPFS.Client.Verify
     ( VerifyError
     , verifyBootFacts
-    , verifyEndTxResponse
     , verifyRejectTxResponse
     , verifyRequestTxResponse
     , verifyRetractTxResponse
@@ -225,20 +221,6 @@ instance ToJSON UpdateParams where
             , "address" .= updateAddress
             ]
 
--- | @POST /tx/end@ request body.
-data EndParams = EndParams
-    { endToken :: Hex
-    , endAddress :: Hex
-    }
-    deriving stock (Eq, Show)
-
-instance ToJSON EndParams where
-    toJSON EndParams{..} =
-        object
-            [ "token" .= endToken
-            , "address" .= endAddress
-            ]
-
 -- | Fetch boot facts. The post-split #243 shape: caller supplies
 -- an externally-trusted CSMT root; the verifier checks
 -- @snapshot.utxo_root@ matches that root and replays each bundled
@@ -306,14 +288,6 @@ updateTx
     -> IO (Either ClientError UpdateTxResponse)
 updateTx http params =
     runWriteEndpoint http params txUpdateClient verifyUpdateTxResponse
-
--- | Build an end transaction.
-endTx
-    :: MpfsHttp
-    -> EndParams
-    -> IO (Either ClientError EndTxResponse)
-endTx http params =
-    runWriteEndpoint http params txEndClient verifyEndTxResponse
 
 runWriteEndpoint
     :: ( ToJSON params
@@ -393,8 +367,6 @@ txRetractClient
     :: Wire.RetractRequest -> ClientM Wire.RetractTxResponse
 txSweepClient
     :: Wire.SweepRequest -> ClientM Wire.SweepTxResponse
-txEndClient
-    :: Wire.EndRequest -> ClientM Wire.EndTxResponse
 factsBootClient =
     client (Proxy :: Proxy FactsBootAPI)
 
@@ -404,8 +376,7 @@ txInsertClient
     :<|> txRejectClient
     :<|> txUpdateClient
     :<|> txRetractClient
-    :<|> txSweepClient
-    :<|> txEndClient =
+    :<|> txSweepClient =
         client (Proxy :: Proxy TxWriteAPI)
 
 -- | @POST /tx/sweep@ request body.

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
@@ -15,7 +15,9 @@ module Cardano.MPFS.Client.Verify
     ( VerifyError (..)
     , verifyVerificationSnapshot
     , VerifiedBootFacts
+    , VerifiedEndFacts
     , verifyBootFacts
+    , verifyEndFacts
 
       -- * Per-endpoint verifiers
     , verifyBootTxResponse
@@ -51,7 +53,9 @@ import Cardano.MPFS.Client.Bundle
     )
 import Cardano.MPFS.Client.Facts
     ( VerifiedBootFacts
+    , VerifiedEndFacts
     , verifyBootFacts
+    , verifyEndFacts
     )
 import Cardano.MPFS.Client.Snapshot
     ( ChainPoint (..)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
@@ -7,8 +7,75 @@
 -- supported and is the load-bearing primitive for
 -- @POST \/tx\/oracle\/end@.
 --
--- Populated by tasks T013 + T014 — see
--- @specs\/243-proof-redesign\/tasks.md@.
+-- Used by end-facts verification to prove the locally-derived
+-- request-address subtree is complete.
 module Cardano.MPFS.Client.Verify.Completeness
-    (
+    ( verifyUtxoSetCompleteness
     ) where
+
+import Data.ByteString (ByteString)
+import Data.List (sort)
+import Data.Text (Text)
+
+import CSMT.Core.Hash
+    ( Hash (..)
+    , byteStringToKey
+    )
+import CSMT.Core.Types
+    ( Indirect (..)
+    , Key
+    )
+import CSMT.Verify
+    ( verifyCompletenessProof
+    )
+import CSMT.Verify.Blake2b
+    ( blake2b256
+    )
+
+import Cardano.MPFS.API.Encoding qualified as Wire
+import Cardano.MPFS.API.Types.Common
+    ( UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    )
+import Cardano.MPFS.Client.Verify.Replay
+    ( VerifyError (..)
+    , encodeTxIn
+    )
+
+-- | Verify a CSMT request-set completeness witness against a
+-- trusted root and a locally-derived address prefix.
+verifyUtxoSetCompleteness
+    :: Text
+    -- ^ Dotted path to the request set.
+    -> ByteString
+    -- ^ Trusted UTxO-CSMT root bytes.
+    -> Key
+    -- ^ Locally-derived address prefix.
+    -> UtxoSetWitness
+    -> Either VerifyError ()
+verifyUtxoSetCompleteness path trustedRoot prefix UtxoSetWitness{..}
+    | verifyCompletenessProof
+        trustedRoot
+        prefix
+        (sort (map (entryLeaf prefix) uswEntries))
+        (Wire.unHex uswCompletenessProof) =
+        Right ()
+    | otherwise =
+        Left
+            ( CompletenessProofInvalid
+                (path <> ".completeness_proof")
+            )
+
+entryLeaf :: Key -> UtxoEntryRefOnly -> Indirect Hash
+entryLeaf prefix UtxoEntryRefOnly{..} =
+    Indirect
+        { jump =
+            prefix
+                <> byteStringToKey
+                    ( encodeTxIn
+                        (Wire.unHex (urTxId uerRef))
+                        (urTxIx uerRef)
+                    )
+        , value = Hash (blake2b256 (Wire.unHex uerTxOutCbor))
+        }

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Replay.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Replay.hs
@@ -16,6 +16,7 @@
 -- structural → binding → root.
 module Cardano.MPFS.Client.Verify.Replay
     ( VerifyError (..)
+    , encodeTxIn
     , replayWitnessedUtxo
     , replayUtxoEntry
     , replayTrieFact

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/APITypeSplitSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/APITypeSplitSpec.hs
@@ -1,0 +1,87 @@
+-- |
+-- Module      : Cardano.MPFS.Client.APITypeSplitSpec
+-- Description : Import smoke test for focused API DTO modules.
+module Cardano.MPFS.Client.APITypeSplitSpec
+    ( spec
+    ) where
+
+import Data.Aeson (decode, encode)
+import Data.ByteString qualified as BS
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts
+    ( BootFacts (..)
+    )
+
+spec :: Spec
+spec = describe "API type split" $ do
+    it "constructs facts DTOs from focused API modules" $ do
+        decode (encode bootFacts) `shouldBe` Just bootFacts
+        decode (encode utxoSetWitness) `shouldBe` Just utxoSetWitness
+        decode (encode tokenId) `shouldBe` Just tokenId
+
+tokenId :: TokenIdJSON
+tokenId = TokenIdJSON (BS.replicate 32 0x05)
+
+bootFacts :: BootFacts
+bootFacts =
+    BootFacts
+        { bfSnapshot =
+            VerificationSnapshot
+                { vsUtxoRoot = Hex (BS.replicate 32 0x01)
+                , vsChainPoint =
+                    ChainPointJSON
+                        { cpSlot = 42
+                        , cpBlockId = Hex (BS.replicate 32 0x02)
+                        }
+                }
+        , bfWalletUtxos = [utxoEntry]
+        , bfProtocolParameters =
+            UnverifiedPParams
+                { uppVerified = False
+                , uppCbor = Hex "\x82\x01\x02"
+                }
+        }
+
+utxoEntry :: UtxoEntry
+utxoEntry =
+    UtxoEntry
+        { ueRef = utxoRef
+        , ueTxOutCbor = Hex "\x82\x01\x02"
+        , ueInclusionProof = Hex "\x83\x03\x04"
+        }
+
+utxoSetWitness :: UtxoSetWitness
+utxoSetWitness =
+    UtxoSetWitness
+        { uswEntries =
+            [ UtxoEntryRefOnly
+                { uerRef = utxoRef
+                , uerTxOutCbor = Hex "\x82\x01\x02"
+                }
+            ]
+        , uswCompletenessProof = Hex "\x84\x05\x06"
+        }
+
+utxoRef :: UtxoRef
+utxoRef =
+    UtxoRef
+        { urTxId = Hex (BS.replicate 32 0x03)
+        , urTxIx = 1
+        }

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
@@ -1,0 +1,595 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Module      : Cardano.MPFS.Client.Cage.EndSpec
+-- Description : Unit tests for local end cage transaction construction.
+module Cardano.MPFS.Client.Cage.EndSpec
+    ( spec
+    ) where
+
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Coerce (coerce)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromJust)
+import Data.Set qualified as Set
+import Lens.Micro ((&), (.~), (^.))
+import System.Environment (getEnv)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import CSMT
+    ( Direction
+    , Standalone (StandaloneCSMTCol)
+    )
+import CSMT.Backend.Pure
+    ( runPureTransaction
+    )
+import CSMT.Core.CBOR
+    ( renderCompletenessProof
+    , renderProof
+    )
+import CSMT.Core.Hash
+    ( Hash
+    , byteStringToKey
+    , renderHash
+    )
+import CSMT.Hashes
+    ( hashHashing
+    , mkHash
+    )
+import CSMT.Proof.Completeness
+    ( CompletenessProof
+    , generateProof
+    )
+import CSMT.Test.Lib
+    ( evalPureFromEmptyDB
+    , getRootHashM
+    , hashCodecs
+    , identityFromKV
+    , insertMHash
+    , proofM
+    )
+import Cardano.Crypto.Hash
+    ( Blake2b_224
+    , Blake2b_256
+    , hashFromBytes
+    , hashFromStringAsHex
+    , hashToBytes
+    )
+import Cardano.Ledger.Address
+    ( Addr (..)
+    )
+import Cardano.Ledger.Alonzo.TxBody
+    ( reqSignerHashesTxBodyL
+    , scriptIntegrityHashTxBodyL
+    )
+import Cardano.Ledger.Api.PParams
+    ( emptyPParams
+    , ppCoinsPerUTxOByteL
+    )
+import Cardano.Ledger.Api.Scripts.Data
+    ( Data (..)
+    , Datum (..)
+    , dataToBinaryData
+    )
+import Cardano.Ledger.Api.Tx
+    ( Tx
+    , bodyTxL
+    , witsTxL
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( inputsTxBodyL
+    , mintTxBodyL
+    , outputsTxBodyL
+    )
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , addrTxOutL
+    , datumTxOutL
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.Api.Tx.Wits
+    ( Redeemers (..)
+    , rdmrsTxWitsL
+    , scriptTxWitsL
+    )
+import Cardano.Ledger.Babbage.PParams
+    ( CoinPerByte (..)
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , Network (..)
+    , TxIx (..)
+    )
+import Cardano.Ledger.Binary
+    ( natVersion
+    , serialize'
+    )
+import Cardano.Ledger.Coin
+    ( Coin (..)
+    )
+import Cardano.Ledger.Core
+    ( PParams
+    , hashScript
+    )
+import Cardano.Ledger.Credential
+    ( Credential (..)
+    , StakeReference (..)
+    )
+import Cardano.Ledger.Hashes
+    ( unsafeMakeSafeHash
+    )
+import Cardano.Ledger.Keys
+    ( KeyHash (..)
+    , KeyRole (..)
+    )
+import Cardano.Ledger.Mary.Value
+    ( MaryValue (..)
+    , MultiAsset (..)
+    )
+import Cardano.Ledger.Plutus.ExUnits
+    ( ExUnits (..)
+    , Prices (..)
+    )
+import Cardano.Ledger.Plutus.Language
+    ( Language (..)
+    )
+import Cardano.Ledger.TxIn
+    ( TxId (..)
+    , TxIn (..)
+    )
+import Cardano.MPFS.API.Encoding
+    ( Hex (..)
+    )
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts
+    ( EndFacts (..)
+    )
+import Cardano.MPFS.Cage.Blueprint
+    ( extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Cage.Ledger
+    ( AssetName
+    , ConwayEra
+    , TokenId (..)
+    )
+import Cardano.MPFS.Cage.Types
+    ( CageDatum (..)
+    , OnChainRoot (..)
+    , OnChainTokenState (..)
+    )
+import Cardano.MPFS.Client.Cage.BuildError
+    ( BuildError (..)
+    )
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , cagePolicyIdFromCfg
+    , computeScriptHash
+    , mkCageScript
+    )
+import Cardano.MPFS.Client.Cage.End
+    ( endCageTx
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( requestSetPrefixFromCfg
+    , tokenIdFromJSON
+    )
+import Cardano.MPFS.Client.Cage.Policy
+    ( PolicyViolationDetail (..)
+    , WalletPolicy (..)
+    )
+import Cardano.MPFS.Client.Facts
+    ( VerifiedEndFacts
+    , verifyEndFacts
+    )
+import Cardano.MPFS.Client.TrustedRoot
+    ( TrustedRoot (..)
+    )
+import Cardano.Node.Client.Balance
+    ( computeScriptIntegrity
+    , evalBudgetExUnits
+    )
+import Cardano.Slotting.Slot
+    ( SlotNo (..)
+    )
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    , BuiltinData (..)
+    )
+import PlutusTx.IsData.Class
+    ( ToData (..)
+    )
+
+spec :: Spec
+spec = describe "endCageTx" $ do
+    it "rejects empty funding before building" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+            emptyFunding = facts{efWalletUtxos = []}
+        verified <- expectVerified cfg trustedRoot emptyFunding
+        endCageTx cfg permissiveWalletPolicy verified
+            `shouldBe` Left EmptyFunding
+
+    it "rejects wallet policy caps before signing" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+            policy =
+                permissiveWalletPolicy
+                    { wpMaxMinUtxoCoinPerByte = Coin 1
+                    }
+        verified <- expectVerified cfg trustedRoot facts
+        endCageTx cfg policy verified
+            `shouldBe` Left
+                ( PolicyViolation
+                    ( MinUtxoCoinPerByteTooHigh
+                        (Coin 4_310)
+                        (Coin 1)
+                    )
+                )
+
+    it "builds an unsigned burn transaction for the verified facts" $ do
+        cfg <- testCageConfig
+        let EndFixture
+                { trustedRoot
+                , facts
+                , stateInput
+                , walletInput
+                , tokenAsset
+                } = honestEndFixture cfg
+            policyId = cagePolicyIdFromCfg cfg
+        verified <- expectVerified cfg trustedRoot facts
+        tx <-
+            case endCageTx cfg permissiveWalletPolicy verified of
+                Left err ->
+                    expectationFailure
+                        ("endCageTx failed: " <> show err)
+                        *> error "unreachable"
+                Right tx -> pure tx
+        let inputs =
+                tx ^. bodyTxL . inputsTxBodyL
+            MultiAsset minted =
+                tx ^. bodyTxL . mintTxBodyL
+            scripts =
+                tx ^. witsTxL . scriptTxWitsL
+            redeemers@(Redeemers rdmrs) =
+                tx ^. witsTxL . rdmrsTxWitsL
+            budgets =
+                snd <$> Map.elems rdmrs
+            integrity =
+                tx ^. bodyTxL . scriptIntegrityHashTxBodyL
+            expectedIntegrity =
+                computeScriptIntegrity
+                    PlutusV3
+                    realisticPParams
+                    redeemers
+        Set.member stateInput inputs `shouldBe` True
+        Set.member walletInput inputs `shouldBe` True
+        Map.lookup policyId minted
+            `shouldBe` Just (Map.singleton tokenAsset (-1))
+        Map.member (hashScript (mkCageScript cfg)) scripts
+            `shouldBe` True
+        fundingAddr `shouldSatisfy` (/= ownerAddr)
+        txOutputAddresses tx
+            `shouldSatisfy` elem fundingAddr
+        tx ^. bodyTxL . reqSignerHashesTxBodyL
+            `shouldBe` Set.singleton expectedOwnerWitness
+        Map.size rdmrs `shouldBe` 2
+        budgets `shouldBe` [evalBudgetExUnits, evalBudgetExUnits]
+        budgets `shouldSatisfy` all nonZeroExUnits
+        integrity `shouldBe` expectedIntegrity
+
+data EndFixture = EndFixture
+    { trustedRoot :: TrustedRoot
+    , facts :: EndFacts
+    , stateInput :: TxIn
+    , walletInput :: TxIn
+    , tokenAsset :: TokenIdAsset
+    }
+
+type TokenIdAsset = AssetName
+
+honestEndFixture :: CageConfig -> EndFixture
+honestEndFixture cfg =
+    let requestPrefix = requestSetPrefixFromCfg cfg sampleToken
+        token = tokenIdFromJSON sampleToken
+        asset = unTokenId token
+        stateBytes = stateTxOutBytes cfg asset
+        walletBytes = walletTxOutBytes
+        (root, stateEntry, walletEntry, proofBs) =
+            csmtEndRows requestPrefix stateBytes walletBytes
+        endFacts =
+            EndFacts
+                { efSnapshot = snapshotWithRoot root
+                , efToken = sampleToken
+                , efStateUtxo = stateEntry
+                , efWalletUtxos = [walletEntry]
+                , efRequestSet =
+                    UtxoSetWitness
+                        { uswEntries = []
+                        , uswCompletenessProof = Hex proofBs
+                        }
+                , efProtocolParameters =
+                    pparamsFacts realisticPParams
+                }
+    in  EndFixture
+            { trustedRoot = TrustedRoot (Hex root)
+            , facts = endFacts
+            , stateInput = txInFromBytes stateTxId 0
+            , walletInput = txInFromBytes walletTxId 1
+            , tokenAsset = asset
+            }
+
+csmtEndRows
+    :: [Direction]
+    -> ByteString
+    -> ByteString
+    -> (ByteString, UtxoEntry, UtxoEntry, ByteString)
+csmtEndRows requestPrefix stateBytes walletBytes =
+    evalPureFromEmptyDB $ do
+        let stateKey =
+                byteStringToKey (encodeTxIn stateTxId 0)
+            walletKey =
+                byteStringToKey (encodeTxIn walletTxId 1)
+            rows =
+                [ (stateKey, stateBytes)
+                , (walletKey, walletBytes)
+                ]
+        mapM_ (\(key, txOut) -> insertMHash key (mkHash txOut)) rows
+        stateProof <- proofBytes stateKey
+        walletProof <- proofBytes walletKey
+        completenessProof <-
+            runPureTransaction hashCodecs
+                $ generateProof StandaloneCSMTCol [] requestPrefix
+        root <- maybe BS.empty renderHash <$> getRootHashM
+        pure
+            ( root
+            , UtxoEntry
+                { ueRef =
+                    UtxoRef
+                        { urTxId = Hex stateTxId
+                        , urTxIx = 0
+                        }
+                , ueTxOutCbor = Hex stateBytes
+                , ueInclusionProof = Hex stateProof
+                }
+            , UtxoEntry
+                { ueRef =
+                    UtxoRef
+                        { urTxId = Hex walletTxId
+                        , urTxIx = 1
+                        }
+                , ueTxOutCbor = Hex walletBytes
+                , ueInclusionProof = Hex walletProof
+                }
+            , case completenessProof of
+                Just proof ->
+                    renderCompletenessProof
+                        (proof :: CompletenessProof Hash)
+                Nothing ->
+                    error "expected request-set completeness proof"
+            )
+  where
+    proofBytes key = do
+        mProof <-
+            proofM
+                hashCodecs
+                identityFromKV
+                hashHashing
+                key
+        pure $ case mProof of
+            Just (_, proof) -> renderProof proof
+            Nothing -> BS.empty
+
+expectVerified
+    :: CageConfig
+    -> TrustedRoot
+    -> EndFacts
+    -> IO VerifiedEndFacts
+expectVerified cfg trusted facts =
+    case verifyEndFacts cfg trusted facts of
+        Left err ->
+            expectationFailure ("verifyEndFacts failed: " <> show err)
+                *> error "unreachable"
+        Right verified ->
+            pure verified
+
+pparamsFacts :: PParams ConwayEra -> UnverifiedPParams
+pparamsFacts pp =
+    UnverifiedPParams
+        { uppVerified = False
+        , uppCbor = Hex (serialize' (natVersion @11) pp)
+        }
+
+snapshotWithRoot :: ByteString -> VerificationSnapshot
+snapshotWithRoot root =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex root
+        , vsChainPoint =
+            ChainPointJSON
+                { cpSlot = 0
+                , cpBlockId = Hex (BS.replicate 32 0)
+                }
+        }
+
+encodeTxIn :: ByteString -> Word -> ByteString
+encodeTxIn txIdBytes txIx =
+    CBOR.toStrictByteString
+        $ mconcat
+            [ CBOR.encodeListLen 2
+            , CBOR.encodeBytes txIdBytes
+            , CBOR.encodeWord64 (fromIntegral txIx)
+            ]
+
+txInFromBytes :: ByteString -> Word -> TxIn
+txInFromBytes txIdBytes txIx =
+    TxIn
+        ( TxId
+            $ unsafeMakeSafeHash
+            $ fromJust
+            $ hashFromBytes @Blake2b_256 txIdBytes
+        )
+        (TxIx $ fromIntegral txIx)
+
+stateTxOutBytes
+    :: CageConfig -> TokenIdAsset -> ByteString
+stateTxOutBytes cfg asset =
+    serialize' (natVersion @11)
+        $ stateTxOut cfg asset
+
+stateTxOut :: CageConfig -> TokenIdAsset -> TxOut ConwayEra
+stateTxOut cfg asset =
+    mkBasicTxOut
+        (Addr Testnet (ScriptHashObj $ cfgScriptHash cfg) StakeRefNull)
+        stateValue
+        & datumTxOutL .~ mkInlineDatum stateDatum
+  where
+    stateValue =
+        MaryValue
+            (Coin 2_000_000)
+            ( MultiAsset
+                $ Map.singleton
+                    (cagePolicyIdFromCfg cfg)
+                    (Map.singleton asset 1)
+            )
+    stateDatum =
+        StateDatum
+            OnChainTokenState
+                { stateOwner =
+                    BuiltinByteString
+                        $ hashToBytes
+                        $ let KeyHash h = testKh in h
+                , stateRoot = OnChainRoot (BS.replicate 32 0x44)
+                , stateMaxFee = 1_000_000
+                , stateProcessTime = 60_000
+                , stateRetractTime = 30_000
+                }
+
+walletTxOutBytes :: ByteString
+walletTxOutBytes =
+    serialize' (natVersion @11) walletTxOut
+
+walletTxOut :: TxOut ConwayEra
+walletTxOut =
+    mkBasicTxOut
+        fundingAddr
+        (inject (Coin 50_000_000))
+
+ownerAddr :: Addr
+ownerAddr = Addr Testnet (KeyHashObj testKh) StakeRefNull
+
+fundingAddr :: Addr
+fundingAddr =
+    Addr
+        Testnet
+        (KeyHashObj testKh)
+        (StakeRefBase $ KeyHashObj stakeKh)
+
+txOutputAddresses :: Tx ConwayEra -> [Addr]
+txOutputAddresses tx =
+    fmap (^. addrTxOutL)
+        $ foldr (:) []
+        $ tx ^. bodyTxL . outputsTxBodyL
+
+mkInlineDatum :: (ToData a) => a -> Datum ConwayEra
+mkInlineDatum datum =
+    let BuiltinData d = toBuiltinData datum
+    in  Datum $ dataToBinaryData (Data d :: Data ConwayEra)
+
+permissiveWalletPolicy :: WalletPolicy
+permissiveWalletPolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+nonZeroExUnits :: ExUnits -> Bool
+nonZeroExUnits (ExUnits mem steps) =
+    mem > 0 && steps > 0
+
+testCageConfig :: IO CageConfig
+testCageConfig = do
+    blueprintPath <- getEnv "MPFS_BLUEPRINT"
+    eBlueprint <- loadBlueprint blueprintPath
+    blueprint <- case eBlueprint of
+        Left err ->
+            expectationFailure
+                ("loadBlueprint failed: " <> err)
+                *> error "unreachable"
+        Right bp -> pure bp
+    scriptBytes <-
+        case extractCompiledCode "state." blueprint of
+            Just bytes -> pure bytes
+            Nothing ->
+                expectationFailure
+                    "state script not found in MPFS_BLUEPRINT"
+                    *> error "unreachable"
+    requestBytes <-
+        case extractCompiledCode "request." blueprint of
+            Just bytes -> pure bytes
+            Nothing ->
+                expectationFailure
+                    "request script not found in MPFS_BLUEPRINT"
+                    *> error "unreachable"
+    pure
+        CageConfig
+            { cageScriptBytes = scriptBytes
+            , requestScriptBytes = requestBytes
+            , cfgScriptHash = computeScriptHash scriptBytes
+            , defaultProcessTime = 60_000
+            , defaultRetractTime = 30_000
+            , defaultTip = Coin 1_000_000
+            , network = Testnet
+            }
+
+realisticPParams :: PParams ConwayEra
+realisticPParams =
+    emptyPParams
+        & ppCoinsPerUTxOByteL
+            .~ CoinPerByte (Coin 4_310)
+
+stateTxId, walletTxId :: ByteString
+stateTxId = BS.replicate 32 0xA0
+walletTxId = BS.replicate 32 0xC2
+
+sampleToken :: TokenIdJSON
+sampleToken = TokenIdJSON (BS.replicate 32 0xE4)
+
+expectedOwnerWitness :: KeyHash 'Witness
+expectedOwnerWitness = coerce testKh
+
+testKh :: KeyHash 'Payment
+testKh =
+    KeyHash
+        $ fromJust
+        $ hashFromStringAsHex @Blake2b_224
+            "cccccccccccccccccccccccccccc\
+            \cccccccccccccccccccccccccccc"
+
+stakeKh :: KeyHash 'Staking
+stakeKh =
+    KeyHash
+        $ fromJust
+        $ hashFromStringAsHex @Blake2b_224
+            "dddddddddddddddddddddddddddd\
+            \dddddddddddddddddddddddddddd"

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
@@ -76,6 +76,7 @@ import Cardano.Ledger.Alonzo.TxBody
 import Cardano.Ledger.Api.PParams
     ( emptyPParams
     , ppCoinsPerUTxOByteL
+    , ppMaxTxExUnitsL
     )
 import Cardano.Ledger.Api.Scripts.Data
     ( Data (..)
@@ -274,6 +275,8 @@ spec = describe "endCageTx" $ do
                 tx ^. witsTxL . rdmrsTxWitsL
             budgets =
                 snd <$> Map.elems rdmrs
+            maxTxBudget =
+                realisticPParams ^. ppMaxTxExUnitsL
             integrity =
                 tx ^. bodyTxL . scriptIntegrityHashTxBodyL
             expectedIntegrity =
@@ -293,8 +296,12 @@ spec = describe "endCageTx" $ do
         tx ^. bodyTxL . reqSignerHashesTxBodyL
             `shouldBe` Set.singleton expectedOwnerWitness
         Map.size rdmrs `shouldBe` 2
-        budgets `shouldBe` [evalBudgetExUnits, evalBudgetExUnits]
         budgets `shouldSatisfy` all nonZeroExUnits
+        budgets
+            `shouldSatisfy` all
+                (`withinExUnits` evalBudgetExUnits)
+        sumExUnits budgets
+            `shouldSatisfy` (`withinExUnits` maxTxBudget)
         integrity `shouldBe` expectedIntegrity
 
 data EndFixture = EndFixture
@@ -527,6 +534,18 @@ nonZeroExUnits :: ExUnits -> Bool
 nonZeroExUnits (ExUnits mem steps) =
     mem > 0 && steps > 0
 
+sumExUnits :: [ExUnits] -> ExUnits
+sumExUnits =
+    foldr addExUnits (ExUnits 0 0)
+
+addExUnits :: ExUnits -> ExUnits -> ExUnits
+addExUnits (ExUnits memA stepsA) (ExUnits memB stepsB) =
+    ExUnits (memA + memB) (stepsA + stepsB)
+
+withinExUnits :: ExUnits -> ExUnits -> Bool
+withinExUnits (ExUnits mem steps) (ExUnits maxMem maxSteps) =
+    mem <= maxMem && steps <= maxSteps
+
 testCageConfig :: IO CageConfig
 testCageConfig = do
     blueprintPath <- getEnv "MPFS_BLUEPRINT"
@@ -567,6 +586,8 @@ realisticPParams =
     emptyPParams
         & ppCoinsPerUTxOByteL
             .~ CoinPerByte (Coin 4_310)
+        & ppMaxTxExUnitsL
+            .~ ExUnits 140_000_000 10_000_000_000
 
 stateTxId, walletTxId :: ByteString
 stateTxId = BS.replicate 32 0xA0

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs
@@ -1,0 +1,435 @@
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Module      : Cardano.MPFS.Client.EndFactsSpec
+-- Description : Unit tests for end facts JSON and verification.
+module Cardano.MPFS.Client.EndFactsSpec
+    ( spec
+    ) where
+
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
+import Data.Aeson
+    ( Value
+    , decode
+    , encode
+    , object
+    , (.=)
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Either (isRight)
+import System.Environment (getEnv)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import CSMT
+    ( Direction
+    , Standalone (StandaloneCSMTCol)
+    )
+import CSMT.Backend.Pure
+    ( runPureTransaction
+    )
+import CSMT.Core.CBOR
+    ( renderCompletenessProof
+    , renderProof
+    )
+import CSMT.Core.Hash
+    ( Hash
+    , byteStringToKey
+    , renderHash
+    )
+import CSMT.Hashes
+    ( hashHashing
+    , mkHash
+    )
+import CSMT.Proof.Completeness
+    ( CompletenessProof
+    , generateProof
+    )
+import CSMT.Test.Lib
+    ( evalPureFromEmptyDB
+    , getRootHashM
+    , hashCodecs
+    , identityFromKV
+    , insertMHash
+    , proofM
+    )
+import Cardano.Ledger.BaseTypes
+    ( Network (Testnet)
+    )
+import Cardano.MPFS.API.Encoding
+    ( Hex (..)
+    )
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.Cage.Blueprint
+    ( extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Cage.Ledger
+    ( Coin (..)
+    )
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , computeScriptHash
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( requestSetPrefixFromCfg
+    )
+import Cardano.MPFS.Client.Facts
+    ( EndFacts (..)
+    , VerifiedEndFacts
+    , verifiedEndFacts
+    )
+import Cardano.MPFS.Client.TrustedRoot
+    ( TrustedRoot (..)
+    )
+import Cardano.MPFS.Client.Verify
+    ( VerifyError (..)
+    , verifyEndFacts
+    )
+import Cardano.MPFS.Client.Verify.DSL
+    ( flipApiHexMidByte
+    )
+
+spec :: Spec
+spec = describe "verifyEndFacts" $ do
+    it "round-trips the end facts JSON shape" $ do
+        cfg <- testCageConfig
+        let EndFixture{facts} = honestEndFixture cfg
+            encoded = encode facts
+        decode encoded `shouldBe` Just facts
+        decode encoded `shouldBe` Just (endFactsJson facts)
+
+    it "accepts honest facts with a matching trusted root" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+        verifyEndFacts cfg trustedRoot facts `shouldSatisfy` isRight
+
+    it "returns an opaque witness with an accessor" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+        verified <- expectVerified cfg trustedRoot facts
+        verifiedEndFacts verified `shouldBe` facts
+
+    it "rejects a malformed trusted root before replay" $ do
+        cfg <- testCageConfig
+        let EndFixture{facts} = honestEndFixture cfg
+        verifyEndFacts cfg (TrustedRoot (Hex "\x01")) facts
+            `shouldBe` Left (WrongHexLength "end.trusted_root" 32 1)
+
+    it "rejects a malformed snapshot root before replay" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+            forged =
+                facts
+                    { efSnapshot =
+                        (efSnapshot facts)
+                            { vsUtxoRoot = Hex "\x01"
+                            }
+                    }
+        verifyEndFacts cfg trustedRoot forged
+            `shouldBe` Left
+                (WrongHexLength "end.snapshot.utxo_root" 32 1)
+
+    it "rejects a trusted-root mismatch" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+            TrustedRoot rootHex = trustedRoot
+            forged = TrustedRoot (flipApiHexMidByte rootHex)
+        verifyEndFacts cfg forged facts
+            `shouldBe` Left
+                (TrustedRootMismatch "end.snapshot.utxo_root")
+
+    it "rejects a tampered state inclusion proof" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+            entry = efStateUtxo facts
+            forged =
+                facts
+                    { efStateUtxo =
+                        entry
+                            { ueInclusionProof =
+                                Hex "\x00"
+                            }
+                    }
+        verifyEndFacts cfg trustedRoot forged
+            `shouldBe` Left
+                ( CsmtReplayFailed
+                    "end.state_utxo.inclusion_proof"
+                    "malformed proof CBOR"
+                )
+
+    it "rejects a tampered wallet inclusion proof" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+            entry = soleWalletUtxo facts
+            forgedEntry =
+                entry
+                    { ueInclusionProof =
+                        Hex "\x00"
+                    }
+            forged = facts{efWalletUtxos = [forgedEntry]}
+        verifyEndFacts cfg trustedRoot forged
+            `shouldBe` Left
+                ( CsmtReplayFailed
+                    "end.wallet_utxos[0].inclusion_proof"
+                    "malformed proof CBOR"
+                )
+
+    it "rejects non-empty request-set entries before completeness replay"
+        $ do
+            cfg <- testCageConfig
+            let EndFixture{trustedRoot, facts, requestEntry} =
+                    honestEndFixture cfg
+                forged =
+                    facts
+                        { efRequestSet =
+                            (efRequestSet facts)
+                                { uswEntries = [requestEntry]
+                                }
+                        }
+            verifyEndFacts cfg trustedRoot forged
+                `shouldBe` Left
+                    ( CompletenessExtraLeaf
+                        "end.request_set.entries[0]"
+                        (uerRef requestEntry)
+                    )
+
+    it "rejects a tampered request-set completeness proof" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+            requestSet = efRequestSet facts
+            forged =
+                facts
+                    { efRequestSet =
+                        requestSet
+                            { uswCompletenessProof =
+                                flipApiHexMidByte
+                                    (uswCompletenessProof requestSet)
+                            }
+                    }
+        verifyEndFacts cfg trustedRoot forged
+            `shouldBe` Left
+                ( CompletenessProofInvalid
+                    "end.request_set.completeness_proof"
+                )
+
+data EndFixture = EndFixture
+    { trustedRoot :: TrustedRoot
+    , facts :: EndFacts
+    , requestEntry :: UtxoEntryRefOnly
+    }
+
+honestEndFixture :: CageConfig -> EndFixture
+honestEndFixture cfg =
+    let requestPrefix = requestSetPrefixFromCfg cfg sampleToken
+        (root, stateEntry, walletEntry, requestOnly, proofBs) =
+            csmtEndRows requestPrefix
+        endFacts =
+            EndFacts
+                { efSnapshot = snapshotWithRoot root
+                , efToken = sampleToken
+                , efStateUtxo = stateEntry
+                , efWalletUtxos = [walletEntry]
+                , efRequestSet =
+                    UtxoSetWitness
+                        { uswEntries = []
+                        , uswCompletenessProof = Hex proofBs
+                        }
+                , efProtocolParameters =
+                    UnverifiedPParams
+                        { uppVerified = False
+                        , uppCbor = Hex "\x82\x01\x02"
+                        }
+                }
+    in  EndFixture
+            { trustedRoot = TrustedRoot (Hex root)
+            , facts = endFacts
+            , requestEntry = requestOnly
+            }
+
+csmtEndRows
+    :: [Direction]
+    -> (ByteString, UtxoEntry, UtxoEntry, UtxoEntryRefOnly, ByteString)
+csmtEndRows requestPrefix = evalPureFromEmptyDB $ do
+    let stateKey =
+            byteStringToKey (encodeTxIn stateTxId 0)
+        walletKey =
+            byteStringToKey (encodeTxIn walletTxId 1)
+        rows =
+            [ (stateKey, stateTxOut)
+            , (walletKey, walletTxOut)
+            ]
+    mapM_ (\(key, txOut) -> insertMHash key (mkHash txOut)) rows
+    stateProof <- proofBytes stateKey
+    walletProof <- proofBytes walletKey
+    completenessProof <-
+        runPureTransaction hashCodecs
+            $ generateProof StandaloneCSMTCol [] requestPrefix
+    root <- maybe BS.empty renderHash <$> getRootHashM
+    pure
+        ( root
+        , UtxoEntry
+            { ueRef =
+                UtxoRef
+                    { urTxId = Hex stateTxId
+                    , urTxIx = 0
+                    }
+            , ueTxOutCbor = Hex stateTxOut
+            , ueInclusionProof = Hex stateProof
+            }
+        , UtxoEntry
+            { ueRef =
+                UtxoRef
+                    { urTxId = Hex walletTxId
+                    , urTxIx = 1
+                    }
+            , ueTxOutCbor = Hex walletTxOut
+            , ueInclusionProof = Hex walletProof
+            }
+        , UtxoEntryRefOnly
+            { uerRef =
+                UtxoRef
+                    { urTxId = Hex requestTxId
+                    , urTxIx = 2
+                    }
+            , uerTxOutCbor = Hex requestTxOut
+            }
+        , case completenessProof of
+            Just proof ->
+                renderCompletenessProof
+                    (proof :: CompletenessProof Hash)
+            Nothing ->
+                error "expected request-set completeness proof"
+        )
+  where
+    proofBytes key = do
+        mProof <-
+            proofM
+                hashCodecs
+                identityFromKV
+                hashHashing
+                key
+        pure $ case mProof of
+            Just (_, proof) -> renderProof proof
+            Nothing -> BS.empty
+
+expectVerified
+    :: CageConfig
+    -> TrustedRoot
+    -> EndFacts
+    -> IO VerifiedEndFacts
+expectVerified cfg trusted facts =
+    case verifyEndFacts cfg trusted facts of
+        Left err ->
+            expectationFailure ("verifyEndFacts failed: " <> show err)
+                *> error "unreachable"
+        Right verified ->
+            pure verified
+
+soleWalletUtxo :: EndFacts -> UtxoEntry
+soleWalletUtxo EndFacts{efWalletUtxos = [entry]} = entry
+soleWalletUtxo EndFacts{efWalletUtxos = entries} =
+    error
+        ( "EndFactsSpec: expected one wallet UTxO, got "
+            <> show (length entries)
+        )
+
+endFactsJson :: EndFacts -> Value
+endFactsJson EndFacts{..} =
+    object
+        [ "snapshot" .= efSnapshot
+        , "token" .= efToken
+        , "state_utxo" .= efStateUtxo
+        , "wallet_utxos" .= efWalletUtxos
+        , "request_set" .= efRequestSet
+        , "protocol_parameters"
+            .= object
+                [ "verified" .= uppVerified efProtocolParameters
+                , "cbor" .= uppCbor efProtocolParameters
+                ]
+        ]
+
+snapshotWithRoot :: ByteString -> VerificationSnapshot
+snapshotWithRoot root =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex root
+        , vsChainPoint =
+            ChainPointJSON
+                { cpSlot = 0
+                , cpBlockId = Hex (BS.replicate 32 0)
+                }
+        }
+
+encodeTxIn :: ByteString -> Word -> ByteString
+encodeTxIn txIdBytes txIx =
+    CBOR.toStrictByteString
+        $ mconcat
+            [ CBOR.encodeListLen 2
+            , CBOR.encodeBytes txIdBytes
+            , CBOR.encodeWord64 (fromIntegral txIx)
+            ]
+
+testCageConfig :: IO CageConfig
+testCageConfig = do
+    blueprintPath <- getEnv "MPFS_BLUEPRINT"
+    eBlueprint <- loadBlueprint blueprintPath
+    blueprint <- case eBlueprint of
+        Left err ->
+            expectationFailure
+                ("loadBlueprint failed: " <> err)
+                *> error "unreachable"
+        Right bp -> pure bp
+    scriptBytes <-
+        case extractCompiledCode "state." blueprint of
+            Just bytes -> pure bytes
+            Nothing ->
+                expectationFailure
+                    "state script not found in MPFS_BLUEPRINT"
+                    *> error "unreachable"
+    requestBytes <-
+        case extractCompiledCode "request." blueprint of
+            Just bytes -> pure bytes
+            Nothing ->
+                expectationFailure
+                    "request script not found in MPFS_BLUEPRINT"
+                    *> error "unreachable"
+    pure
+        CageConfig
+            { cageScriptBytes = scriptBytes
+            , requestScriptBytes = requestBytes
+            , cfgScriptHash = computeScriptHash scriptBytes
+            , defaultProcessTime = 60_000
+            , defaultRetractTime = 30_000
+            , defaultTip = Coin 1_000_000
+            , network = Testnet
+            }
+
+stateTxId, walletTxId, requestTxId :: ByteString
+stateTxId = BS.replicate 32 0xA0
+walletTxId = BS.replicate 32 0xC2
+requestTxId = BS.replicate 32 0xB1
+
+stateTxOut, walletTxOut, requestTxOut :: ByteString
+stateTxOut = "state-txout"
+walletTxOut = "wallet-txout"
+requestTxOut = "request-txout"
+
+sampleToken :: TokenIdJSON
+sampleToken = TokenIdJSON (BS.replicate 32 0xE4)

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/HttpSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/HttpSpec.hs
@@ -44,7 +44,6 @@ import Cardano.MPFS.Client
     ( BaseUrl (..)
     , BootFactsParams (..)
     , ClientError (..)
-    , EndParams (..)
     , Hex (..)
     , MpfsHttp (..)
     , RejectParams (..)
@@ -57,7 +56,6 @@ import Cardano.MPFS.Client
     , VerifierMode (..)
     , VerifyError (..)
     , bootFacts
-    , endTx
     , rejectTx
     , requestDeleteTx
     , requestInsertTx
@@ -67,7 +65,6 @@ import Cardano.MPFS.Client
     )
 import Cardano.MPFS.Client.Fixtures
     ( honestBootTrustedRoot
-    , honestEndResponse
     , honestRejectResponse
     , honestRequestResponse
     , honestRetractResponse
@@ -234,11 +231,6 @@ writeEndpointCases =
         (Aeson.toJSON updateParams)
         (Aeson.encode honestUpdateResponse)
         (voidRight . (`updateTx` updateParams))
-    , EndpointCase
-        ["tx", "end"]
-        (Aeson.toJSON endParams)
-        (Aeson.encode honestEndResponse)
-        (voidRight . (`endTx` endParams))
     ]
 
 bootFactsParams :: BootFactsParams
@@ -283,9 +275,6 @@ rejectParams = RejectParams sampleToken sampleAddress
 
 updateParams :: UpdateParams
 updateParams = UpdateParams sampleToken sampleAddress
-
-endParams :: EndParams
-endParams = EndParams sampleToken sampleAddress
 
 sampleAddress
     , sampleToken

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -4,6 +4,7 @@ import Cardano.MPFS.Client.APITypeSplitSpec qualified as APITypeSplitSpec
 import Cardano.MPFS.Client.BootFactsSpec qualified as BootFactsSpec
 import Cardano.MPFS.Client.BundleSpec qualified as BundleSpec
 import Cardano.MPFS.Client.Cage.BootSpec qualified as BootSpec
+import Cardano.MPFS.Client.Cage.EndSpec qualified as EndSpec
 import Cardano.MPFS.Client.EndFactsSpec qualified as EndFactsSpec
 import Cardano.MPFS.Client.HttpSpec qualified as HttpSpec
 import Cardano.MPFS.Client.SnapshotSpec qualified as SnapshotSpec
@@ -19,6 +20,7 @@ main = hspec $ do
     BootFactsSpec.spec
     EndFactsSpec.spec
     BootSpec.spec
+    EndSpec.spec
     VerifySpec.spec
     WriteSpec.spec
     HttpSpec.spec

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -4,6 +4,7 @@ import Cardano.MPFS.Client.APITypeSplitSpec qualified as APITypeSplitSpec
 import Cardano.MPFS.Client.BootFactsSpec qualified as BootFactsSpec
 import Cardano.MPFS.Client.BundleSpec qualified as BundleSpec
 import Cardano.MPFS.Client.Cage.BootSpec qualified as BootSpec
+import Cardano.MPFS.Client.EndFactsSpec qualified as EndFactsSpec
 import Cardano.MPFS.Client.HttpSpec qualified as HttpSpec
 import Cardano.MPFS.Client.SnapshotSpec qualified as SnapshotSpec
 import Cardano.MPFS.Client.Verify.WriteSpec qualified as WriteSpec
@@ -16,6 +17,7 @@ main = hspec $ do
     SnapshotSpec.spec
     BundleSpec.spec
     BootFactsSpec.spec
+    EndFactsSpec.spec
     BootSpec.spec
     VerifySpec.spec
     WriteSpec.spec

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import Cardano.MPFS.Client.APITypeSplitSpec qualified as APITypeSplitSpec
 import Cardano.MPFS.Client.BootFactsSpec qualified as BootFactsSpec
 import Cardano.MPFS.Client.BundleSpec qualified as BundleSpec
 import Cardano.MPFS.Client.Cage.BootSpec qualified as BootSpec
@@ -11,6 +12,7 @@ import Test.Hspec (hspec)
 
 main :: IO ()
 main = hspec $ do
+    APITypeSplitSpec.spec
     SnapshotSpec.spec
     BundleSpec.spec
     BootFactsSpec.spec

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -259,12 +259,14 @@ test-suite unit-tests
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-babbage
+    , cardano-ledger-binary
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-mpfs-offchain
     , cardano-node-clients
     , cardano-strict-containers
+    , cardano-utxo-csmt:application
     , cardano-utxo-csmt:library
     , cborg
     , chain-follower
@@ -277,6 +279,7 @@ test-suite unit-tests
     , lens
     , microlens
     , mts:csmt
+    , mts:csmt-core
     , mts:mpf
     , mts:mpf-test-lib
     , mts:rollbacks
@@ -309,6 +312,7 @@ test-suite unit-tests
     Cardano.MPFS.Indexer.FollowerSpec
     Cardano.MPFS.Indexer.InverseSpec
     Cardano.MPFS.Indexer.PersistentSpec
+    Cardano.MPFS.Indexer.ReadsSpec
     Cardano.MPFS.Indexer.RollbackSpec
     Cardano.MPFS.Indexer.TxFixtures
     Cardano.MPFS.Indexer.UnifiedSpec

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -99,6 +99,7 @@ library
     Cardano.MPFS.HTTP.Server
     Cardano.MPFS.HTTP.Swagger
     Cardano.MPFS.HTTP.Types
+    Cardano.MPFS.HTTP.Types.Facts
     Cardano.MPFS.Indexer.Backend
     Cardano.MPFS.Indexer.CageFollower
     Cardano.MPFS.Indexer.Codecs
@@ -296,6 +297,7 @@ test-suite unit-tests
     Cardano.MPFS.BalanceSpec
     Cardano.MPFS.Generators
     Cardano.MPFS.HTTP.BootFactsSpec
+    Cardano.MPFS.HTTP.EndFactsSpec
     Cardano.MPFS.HTTP.RequestsSpec
     Cardano.MPFS.HTTP.StatusSpec
     Cardano.MPFS.HTTP.TokenSpec

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -27,6 +27,7 @@ module Cardano.MPFS.E2E.ProofsSpec
     ) where
 
 import Control.Concurrent (threadDelay)
+import Control.Monad (void)
 import Data.Aeson
     ( FromJSON (..)
     , Value
@@ -43,6 +44,7 @@ import Data.Aeson.Types (parseEither)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short qualified as SBS
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
@@ -85,11 +87,13 @@ import Cardano.Ledger.Address (Addr, serialiseAddr)
 import Cardano.Ledger.Api.Tx (Tx, bodyTxL, txIdTx)
 import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
 import Cardano.Ledger.BaseTypes (Network (..), TxIx (..))
+import Cardano.Ledger.Binary (decodeFull, natVersion)
 import Cardano.Ledger.Hashes (extractHash)
 import Cardano.Ledger.Mary.Value
     ( AssetName (..)
     , MultiAsset (..)
     )
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 
 import Cardano.Chain.Slotting (EpochSlots (..))
@@ -141,26 +145,29 @@ import Cardano.Node.Client.E2E.Setup
     , genesisSignKey
     )
 
+import Cardano.MPFS.API.Encoding qualified as Api
+import Cardano.MPFS.API.Types.Common (UtxoEntry (..))
+import Cardano.MPFS.API.Types.Common qualified as Common
 import Cardano.MPFS.Client
-    ( EndTxResponse
+    ( EndFacts (..)
     , Hex (..)
-    , RejectTxResponse
+    , RejectTxResponse (..)
     , RequestTxResponse
     , RetractTxResponse
     , UpdateTxResponse
-    , VerificationSnapshot
+    , VerificationSnapshot (..)
+    , VerifiedEndFacts
     , csmtReplayFailedAt
     , flipProof
     , flipSnapshotRoot
     , flipTxOut
-    , runForgeEnd
     , runForgeReject
     , runForgeRequest
     , runForgeRetract
     , runForgeUpdate
     , shouldAccept
     , shouldRejectWith
-    , verifyEndTxResponse
+    , verifyEndFacts
     , verifyRejectTxResponse
     , verifyRequestTxResponse
     , verifyRetractTxResponse
@@ -168,6 +175,10 @@ import Cardano.MPFS.Client
     , verifyVerificationSnapshot
     , withReason
     )
+import Cardano.MPFS.Client.Cage.Config qualified as Client
+import Cardano.MPFS.Client.Cage.End (endCageTx)
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 
 -- | Skips when @MPFS_BLUEPRINT@ is not set.
 spec :: Spec
@@ -316,12 +327,11 @@ proofsSpec scripts =
 
             assertRequestsEnvelope requestsObj
 
-            -- Drive every write endpoint over HTTP and
-            -- verify its response with the offline
-            -- Client.Verify DSL. We do not submit the
-            -- returned unsigned txs — the goal is to
-            -- confirm the server emits well-formed
-            -- proof envelopes at the current state.
+            -- Drive every remaining server-built write
+            -- endpoint over HTTP and verify its response
+            -- with the offline Client.Verify DSL. The end
+            -- path is facts-only after #268, so the final
+            -- step verifies facts and builds the tx wallet-side.
             let addrHex = hexAddr genesisAddr
                 retractUtxoRef =
                     txInUrlRef reqTxIn
@@ -409,18 +419,31 @@ proofsSpec scripts =
                 $ csmtReplayFailedAt
                     "reject.request_ins[0].utxo_proof"
 
-            endResp <-
-                postJSON app "/tx/end"
+            _ <-
+                submitResponseTx awaitTimeout app ctx (tx rejectResp)
+
+            endFacts <-
+                postJSON app "/facts/end"
                     $ object
                         [ "token" .= Hex (TE.decodeUtf8 tidHex)
                         , "address" .= addrHex
                         ]
-            (endResp :: EndTxResponse)
-                `shouldAccept` verifyEndTxResponse
-            runForgeEnd (flipProof "state") endResp
-                `shouldRejectWith` verifyEndTxResponse
+            let trusted = endFactsTrustedRoot endFacts
+                verifyEndFactsUnit =
+                    void
+                        . verifyEndFacts
+                            (toClientCageConfig cfg)
+                            trusted
+            (endFacts :: EndFacts)
+                `shouldAccept` verifyEndFactsUnit
+            tamperEndStateProof endFacts
+                `shouldRejectWith` verifyEndFactsUnit
                 $ csmtReplayFailedAt
-                    "end.state.utxo_proof"
+                    "end.state_utxo.inclusion_proof"
+                    `withReason` "malformed proof CBOR"
+            verifiedEndFacts <-
+                expectEndFactsVerified cfg trusted endFacts
+            void (buildEndTx cfg verifiedEndFacts)
 
 -- -------------------------------------------------
 -- Assertions on response shape
@@ -502,6 +525,81 @@ assertRequestsEnvelope v = do
             assertWitnessedUtxo wreq
             _ <- lookupObj wreq "request"
             pure ()
+
+-- | The trusted root for facts-only end verification is
+-- supplied externally by the caller. In this e2e harness,
+-- the app itself is that trusted source, so we pin it to
+-- the snapshot returned by the same facts response.
+endFactsTrustedRoot :: EndFacts -> TrustedRoot
+endFactsTrustedRoot EndFacts{efSnapshot} =
+    TrustedRoot (Common.vsUtxoRoot efSnapshot)
+
+tamperEndStateProof :: EndFacts -> EndFacts
+tamperEndStateProof facts@EndFacts{efStateUtxo} =
+    facts
+        { efStateUtxo =
+            efStateUtxo
+                { ueInclusionProof = Api.Hex "\x00"
+                }
+        }
+
+expectEndFactsVerified
+    :: CageConfig
+    -> TrustedRoot
+    -> EndFacts
+    -> IO VerifiedEndFacts
+expectEndFactsVerified cfg trusted facts =
+    case verifyEndFacts (toClientCageConfig cfg) trusted facts of
+        Right verified -> pure verified
+        Left err ->
+            expectationFailure
+                ("verifyEndFacts failed: " <> show err)
+                *> error "unreachable"
+
+buildEndTx
+    :: CageConfig
+    -> VerifiedEndFacts
+    -> IO (Tx ConwayEra)
+buildEndTx cfg verified =
+    case endCageTx
+        (toClientCageConfig cfg)
+        permissiveWalletPolicy
+        verified of
+        Right tx -> pure tx
+        Left err ->
+            expectationFailure
+                ("endCageTx failed: " <> show err)
+                *> error "unreachable"
+
+submitResponseTx
+    :: Int
+    -> Application
+    -> Context IO
+    -> Hex
+    -> IO (Tx ConwayEra)
+submitResponseTx timeout app ctx txHex = do
+    unsigned <- decodeResponseTx txHex
+    let signed =
+            addKeyWitness genesisSignKey unsigned
+    result <- submitTx (submitter ctx) signed
+    assertSubmitted result
+    awaitTx timeout app (txIdTx signed)
+    pure signed
+
+decodeResponseTx :: Hex -> IO (Tx ConwayEra)
+decodeResponseTx (Hex txText) =
+    case B16.decode (TE.encodeUtf8 txText) of
+        Left err ->
+            expectationFailure
+                ("response tx hex decode failed: " <> err)
+                *> error "unreachable"
+        Right txBytes ->
+            case decodeFull (natVersion @11) (BSL.fromStrict txBytes) of
+                Left err ->
+                    expectationFailure
+                        ("response tx CBOR decode failed: " <> show err)
+                        *> error "unreachable"
+                Right txValue -> pure txValue
 
 -- -------------------------------------------------
 -- JSON plumbing
@@ -684,6 +782,27 @@ extractTokenId cfg tx =
                 error
                     "extractTokenId: \
                     \unexpected mint"
+
+permissiveWalletPolicy :: WalletPolicy
+permissiveWalletPolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+toClientCageConfig :: CageConfig -> Client.CageConfig
+toClientCageConfig cfg =
+    Client.CageConfig
+        { Client.cageScriptBytes = cageScriptBytes cfg
+        , Client.requestScriptBytes = requestScriptBytes cfg
+        , Client.cfgScriptHash = cfgScriptHash cfg
+        , Client.defaultProcessTime = defaultProcessTime cfg
+        , Client.defaultRetractTime = defaultRetractTime cfg
+        , Client.defaultTip = defaultTip cfg
+        , Client.network = network cfg
+        }
 
 -- -------------------------------------------------
 -- Bracket

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
@@ -45,7 +45,6 @@ module Cardano.MPFS.HTTP.API
     , TxUpdateAPI
     , TxRetractAPI
     , TxSweepAPI
-    , TxEndAPI
     , TxWriteAPI
     , TxSubmitAPI
     ) where
@@ -72,7 +71,6 @@ import Cardano.MPFS.API
     , TokensAPI
     , TxAwaitAPI
     , TxDeleteAPI
-    , TxEndAPI
     , TxInsertAPI
     , TxRejectAPI
     , TxRequestUpdateAPI

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs
@@ -35,6 +35,7 @@ module Cardano.MPFS.HTTP.API
 
       -- * Facts endpoints
     , FactsBootAPI
+    , FactsEndAPI
 
       -- * Transaction endpoints
     , TxInsertAPI
@@ -61,6 +62,7 @@ import Servant.API
 
 import Cardano.MPFS.API
     ( FactsBootAPI
+    , FactsEndAPI
     , StatusAPI
     , TokenAPI
     , TokenFactAPI

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -14,6 +14,7 @@ module Cardano.MPFS.HTTP.Server
     ( -- * Application
       mkApp
     , mkBootFacts
+    , mkEndFacts
     ) where
 
 import Control.Applicative ((<|>))
@@ -61,6 +62,7 @@ import Cardano.Ledger.TxIn
     , mkTxInPartial
     )
 
+import Cardano.MPFS.API.Types.Facts (EndFacts)
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
     ( Addr
@@ -125,8 +127,11 @@ import Cardano.MPFS.HTTP.Types
     , tokenStateToJSON
     , txInToJSON
     )
+import Cardano.MPFS.HTTP.Types.Facts (mkEndFacts)
 import Cardano.MPFS.Indexer.Reads
-    ( readSnapshot
+    ( readRequestSetAt
+    , readSnapshot
+    , readStateUtxoAt
     , readWalletInputsAt
     )
 import Cardano.MPFS.Provider (Provider (..))
@@ -143,7 +148,13 @@ import Cardano.MPFS.TxBuilder
     , ResolvedWalletInput
     )
 import Cardano.MPFS.TxBuilder qualified as Tx
+import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
 import Cardano.MPFS.TxBuilder.Real (sweepUtxoImpl)
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( cageAddrFromCfg
+    , cagePolicyIdFromCfg
+    , requestAddrFromCfg
+    )
 
 -- | Combined API with Swagger UI.
 type FullAPI = SwaggerAPI :<|> API
@@ -167,6 +178,7 @@ mkApp ctx =
             :<|> utxoRootHandler ctx
             :<|> txAwaitHandler ctx
             :<|> factsBootHandler ctx
+            :<|> factsEndHandler ctx
             :<|> txInsertHandler ctx
             :<|> txDeleteHandler ctx
             :<|> txUpdateValueHandler ctx
@@ -669,6 +681,102 @@ mkBootFacts snap inputs pparams =
                         )
                 }
         }
+
+-- | @POST \/facts\/end@. Reads snapshot, owner funding
+-- inputs, state UTxO, and the request-set completeness
+-- witness inside ONE indexer transaction, then returns
+-- facts for wallet-side end transaction construction.
+factsEndHandler
+    :: Context IO
+    -> EndRequest
+    -> Handler EndFacts
+factsEndHandler
+    ctx
+    EndRequest
+        { erToken = tokenId
+        , erAddr = addrHex
+        } = do
+        let tid = tokenIdFromJSON tokenId
+            cfg = cfgCage ctx
+            cageAddr = cageAddrFromCfg cfg (network cfg)
+            requestAddr = requestAddrFromCfg cfg tid (network cfg)
+            policyId = cagePolicyIdFromCfg cfg
+        addr <- requireAddr addrHex
+        (mSnap, funding, mStateUtxo, requestSet) <-
+            liftIO
+                $ runIndexerTx ctx
+                $ do
+                    snap <- readSnapshot
+                    ins <- readWalletInputsAt addr
+                    stateUtxo <-
+                        readStateUtxoAt
+                            cageAddr
+                            policyId
+                            tid
+                    reqSet <- readRequestSetAt requestAddr
+                    pure (snap, ins, stateUtxo, reqSet)
+        case mSnap of
+            Nothing ->
+                throwError
+                    err503
+                        { errBody =
+                            "Indexer not ready: \
+                            \snapshot unavailable"
+                        }
+            Just snap -> do
+                stateUtxo <- case mStateUtxo of
+                    Nothing ->
+                        throwError
+                            err404
+                                { errBody =
+                                    "State UTxO not \
+                                    \found for token"
+                                }
+                    Just row -> pure row
+                if null funding
+                    then
+                        throwError
+                            err400
+                                { errBody =
+                                    "No wallet UTxOs \
+                                    \at address"
+                                }
+                    else case requestSet of
+                        ([], _) -> do
+                            pp <-
+                                liftIO
+                                    $ queryProtocolParams
+                                        (provider ctx)
+                            pure
+                                $ mkEndFacts
+                                    snap
+                                    tid
+                                    stateUtxo
+                                    funding
+                                    requestSet
+                                    pp
+                        (entries, _) ->
+                            throwError
+                                ServerError
+                                    { errHTTPCode = 409
+                                    , errReasonPhrase =
+                                        "Conflict"
+                                    , errBody =
+                                        "Cannot end token: \
+                                        \pending request \
+                                        \UTxOs exist at \
+                                        \the request \
+                                        \address"
+                                    , errHeaders =
+                                        [
+                                            ( "X-MPFS-Request-Set-Size"
+                                            , TE.encodeUtf8
+                                                $ T.pack
+                                                $ show
+                                                $ length entries
+                                            )
+                                        ]
+                                    }
 
 txInsertHandler
     :: Context IO

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -87,7 +87,6 @@ import Cardano.MPFS.HTTP.Types
     , ChainPointJSON (..)
     , DeleteRequest (..)
     , EndRequest (..)
-    , EndTxResponse
     , FactResponse (..)
     , FactWitness (..)
     , InsertRequest (..)
@@ -113,7 +112,6 @@ import Cardano.MPFS.HTTP.Types
     , WitnessedTokenState (..)
     , WitnessedUtxo (..)
     , bundleSnapshotToJSON
-    , mkEndTxResponse
     , mkRejectTxResponse
     , mkRequestTxResponse
     , mkRetractTxResponse
@@ -186,7 +184,6 @@ mkApp ctx =
             :<|> txUpdateHandler ctx
             :<|> txRetractHandler ctx
             :<|> txSweepHandler ctx
-            :<|> txEndHandler ctx
             :<|> txSubmitHandler ctx
 
 -- ---------------------------------------------------------
@@ -947,28 +944,6 @@ txSweepHandler
                     txIn
                     addr
         pure (mkSweepTxResponse tx)
-
-txEndHandler
-    :: Context IO
-    -> EndRequest
-    -> Handler EndTxResponse
-txEndHandler
-    ctx
-    EndRequest
-        { erToken = tokenId
-        , erAddr = addrHex
-        } = do
-        let tid = tokenIdFromJSON tokenId
-        addr <- requireAddr addrHex
-        snap <- requireBundleSnapshot ctx
-        bundle <-
-            liftIO
-                $ Tx.endToken
-                    (txBuilder ctx)
-                    snap
-                    tid
-                    addr
-        pure (mkEndTxResponse bundle)
 
 txSubmitHandler
     :: Context IO -> SubmitRequest -> Handler Hex

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types/Facts.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types/Facts.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Module      : Cardano.MPFS.HTTP.Types.Facts
+-- Description : Server-side conversion helpers for facts responses.
+-- License     : Apache-2.0
+--
+-- Keeps facts-only response assembly out of the legacy
+-- @Cardano.MPFS.HTTP.Types@ compatibility surface.
+module Cardano.MPFS.HTTP.Types.Facts
+    ( mkEndFacts
+    ) where
+
+import Data.ByteString (ByteString)
+
+import Cardano.Crypto.Hash.Class qualified as Crypto
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Binary (natVersion, serialize')
+import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.TxIn
+    ( TxId (..)
+    , TxIn (..)
+    )
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types.Common
+    ( UnverifiedPParams (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    )
+import Cardano.MPFS.API.Types.Facts (EndFacts (..))
+import Cardano.MPFS.Core.Types
+    ( ConwayEra
+    , PParams
+    , TokenId
+    )
+import Cardano.MPFS.HTTP.Types
+    ( bundleSnapshotToJSON
+    , resolvedWalletInputToUtxoEntry
+    , tokenIdToJSON
+    )
+import Cardano.MPFS.Indexer.Reads (ResolvedUtxoSet)
+import Cardano.MPFS.TxBuilder
+    ( BundleSnapshot
+    , ResolvedWalletInput
+    )
+
+-- | Build the facts-only end response from one atomic
+-- indexer snapshot, the state UTxO, owner funding UTxOs,
+-- the request-set completeness witness, and node protocol
+-- parameters.
+mkEndFacts
+    :: BundleSnapshot
+    -> TokenId
+    -> ResolvedWalletInput
+    -> [ResolvedWalletInput]
+    -> ResolvedUtxoSet
+    -> PParams ConwayEra
+    -> EndFacts
+mkEndFacts snap tid stateUtxo walletUtxos requestSet pparams =
+    EndFacts
+        { efSnapshot = bundleSnapshotToJSON snap
+        , efToken = tokenIdToJSON tid
+        , efStateUtxo =
+            resolvedWalletInputToUtxoEntry stateUtxo
+        , efWalletUtxos =
+            map resolvedWalletInputToUtxoEntry walletUtxos
+        , efRequestSet = requestSetToJSON requestSet
+        , efProtocolParameters =
+            UnverifiedPParams
+                { uppVerified = False
+                , uppCbor =
+                    Hex
+                        ( serialize'
+                            (natVersion @11)
+                            pparams
+                        )
+                }
+        }
+
+requestSetToJSON :: ResolvedUtxoSet -> UtxoSetWitness
+requestSetToJSON (entries, proofBytes) =
+    UtxoSetWitness
+        { uswEntries = map requestSetEntryToJSON entries
+        , uswCompletenessProof = Hex proofBytes
+        }
+
+requestSetEntryToJSON
+    :: (TxIn, ByteString) -> UtxoEntryRefOnly
+requestSetEntryToJSON (txIn, txOutBytes) =
+    UtxoEntryRefOnly
+        { uerRef = txInToUtxoRef txIn
+        , uerTxOutCbor = Hex txOutBytes
+        }
+
+txInToUtxoRef :: TxIn -> UtxoRef
+txInToUtxoRef (TxIn (TxId sh) (TxIx ix)) =
+    UtxoRef
+        { urTxId =
+            Hex
+                ( Crypto.hashToBytes
+                    (extractHash sh)
+                )
+        , urTxIx = fromIntegral ix
+        }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
@@ -37,10 +37,14 @@ module Cardano.MPFS.Indexer.Reads
     , readRequestSetAt
     , readWalletInputsAt
     , ResolvedUtxoSet
+
+      -- * UTxO key helpers
+    , addressScopedLeafKey
     ) where
 
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BSL
+import Data.List (stripPrefix)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe)
 
@@ -65,7 +69,10 @@ import Cardano.Ledger.Mary.Value
     )
 
 import CSMT.Core.CBOR (renderCompletenessProof)
-import CSMT.Core.Types (Indirect (..))
+import CSMT.Core.Types
+    ( Indirect (..)
+    , Key
+    )
 import CSMT.Hashes
     ( generateInclusionProof
     , renderHash
@@ -242,10 +249,16 @@ readWalletInputsAt addr =
                     hashAddressKey (serialiseAddr addr)
             indirects <-
                 collectValues CSMTCol [] addrKey
-            catMaybes <$> traverse (loadOne fkv) indirects
+            catMaybes <$> traverse (loadOne fkv addrKey) indirects
   where
-    loadOne fkv Indirect{jump} = do
-        let lazyKey = review (isoK fkv) jump
+    loadOne fkv addrKey leaf = do
+        let lazyKey =
+                case addressScopedLeafKey fkv addrKey leaf of
+                    Right key -> key
+                    Left e ->
+                        error
+                            $ "readWalletInputsAt: "
+                                <> e
             txInDecoded =
                 case decodeFull
                     (natVersion @11)
@@ -335,7 +348,7 @@ readRequestSetAt addr =
                     hashAddressKey (serialiseAddr addr)
             indirects <-
                 collectValues CSMTCol [] addrKey
-            entries <- traverse (loadOne fkv) indirects
+            entries <- traverse (loadOne fkv addrKey) indirects
             mProof <- generateProof CSMTCol [] addrKey
             let proofBytes = case mProof of
                     Just proof ->
@@ -350,8 +363,14 @@ readRequestSetAt addr =
                             \subtree"
             pure (entries, proofBytes)
   where
-    loadOne fkv Indirect{jump} = do
-        let lazyKey = review (isoK fkv) jump
+    loadOne fkv addrKey leaf = do
+        let lazyKey =
+                case addressScopedLeafKey fkv addrKey leaf of
+                    Right key -> key
+                    Left e ->
+                        error
+                            $ "readRequestSetAt: "
+                                <> e
             txInDecoded =
                 case decodeFull
                     (natVersion @11)
@@ -378,6 +397,20 @@ readRequestSetAt addr =
                         <> ")"
             Just txOutBytes ->
                 pure (txInDecoded, BSL.toStrict txOutBytes)
+
+addressScopedLeafKey
+    :: FromKV key value hash
+    -> Key
+    -> Indirect leaf
+    -> Either String key
+addressScopedLeafKey fkv addressKey Indirect{jump} =
+    case stripPrefix addressKey jump of
+        Just key ->
+            Right $ review (isoK fkv) key
+        Nothing ->
+            Left
+                "indexer CSMT column produced a leaf whose key \
+                \did not start with queried address prefix"
 
 decodeTxOut
     :: ByteString -> Either DecoderError (TxOut ConwayEra)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
@@ -33,21 +33,38 @@ module Cardano.MPFS.Indexer.Reads
     , readCheckpoint
     , readMerkleRoot
     , readSnapshot
+    , readStateUtxoAt
+    , readRequestSetAt
     , readWalletInputsAt
+    , ResolvedUtxoSet
     ) where
 
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BSL
+import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe)
 
-import Control.Lens (review)
-
-import Cardano.Ledger.Address (Addr, serialiseAddr)
-import Cardano.Ledger.Binary
-    ( decodeFull
-    , natVersion
+import Control.Lens
+    ( review
+    , (^.)
     )
 
+import Cardano.Ledger.Address (Addr, serialiseAddr)
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , valueTxOutL
+    )
+import Cardano.Ledger.Binary
+    ( DecoderError
+    , decodeFull
+    , natVersion
+    )
+import Cardano.Ledger.Mary.Value
+    ( MaryValue (..)
+    , MultiAsset (..)
+    )
+
+import CSMT.Core.CBOR (renderCompletenessProof)
 import CSMT.Core.Types (Indirect (..))
 import CSMT.Hashes
     ( generateInclusionProof
@@ -55,7 +72,11 @@ import CSMT.Hashes
     )
 import CSMT.Hashes.Types (Hash)
 import CSMT.Interface (FromKV (..))
-import CSMT.Proof.Completeness (collectValues)
+import CSMT.Proof.Completeness
+    ( CompletenessProof
+    , collectValues
+    , generateProof
+    )
 
 import Database.KV.Transaction
     ( mapColumns
@@ -82,13 +103,23 @@ import ChainFollower.Rollbacks.Types (RollbackPoint (..))
 
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
+    , ConwayEra
+    , PolicyID
     , SlotNo (..)
+    , TokenId (..)
+    , TxIn
     )
 import Cardano.MPFS.Indexer.Columns (UnifiedColumns (..))
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
     , ResolvedWalletInput
     )
+
+-- | Request-address UTxO set witness read from the indexer:
+-- each entry carries only @(TxIn, TxOut CBOR)@ because the
+-- enclosing completeness proof attests the whole address subtree.
+type ResolvedUtxoSet =
+    ([(TxIn, ByteString)], ByteString)
 
 -- | An action over the unified-columns database
 -- transaction. The @cf@ and @op@ existentials are
@@ -266,3 +297,98 @@ readWalletInputsAt addr =
                         , BSL.toStrict txOutBytes
                         , proofBytes
                         )
+
+-- | Read the current state UTxO for a token at the state
+-- validator address and return it with a CSMT inclusion proof.
+readStateUtxoAt
+    :: Addr
+    -> PolicyID
+    -> TokenId
+    -> IndexerTx (Maybe ResolvedWalletInput)
+readStateUtxoAt stateAddr policyId tid =
+    findState <$> readWalletInputsAt stateAddr
+  where
+    findState [] = Nothing
+    findState (row@(_, txOutBytes, _) : rest)
+        | carriesToken txOutBytes = Just row
+        | otherwise = findState rest
+    carriesToken txOutBytes =
+        case decodeTxOut txOutBytes of
+            Right txOut -> txOutCarriesToken policyId tid txOut
+            Left err ->
+                error
+                    $ "readStateUtxoAt: indexer KV column \
+                      \produced a state-address leaf whose \
+                      \value did not decode as a TxOut: "
+                        <> show err
+
+-- | Walk the UTxO-CSMT subtree at a request address and
+-- produce the enumerated UTxOs plus a production
+-- prefix-completeness proof for that exact subtree.
+readRequestSetAt :: Addr -> IndexerTx ResolvedUtxoSet
+readRequestSetAt addr =
+    IndexerTx
+        $ mapColumns InUtxo
+        $ do
+            let fkv = fromKV context
+                addrKey =
+                    hashAddressKey (serialiseAddr addr)
+            indirects <-
+                collectValues CSMTCol [] addrKey
+            entries <- traverse (loadOne fkv) indirects
+            mProof <- generateProof CSMTCol [] addrKey
+            let proofBytes = case mProof of
+                    Just proof ->
+                        renderCompletenessProof
+                            (proof :: CompletenessProof Hash)
+                    Nothing ->
+                        error
+                            "readRequestSetAt: indexer \
+                            \corruption — \
+                            \generateProof returned \
+                            \Nothing for request-address \
+                            \subtree"
+            pure (entries, proofBytes)
+  where
+    loadOne fkv Indirect{jump} = do
+        let lazyKey = review (isoK fkv) jump
+            txInDecoded =
+                case decodeFull
+                    (natVersion @11)
+                    lazyKey of
+                    Right t -> t
+                    Left e ->
+                        error
+                            $ "readRequestSetAt: \
+                              \indexer KV column \
+                              \produced a leaf whose \
+                              \key did not decode as \
+                              \a TxIn: "
+                                <> show e
+        mTxOut <- query KVCol lazyKey
+        case mTxOut of
+            Nothing ->
+                error
+                    $ "readRequestSetAt: indexer \
+                      \corruption — CSMT contains a \
+                      \leaf at this address whose KV \
+                      \column has no TxOut bytes \
+                      \(input: "
+                        <> show txInDecoded
+                        <> ")"
+            Just txOutBytes ->
+                pure (txInDecoded, BSL.toStrict txOutBytes)
+
+decodeTxOut
+    :: ByteString -> Either DecoderError (TxOut ConwayEra)
+decodeTxOut =
+    decodeFull (natVersion @11) . BSL.fromStrict
+
+txOutCarriesToken
+    :: PolicyID -> TokenId -> TxOut ConwayEra -> Bool
+txOutCarriesToken policyId (TokenId assetName) txOut =
+    case txOut ^. valueTxOutL of
+        MaryValue _ (MultiAsset ma) ->
+            case Map.lookup policyId ma of
+                Just assets -> Map.member assetName assets
+                Nothing -> False

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.HTTP.EndFactsSpec
+-- Description : Tests for POST /facts/end
+-- License     : Apache-2.0
+module Cardano.MPFS.HTTP.EndFactsSpec (spec) where
+
+import Data.Aeson
+    ( ToJSON (toJSON)
+    , eitherDecode
+    )
+import Data.Aeson.KeyMap qualified as KM
+import Data.Aeson.Types (Value (..))
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy.Char8 qualified as BL
+import Data.ByteString.Short qualified as SBS
+import Network.HTTP.Types
+    ( hContentType
+    , methodPost
+    , status400
+    )
+import Network.Wai (Request (..))
+import Network.Wai.Test
+    ( SRequest (..)
+    , SResponse (..)
+    , defaultRequest
+    , runSession
+    , setPath
+    , srequest
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    )
+import Test.QuickCheck (generate)
+
+import Cardano.Ledger.Api.PParams (emptyPParams)
+import Cardano.Ledger.Mary.Value (AssetName (..))
+import Cardano.MPFS.Context (Context)
+import Cardano.MPFS.Core.Types
+    ( BlockId (..)
+    , SlotNo (..)
+    , TokenId (..)
+    )
+import Cardano.MPFS.Generators (genTxIn)
+import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
+import Cardano.MPFS.HTTP.Swagger (renderSwaggerJSON)
+import Cardano.MPFS.HTTP.Types.Facts (mkEndFacts)
+import Cardano.MPFS.TxBuilder (BundleSnapshot (..))
+
+spec :: Spec
+spec = describe "POST /facts/end" $ do
+    it "is routed and rejects malformed addresses with 400" $ do
+        ctx <- mkTestContext
+        resp <- postJson ctx "/facts/end" badEndRequest
+        simpleStatus resp `shouldBe` status400
+
+    it "documents facts route while keeping legacy tx route"
+        $ case eitherDecode renderSwaggerJSON of
+            Right (Object swagger) ->
+                case KM.lookup "paths" swagger of
+                    Just (Object paths) -> do
+                        KM.member "/facts/end" paths
+                            `shouldBe` True
+                        KM.member "/tx/end" paths
+                            `shouldBe` True
+                    _ ->
+                        expectationFailure
+                            "Swagger paths are not an object"
+            Right _ ->
+                expectationFailure
+                    "Swagger document is not an object"
+            Left err ->
+                expectationFailure
+                    $ "Could not decode Swagger JSON: "
+                        <> err
+
+    it "packages end facts without unsigned tx cbor" $ do
+        stateTxIn <- generate genTxIn
+        walletTxIn <- generate genTxIn
+        let facts =
+                mkEndFacts
+                    BundleSnapshot
+                        { snapshotUtxoRoot = "root"
+                        , snapshotSlot = SlotNo 42
+                        , snapshotBlockId = BlockId "block-id"
+                        }
+                    sampleToken
+                    (stateTxIn, "state-tx-out", "state-proof")
+                    [(walletTxIn, "wallet-tx-out", "wallet-proof")]
+                    ([], "request-set-proof")
+                    emptyPParams
+        case toJSON facts of
+            Object obj -> do
+                KM.member "unsigned_tx_cbor" obj
+                    `shouldBe` False
+                KM.member "tx" obj
+                    `shouldBe` False
+                KM.member "snapshot" obj
+                    `shouldBe` True
+                KM.member "token" obj
+                    `shouldBe` True
+                KM.member "state_utxo" obj
+                    `shouldBe` True
+                KM.member "wallet_utxos" obj
+                    `shouldBe` True
+                KM.member "request_set" obj
+                    `shouldBe` True
+                KM.member "protocol_parameters" obj
+                    `shouldBe` True
+            _ ->
+                expectationFailure
+                    "Expected EndFacts JSON object"
+
+-- | Deliberately malformed serialized address with a valid token
+-- field, so handler-level address validation determines the status.
+badEndRequest :: String
+badEndRequest =
+    "{\"token\":\"63616665\",\"address\":\"00\"}"
+
+sampleToken :: TokenId
+sampleToken = TokenId (AssetName (SBS.toShort "cafe"))
+
+postJson
+    :: Context IO
+    -> ByteString
+    -> String
+    -> IO SResponse
+postJson ctx path body =
+    runSession
+        ( srequest
+            SRequest
+                { simpleRequest =
+                    (setPath defaultRequest path)
+                        { requestMethod = methodPost
+                        , requestHeaders =
+                            [
+                                ( hContentType
+                                , "application/json"
+                                )
+                            ]
+                        }
+                , simpleRequestBody =
+                    BL.pack body
+                }
+        )
+        (mkApp ctx)

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs
@@ -60,7 +60,7 @@ spec = describe "POST /facts/end" $ do
         resp <- postJson ctx "/facts/end" badEndRequest
         simpleStatus resp `shouldBe` status400
 
-    it "documents facts route while keeping legacy tx route"
+    it "documents facts route and drops legacy tx route"
         $ case eitherDecode renderSwaggerJSON of
             Right (Object swagger) ->
                 case KM.lookup "paths" swagger of
@@ -68,7 +68,7 @@ spec = describe "POST /facts/end" $ do
                         KM.member "/facts/end" paths
                             `shouldBe` True
                         KM.member "/tx/end" paths
-                            `shouldBe` True
+                            `shouldBe` False
                     _ ->
                         expectationFailure
                             "Swagger paths are not an object"

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ReadsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ReadsSpec.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.Indexer.ReadsSpec
+-- Description : Tests for indexer read primitives
+-- License     : Apache-2.0
+module Cardano.MPFS.Indexer.ReadsSpec (spec) where
+
+import Control.Lens (view)
+import Data.ByteString.Lazy qualified as BSL
+
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldContain
+    )
+import Test.QuickCheck (generate)
+
+import CSMT.Core.Types (Indirect (..))
+import CSMT.Hashes (mkHash)
+import CSMT.Interface (FromKV (..))
+import Cardano.Ledger.Binary
+    ( decodeFull
+    , natVersion
+    , serialize
+    )
+import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
+    ( CSMTContext (..)
+    )
+import Cardano.UTxOCSMT.Application.Run.Config
+    ( context
+    , hashAddressKey
+    )
+
+import Cardano.MPFS.Core.Types (TxIn)
+import Cardano.MPFS.Generators (genTxIn)
+import Cardano.MPFS.Indexer.Reads (addressScopedLeafKey)
+
+spec :: Spec
+spec = describe "address-prefixed UTxO leaves" $ do
+    it "strips the queried address prefix before decoding TxIn" $ do
+        txIn <- generate genTxIn
+        let CSMTContext{fromKV = fkv} = context
+            txInBytes = encodeTxIn txIn
+            addressKey = hashAddressKey "queried-address"
+            leaf =
+                Indirect
+                    { jump =
+                        addressKey
+                            <> view (isoK fkv) txInBytes
+                    , value = mkHash "unused"
+                    }
+        case addressScopedLeafKey fkv addressKey leaf of
+            Right keyBytes ->
+                decodeTxIn keyBytes `shouldBe` Right txIn
+            Left err ->
+                expectationFailure err
+
+    it "reports a mismatch when a leaf is outside the queried prefix" $ do
+        txIn <- generate genTxIn
+        let CSMTContext{fromKV = fkv} = context
+            txInBytes = encodeTxIn txIn
+            queriedKey = hashAddressKey "queried-address"
+            otherKey = hashAddressKey "other-address"
+            leaf =
+                Indirect
+                    { jump =
+                        otherKey
+                            <> view (isoK fkv) txInBytes
+                    , value = mkHash "unused"
+                    }
+        case addressScopedLeafKey fkv queriedKey leaf of
+            Left err ->
+                err
+                    `shouldContain` "did not start with queried \
+                                    \address prefix"
+            Right _ ->
+                expectationFailure
+                    "Expected address prefix mismatch"
+
+encodeTxIn :: TxIn -> BSL.ByteString
+encodeTxIn =
+    serialize (natVersion @11)
+
+decodeTxIn :: BSL.ByteString -> Either String TxIn
+decodeTxIn bs =
+    case decodeFull (natVersion @11) bs of
+        Left err -> Left (show err)
+        Right txIn -> Right txIn

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -27,6 +27,7 @@ import Cardano.MPFS.Indexer.EventSpec qualified as CageEventSpec
 import Cardano.MPFS.Indexer.FollowerSpec qualified as CageFollowerSpec
 import Cardano.MPFS.Indexer.InverseSpec qualified as InverseSpec
 import Cardano.MPFS.Indexer.PersistentSpec qualified as PersistentStateSpec
+import Cardano.MPFS.Indexer.ReadsSpec qualified as ReadsSpec
 import Cardano.MPFS.Indexer.RollbackSpec qualified as RollbackSpec
 import Cardano.MPFS.Indexer.UnifiedSpec qualified as UnifiedSpec
 import Cardano.MPFS.OnChainSpec qualified as OnChainSpec
@@ -64,6 +65,7 @@ main =
                 ProofSpec.spec
                 OnChainSpec.spec
                 ArmageddonSpec.spec
+                ReadsSpec.spec
                 UnifiedSpec.spec
                 RollbackSpec.spec
                 BootFactsSpec.spec

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -15,6 +15,7 @@ import Cardano.MPFS.Trie.PureManager
 
 import Cardano.MPFS.BalanceSpec qualified as BalanceSpec
 import Cardano.MPFS.HTTP.BootFactsSpec qualified as BootFactsSpec
+import Cardano.MPFS.HTTP.EndFactsSpec qualified as EndFactsSpec
 import Cardano.MPFS.HTTP.RequestsSpec qualified as RequestsSpec
 import Cardano.MPFS.HTTP.StatusSpec qualified as StatusSpec
 import Cardano.MPFS.HTTP.TokenSpec qualified as TokenSpec
@@ -66,6 +67,7 @@ main =
                 UnifiedSpec.spec
                 RollbackSpec.spec
                 BootFactsSpec.spec
+                EndFactsSpec.spec
                 RequestsSpec.spec
                 StatusSpec.spec
                 TokenSpec.spec

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -78,6 +78,41 @@
             ],
             "type": "object"
         },
+        "EndFacts": {
+            "description": "Facts-only end response. Carries state and wallet UTxO witnesses plus a request-set completeness proof, with no unsigned transaction CBOR.",
+            "properties": {
+                "protocol_parameters": {
+                    "$ref": "#/definitions/UnverifiedPParams"
+                },
+                "request_set": {
+                    "$ref": "#/definitions/UtxoSetWitness"
+                },
+                "snapshot": {
+                    "$ref": "#/definitions/VerificationSnapshot"
+                },
+                "state_utxo": {
+                    "$ref": "#/definitions/UtxoEntry"
+                },
+                "token": {
+                    "$ref": "#/definitions/TokenIdJSON"
+                },
+                "wallet_utxos": {
+                    "items": {
+                        "$ref": "#/definitions/UtxoEntry"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "snapshot",
+                "token",
+                "state_utxo",
+                "wallet_utxos",
+                "request_set",
+                "protocol_parameters"
+            ],
+            "type": "object"
+        },
         "EndProofJSON": {
             "description": "Proof payload for POST /tx/end",
             "properties": {
@@ -878,6 +913,22 @@
             ],
             "type": "object"
         },
+        "UtxoEntryRefOnly": {
+            "description": "UTxO ref and CBOR body, without a per-entry inclusion proof. Used inside a UtxoSetWitness.",
+            "properties": {
+                "ref": {
+                    "$ref": "#/definitions/UtxoRef"
+                },
+                "txout_cbor": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "ref",
+                "txout_cbor"
+            ],
+            "type": "object"
+        },
         "UtxoRef": {
             "description": "UTxO reference",
             "properties": {
@@ -894,6 +945,25 @@
             "required": [
                 "tx_id",
                 "tx_ix"
+            ],
+            "type": "object"
+        },
+        "UtxoSetWitness": {
+            "description": "Enumerated UTxOs at a known script-hash prefix, with a single CSMT prefix-completeness proof attesting the set is exactly the leaves under that prefix.",
+            "properties": {
+                "completeness_proof": {
+                    "$ref": "#/definitions/Hex"
+                },
+                "entries": {
+                    "items": {
+                        "$ref": "#/definitions/UtxoEntryRefOnly"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "entries",
+                "completeness_proof"
             ],
             "type": "object"
         },
@@ -998,6 +1068,37 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/BootFacts"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid `body`"
+                    }
+                }
+            }
+        },
+        "/facts/end": {
+            "post": {
+                "consumes": [
+                    "application/json;charset=utf-8"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/EndRequest"
+                        }
+                    }
+                ],
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/EndFacts"
                         }
                     },
                     "400": {

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -113,25 +113,6 @@
             ],
             "type": "object"
         },
-        "EndProofJSON": {
-            "description": "Proof payload for POST /tx/end",
-            "properties": {
-                "funding": {
-                    "items": {
-                        "$ref": "#/definitions/WitnessedUtxo"
-                    },
-                    "type": "array"
-                },
-                "state": {
-                    "$ref": "#/definitions/WitnessedUtxo"
-                }
-            },
-            "required": [
-                "state",
-                "funding"
-            ],
-            "type": "object"
-        },
         "EndRequest": {
             "description": "End a token",
             "properties": {
@@ -145,26 +126,6 @@
             "required": [
                 "token",
                 "address"
-            ],
-            "type": "object"
-        },
-        "EndTxResponse": {
-            "description": "Proof-bearing response for POST /tx/end",
-            "properties": {
-                "proof": {
-                    "$ref": "#/definitions/EndProofJSON"
-                },
-                "snapshot": {
-                    "$ref": "#/definitions/VerificationSnapshot"
-                },
-                "tx": {
-                    "$ref": "#/definitions/Hex"
-                }
-            },
-            "required": [
-                "tx",
-                "snapshot",
-                "proof"
             ],
             "type": "object"
         },
@@ -1308,37 +1269,6 @@
                     },
                     "400": {
                         "description": "Invalid `id`"
-                    }
-                }
-            }
-        },
-        "/tx/end": {
-            "post": {
-                "consumes": [
-                    "application/json;charset=utf-8"
-                ],
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/EndRequest"
-                        }
-                    }
-                ],
-                "produces": [
-                    "application/json;charset=utf-8"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/EndTxResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid `body`"
                     }
                 }
             }

--- a/gate.sh
+++ b/gate.sh
@@ -73,8 +73,7 @@ for non_boot_route in \
   TxRejectAPI \
   TxUpdateAPI \
   TxRetractAPI \
-  TxSweepAPI \
-  TxEndAPI
+  TxSweepAPI
 do
   check_present \
     "non-boot write route alias is missing: $non_boot_route" \
@@ -84,9 +83,32 @@ do
 done
 
 check_absent \
+  "legacy end tx API/server route returned" \
+  'TxEndAPI|txEndHandler|"tx" :> "end"' \
+  cardano-mpfs-api/lib/Cardano/MPFS/API.hs \
+  cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/API.hs \
+  cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+
+check_absent \
+  "legacy end tx Swagger route returned" \
+  '"/tx/end"' \
+  docs/assets/swagger.json
+
+check_present \
+  "facts end Swagger path is missing" \
+  '"/facts/end"' \
+  docs/assets/swagger.json
+
+check_absent \
   "boot facts verifier imports transaction grammar" \
   'Cardano\.Ledger\.Api\.Tx|TxView|verifyTxInputBinding|unsigned_tx_cbor|Tx ConwayEra' \
   cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs \
   cardano-mpfs-client/test/Cardano/MPFS/Client/BootFactsSpec.hs
+
+check_absent \
+  "end facts verifier imports transaction grammar" \
+  'Cardano\.Ledger\.Api\.Tx|TxView|verifyTxInputBinding|unsigned_tx_cbor|Tx ConwayEra' \
+  cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs \
+  cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
 
 nix develop --quiet -c just ci

--- a/specs/268-end-fact-provider-pivot/checklists/requirements.md
+++ b/specs/268-end-fact-provider-pivot/checklists/requirements.md
@@ -1,0 +1,8 @@
+# Requirements Checklist: End fact-provider pivot
+
+- [x] User stories are independently testable.
+- [x] Legacy route removal is stated as a same-PR hard swap.
+- [x] Empty request-set completeness is explicit.
+- [x] Protocol parameters are marked unverified.
+- [x] MOOG boundary status follows the boot decision and does not require old caller migration.
+- [x] Acceptance criteria include source, Swagger, verifier, builder, and handler evidence.

--- a/specs/268-end-fact-provider-pivot/checklists/requirements.md
+++ b/specs/268-end-fact-provider-pivot/checklists/requirements.md
@@ -4,5 +4,5 @@
 - [x] Legacy route removal is stated as a same-PR hard swap.
 - [x] Empty request-set completeness is explicit.
 - [x] Protocol parameters are marked unverified.
-- [x] MOOG boundary status follows the boot decision and does not require old caller migration.
+- [x] MOOG boundary status follows the boot decision and does not claim MOOG production readiness.
 - [x] Acceptance criteria include source, Swagger, verifier, builder, and handler evidence.

--- a/specs/268-end-fact-provider-pivot/contracts/end-client.md
+++ b/specs/268-end-fact-provider-pivot/contracts/end-client.md
@@ -1,0 +1,34 @@
+# Contract: End Client Surface
+
+```haskell
+verifyEndFacts
+    :: CageConfig
+    -> TrustedRoot
+    -> EndFacts
+    -> Either VerifyError VerifiedEndFacts
+
+verifiedEndFacts :: VerifiedEndFacts -> EndFacts
+
+endCageTx
+    :: CageConfig
+    -> WalletPolicy
+    -> VerifiedEndFacts
+    -> Either BuildError (Tx ConwayEra)
+```
+
+Verification checks:
+
+- trusted root is 32 bytes,
+- `snapshot.utxo_root` is 32 bytes and equals the trusted root,
+- `state_utxo.inclusion_proof` replays against the snapshot root,
+- every `wallet_utxos[*].inclusion_proof` replays against the snapshot root,
+- `request_set.entries` is empty,
+- `request_set.completeness_proof` verifies against the locally-derived per-cage request address prefix.
+
+Builder checks:
+
+- protocol parameters decode,
+- wallet policy accepts protocol parameters and built transaction,
+- state UTxO decodes to a state datum with an owner key hash,
+- at least one funding UTxO exists,
+- returned transaction consumes the state UTxO, burns exactly one token, has spending and minting redeemers, attaches the cage script, and requires the owner signer.

--- a/specs/268-end-fact-provider-pivot/contracts/facts-end-api.md
+++ b/specs/268-end-fact-provider-pivot/contracts/facts-end-api.md
@@ -1,0 +1,59 @@
+# Contract: POST /facts/end
+
+## Request
+
+```http
+POST /facts/end
+Content-Type: application/json
+```
+
+```json
+{
+  "token": "<hex token id>",
+  "address": "<hex serialized owner/funding address>"
+}
+```
+
+## Response
+
+```json
+{
+  "snapshot": {
+    "utxo_root": "<hex>",
+    "chainpoint": {
+      "slot": 0,
+      "block_id": "<hex>"
+    }
+  },
+  "token": "<hex token id>",
+  "state_utxo": {
+    "ref": { "tx_id": "<hex>", "tx_ix": 0 },
+    "txout_cbor": "<hex>",
+    "inclusion_proof": "<hex>"
+  },
+  "wallet_utxos": [
+    {
+      "ref": { "tx_id": "<hex>", "tx_ix": 1 },
+      "txout_cbor": "<hex>",
+      "inclusion_proof": "<hex>"
+    }
+  ],
+  "request_set": {
+    "entries": [],
+    "completeness_proof": "<hex>"
+  },
+  "protocol_parameters": {
+    "verified": false,
+    "cbor": "<hex>"
+  }
+}
+```
+
+The response contains no unsigned transaction CBOR.
+
+## Errors
+
+- `400`: malformed address or no wallet funding UTxOs at the requested address.
+- `404`: token state UTxO is not present in the indexed UTxO set.
+- `503`: snapshot unavailable.
+- `500`: indexer corruption while loading a CSMT leaf or proof.

--- a/specs/268-end-fact-provider-pivot/data-model.md
+++ b/specs/268-end-fact-provider-pivot/data-model.md
@@ -1,0 +1,55 @@
+# Data Model: End fact-provider pivot
+
+## EndFacts
+
+```haskell
+data EndFacts = EndFacts
+    { efSnapshot :: VerificationSnapshot
+    , efToken :: TokenIdJSON
+    , efStateUtxo :: UtxoEntry
+    , efWalletUtxos :: [UtxoEntry]
+    , efRequestSet :: UtxoSetWitness
+    , efProtocolParameters :: UnverifiedPParams
+    }
+```
+
+`efRequestSet.entries` must be empty for end. The completeness proof is still required so the verifier can distinguish "no requests exist" from "the server omitted requests".
+
+## VerifiedEndFacts
+
+```haskell
+newtype VerifiedEndFacts = VerifiedEndFacts EndFacts
+
+verifyEndFacts
+    :: CageConfig
+    -> TrustedRoot
+    -> EndFacts
+    -> Either VerifyError VerifiedEndFacts
+```
+
+The constructor is not exported. `endCageTx` consumes `VerifiedEndFacts`.
+
+## Request-Set Prefix
+
+The verifier derives:
+
+```text
+requestAddr = requestAddrFromCfg cageConfig token network
+prefix = blake2b256(serialiseAddr requestAddr) as a CSMT Key
+```
+
+No server-provided prefix is trusted.
+
+## Indexer Reads
+
+```haskell
+type ResolvedStateUtxo = (TxIn, ByteString, ByteString)
+
+readStateUtxoAt
+    :: Addr -> PolicyID -> TokenId -> IndexerTx (Maybe ResolvedStateUtxo)
+
+readRequestSetAt
+    :: Addr -> IndexerTx UtxoSetWitnessBytes
+```
+
+The exact helper names may vary, but both reads stay inside one `IndexerTx` composition in the handler.

--- a/specs/268-end-fact-provider-pivot/data-model.md
+++ b/specs/268-end-fact-provider-pivot/data-model.md
@@ -35,7 +35,8 @@ The constructor is not exported. `endCageTx` consumes `VerifiedEndFacts`.
 
 ## Request-Set Prefix
 
-The verifier derives:
+The verifier derives this through
+`Cardano.MPFS.Client.Cage.Identity`:
 
 ```text
 requestAddr = requestAddrFromCfg cageConfig token network

--- a/specs/268-end-fact-provider-pivot/data-model.md
+++ b/specs/268-end-fact-provider-pivot/data-model.md
@@ -2,6 +2,10 @@
 
 ## EndFacts
 
+**Location**: `Cardano.MPFS.API.Types.Facts`. Do not add this record to
+the already-large `Cardano.MPFS.API.Types` module except through a
+temporary compatibility re-export.
+
 ```haskell
 data EndFacts = EndFacts
     { efSnapshot :: VerificationSnapshot

--- a/specs/268-end-fact-provider-pivot/plan.md
+++ b/specs/268-end-fact-provider-pivot/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: End fact-provider pivot
+
+**Branch**: `268-end-fact-provider-pivot` | **Date**: 2026-05-18 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Ship the end slice of the fact-provider pivot. The server adds `POST /facts/end`, returning only proof-bearing facts for the token state UTxO, owner funding UTxOs, an empty per-cage request-set completeness witness, and unverified protocol parameters. The client verifies those facts against a trusted UTxO root and locally builds the burn transaction with `endCageTx`. The legacy server-built `POST /tx/end` path is removed.
+
+MOOG coordination follows the boot decision: this PR records boundary status and links the MPFS-v2 canary/replacement track; it does not require a production migration of the old MOOG caller.
+
+## Technical Context
+
+**Language/Version**: Haskell GHC 9.10.1.
+
+**Packages**: `cardano-mpfs-api` owns wire DTOs and Servant API, `cardano-mpfs-client` owns pure verification and local construction, and `cardano-mpfs-offchain` owns HTTP handler and indexer reads.
+
+**Proof dependencies**: Existing CSMT inclusion replay plus `CSMT.Verify.verifyCompletenessProof` for the empty request-set witness.
+
+**Gate**: Baseline `./gate.sh` passed on 2026-05-18 before edits.
+
+## Constitution Check
+
+- Ledger-native types: PASS. `endCageTx` returns `Tx ConwayEra` and decodes ledger `TxOut` bytes only at builder boundaries.
+- Records of functions: PASS. No new service typeclass.
+- Atomic reads: PASS by adding end-specific `IndexerTx` primitives and composing them under one `runIndexerTx ctx`.
+- Client-side construction: PASS. The server returns no end transaction CBOR.
+- Aiken compatibility: PASS with required regression tests for burn/redeemer shape and submit-valid budgets.
+- Local verification: PASS. Focused tests and `./gate.sh` remain required.
+- Nix reproducibility: PASS. Commands run through `nix develop` or existing Just recipes.
+- Pure offline verification: PASS. `verifyEndFacts` performs only proof checks and local prefix derivation.
+- One verifier, many targets: PASS. No transaction grammar import is added to the facts verifier surface.
+
+## Work Breakdown
+
+1. Spec and task artifacts with corrected MOOG boundary language.
+2. Wire type, verifier, and request-set completeness primitive.
+3. Client-side `endCageTx` and focused builder tests.
+4. Server hard swap: `POST /facts/end`, indexer reads, route removal, Swagger.
+5. Gate extension, PR metadata, and final verification.
+
+## Design Decisions
+
+- `EndFacts` carries the token id so `verifyEndFacts` and `endCageTx` are self-contained.
+- `verifyEndFacts` takes `CageConfig` because the request-set completeness prefix is locally derived from `(request validator bytes, state policy id, token id, network)`.
+- End requires `request_set.entries == []`. A valid completeness proof over non-empty entries is still rejected for this operation.
+- `readStateUtxoAt` scans the state-validator address prefix in the UTxO CSMT and filters for the cage policy id plus token asset name.
+- `readRequestSetAt` generates a completeness proof for the per-cage request address prefix. It is used by the end handler to prove emptiness.
+
+## Files
+
+```text
+cardano-mpfs-api/lib/Cardano/MPFS/API.hs
+cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs
+cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
+cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
+cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Config.hs
+cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/End.hs
+cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs
+cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
+cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
+cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs
+docs/assets/swagger.json
+gate.sh
+```

--- a/specs/268-end-fact-provider-pivot/plan.md
+++ b/specs/268-end-fact-provider-pivot/plan.md
@@ -33,10 +33,12 @@ MOOG coordination follows the boot decision: this PR records boundary status and
 ## Work Breakdown
 
 1. Spec and task artifacts with corrected MOOG boundary language.
-2. Wire type, verifier, and request-set completeness primitive.
-3. Client-side `endCageTx` and focused builder tests.
-4. Server hard swap: `POST /facts/end`, indexer reads, route removal, Swagger.
-5. Gate extension, PR metadata, and final verification.
+2. Break the API package wire DTOs out of the monolithic `API.Types`
+   surface before adding the end facts shape.
+3. Wire type, verifier, and request-set completeness primitive.
+4. Client-side `endCageTx` and focused builder tests.
+5. Server hard swap: `POST /facts/end`, indexer reads, route removal, Swagger.
+6. Gate extension, PR metadata, and final verification.
 
 ## Design Decisions
 
@@ -45,12 +47,18 @@ MOOG coordination follows the boot decision: this PR records boundary status and
 - End requires `request_set.entries == []`. A valid completeness proof over non-empty entries is still rejected for this operation.
 - `readStateUtxoAt` scans the state-validator address prefix in the UTxO CSMT and filters for the cage policy id plus token asset name.
 - `readRequestSetAt` generates a completeness proof for the per-cage request address prefix. It is used by the end handler to prove emptiness.
+- New facts DTOs must not grow `Cardano.MPFS.API.Types`. The first
+  implementation slice splits shared primitives and per-operation facts
+  into smaller modules, with `API.Types` kept as a compatibility
+  re-export only if downstream imports require it.
 
 ## Files
 
 ```text
 cardano-mpfs-api/lib/Cardano/MPFS/API.hs
-cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs              # compatibility only
+cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs
+cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs
 cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs
 cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
 cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
@@ -60,7 +68,8 @@ cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs
 cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
 cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
 cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
-cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs        # compatibility only
+cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types/Facts.hs
 cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs
 docs/assets/swagger.json
 gate.sh

--- a/specs/268-end-fact-provider-pivot/plan.md
+++ b/specs/268-end-fact-provider-pivot/plan.md
@@ -6,7 +6,7 @@
 
 Ship the end slice of the fact-provider pivot. The server adds `POST /facts/end`, returning only proof-bearing facts for the token state UTxO, owner funding UTxOs, an empty per-cage request-set completeness witness, and unverified protocol parameters. The client verifies those facts against a trusted UTxO root and locally builds the burn transaction with `endCageTx`. The legacy server-built `POST /tx/end` path is removed.
 
-MOOG coordination follows the boot decision: this PR records boundary status and links the MPFS-v2 canary/replacement track; it does not require a production migration of the old MOOG caller.
+MOOG coordination follows the boot decision: this PR records boundary status and links the MPFS-v2 canary/replacement track; it does not make MOOG production migration part of this offchain PR.
 
 ## Technical Context
 

--- a/specs/268-end-fact-provider-pivot/plan.md
+++ b/specs/268-end-fact-provider-pivot/plan.md
@@ -35,15 +35,17 @@ MOOG coordination follows the boot decision: this PR records boundary status and
 1. Spec and task artifacts with corrected MOOG boundary language.
 2. Break the API package wire DTOs out of the monolithic `API.Types`
    surface before adding the end facts shape.
-3. Wire type, verifier, and request-set completeness primitive.
-4. Client-side `endCageTx` and focused builder tests.
+3. Wire type, verifier, request-address identity helper, and
+   request-set completeness primitive.
+4. Client-side `endCageTx` and focused builder tests that reuse the
+   identity helper.
 5. Server hard swap: `POST /facts/end`, indexer reads, route removal, Swagger.
 6. Gate extension, PR metadata, and final verification.
 
 ## Design Decisions
 
 - `EndFacts` carries the token id so `verifyEndFacts` and `endCageTx` are self-contained.
-- `verifyEndFacts` takes `CageConfig` because the request-set completeness prefix is locally derived from `(request validator bytes, state policy id, token id, network)`.
+- `verifyEndFacts` takes `CageConfig` because the request-set completeness prefix is locally derived from `(request validator bytes, state policy id, token id, network)` through a dedicated client cage identity helper.
 - End requires `request_set.entries == []`. A valid completeness proof over non-empty entries is still rejected for this operation.
 - `readStateUtxoAt` scans the state-validator address prefix in the UTxO CSMT and filters for the cage policy id plus token asset name.
 - `readRequestSetAt` generates a completeness proof for the per-cage request address prefix. It is used by the end handler to prove emptiness.
@@ -62,7 +64,7 @@ cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs
 cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs
 cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify.hs
 cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
-cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Config.hs
+cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Identity.hs
 cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/End.hs
 cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs
 cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs

--- a/specs/268-end-fact-provider-pivot/quickstart.md
+++ b/specs/268-end-fact-provider-pivot/quickstart.md
@@ -1,0 +1,24 @@
+# Quickstart: End fact-provider pivot
+
+Baseline:
+
+```bash
+./gate.sh
+```
+
+Focused commands expected during implementation:
+
+```bash
+nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests --test-options '--match "/verifyEndFacts/"'
+nix develop --quiet -c cabal test cardano-mpfs-client:unit-tests --test-options '--match "/endCageTx/"'
+nix develop --quiet -c cabal test cardano-mpfs-offchain:unit-tests --test-options '--match "/POST /facts/end/"'
+nix develop --quiet -c just update-swagger
+./gate.sh
+```
+
+Source checks:
+
+```bash
+rg 'POST /tx/end|\"/tx/end\"|TxEndAPI|txEndHandler' cardano-mpfs-api cardano-mpfs-offchain docs/assets/swagger.json
+rg 'Cardano.Ledger.Api.Tx' cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs cardano-mpfs-client/lib/Cardano/MPFS/Client/Verify/Completeness.hs
+```

--- a/specs/268-end-fact-provider-pivot/research.md
+++ b/specs/268-end-fact-provider-pivot/research.md
@@ -2,7 +2,7 @@
 
 ## Boot Decision Applied To End
 
-Boot issue #261 changed the MOOG boundary. The paired MOOG work is a boundary spike and canary track, not evidence that the old production requester/oracle/agent caller has been migrated. End issue #268 therefore records boundary status and links cardano-foundation/moog#96 instead of requiring a legacy MOOG caller migration.
+Boot issue #261 changed the MOOG boundary. The paired MOOG work is a boundary spike and canary track, not production migration evidence. End issue #268 therefore records boundary status and links cardano-foundation/moog#96 instead of making MOOG production migration part of this offchain PR.
 
 ## Completeness Proof
 

--- a/specs/268-end-fact-provider-pivot/research.md
+++ b/specs/268-end-fact-provider-pivot/research.md
@@ -1,0 +1,24 @@
+# Research: End fact-provider pivot
+
+## Boot Decision Applied To End
+
+Boot issue #261 changed the MOOG boundary. The paired MOOG work is a boundary spike and canary track, not evidence that the old production requester/oracle/agent caller has been migrated. End issue #268 therefore records boundary status and links cardano-foundation/moog#96 instead of requiring a legacy MOOG caller migration.
+
+## Completeness Proof
+
+`CSMT.Verify.verifyCompletenessProof` verifies a proof against:
+
+- trusted UTxO root bytes,
+- a prefix `Key`,
+- the absolute leaves under that prefix,
+- serialized completeness proof bytes.
+
+For end, the prefix is the per-cage request validator address. The verifier derives it locally from client cage configuration and token id, then requires an empty leaf list. This proves there are no pending request UTxOs under that request address at the snapshot root.
+
+## State UTxO Read
+
+The state UTxO is found by scanning the global state validator address prefix in the UTxO CSMT and filtering decoded `TxOut` values for the configured state policy id plus the requested token asset name. The read returns `(TxIn, TxOut CBOR, inclusion proof)` so the server does not need a node UTxO query.
+
+## Protocol Parameters
+
+Protocol parameters remain unverified facts. `endCageTx` decodes them and enforces `WalletPolicy` caps before returning a transaction.

--- a/specs/268-end-fact-provider-pivot/spec.md
+++ b/specs/268-end-fact-provider-pivot/spec.md
@@ -1,0 +1,79 @@
+# Feature Specification: End fact-provider pivot
+
+**Feature Branch**: `268-end-fact-provider-pivot`
+**Created**: 2026-05-18
+**Status**: Draft
+**Input**: Issue #268: replace the legacy server-built end transaction endpoint with `POST /facts/end`, `verifyEndFacts`, and `endCageTx`.
+
+## User Scenarios & Testing
+
+### User Story 1 - End through verified facts and local transaction construction (Priority: P1)
+
+An MPFS operator or client retires a token without trusting the MPFS server to choose a transaction body. The client requests end facts for a token and funding address, verifies the proof-bearing facts against a trusted root, proves the per-cage request set is empty, builds the unsigned end transaction locally with `endCageTx`, signs it, submits it, and observes the burn indexed.
+
+**Independent Test**: Against deterministic fixtures and the HTTP handler test surface, `POST /facts/end { token, address }` returns state, funding, empty-request-set completeness, and unverified protocol parameters. The client verifies those facts and builds an end transaction with the same ledger shape as the legacy builder.
+
+**Acceptance Scenarios**:
+
+1. **Given** an indexed token state UTxO, an empty per-cage request set, funding at the owner address, and a trusted UTxO root, **When** a client calls `POST /facts/end`, **Then** the response contains one coherent snapshot, token id, state UTxO inclusion proof, wallet UTxO inclusion proofs, empty request-set completeness proof, and unverified protocol parameters.
+2. **Given** valid end facts, **When** `verifyEndFacts` runs with the client-owned cage config and trusted root, **Then** it succeeds and returns an opaque `VerifiedEndFacts` value.
+3. **Given** `VerifiedEndFacts` and an acceptable wallet policy, **When** `endCageTx` runs, **Then** it returns an unsigned transaction that consumes the state UTxO, burns one token, carries spending and minting redeemers, and requires the owner signer.
+4. **Given** a tampered trusted root, state proof, funding proof, or request-set completeness proof, **When** `verifyEndFacts` runs, **Then** it rejects before transaction building or signing.
+5. **Given** non-empty request-set entries under the per-cage request address, **When** `verifyEndFacts` runs for the end operation, **Then** it rejects because end requires an empty request set.
+
+### User Story 2 - Legacy end transaction endpoint is gone (Priority: P1)
+
+After this slice lands, the offchain server exposes `POST /facts/end` as the only end write path. The previous `POST /tx/end` endpoint and server-side end transaction handler are removed in the same PR, and Swagger reflects only the new facts shape.
+
+**Independent Test**: Source and Swagger searches find `POST /facts/end` and find no live `POST /tx/end` route.
+
+### User Story 3 - End verifier is proof-only (Priority: P2)
+
+The end verifier checks snapshot/root equality, state and funding CSMT inclusion, and the per-cage request-set completeness proof. It does not inspect an unsigned transaction because the client builds that transaction after verification.
+
+**Independent Test**: Focused tests cover happy path, root mismatch, state proof tamper, funding proof tamper, completeness proof tamper, and non-empty request-set rejection. A source search confirms the new end facts verifier surface does not import transaction grammar modules.
+
+### User Story 4 - MOOG boundary status is recorded (Priority: P2)
+
+The boot slice established that paired MOOG work is not a normal legacy caller migration. MOOG PR #95 is boundary-spike evidence, and cardano-foundation/moog#96 owns the staged MPFS-v2 canary or replacement decision. This issue records the boundary status instead of requiring a legacy MOOG caller migration.
+
+**Independent Test**: Issue #268 and the PR body state the MOOG boundary status and do not claim a production old-MOOG requester/oracle/agent migration.
+
+## Requirements
+
+- **FR-001**: The server MUST expose `POST /facts/end` accepting `token` and `address`.
+- **FR-002**: `EndFacts` MUST contain `snapshot`, `token`, `state_utxo`, `wallet_utxos`, `request_set`, and `protocol_parameters`.
+- **FR-003**: The end facts handler MUST read snapshot, state UTxO, wallet UTxOs, and request-set completeness inside one `runIndexerTx ctx` block.
+- **FR-004**: `request_set` MUST be a `UtxoSetWitness` whose completeness proof targets the locally-derived per-cage request address prefix. For end, `entries` MUST be empty.
+- **FR-005**: The facts endpoint MUST NOT return unsigned transaction CBOR.
+- **FR-006**: The legacy `POST /tx/end` route and server handler MUST be removed in the same PR.
+- **FR-007**: The client library MUST expose `EndFacts`, `VerifiedEndFacts`, `verifyEndFacts`, and `endCageTx`.
+- **FR-008**: `VerifiedEndFacts` MUST be opaque to downstream clients.
+- **FR-009**: `verifyEndFacts` MUST reject trusted-root mismatch, malformed roots, state/funding CSMT proof failures, request-set completeness failures, and non-empty request sets.
+- **FR-010**: `endCageTx` MUST enforce `WalletPolicy` before returning a transaction for signing.
+- **FR-011**: `docs/assets/swagger.json` MUST document `POST /facts/end` and MUST NOT document `POST /tx/end`.
+- **FR-012**: The PR metadata MUST record the MOOG boundary status and MUST NOT require a legacy MOOG caller migration.
+
+## Key Entities
+
+- **EndFacts**: Facts bundle for one token end operation: snapshot, token id, state UTxO, wallet UTxOs, empty request-set witness, and unverified protocol parameters.
+- **VerifiedEndFacts**: Opaque verifier output consumed by `endCageTx`.
+- **UtxoSetWitness**: Completeness proof plus entries under a locally-derived address prefix. End requires an empty witness.
+- **TrustedRoot**: Client-supplied UTxO-CSMT root.
+- **WalletPolicy**: Client-side caps for protocol parameters and built transaction bounds.
+- **endCageTx**: Local transaction builder for the end operation.
+
+## Success Criteria
+
+- **SC-001**: End facts verifier tests pass for happy path and all tamper cases.
+- **SC-002**: `endCageTx` focused tests pass for burn shape, owner signer, wallet policy rejection, and non-placeholder script budgets.
+- **SC-003**: HTTP tests prove `POST /facts/end` exists, returns no tx CBOR, assembles facts atomically, and removes `POST /tx/end`.
+- **SC-004**: Swagger and gate searches enforce the hard swap.
+- **SC-005**: Issue and PR metadata record the MOOG-v2 boundary status without a legacy caller migration claim.
+
+## Assumptions
+
+- Boot issue #261 is merged and establishes the local builder/verifier pattern.
+- This slice handles only the end operation. Request, retract, update, and reject facts remain in their own child issues.
+- Protocol parameters remain explicitly unverified; wallet policy caps are the mitigation.
+- The verifier derives the request-set prefix from client-owned cage configuration and token id, not from server-provided text.

--- a/specs/268-end-fact-provider-pivot/spec.md
+++ b/specs/268-end-fact-provider-pivot/spec.md
@@ -35,9 +35,9 @@ The end verifier checks snapshot/root equality, state and funding CSMT inclusion
 
 ### User Story 4 - MOOG boundary status is recorded (Priority: P2)
 
-The boot slice established that paired MOOG work is not a normal legacy caller migration. MOOG PR #95 is boundary-spike evidence, and cardano-foundation/moog#96 owns the staged MPFS-v2 canary or replacement decision. This issue records the boundary status instead of requiring a legacy MOOG caller migration.
+The boot slice established that paired MOOG work is a boundary track. MOOG PR #95 is boundary-spike evidence, and cardano-foundation/moog#96 owns the staged MPFS-v2 canary or replacement decision. This issue records the boundary status instead of making MOOG production migration part of this offchain PR.
 
-**Independent Test**: Issue #268 and the PR body state the MOOG boundary status and do not claim a production old-MOOG requester/oracle/agent migration.
+**Independent Test**: Issue #268 and the PR body state the MOOG boundary status and do not claim MOOG production readiness.
 
 ## Requirements
 
@@ -52,7 +52,7 @@ The boot slice established that paired MOOG work is not a normal legacy caller m
 - **FR-009**: `verifyEndFacts` MUST reject trusted-root mismatch, malformed roots, state/funding CSMT proof failures, request-set completeness failures, and non-empty request sets.
 - **FR-010**: `endCageTx` MUST enforce `WalletPolicy` before returning a transaction for signing.
 - **FR-011**: `docs/assets/swagger.json` MUST document `POST /facts/end` and MUST NOT document `POST /tx/end`.
-- **FR-012**: The PR metadata MUST record the MOOG boundary status and MUST NOT require a legacy MOOG caller migration.
+- **FR-012**: The PR metadata MUST record the MOOG boundary status and MUST NOT make MOOG production migration part of this offchain PR.
 
 ## Key Entities
 
@@ -69,7 +69,7 @@ The boot slice established that paired MOOG work is not a normal legacy caller m
 - **SC-002**: `endCageTx` focused tests pass for burn shape, owner signer, wallet policy rejection, and non-placeholder script budgets.
 - **SC-003**: HTTP tests prove `POST /facts/end` exists, returns no tx CBOR, assembles facts atomically, and removes `POST /tx/end`.
 - **SC-004**: Swagger and gate searches enforce the hard swap.
-- **SC-005**: Issue and PR metadata record the MOOG-v2 boundary status without a legacy caller migration claim.
+- **SC-005**: Issue and PR metadata record the MOOG-v2 boundary status without a MOOG production-readiness claim.
 
 ## Assumptions
 

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -11,9 +11,9 @@
 
 ## Phase 2: API type split
 
-- [ ] T005 RED: add a compile/import smoke proving new facts DTOs can be imported from `Cardano.MPFS.API.Types.Facts` without adding constructors to `Cardano.MPFS.API.Types`.
-- [ ] T006 GREEN: split common wire primitives into `cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs` and per-operation facts into `cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs`; keep `Cardano.MPFS.API.Types` as a temporary compatibility re-export.
-- [ ] T007 Wire the new API modules into `cardano-mpfs-api/cardano-mpfs-api.cabal` and update imports in server/client code opportunistically, without changing behavior.
+- [X] T005 (commit: 7c1091b) RED: add a compile/import smoke proving new facts DTOs can be imported from `Cardano.MPFS.API.Types.Facts` without adding constructors to `Cardano.MPFS.API.Types`.
+- [X] T006 (commit: 7c1091b) GREEN: split common wire primitives into `cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs` and per-operation facts into `cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs`; keep `Cardano.MPFS.API.Types` as a temporary compatibility re-export.
+- [X] T007 (commit: 7c1091b) Wire the new API modules into `cardano-mpfs-api/cardano-mpfs-api.cabal` and update imports in server/client code opportunistically, without changing behavior.
 
 ## Phase 3: End facts verifier
 

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -9,30 +9,36 @@
 - [x] T003 Run baseline `./gate.sh` before edits.
 - [x] T004 Add issue #268 spec, plan, contracts, quickstart, checklist, and tasks artifacts.
 
-## Phase 2: End facts verifier
+## Phase 2: API type split
 
-- [ ] T005 RED: add `EndFacts` JSON and `verifyEndFacts` tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs`.
-- [ ] T006 GREEN: add `EndFacts` wire type in `cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs`.
-- [ ] T007 GREEN: implement `VerifiedEndFacts`, `verifyEndFacts`, and request-set completeness replay in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs`, `Cardano/MPFS/Client/Verify.hs`, and `Cardano/MPFS/Client/Verify/Completeness.hs`.
-- [ ] T008 Wire new modules/tests into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
+- [ ] T005 RED: add a compile/import smoke proving new facts DTOs can be imported from `Cardano.MPFS.API.Types.Facts` without adding constructors to `Cardano.MPFS.API.Types`.
+- [ ] T006 GREEN: split common wire primitives into `cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs` and per-operation facts into `cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Facts.hs`; keep `Cardano.MPFS.API.Types` as a temporary compatibility re-export.
+- [ ] T007 Wire the new API modules into `cardano-mpfs-api/cardano-mpfs-api.cabal` and update imports in server/client code opportunistically, without changing behavior.
 
-## Phase 3: End cage builder
+## Phase 3: End facts verifier
 
-- [ ] T009 RED: add `endCageTx` focused tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs`.
-- [ ] T010 GREEN: add request-address helpers to `Cardano.MPFS.Client.Cage.Config`.
-- [ ] T011 GREEN: implement `Cardano.MPFS.Client.Cage.End.endCageTx`.
-- [ ] T012 Wire the end cage module/test into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
+- [ ] T008 RED: add `EndFacts` JSON and `verifyEndFacts` tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs`.
+- [ ] T009 GREEN: add `EndFacts` wire type in `Cardano.MPFS.API.Types.Facts`.
+- [ ] T010 GREEN: implement `VerifiedEndFacts`, `verifyEndFacts`, and request-set completeness replay in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs`, `Cardano/MPFS/Client/Verify.hs`, and `Cardano/MPFS/Client/Verify/Completeness.hs`.
+- [ ] T011 Wire new modules/tests into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
 
-## Phase 4: Server hard swap
+## Phase 4: End cage builder
 
-- [ ] T013 RED: add `POST /facts/end` HTTP tests in `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs`.
-- [ ] T014 GREEN: add end state and request-set `IndexerTx` reads in `Cardano.MPFS.Indexer.Reads`.
-- [ ] T015 GREEN: add `factsEndHandler` and `mkEndFacts` in `Cardano.MPFS.HTTP.Server` / `Types`.
-- [ ] T016 Remove `TxEndAPI`, `txEndHandler`, and the legacy end transaction route from API/server wiring.
-- [ ] T017 Regenerate `docs/assets/swagger.json`.
+- [ ] T012 RED: add `endCageTx` focused tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs`.
+- [ ] T013 GREEN: add request-address helpers to a dedicated client cage identity module instead of growing `Cardano.MPFS.Client.Cage.Config`.
+- [ ] T014 GREEN: implement `Cardano.MPFS.Client.Cage.End.endCageTx`.
+- [ ] T015 Wire the end cage module/test into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
 
-## Phase 5: Gate and PR
+## Phase 5: Server hard swap
 
-- [ ] T018 Extend `gate.sh` with stable end hard-swap and verifier source checks.
-- [ ] T019 Run focused tests and `./gate.sh`.
-- [ ] T020 Open/update draft PR for issue #268 with MOOG boundary status and verification evidence.
+- [ ] T016 RED: add `POST /facts/end` HTTP tests in `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs`.
+- [ ] T017 GREEN: add end state and request-set `IndexerTx` reads in `Cardano.MPFS.Indexer.Reads`.
+- [ ] T018 GREEN: add `factsEndHandler` and `mkEndFacts` in `Cardano.MPFS.HTTP.Server` plus a focused facts conversion module; do not grow `Cardano.MPFS.HTTP.Types`.
+- [ ] T019 Remove `TxEndAPI`, `txEndHandler`, and the legacy end transaction route from API/server wiring.
+- [ ] T020 Regenerate `docs/assets/swagger.json`.
+
+## Phase 6: Gate and PR
+
+- [ ] T021 Extend `gate.sh` with stable end hard-swap and verifier source checks.
+- [ ] T022 Run focused tests and `./gate.sh`.
+- [ ] T023 Open/update draft PR for issue #268 with MOOG boundary status and verification evidence.

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -31,9 +31,9 @@
 
 ## Phase 5: Server hard swap
 
-- [ ] T016 RED: add `POST /facts/end` HTTP tests in `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs`.
-- [ ] T017 GREEN: add end state and request-set `IndexerTx` reads in `Cardano.MPFS.Indexer.Reads`.
-- [ ] T018 GREEN: add `factsEndHandler` and `mkEndFacts` in `Cardano.MPFS.HTTP.Server` plus a focused facts conversion module; do not grow `Cardano.MPFS.HTTP.Types`.
+- [X] T016 RED: add `POST /facts/end` HTTP tests in `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs`.
+- [X] T017 GREEN: add end state and request-set `IndexerTx` reads in `Cardano.MPFS.Indexer.Reads`.
+- [X] T018 GREEN: add `factsEndHandler` and `mkEndFacts` in `Cardano.MPFS.HTTP.Server` plus a focused facts conversion module; do not grow `Cardano.MPFS.HTTP.Types`.
 - [ ] T019 Remove `TxEndAPI`, `txEndHandler`, and the legacy end transaction route from API/server wiring.
 - [ ] T020 Regenerate `docs/assets/swagger.json`.
 

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: End fact-provider pivot
+
+**Input**: Design documents from `/specs/268-end-fact-provider-pivot/`
+
+## Phase 1: Specification and Baseline
+
+- [x] T001 Record corrected MOOG boundary language in issue #268 and sibling tickets.
+- [x] T002 Create `268-end-fact-provider-pivot` worktree from `origin/main`.
+- [x] T003 Run baseline `./gate.sh` before edits.
+- [x] T004 Add issue #268 spec, plan, contracts, quickstart, checklist, and tasks artifacts.
+
+## Phase 2: End facts verifier
+
+- [ ] T005 RED: add `EndFacts` JSON and `verifyEndFacts` tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs`.
+- [ ] T006 GREEN: add `EndFacts` wire type in `cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs`.
+- [ ] T007 GREEN: implement `VerifiedEndFacts`, `verifyEndFacts`, and request-set completeness replay in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs`, `Cardano/MPFS/Client/Verify.hs`, and `Cardano/MPFS/Client/Verify/Completeness.hs`.
+- [ ] T008 Wire new modules/tests into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
+
+## Phase 3: End cage builder
+
+- [ ] T009 RED: add `endCageTx` focused tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs`.
+- [ ] T010 GREEN: add request-address helpers to `Cardano.MPFS.Client.Cage.Config`.
+- [ ] T011 GREEN: implement `Cardano.MPFS.Client.Cage.End.endCageTx`.
+- [ ] T012 Wire the end cage module/test into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
+
+## Phase 4: Server hard swap
+
+- [ ] T013 RED: add `POST /facts/end` HTTP tests in `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs`.
+- [ ] T014 GREEN: add end state and request-set `IndexerTx` reads in `Cardano.MPFS.Indexer.Reads`.
+- [ ] T015 GREEN: add `factsEndHandler` and `mkEndFacts` in `Cardano.MPFS.HTTP.Server` / `Types`.
+- [ ] T016 Remove `TxEndAPI`, `txEndHandler`, and the legacy end transaction route from API/server wiring.
+- [ ] T017 Regenerate `docs/assets/swagger.json`.
+
+## Phase 5: Gate and PR
+
+- [ ] T018 Extend `gate.sh` with stable end hard-swap and verifier source checks.
+- [ ] T019 Run focused tests and `./gate.sh`.
+- [ ] T020 Open/update draft PR for issue #268 with MOOG boundary status and verification evidence.

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -34,11 +34,11 @@
 - [X] T016 RED: add `POST /facts/end` HTTP tests in `cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/EndFactsSpec.hs`.
 - [X] T017 GREEN: add end state and request-set `IndexerTx` reads in `Cardano.MPFS.Indexer.Reads`.
 - [X] T018 GREEN: add `factsEndHandler` and `mkEndFacts` in `Cardano.MPFS.HTTP.Server` plus a focused facts conversion module; do not grow `Cardano.MPFS.HTTP.Types`.
-- [ ] T019 Remove `TxEndAPI`, `txEndHandler`, and the legacy end transaction route from API/server wiring.
-- [ ] T020 Regenerate `docs/assets/swagger.json`.
+- [X] T019 Remove `TxEndAPI`, `txEndHandler`, and the legacy end transaction route from API/server wiring.
+- [X] T020 Regenerate `docs/assets/swagger.json`.
 
 ## Phase 6: Gate and PR
 
-- [ ] T021 Extend `gate.sh` with stable end hard-swap and verifier source checks.
-- [ ] T022 Run focused tests and `./gate.sh`.
+- [X] T021 Extend `gate.sh` with stable end hard-swap and verifier source checks.
+- [X] T022 Run focused tests and `./gate.sh`.
 - [X] T023 (MOOG PR #99, live transcript recorded) Open/update draft PR for issue #268 with MOOG boundary status and verification evidence.

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -19,13 +19,13 @@
 
 - [ ] T008 RED: add `EndFacts` JSON and `verifyEndFacts` tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs`.
 - [ ] T009 GREEN: add `EndFacts` wire type in `Cardano.MPFS.API.Types.Facts`.
-- [ ] T010 GREEN: implement `VerifiedEndFacts`, `verifyEndFacts`, and request-set completeness replay in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs`, `Cardano/MPFS/Client/Verify.hs`, and `Cardano/MPFS/Client/Verify/Completeness.hs`.
+- [ ] T010 GREEN: implement `VerifiedEndFacts`, `verifyEndFacts`, request-set completeness replay, and the narrowly-scoped request-address helper needed by the verifier in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs`, `Cardano/MPFS/Client/Verify.hs`, `Cardano/MPFS/Client/Verify/Completeness.hs`, and `Cardano/MPFS/Client/Cage/Identity.hs`.
 - [ ] T011 Wire new modules/tests into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
 
 ## Phase 4: End cage builder
 
 - [ ] T012 RED: add `endCageTx` focused tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs`.
-- [ ] T013 GREEN: add request-address helpers to a dedicated client cage identity module instead of growing `Cardano.MPFS.Client.Cage.Config`.
+- [ ] T013 GREEN: reuse the dedicated client cage identity helper when implementing `Cardano.MPFS.Client.Cage.End.endCageTx`; do not grow `Cardano.MPFS.Client.Cage.Config`.
 - [ ] T014 GREEN: implement `Cardano.MPFS.Client.Cage.End.endCageTx`.
 - [ ] T015 Wire the end cage module/test into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
 

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -41,4 +41,4 @@
 
 - [ ] T021 Extend `gate.sh` with stable end hard-swap and verifier source checks.
 - [ ] T022 Run focused tests and `./gate.sh`.
-- [ ] T023 Open/update draft PR for issue #268 with MOOG boundary status and verification evidence.
+- [X] T023 (MOOG PR #99, live transcript recorded) Open/update draft PR for issue #268 with MOOG boundary status and verification evidence.

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -17,10 +17,10 @@
 
 ## Phase 3: End facts verifier
 
-- [ ] T008 RED: add `EndFacts` JSON and `verifyEndFacts` tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs`.
-- [ ] T009 GREEN: add `EndFacts` wire type in `Cardano.MPFS.API.Types.Facts`.
-- [ ] T010 GREEN: implement `VerifiedEndFacts`, `verifyEndFacts`, request-set completeness replay, and the narrowly-scoped request-address helper needed by the verifier in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs`, `Cardano/MPFS/Client/Verify.hs`, `Cardano/MPFS/Client/Verify/Completeness.hs`, and `Cardano/MPFS/Client/Cage/Identity.hs`.
-- [ ] T011 Wire new modules/tests into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
+- [X] T008 (commit: 1d9414b) RED: add `EndFacts` JSON and `verifyEndFacts` tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/EndFactsSpec.hs`.
+- [X] T009 (commit: 1d9414b) GREEN: add `EndFacts` wire type in `Cardano.MPFS.API.Types.Facts`.
+- [X] T010 (commit: 1d9414b) GREEN: implement `VerifiedEndFacts`, `verifyEndFacts`, request-set completeness replay, and the narrowly-scoped request-address helper needed by the verifier in `cardano-mpfs-client/lib/Cardano/MPFS/Client/Facts.hs`, `Cardano/MPFS/Client/Verify.hs`, `Cardano/MPFS/Client/Verify/Completeness.hs`, and `Cardano/MPFS/Client/Cage/Identity.hs`.
+- [X] T011 (commit: 1d9414b) Wire new modules/tests into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
 
 ## Phase 4: End cage builder
 

--- a/specs/268-end-fact-provider-pivot/tasks.md
+++ b/specs/268-end-fact-provider-pivot/tasks.md
@@ -24,10 +24,10 @@
 
 ## Phase 4: End cage builder
 
-- [ ] T012 RED: add `endCageTx` focused tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs`.
-- [ ] T013 GREEN: reuse the dedicated client cage identity helper when implementing `Cardano.MPFS.Client.Cage.End.endCageTx`; do not grow `Cardano.MPFS.Client.Cage.Config`.
-- [ ] T014 GREEN: implement `Cardano.MPFS.Client.Cage.End.endCageTx`.
-- [ ] T015 Wire the end cage module/test into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
+- [X] T012 (commit: a3ac47c) RED: add `endCageTx` focused tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs`.
+- [X] T013 (commit: a3ac47c) GREEN: reuse the dedicated client cage identity helper when implementing `Cardano.MPFS.Client.Cage.End.endCageTx`; do not grow `Cardano.MPFS.Client.Cage.Config`.
+- [X] T014 (commit: a3ac47c) GREEN: implement `Cardano.MPFS.Client.Cage.End.endCageTx`.
+- [X] T015 (commit: a3ac47c) Wire the end cage module/test into `cardano-mpfs-client/cardano-mpfs-client.cabal`.
 
 ## Phase 5: Server hard swap
 


### PR DESCRIPTION
## Status

Ready-for-review PR for https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/268.

This PR implements the end slice of the fact-provider pivot:

- server exposes `POST /facts/end`
- client verifies `EndFacts` with `verifyEndFacts`
- client builds the end transaction locally with `endCageTx`
- legacy live `POST /tx/end` route/client wrapper is removed
- Swagger and the hard-swap gate reject live `/tx/end` reintroduction
- proof-bearing e2e coverage now follows the new `/facts/end -> verifyEndFacts -> endCageTx` flow

Remote checks on head `6e29dc0a1933b2259bf666b4bfac519c32f788fb` are green.

## Accepted Implementation Slices

- Planning/spec updates: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/d96b340, https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/c8dcc4c, https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/2b87765, https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/8b87786
- API facts/common DTO split: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/7c1091b3fb603a43ce943fefb0e3fe50ad1ed4de
- MTS dependency unblocker for empty completeness proofs: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/a47fc734432c25b5c001a9109a61ca7ba4c01aec
- End facts verifier: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/1d9414b1b8a0b55431204b8f21806d4fab749165
- End cage builder: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/a3ac47cfcdc756806994dfb676dc6bc3aa5519e8
- Server end facts endpoint: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/347e880d6daf7671bb4d910d52f093d95978f948
- Live-boundary indexer fix: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/4386f0e9feeeaa684e6a2061a729032892127981
- End redeemer budget cap: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/28ae8af569dea2466903bf5460dd969c52e4afdd
- Legacy `/tx/end` route/client wrapper removal: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/8f5e6cecaaef3b21b1f359806ae2278896da2e1e
- Proof-bearing e2e `/facts/end` repair: https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/6e29dc0a1933b2259bf666b4bfac519c32f788fb

## Remaining

- Review and merge sequencing for PR #273.

## MOOG Boundary Evidence

MOOG boundary issue: https://github.com/cardano-foundation/moog/issues/96
MOOG end boundary canary PR: https://github.com/cardano-foundation/moog/pull/99

The canary is pinned to paired offchain implementation commit `28ae8af569dea2466903bf5460dd969c52e4afdd` and proves this live path:

```text
wallet -> GET /status -> POST /facts/boot -> verifyBootFacts -> bootCageTx -> sign -> submit -> observe token -> GET /status -> POST /facts/end -> verifyEndFacts -> endCageTx -> sign -> submit -> observe token gone
```

Boundary transcript:

```json
{"bootTransactionObserved":true,"bootTransactionPolls":0,"bootTxHash":"61c46086f6057956da4ebce3e294fe311cc0086c6ef8c848f6feaf592e79763f","boundary":"mpfs-v2-end","endTransactionObserved":true,"endTransactionPolls":0,"endTxHash":"f11adb0dd94bdebc5eb8d1726f5f576fc6e7c0ea87bf004dca8f6faccfe53168","tokenBeforeEndPolls":0,"tokenGoneObserved":true,"tokenGonePolls":0,"tokenId":"a9e01a784e7f16061a53ddc85272a0e2ab5b32dfc29f85ae2108e56a47f7d49a","tokenObservedBeforeEnd":true}
```

This is boundary evidence only. It does not validate requester, oracle, agent, or Antithesis test-run semantics.

## Local Verification

- `nix run --quiet .#e2e-tests -- --match "/Proof-bearing envelopes E2E/read and write envelopes carry verifiable proofs/" --seed 45964064`: passed, 1 example, 0 failures.
- `./gate.sh`: passed; `just unit` and `just unit-offchain` each reported 365 examples, 0 failures; `format-check` passed; HLint reported `No hints`.

## Remote Verification

- `Build Gate`: passed — https://github.com/lambdasistemi/cardano-mpfs-offchain/actions/runs/26099164821/job/76745030427
- `build`: passed — https://github.com/lambdasistemi/cardano-mpfs-offchain/actions/runs/26099164821/job/76745332224
- `deploy`: passed — https://github.com/lambdasistemi/cardano-mpfs-offchain/actions/runs/26099164818/job/76745030421
- `e2e`: passed — https://github.com/lambdasistemi/cardano-mpfs-offchain/actions/runs/26099164821/job/76745332199

Refs https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/268
