### PR TITLE
feat(submit): add POST /submit endpoint

### DIFF
--- a/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API.hs
@@ -76,6 +76,7 @@ import Cardano.MPFS.API.Types
     , RetractRequest
     , StatusResponse
     , SubmitRequest
+    , SubmitResponse
     , SweepRequest
     , SweepTxResponse
     , TokenResponse
@@ -269,13 +270,12 @@ type TxSweepAPI =
 -- server package.
 type TxWriteAPI = TxSweepAPI
 
--- | @POST \/tx\/submit@ — submit a signed
+-- | @POST \/submit@ — submit a signed
 -- transaction.
 type TxSubmitAPI =
-    "tx"
-        :> "submit"
+    "submit"
         :> ReqBody '[JSON] SubmitRequest
-        :> Post '[JSON] Hex
+        :> Post '[JSON] SubmitResponse
 
 -- | Proxy for the complete API.
 api :: Proxy API

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -63,6 +63,8 @@ module Cardano.MPFS.API.Types
     , SweepRequest (..)
     , EndRequest (..)
     , SubmitRequest (..)
+    , SubmitResponse (..)
+    , SubmitError (..)
 
       -- * Proof-bearing tx responses
     , TrieFactJSON (..)
@@ -740,20 +742,58 @@ instance FromJSON EndRequest where
             <$> o .: "token"
             <*> o .: "address"
 
--- | @POST \/tx\/submit@ request body.
+-- | @POST \/submit@ request body.
 -- Accepts a hex-encoded signed transaction CBOR.
 newtype SubmitRequest = SubmitRequest
-    { srTxCbor :: Hex
+    { srSignedTxCbor :: Hex
     -- ^ Signed transaction CBOR (hex)
     }
 
 instance ToJSON SubmitRequest where
     toJSON SubmitRequest{..} =
-        object ["tx" .= srTxCbor]
+        object ["signedTxCbor" .= srSignedTxCbor]
 
 instance FromJSON SubmitRequest where
     parseJSON = withObject "SubmitRequest" $ \o ->
-        SubmitRequest <$> o .: "tx"
+        SubmitRequest <$> o .: "signedTxCbor"
+
+-- | @POST \/submit@ success body. Carries the
+-- accepted transaction id as hex.
+newtype SubmitResponse = SubmitResponse
+    { srTxId :: Hex
+    -- ^ Accepted transaction id (hex)
+    }
+
+instance ToJSON SubmitResponse where
+    toJSON SubmitResponse{..} =
+        object ["txId" .= srTxId]
+
+instance FromJSON SubmitResponse where
+    parseJSON = withObject "SubmitResponse" $ \o ->
+        SubmitResponse <$> o .: "txId"
+
+-- | @POST \/submit@ structured error body. Returned
+-- on a 400 (undecodable CBOR) or 502 (node-side
+-- rejection).
+data SubmitError = SubmitError
+    { seError :: Text
+    -- ^ Short error code
+    , seDetail :: Text
+    -- ^ Human-readable detail
+    }
+
+instance ToJSON SubmitError where
+    toJSON SubmitError{..} =
+        object
+            [ "error" .= seError
+            , "detail" .= seDetail
+            ]
+
+instance FromJSON SubmitError where
+    parseJSON = withObject "SubmitError" $ \o ->
+        SubmitError
+            <$> o .: "error"
+            <*> o .: "detail"
 
 -- ---------------------------------------------------------
 -- Proof-bearing tx envelope responses
@@ -1445,10 +1485,27 @@ instance ToSchema SubmitRequest where
             & Swagger.type_
                 ?~ Swagger.SwaggerObject
             & properties
-                .~ fromList [("tx", hexSchema)]
-            & required .~ ["tx"]
+                .~ fromList
+                    [("signedTxCbor", hexSchema)]
+            & required .~ ["signedTxCbor"]
             & description
                 ?~ "Submit a signed transaction"
+
+instance ToSchema SubmitResponse where
+    declareNamedSchema _ = do
+        hexSchema <-
+            declareSchemaRef (Proxy @Hex)
+        pure
+            $ Swagger.NamedSchema
+                (Just "SubmitResponse")
+            $ mempty
+            & Swagger.type_
+                ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList [("txId", hexSchema)]
+            & required .~ ["txId"]
+            & description
+                ?~ "Accepted transaction id"
 
 instance ToSchema TxInJSON where
     declareNamedSchema _ = do

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -387,4 +387,5 @@ test-suite e2e-tests
     Cardano.MPFS.E2E.IndexerSpec
     Cardano.MPFS.E2E.ProofsSpec
     Cardano.MPFS.E2E.ProviderSpec
+    Cardano.MPFS.E2E.SubmitEndpointSpec
     Cardano.MPFS.E2E.SubmitterSpec

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -313,6 +313,7 @@ test-suite unit-tests
     Cardano.MPFS.HTTP.RequestUpdateFactsSpec
     Cardano.MPFS.HTTP.RetractFactsSpec
     Cardano.MPFS.HTTP.StatusSpec
+    Cardano.MPFS.HTTP.SubmitSpec
     Cardano.MPFS.HTTP.TokenSpec
     Cardano.MPFS.HTTP.TokensSpec
     Cardano.MPFS.HTTP.TrieSpec

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
@@ -1,0 +1,316 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.E2E.SubmitEndpointSpec
+-- Description : HTTP-level E2E for POST /submit
+-- License     : Apache-2.0
+--
+-- Boots a devnet + full application, builds and
+-- signs a genesis ADA-transfer tx, POSTs its CBOR to
+-- @POST \/submit@ over HTTP, and awaits the returned
+-- txId against the node. This is the live-boundary
+-- proof that the locked wire contract works against a
+-- real N2C submitter and a real chain.
+module Cardano.MPFS.E2E.SubmitEndpointSpec
+    ( spec
+    ) where
+
+import Control.Concurrent (threadDelay)
+import Data.Aeson (decode, encode)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as BSL
+import Lens.Micro ((&), (.~))
+import Network.HTTP.Types
+    ( hContentType
+    , methodPost
+    , status200
+    , status400
+    )
+import Network.Wai
+    ( Application
+    , requestHeaders
+    , requestMethod
+    )
+import Network.Wai.Test
+    ( SRequest (..)
+    , SResponse (..)
+    , defaultRequest
+    , request
+    , runSession
+    , setPath
+    , srequest
+    )
+import System.Environment (lookupEnv)
+import System.FilePath ((</>))
+import System.IO.Temp
+    ( withSystemTempDirectory
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , runIO
+    , shouldBe
+    )
+
+import Cardano.Chain.Slotting (EpochSlots (..))
+import Control.Tracer (nullTracer)
+
+import Cardano.Ledger.Allegra.Scripts
+    ( ValidityInterval (..)
+    )
+import Cardano.Ledger.Api.Tx (mkBasicTx)
+import Cardano.Ledger.Api.Tx.Body
+    ( mkBasicTxBody
+    , vldtTxBodyL
+    )
+import Cardano.Ledger.BaseTypes
+    ( Network (..)
+    , SlotNo (..)
+    , StrictMaybe (SJust, SNothing)
+    )
+import Cardano.Ledger.Binary
+    ( natVersion
+    , serialize'
+    )
+
+import Cardano.MPFS.Application
+    ( AppConfig (..)
+    , withApplication
+    )
+import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Core.Blueprint
+    ( CageScripts
+    , loadCageScripts
+    )
+import Cardano.MPFS.Core.Types (Coin (..))
+import Cardano.MPFS.E2E.Helpers.Boot
+    ( withBootFactsTxBuilder
+    )
+import Cardano.MPFS.HTTP.Encoding (Hex (..))
+import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.HTTP.Types
+    ( SubmitRequest (..)
+    , SubmitResponse (..)
+    )
+import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.TxBuilder.Config
+    ( CageConfig (..)
+    )
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( computeScriptHash
+    )
+import Cardano.Node.Client.Balance
+    ( BalanceResult (..)
+    , balanceTx
+    )
+import Cardano.Node.Client.E2E.Devnet
+    ( withCardanoNode
+    )
+import Cardano.Node.Client.E2E.Setup
+    ( addKeyWitness
+    , genesisAddr
+    , genesisDir
+    , genesisSignKey
+    )
+
+-- | Skips when @MPFS_BLUEPRINT@ is not set.
+spec :: Spec
+spec = describe "POST /submit (e2e)" $ do
+    mPath <-
+        runIO $ lookupEnv "MPFS_BLUEPRINT"
+    case mPath of
+        Nothing ->
+            it "skipped (no MPFS_BLUEPRINT)"
+                $ pure @IO ()
+        Just path -> do
+            eScripts <- runIO $ loadCageScripts path
+            case eScripts of
+                Left err ->
+                    it ("blueprint: " <> err)
+                        $ expectationFailure err
+                Right scripts ->
+                    submitEndpointSpec scripts
+
+-- | Await timeout in seconds. Devnet slots are
+-- 100ms so 60s is plenty.
+awaitTimeout :: Int
+awaitTimeout = 60
+
+submitEndpointSpec :: CageScripts -> Spec
+submitEndpointSpec scripts =
+    it "signs, submits, and awaits a real tx"
+        $ withE2E scripts
+        $ \_cfg ctx -> do
+            let app = mkApp ctx
+            utxos <-
+                queryUTxOs (provider ctx) genesisAddr
+            pp <- queryProtocolParams (provider ctx)
+            case utxos of
+                [] ->
+                    expectationFailure
+                        "no genesis UTxOs"
+                (feeUtxo : _) -> do
+                    let vldt =
+                            ValidityInterval
+                                SNothing
+                                (SJust (SlotNo 100_000))
+                        body =
+                            mkBasicTxBody
+                                & vldtTxBodyL .~ vldt
+                        tx = mkBasicTx body
+                    case balanceTx
+                        pp
+                        [feeUtxo]
+                        genesisAddr
+                        tx of
+                        Left err ->
+                            expectationFailure
+                                $ "balanceTx failed: "
+                                    <> show err
+                        Right BalanceResult{balancedTx = balanced} -> do
+                            let signed =
+                                    addKeyWitness
+                                        genesisSignKey
+                                        balanced
+                                rawCbor =
+                                    serialize'
+                                        (natVersion @11)
+                                        signed
+                                reqBody =
+                                    encode
+                                        ( SubmitRequest
+                                            (Hex rawCbor)
+                                        )
+                            resp <- post app reqBody
+                            simpleStatus resp
+                                `shouldBe` status200
+                            case decode (simpleBody resp) of
+                                Nothing ->
+                                    expectationFailure
+                                        "expected a \
+                                        \SubmitResponse \
+                                        \JSON body"
+                                Just (SubmitResponse (Hex txIdBytes)) -> do
+                                    BS.length txIdBytes
+                                        `shouldBe` 32
+                                    awaitTx
+                                        awaitTimeout
+                                        app
+                                        (B16.encode txIdBytes)
+                            -- Bonus: undecodable CBOR is a
+                            -- 400 (reuses the same booted
+                            -- app; never reaches the node).
+                            garbage <-
+                                post
+                                    app
+                                    ( encode
+                                        ( SubmitRequest
+                                            (Hex "\NUL")
+                                        )
+                                    )
+                            simpleStatus garbage
+                                `shouldBe` status400
+
+-- | @POST \/submit@ with a JSON body.
+post :: Application -> BSL.ByteString -> IO SResponse
+post app body =
+    runSession (srequest (SRequest req body)) app
+  where
+    req =
+        (setPath defaultRequest "/submit")
+            { requestMethod = methodPost
+            , requestHeaders =
+                [(hContentType, "application/json")]
+            }
+
+-- | @GET \/tx\/:txId?timeout=N@ — block until the
+-- indexer has seen this transaction.
+awaitTx
+    :: Int -> Application -> ByteString -> IO ()
+awaitTx timeout app txIdHex = do
+    resp <-
+        runSession
+            (request (setPath defaultRequest path))
+            app
+    simpleStatus resp `shouldBe` status200
+  where
+    path =
+        "/tx/"
+            <> txIdHex
+            <> "?timeout="
+            <> bshow timeout
+    bshow =
+        BS.pack
+            . map (fromIntegral . fromEnum)
+            . show
+
+-- -------------------------------------------------
+-- Bracket
+-- -------------------------------------------------
+
+-- | Devnet node + full application + 10s warmup.
+withE2E
+    :: CageScripts
+    -> (CageConfig -> Context IO -> IO a)
+    -> IO a
+withE2E scripts action = do
+    gDir <- genesisDir
+    withCardanoNode gDir $ \sock _startMs ->
+        withSystemTempDirectory
+            "mpfs-submit-endpoint"
+            $ \tmpDir -> do
+                let cfg =
+                        cageCfg
+                            scripts
+                    appCfg =
+                        AppConfig
+                            { epochSlots =
+                                EpochSlots 4320
+                            , shelleyGenesisPath =
+                                gDir
+                                    </> "shelley-genesis.json"
+                            , socketPath = sock
+                            , dbPath =
+                                tmpDir </> "db"
+                            , channelCapacity = 16
+                            , cageConfig = cfg
+                            , byronGenesisPath =
+                                Nothing
+                            , followerEnabled =
+                                True
+                            , appTracer =
+                                nullTracer
+                            }
+                withApplication appCfg $ \ctx -> do
+                    let ctx' =
+                            withBootFactsTxBuilder cfg ctx
+                    _ <-
+                        queryProtocolParams
+                            (provider ctx')
+                    threadDelay 10_000_000
+                    action cfg ctx'
+
+-- -------------------------------------------------
+-- Config
+-- -------------------------------------------------
+
+cageCfg
+    :: CageScripts -> CageConfig
+cageCfg (stateBytes, requestBytes) =
+    CageConfig
+        { cageScriptBytes = stateBytes
+        , requestScriptBytes = requestBytes
+        , cfgScriptHash =
+            computeScriptHash stateBytes
+        , defaultProcessTime = 5_000
+        , defaultRetractTime = 5_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }

--- a/cardano-mpfs-offchain/e2e-test/main.hs
+++ b/cardano-mpfs-offchain/e2e-test/main.hs
@@ -12,12 +12,14 @@ import Cardano.MPFS.E2E.HTTPLifecycleSpec qualified as HTTPLifecycleSpec
 import Cardano.MPFS.E2E.IndexerSpec qualified as IndexerSpec
 import Cardano.MPFS.E2E.ProofsSpec qualified as ProofsSpec
 import Cardano.MPFS.E2E.ProviderSpec qualified as ProviderSpec
+import Cardano.MPFS.E2E.SubmitEndpointSpec qualified as SubmitEndpointSpec
 import Cardano.MPFS.E2E.SubmitterSpec qualified as SubmitterSpec
 
 main :: IO ()
 main = hspec $ do
     ProviderSpec.spec
     SubmitterSpec.spec
+    SubmitEndpointSpec.spec
     CageSpec.spec
     CageFlowSpec.spec
     IndexerSpec.spec

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -29,6 +29,7 @@ module Cardano.MPFS.HTTP.Server
 import Control.Applicative ((<|>))
 import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
+import Data.Aeson qualified as Aeson
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Lazy qualified as BSL
 import Data.Proxy (Proxy (..))
@@ -115,7 +116,9 @@ import Cardano.MPFS.HTTP.Types
     , RequestsResponse (..)
     , RetractRequest (..)
     , StatusResponse (..)
+    , SubmitError (..)
     , SubmitRequest (..)
+    , SubmitResponse (..)
     , SweepRequest (..)
     , SweepTxResponse (..)
     , TokenIdJSON
@@ -1583,29 +1586,45 @@ txSweepHandler
                     addr
         pure (mkSweepTxResponse tx)
 
+-- | Build a structured JSON error body for the
+-- @POST \/submit@ endpoint.
+submitError
+    :: ServerError -> Text -> Text -> ServerError
+submitError base errTxt detailTxt =
+    base
+        { errBody =
+            Aeson.encode
+                (SubmitError errTxt detailTxt)
+        , errHeaders =
+            [("Content-Type", "application/json")]
+        }
+
 txSubmitHandler
-    :: Context IO -> SubmitRequest -> Handler Hex
+    :: Context IO -> SubmitRequest -> Handler SubmitResponse
 txSubmitHandler ctx (SubmitRequest (Hex txCbor)) = do
     tx <- case decodeTx txCbor of
         Right t -> pure t
         Left msg ->
             throwError
-                err400
-                    { errBody =
-                        BL.pack (show msg)
-                    }
+                $ submitError
+                    err400
+                    "decode failed"
+                    (T.pack (show msg))
     result <-
         liftIO
             $ Sub.submitTx (submitter ctx) tx
     case result of
         Sub.Submitted txId ->
-            pure (Hex (txIdToBytes txId))
+            pure
+                ( SubmitResponse
+                    (Hex (txIdToBytes txId))
+                )
         Sub.Rejected reason ->
             throwError
-                err502
-                    { errBody =
-                        BL.fromStrict reason
-                    }
+                $ submitError
+                    err502
+                    "submission rejected"
+                    (TE.decodeUtf8 reason)
 
 -- ---------------------------------------------------------
 -- Helpers

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -58,6 +58,8 @@ module Cardano.MPFS.HTTP.Types
     , SweepRequest (..)
     , EndRequest (..)
     , SubmitRequest (..)
+    , SubmitResponse (..)
+    , SubmitError (..)
 
       -- * Proof-bearing tx responses
     , TrieFactJSON (..)
@@ -127,7 +129,9 @@ import Cardano.MPFS.API.Types
     , RetractRequest (..)
     , RetractTxResponse (..)
     , StatusResponse (..)
+    , SubmitError (..)
     , SubmitRequest (..)
+    , SubmitResponse (..)
     , SweepRequest (..)
     , SweepTxResponse (..)
     , TokenIdJSON (..)

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/SubmitSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/SubmitSpec.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.HTTP.SubmitSpec
+-- Description : Tests for the POST /submit endpoint contract
+-- License     : Apache-2.0
+module Cardano.MPFS.HTTP.SubmitSpec
+    ( spec
+    ) where
+
+import Data.Aeson (decode, encode, toJSON)
+import Data.Aeson.KeyMap qualified as KM
+import Data.Aeson.Types (Value (..))
+import Network.HTTP.Types
+    ( methodPost
+    , status400
+    )
+import Network.Wai
+    ( requestHeaders
+    , requestMethod
+    )
+import Network.Wai.Test
+    ( SResponse (..)
+    , defaultRequest
+    , runSession
+    , setPath
+    )
+import Network.Wai.Test qualified as WaiTest
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    )
+
+import Cardano.MPFS.HTTP.Encoding (Hex (..))
+import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
+import Cardano.MPFS.HTTP.Types (SubmitRequest (..))
+
+-- | POST a raw JSON body to /submit through the WAI app.
+postSubmit :: Value -> IO SResponse
+postSubmit body = do
+    ctx <- mkTestContext
+    runSession
+        ( WaiTest.srequest
+            ( WaiTest.SRequest
+                ( ( setPath
+                        defaultRequest
+                        "/submit"
+                  )
+                    { requestMethod = methodPost
+                    , requestHeaders =
+                        [("Content-Type", "application/json")]
+                    }
+                )
+                (encode body)
+            )
+        )
+        (mkApp ctx)
+
+spec :: Spec
+spec = describe "POST /submit" $ do
+    it "SubmitRequest JSON uses the signedTxCbor key" $ do
+        case toJSON (SubmitRequest (Hex "\NUL")) of
+            Object obj -> do
+                KM.member "signedTxCbor" obj
+                    `shouldBe` True
+                KM.member "tx" obj `shouldBe` False
+            _ ->
+                expectationFailure
+                    "Expected SubmitRequest to encode \
+                    \to a JSON object"
+
+    it "returns 400 JSON error on undecodable CBOR" $ do
+        resp <-
+            postSubmit
+                (Object (KM.fromList [("signedTxCbor", "00")]))
+        simpleStatus resp `shouldBe` status400
+        case decode (simpleBody resp) of
+            Just (Object obj) -> do
+                KM.member "error" obj `shouldBe` True
+                KM.member "detail" obj `shouldBe` True
+            _ ->
+                expectationFailure
+                    "Expected a JSON error body with \
+                    \error and detail keys"

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -23,6 +23,7 @@ import Cardano.MPFS.HTTP.RequestUpdateFactsSpec qualified as RequestUpdateFactsS
 import Cardano.MPFS.HTTP.RequestsSpec qualified as RequestsSpec
 import Cardano.MPFS.HTTP.RetractFactsSpec qualified as RetractFactsSpec
 import Cardano.MPFS.HTTP.StatusSpec qualified as StatusSpec
+import Cardano.MPFS.HTTP.SubmitSpec qualified as SubmitSpec
 import Cardano.MPFS.HTTP.TokenSpec qualified as TokenSpec
 import Cardano.MPFS.HTTP.TokensSpec qualified as TokensSpec
 import Cardano.MPFS.HTTP.TrieSpec qualified as HTTPTrieSpec
@@ -83,6 +84,7 @@ main =
                 EndFactsSpec.spec
                 RequestsSpec.spec
                 StatusSpec.spec
+                SubmitSpec.spec
                 TokenSpec.spec
                 TokensSpec.spec
                 HTTPTrieSpec.spec

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -697,12 +697,24 @@
         "SubmitRequest": {
             "description": "Submit a signed transaction",
             "properties": {
-                "tx": {
+                "signedTxCbor": {
                     "$ref": "#/definitions/Hex"
                 }
             },
             "required": [
-                "tx"
+                "signedTxCbor"
+            ],
+            "type": "object"
+        },
+        "SubmitResponse": {
+            "description": "Accepted transaction id",
+            "properties": {
+                "txId": {
+                    "$ref": "#/definitions/Hex"
+                }
+            },
+            "required": [
+                "txId"
             ],
             "type": "object"
         },
@@ -1393,6 +1405,37 @@
                 }
             }
         },
+        "/submit": {
+            "post": {
+                "consumes": [
+                    "application/json;charset=utf-8"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/SubmitRequest"
+                        }
+                    }
+                ],
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/SubmitResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid `body`"
+                    }
+                }
+            }
+        },
         "/tokens": {
             "get": {
                 "produces": [
@@ -1549,37 +1592,6 @@
                     },
                     "400": {
                         "description": "Invalid `id`"
-                    }
-                }
-            }
-        },
-        "/tx/submit": {
-            "post": {
-                "consumes": [
-                    "application/json;charset=utf-8"
-                ],
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/SubmitRequest"
-                        }
-                    }
-                ],
-                "produces": [
-                    "application/json;charset=utf-8"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "",
-                        "schema": {
-                            "$ref": "#/definitions/Hex"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid `body`"
                     }
                 }
             }

--- a/specs/288-submit-endpoint/plan.md
+++ b/specs/288-submit-endpoint/plan.md
@@ -1,0 +1,68 @@
+# Plan — #288 POST /submit endpoint
+
+## Tech stack
+
+Haskell GHC 9.10.1, Servant HTTP API, Aeson wire types,
+`cardano-ledger-conway` (`Tx ConwayEra`, `decodeFull'`), existing
+node-to-client `Submitter` (`mkN2CSubmitter`). Hspec for e2e (`withDevnet`
+harness). Nix/cabal via `just`.
+
+## Constitution check
+
+- Ledger-native types: uses `Tx ConwayEra`, `TxId`; no shadow types. ✓
+- Service boundary via record-of-functions: reuses `Submitter`. ✓
+- Fact-provider rule: `/submit` forwards a *client-built, client-signed*
+  tx — the server does not build or sign. Returns only the txId / error.
+  Consistent with "server MUST NOT return unsigned transactions". ✓
+- No new infra: reuses the wired N2C connection. ✓
+
+## Modules touched
+
+- `cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs` — reshape
+  `SubmitRequest` (field `signedTxCbor`); add `SubmitResponse {txId}` and
+  `SubmitError {error, detail}`; their `ToJSON`/`FromJSON`/`ToSchema`.
+- `cardano-mpfs-api/lib/Cardano/MPFS/API.hs` — `TxSubmitAPI` route
+  `"submit"` (drop `"tx"` prefix); response `Post '[JSON] SubmitResponse`;
+  export `SubmitResponse`, `SubmitError`.
+- `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs` — re-export the
+  new types.
+- `cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs` —
+  `txSubmitHandler` returns `SubmitResponse`; 400/502 carry
+  `SubmitError` JSON bodies (content-type application/json).
+- `docs/assets/swagger.json` — regenerated.
+- `cardano-mpfs-offchain/e2e-test/...` — new HTTP-level submit spec +
+  wire it into the e2e suite.
+
+## Structured JSON errors
+
+Current handlers throw `errXXX { errBody = plain text }`. For `/submit`,
+build the body as `encode (SubmitError code detail)` and set
+`errHeaders = [("Content-Type","application/json")]`. A small local
+helper `submitError :: ServerError -> Text -> Text -> ServerError`
+keeps 400 and 502 consistent.
+
+- 400: `error = "decode failed"`, `detail = show DecoderError`.
+- 502: `error = "submission rejected"`, `detail = decodeUtf8 reason`.
+
+## Slices (each one bisect-safe commit)
+
+### Slice S1 — reshape endpoint to the locked contract
+API route + wire types + handler + ToSchema + swagger regen, all in one
+commit so the build and unit suite stay green. Removes `/tx/submit`.
+Proof: `just unit-offchain` + `just ci` (incl. `swagger-up-to-date`).
+
+### Slice S2 — HTTP-level e2e submit test
+A spec that starts the app against `withDevnet`, balances+signs a genesis
+ADA-transfer tx (reusing `balanceTx` / `genesisSignKey` / `addKeyWitness`
+from `Cardano.Node.Client.E2E.Setup`, exactly as `SubmitterSpec` does),
+POSTs `{"signedTxCbor": …}` to `/submit`, asserts 200 + `txId`, then
+awaits the txId against the node (live-boundary proof). Tx construction
+does all fee/ttl work (hard rule #2) — no `/submit`-side mutation.
+
+## Risks
+
+- Structured-JSON-error pattern is new to this codebase — confirm the
+  content-type header makes clients parse it as JSON.
+- E2E must reuse the existing devnet harness; do not add new scaffolding
+  that fakes user actions (hard rule #2).
+```

--- a/specs/288-submit-endpoint/spec.md
+++ b/specs/288-submit-endpoint/spec.md
@@ -1,0 +1,76 @@
+# Spec — #288 POST /submit endpoint
+
+## Context
+
+Child 1 of epic #287 (client front-ends for `cardano-mpfs-client`). The
+CLI (#290) and the PureScript SPA (#291) both need a single canonical
+endpoint to push a locally-built, locally-signed Conway transaction to
+the chain. This endpoint is a **pure forwarder**: it decodes the signed
+tx CBOR and hands it to the node-to-client `LocalTxSubmission` half of
+the connection the indexer already holds.
+
+## P1 user story
+
+As a `cardano-mpfs-client` front-end, after I build and sign a Conway tx
+locally, I POST its CBOR to `/submit` and receive the resulting txId on
+acceptance, or a structured error I can show the user on rejection.
+
+## Existing state (discovered)
+
+- The N2C submit seam already exists and is wired: `Submitter`
+  record-of-functions (`Cardano.MPFS.Submitter`), real implementation
+  `mkN2CSubmitter` (`Cardano.MPFS.Submitter.N2C`), installed into
+  `Context.submitter` at `Application.hs:653`. **No new submission
+  infrastructure is needed** (hard rule #1 satisfied).
+- A legacy endpoint `POST /tx/submit` (`txSubmitHandler`, `Server.hs`)
+  already forwards to `Submitter`, but with a non-conforming contract:
+  request `{"tx": hex}`, response a bare hex string, plain-text errors.
+  It has **zero consumers** (not part of the `TxWriteAPI` client subset,
+  no e2e test, no docs reference).
+
+## Decision
+
+Replace `POST /tx/submit` with `POST /submit` reshaped to the locked
+contract below. This mirrors `b54334e` (add `/facts/reject`, remove
+`/tx/reject` in one commit). The handler's submit logic is preserved;
+only the route, request field, success shape, and error shape change.
+
+## Wire contract (locked, per issue body)
+
+```
+POST /submit
+{ "signedTxCbor": "<hex>" }
+→ 200 { "txId": "<hex>" }
+→ 400 { "error": "...", "detail": "..." }   # malformed/undecodable CBOR
+→ 502 { "error": "...", "detail": "..." }   # node-side rejection (ledger reason in detail)
+```
+
+Field names are taken verbatim from the issue body (camelCase
+`signedTxCbor`, `txId`), overriding the repo's usual snake_case wire
+convention because the contract is locked.
+
+## Functional requirements
+
+- **FR1** — `POST /submit` accepts `{"signedTxCbor": "<hex>"}` and
+  returns `200 {"txId": "<hex>"}` when the node accepts the tx.
+- **FR2** — Malformed hex or CBOR that fails to decode to a
+  `Tx ConwayEra` returns `400 {"error","detail"}` with the decoder
+  error in `detail`.
+- **FR3** — A node-side rejection returns `502 {"error","detail"}` with
+  the ledger rejection reason passed through in `detail`.
+- **FR4** — The handler delegates to the already-wired `Context.submitter`
+  (`mkN2CSubmitter`); no parallel N2C connection is opened.
+- **FR5** — `docs/assets/swagger.json` reflects the new route and shapes
+  (`just update-swagger`; `swagger-up-to-date` check stays green).
+- **FR6** — `/tx/submit` is removed; the API type list and re-exports no
+  longer reference the legacy route shape.
+
+## Success criteria
+
+- `just unit-offchain` green; `just ci` green (build, format, hlint,
+  swagger-up-to-date).
+- E2E: a genesis-signed ADA-transfer tx POSTed to `/submit` returns 200
+  with a txId, and that txId is awaited successfully against the node
+  (proves the tx really reached the mempool — live-boundary smoke).
+- No auth / replay-protection / queueing introduced (hard rule #3).
+```

--- a/specs/288-submit-endpoint/tasks.md
+++ b/specs/288-submit-endpoint/tasks.md
@@ -18,11 +18,11 @@ One commit per slice. Each commit body carries `Tasks: T###-S<n>`.
 
 ## Slice S2 — HTTP-level e2e submit test
 
-- [ ] T288-S2 Add an e2e spec that starts the app under `withDevnet`,
+- [X] T288-S2 Add an e2e spec that starts the app under `withDevnet`,
       balances+signs a genesis ADA-transfer tx (reuse `balanceTx`,
       `genesisSignKey`, `addKeyWitness`, `genesisAddr`), POSTs
       `{"signedTxCbor": …}` to `/submit`, asserts `200` + `txId`.
-- [ ] T288-S2 Await the returned `txId` against the node and assert
+- [X] T288-S2 Await the returned `txId` against the node and assert
       success (live-boundary proof the tx reached the mempool).
-- [ ] T288-S2 Wire the spec into the e2e suite (`main.hs`).
-- [ ] T288-S2 Proof: `just e2e` green for the new row.
+- [X] T288-S2 Wire the spec into the e2e suite (`main.hs`).
+- [X] T288-S2 Proof: `just e2e` green for the new row.

--- a/specs/288-submit-endpoint/tasks.md
+++ b/specs/288-submit-endpoint/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — #288 POST /submit endpoint
+
+One commit per slice. Each commit body carries `Tasks: T###-S<n>`.
+
+## Slice S1 — reshape endpoint to the locked contract
+
+- [ ] T288-S1 Reshape `SubmitRequest` to `{signedTxCbor}`; add
+      `SubmitResponse {txId}` and `SubmitError {error, detail}` with
+      `ToJSON`/`FromJSON`/`ToSchema` in `API/Types.hs`.
+- [ ] T288-S1 Change `TxSubmitAPI` to `"submit" :> ReqBody SubmitRequest
+      :> Post '[JSON] SubmitResponse`; export new types in `API.hs`;
+      re-export from offchain `HTTP/Types.hs`.
+- [ ] T288-S1 Reshape `txSubmitHandler`: return `SubmitResponse`; 400 and
+      502 carry `SubmitError` JSON bodies (application/json). Remove the
+      legacy `/tx/submit` shape.
+- [ ] T288-S1 `just update-swagger`; confirm `swagger-up-to-date` green.
+- [ ] T288-S1 Proof: `just unit-offchain` + `just ci` green.
+
+## Slice S2 — HTTP-level e2e submit test
+
+- [ ] T288-S2 Add an e2e spec that starts the app under `withDevnet`,
+      balances+signs a genesis ADA-transfer tx (reuse `balanceTx`,
+      `genesisSignKey`, `addKeyWitness`, `genesisAddr`), POSTs
+      `{"signedTxCbor": …}` to `/submit`, asserts `200` + `txId`.
+- [ ] T288-S2 Await the returned `txId` against the node and assert
+      success (live-boundary proof the tx reached the mempool).
+- [ ] T288-S2 Wire the spec into the e2e suite (`main.hs`).
+- [ ] T288-S2 Proof: `just e2e` green for the new row.

--- a/specs/288-submit-endpoint/tasks.md
+++ b/specs/288-submit-endpoint/tasks.md
@@ -4,17 +4,17 @@ One commit per slice. Each commit body carries `Tasks: T###-S<n>`.
 
 ## Slice S1 — reshape endpoint to the locked contract
 
-- [ ] T288-S1 Reshape `SubmitRequest` to `{signedTxCbor}`; add
+- [X] T288-S1 Reshape `SubmitRequest` to `{signedTxCbor}`; add
       `SubmitResponse {txId}` and `SubmitError {error, detail}` with
       `ToJSON`/`FromJSON`/`ToSchema` in `API/Types.hs`.
-- [ ] T288-S1 Change `TxSubmitAPI` to `"submit" :> ReqBody SubmitRequest
+- [X] T288-S1 Change `TxSubmitAPI` to `"submit" :> ReqBody SubmitRequest
       :> Post '[JSON] SubmitResponse`; export new types in `API.hs`;
       re-export from offchain `HTTP/Types.hs`.
-- [ ] T288-S1 Reshape `txSubmitHandler`: return `SubmitResponse`; 400 and
+- [X] T288-S1 Reshape `txSubmitHandler`: return `SubmitResponse`; 400 and
       502 carry `SubmitError` JSON bodies (application/json). Remove the
       legacy `/tx/submit` shape.
-- [ ] T288-S1 `just update-swagger`; confirm `swagger-up-to-date` green.
-- [ ] T288-S1 Proof: `just unit-offchain` + `just ci` green.
+- [X] T288-S1 `just update-swagger`; confirm `swagger-up-to-date` green.
+- [X] T288-S1 Proof: `just unit-offchain` + `just ci` green.
 
 ## Slice S2 — HTTP-level e2e submit test
 


### PR DESCRIPTION
## What

Adds `POST /submit` to `cardano-mpfs-offchain`: a pure forwarder that
takes a client-built, client-signed Conway tx (hex CBOR), submits it over
the **already-wired** node-to-client connection, and returns the txId or a
structured submission error. Unblocks the CLI (#290) and PureScript SPA
(#291) front-ends of epic #287.

## Wire contract (locked, per issue body)

```
POST /submit
{ "signedTxCbor": "<hex>" }
→ 200 { "txId": "<hex>" }
→ 400 { "error": "...", "detail": "..." }   # undecodable CBOR
→ 502 { "error": "...", "detail": "..." }   # node-side rejection (ledger reason in detail)
```

## How

The N2C submit seam already existed: the `Submitter` record-of-functions
(`mkN2CSubmitter`) is installed into `Context.submitter` from the same N2C
connection the indexer uses. A legacy `POST /tx/submit` already forwarded
to it, but with a non-conforming contract (`{tx}` → bare hex string,
plain-text errors) and **zero consumers**.

This PR reshapes that endpoint to the locked contract and removes the
legacy `/tx/submit` shape — mirroring `b54334e` (add `/facts/reject`,
remove `/tx/reject`). No new submission infrastructure.

- `SubmitRequest` now uses the `signedTxCbor` key; new `SubmitResponse {txId}`
  and `SubmitError {error, detail}` wire types (`cardano-mpfs-api`).
- `TxSubmitAPI` route is `POST /submit` returning `SubmitResponse`.
- `txSubmitHandler` returns `SubmitResponse`; 400/502 carry JSON
  `SubmitError` bodies (Content-Type: application/json).
- `docs/assets/swagger.json` regenerated.
- Unit test (`SubmitSpec`): asserts the `signedTxCbor` key + the 400 JSON
  error shape through the WAI app.
- E2E (`SubmitEndpointSpec`): genesis-signs a real ADA-transfer tx, POSTs
  it to `/submit` against a devnet node, asserts 200 + `txId`, and awaits
  the tx on-chain (live-boundary proof).

## Hard rules honored

- No new submission infra — reuses the wired N2C connection.
- No `/submit`-side tx mutation — all fee/ttl work at construction time.
- No auth / replay-protection / queueing — pure forwarder.

Closes #288.
