### PR TITLE
feat(289): cardano-mpfs-workflows package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,7 @@ packages:
   cardano-mpfs-offchain/
   cardano-mpfs-client/
   cardano-mpfs-verify/
+  cardano-mpfs-workflows/
 
 repository cardano-haskell-packages
   url: https://chap.intersectmbo.org/

--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -92,6 +92,7 @@ library
     Cardano.MPFS.Client.Cage.Reject
     Cardano.MPFS.Client.Cage.Request
     Cardano.MPFS.Client.Cage.Retract
+    Cardano.MPFS.Client.Cage.Serialize
     Cardano.MPFS.Client.Cage.Update
     Cardano.MPFS.Client.Http
     Cardano.MPFS.Client.Read
@@ -164,6 +165,7 @@ test-suite unit-tests
     Cardano.MPFS.Client.Cage.RejectSpec
     Cardano.MPFS.Client.Cage.RequestSpec
     Cardano.MPFS.Client.Cage.RetractSpec
+    Cardano.MPFS.Client.Cage.SerializeSpec
     Cardano.MPFS.Client.Cage.UpdateSpec
     Cardano.MPFS.Client.EndFactsSpec
     Cardano.MPFS.Client.Fixtures

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Serialize.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Serialize.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.Client.Cage.Serialize
+-- Description : Submission-ready CBOR for cage transactions.
+--
+-- The cage builders in "Cardano.MPFS.Client.Cage.*" return a
+-- @'Tx' 'ConwayEra'@. This module provides the single ledger-aware
+-- step that turns that transaction into submission-ready CBOR, so
+-- downstream packages can emit wire bytes without importing any
+-- @Cardano.Ledger.*@ module themselves.
+module Cardano.MPFS.Client.Cage.Serialize
+    ( serializeCageTx
+    ) where
+
+import Data.ByteString (ByteString)
+
+import Cardano.Ledger.Api.Tx (Tx)
+import Cardano.Ledger.Binary (natVersion, serialize')
+import Cardano.MPFS.Cage.Ledger (ConwayEra)
+
+-- | Serialize a Conway cage transaction to submission-ready CBOR,
+-- using protocol version 11 (the version the on-chain validators
+-- and the rest of the client encode against).
+serializeCageTx :: Tx ConwayEra -> ByteString
+serializeCageTx = serialize' (natVersion @11)

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/SerializeSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/SerializeSpec.hs
@@ -31,8 +31,9 @@ basicTx = mkBasicTx mkBasicTxBody
 
 spec :: Spec
 spec = describe "serializeCageTx" $ do
-    it "matches the ledger CBOR encoding at protocol version 11" $
-        serializeCageTx basicTx
-            `shouldBe` serialize' (natVersion @11) basicTx
-    it "produces non-empty CBOR" $
-        serializeCageTx basicTx `shouldSatisfy` ((> 0) . BS.length)
+    it "matches the ledger CBOR encoding at protocol version 11"
+        $ serializeCageTx basicTx
+        `shouldBe` serialize' (natVersion @11) basicTx
+    it "produces non-empty CBOR"
+        $ serializeCageTx basicTx
+        `shouldSatisfy` ((> 0) . BS.length)

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/SerializeSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/SerializeSpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.Client.Cage.SerializeSpec
+-- Description : Unit tests for submission-ready cage tx serialization.
+module Cardano.MPFS.Client.Cage.SerializeSpec
+    ( spec
+    ) where
+
+import Data.ByteString qualified as BS
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import Cardano.Ledger.Api.Tx (Tx, mkBasicTx)
+import Cardano.Ledger.Api.Tx.Body (mkBasicTxBody)
+import Cardano.Ledger.Binary (natVersion, serialize')
+import Cardano.MPFS.Cage.Ledger (ConwayEra)
+import Cardano.MPFS.Client.Cage.Serialize (serializeCageTx)
+
+-- | A minimal, deterministic Conway transaction. Needs no proof
+-- fixtures: an empty body wrapped in a basic tx is enough to
+-- exercise serialization.
+basicTx :: Tx ConwayEra
+basicTx = mkBasicTx mkBasicTxBody
+
+spec :: Spec
+spec = describe "serializeCageTx" $ do
+    it "matches the ledger CBOR encoding at protocol version 11" $
+        serializeCageTx basicTx
+            `shouldBe` serialize' (natVersion @11) basicTx
+    it "produces non-empty CBOR" $
+        serializeCageTx basicTx `shouldSatisfy` ((> 0) . BS.length)

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -8,6 +8,7 @@ import Cardano.MPFS.Client.Cage.EndSpec qualified as EndSpec
 import Cardano.MPFS.Client.Cage.RejectSpec qualified as CageRejectSpec
 import Cardano.MPFS.Client.Cage.RequestSpec qualified as RequestSpec
 import Cardano.MPFS.Client.Cage.RetractSpec qualified as CageRetractSpec
+import Cardano.MPFS.Client.Cage.SerializeSpec qualified as SerializeSpec
 import Cardano.MPFS.Client.Cage.UpdateSpec qualified as CageUpdateSpec
 import Cardano.MPFS.Client.EndFactsSpec qualified as EndFactsSpec
 import Cardano.MPFS.Client.HttpSpec qualified as HttpSpec
@@ -37,6 +38,7 @@ main = hspec $ do
     EndFactsSpec.spec
     UpdateFactsSpec.spec
     BootSpec.spec
+    SerializeSpec.spec
     RequestSpec.spec
     CageRetractSpec.spec
     CageRejectSpec.spec

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -357,6 +357,7 @@ test-suite e2e-tests
     , cardano-mpfs-api
     , cardano-mpfs-client
     , cardano-mpfs-offchain
+    , cardano-mpfs-workflows
     , cardano-node-clients
     , cardano-node-clients:devnet
     , cardano-utxo-csmt:library
@@ -389,3 +390,4 @@ test-suite e2e-tests
     Cardano.MPFS.E2E.ProviderSpec
     Cardano.MPFS.E2E.SubmitEndpointSpec
     Cardano.MPFS.E2E.SubmitterSpec
+    Cardano.MPFS.E2E.WorkflowsIntegrationSpec

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
@@ -1,0 +1,780 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.E2E.WorkflowsIntegrationSpec
+-- Description : Live-boundary integration for cardano-mpfs-workflows
+-- License     : Apache-2.0
+--
+-- One @it@ per workflow exported by @cardano-mpfs-workflows@. Each row
+-- proves the full live composition that #290 (CLI) and #291 (SPA) will
+-- rely on:
+--
+--   1. Drive @Cardano.MPFS.Workflows.<name>@ with a real 'HttpClient'
+--      backed by the in-process WAI application — the workflow POSTs
+--      its facts request to the running app, verifies the
+--      proof-bearing response against the live trusted root, and
+--      builds an unsigned transaction.
+--   2. Decode that 'UnsignedTx', sign it with the genesis key (the
+--      same e2e signing the @\/submit@ test uses), and POST the signed
+--      CBOR to @\/submit@ (merged in #288).
+--   3. Await the returned txId against the indexer.
+--   4. Assert the expected on-chain side-effect via the read
+--      endpoints (token indexed / request queued / fact materialised /
+--      request drained / token burned).
+--
+-- This is NOT a re-run of the unit suite against a server, and NOT a
+-- smoke for @\/submit@ itself (#288 owns that). It is the proof that
+-- the workflow layer and @\/submit@ compose end to end on a real
+-- chain. Each row boots its own fresh token so per-token state never
+-- bleeds across rows.
+module Cardano.MPFS.E2E.WorkflowsIntegrationSpec
+    ( spec
+    ) where
+
+import Control.Concurrent (threadDelay)
+import Data.Aeson (decode, eitherDecode, encode)
+import Data.Aeson qualified as Aeson
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as SBS
+import Data.Functor (($>))
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Lens.Micro ((^.))
+import Network.HTTP.Types
+    ( hContentType
+    , methodPost
+    , status200
+    )
+import Network.HTTP.Types.Status (statusCode)
+import Network.Wai (Application, Request (..))
+import Network.Wai.Test
+    ( SRequest (..)
+    , SResponse (..)
+    , defaultRequest
+    , request
+    , runSession
+    , setPath
+    , simpleBody
+    , simpleStatus
+    , srequest
+    )
+import System.Environment (lookupEnv)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+    ( Spec
+    , SpecWith
+    , aroundAll
+    , describe
+    , expectationFailure
+    , it
+    , runIO
+    , shouldBe
+    , shouldReturn
+    )
+
+import Cardano.Crypto.Hash.Class qualified as Crypto
+import Cardano.Ledger.Address (serialiseAddr)
+import Cardano.Ledger.Api.Tx (Tx, bodyTxL, txIdTx)
+import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
+import Cardano.Ledger.BaseTypes (Network (..), TxIx (..))
+import Cardano.Ledger.Binary
+    ( decodeFull'
+    , natVersion
+    , serialize'
+    )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.Mary.Value (AssetName (..), MultiAsset (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+
+import Cardano.Chain.Slotting (EpochSlots (..))
+import Control.Tracer (nullTracer)
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types (FactResponse (..), StatusResponse (..))
+import Cardano.MPFS.API.Types.Common
+    ( TokenIdJSON (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.Application (AppConfig (..), withApplication)
+import Cardano.MPFS.Client.Cage.Config qualified as Client
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.MPFS.Client.Facts
+    ( FactPresentFacts (..)
+    , verifyFactPresentFacts
+    )
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Core.Blueprint (CageScripts, loadCageScripts)
+import Cardano.MPFS.Core.Types
+    ( ConwayEra
+    , SlotNo (..)
+    , TokenId (..)
+    )
+import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.HTTP.Types
+    ( SubmitRequest (..)
+    , SubmitResponse (..)
+    )
+import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( cagePolicyIdFromCfg
+    , computeScriptHash
+    )
+import Cardano.Node.Client.E2E.Devnet (withCardanoNode)
+import Cardano.Node.Client.E2E.Setup
+    ( addKeyWitness
+    , genesisAddr
+    , genesisDir
+    , genesisSignKey
+    )
+
+import Cardano.MPFS.Workflows
+    ( BootRequest (..)
+    , DeleteRequest (..)
+    , EndRequest (..)
+    , HttpClient (..)
+    , HttpError (..)
+    , InsertRequest (..)
+    , RejectRequest (..)
+    , RetractRequest (..)
+    , UnsignedTx (..)
+    , UpdateRequest (..)
+    , UpdateValueRequest (..)
+    , WorkflowError
+    , WorkflowsConfig (..)
+    , applyRequests
+    , deleteFact
+    , endCage
+    , insertFact
+    , registerToken
+    , rejectExpired
+    , retractRequest
+    , updateFact
+    )
+
+-- | Shared, read-only environment for every workflow row: the cage
+-- config, the in-process application, and the 'HttpClient' the
+-- workflows post through. Each row boots its own token, so no mutable
+-- state is shared.
+data Env = Env
+    { envCfg :: CageConfig
+    , envApp :: Application
+    , envHttp :: HttpClient
+    }
+
+-- | Skips when @MPFS_BLUEPRINT@ is not set.
+spec :: Spec
+spec = describe "WorkflowsIntegration: workflows through /submit (e2e)" $ do
+    mPath <- runIO $ lookupEnv "MPFS_BLUEPRINT"
+    case mPath of
+        Nothing ->
+            it "skipped (MPFS_BLUEPRINT not set)" $ pure @IO ()
+        Just path -> do
+            eScripts <- runIO $ loadCageScripts path
+            case eScripts of
+                Left err ->
+                    it ("blueprint: " <> err)
+                        $ expectationFailure err
+                Right scripts ->
+                    aroundAll (withSharedEnv scripts) workflowRows
+
+-- | One row per exported workflow. Declaration order is execution
+-- order; each row is self-contained.
+workflowRows :: SpecWith Env
+workflowRows = do
+    it "registerToken boots a token" $ \env -> do
+        signed <- runBoot env
+        tokenVisible (envApp env) (extractTokenId (envCfg env) signed)
+            `shouldReturn` True
+
+    it "insertFact queues an insert request" $ \env -> do
+        tokenId <- bootToken env
+        _ <-
+            runWorkflow
+                env
+                "insertFact"
+                (insertFact (envHttp env))
+                (insertReq tokenId factKey factValue)
+        pendingRequestsNonEmpty (envApp env) tokenId
+
+    it "updateFact queues an update request" $ \env -> do
+        tokenId <- bootToken env
+        _ <-
+            runWorkflow
+                env
+                "updateFact"
+                (updateFact (envHttp env))
+                (updateReq tokenId factKey factValue updatedValue)
+        pendingRequestsNonEmpty (envApp env) tokenId
+
+    it "deleteFact queues a delete request" $ \env -> do
+        tokenId <- bootToken env
+        _ <-
+            runWorkflow
+                env
+                "deleteFact"
+                (deleteFact (envHttp env))
+                (deleteReq tokenId factKey factValue)
+        pendingRequestsNonEmpty (envApp env) tokenId
+
+    it "applyRequests materialises a fact in the trie" $ \env -> do
+        tokenId <- bootToken env
+        _ <-
+            runWorkflow
+                env
+                "insertFact (for apply)"
+                (insertFact (envHttp env))
+                (insertReq tokenId factKey factValue)
+        pendingRequestsNonEmpty (envApp env) tokenId
+        _ <-
+            runWorkflow
+                env
+                "applyRequests"
+                (applyRequests (envHttp env))
+                (updateValueReq tokenId)
+        pendingRequestsEmpty (envApp env) tokenId
+        factIndexed (envApp env) tokenId factKey
+
+    it "retractRequest drains a pending request" $ \env -> do
+        tokenId <- bootToken env
+        insertSigned <-
+            runWorkflow
+                env
+                "insertFact (for retract)"
+                (insertFact (envHttp env))
+                (insertReq tokenId retractKey retractValue)
+        pendingRequestsNonEmpty (envApp env) tokenId
+        let reqTxIn = TxIn (txIdTx insertSigned) (TxIx 0)
+        -- Phase 2 opens after process_time; the cage config below
+        -- uses 5s, so a 7s wall-clock wait lands inside the window.
+        threadDelay 7_000_000
+        _ <-
+            runWorkflow
+                env
+                "retractRequest"
+                (retractRequest (envHttp env))
+                (retractReq reqTxIn)
+        pendingRequestsEmpty (envApp env) tokenId
+
+    it "rejectExpired drains an expired request" $ \env -> do
+        tokenId <- bootToken env
+        _ <-
+            runWorkflow
+                env
+                "insertFact (for reject)"
+                (insertFact (envHttp env))
+                (insertReq tokenId rejectKey rejectValue)
+        pendingRequestsNonEmpty (envApp env) tokenId
+        -- Phase 3 opens after process_time + retract_time (5s + 5s);
+        -- an 11s wall-clock wait crosses the deadline.
+        threadDelay 11_000_000
+        _ <-
+            runWorkflow
+                env
+                "rejectExpired"
+                (rejectExpired (envHttp env))
+                (rejectReq tokenId)
+        pendingRequestsEmpty (envApp env) tokenId
+
+    it "endCage burns the token" $ \env -> do
+        tokenId <- bootToken env
+        _ <-
+            runWorkflow
+                env
+                "endCage"
+                (endCage (envHttp env))
+                (endReq tokenId)
+        tokenRemoved (envApp env) tokenId
+
+-- ---------------------------------------------------------
+-- Workflow driver
+-- ---------------------------------------------------------
+
+-- | Run a workflow end to end: fetch the live trusted root, invoke
+-- the workflow (which posts its facts request through the injected
+-- 'HttpClient'), decode + sign the returned 'UnsignedTx', POST it to
+-- @\/submit@, and await the txId. Returns the signed transaction so
+-- callers can read its outputs (token id, request TxIn).
+runWorkflow
+    :: Env
+    -> String
+    -> (WorkflowsConfig -> req -> IO (Either WorkflowError UnsignedTx))
+    -> req
+    -> IO (Tx ConwayEra)
+runWorkflow env label run req = do
+    trusted <- waitForTrustedRoot (envApp env)
+    result <- run (mkWorkflowsConfig (envCfg env) trusted) req
+    unsigned <-
+        case result of
+            Right u -> pure u
+            Left err ->
+                expectationFailure
+                    (label <> ": workflow failed: " <> show err)
+                    *> error "unreachable"
+    tx <-
+        case decodeFull' (natVersion @11) (unsignedTxCbor unsigned) of
+            Right t -> pure (t :: Tx ConwayEra)
+            Left err ->
+                expectationFailure
+                    (label <> ": UnsignedTx CBOR did not decode: " <> show err)
+                    *> error "unreachable"
+    let signed = addKeyWitness genesisSignKey tx
+    submitAndAwait env label signed
+    pure signed
+
+-- | The boot row keeps its signed tx so the token id can be read off
+-- the mint.
+runBoot :: Env -> IO (Tx ConwayEra)
+runBoot env =
+    runWorkflow
+        env
+        "registerToken"
+        (registerToken (envHttp env))
+        bootReq
+
+-- | Boot a fresh token and wait for it to be indexed; used by the
+-- rows that need an existing cage.
+bootToken :: Env -> IO TokenId
+bootToken env = do
+    signed <- runBoot env
+    let tokenId = extractTokenId (envCfg env) signed
+    visible <- tokenVisible (envApp env) tokenId
+    visible `shouldBe` True
+    pure tokenId
+
+-- | Sign-already-done: serialise, POST to @\/submit@, assert the wire
+-- contract, and await the txId against the indexer.
+submitAndAwait :: Env -> String -> Tx ConwayEra -> IO ()
+submitAndAwait env label signed = do
+    let rawCbor = serialize' (natVersion @11) signed
+    resp <-
+        postJson (envApp env) "/submit" (SubmitRequest (Hex rawCbor))
+    simpleStatus resp `shouldBe` status200
+    case decode (simpleBody resp) of
+        Just (SubmitResponse (Hex txIdBytes)) ->
+            BS.length txIdBytes `shouldBe` 32
+        Nothing ->
+            expectationFailure
+                (label <> ": /submit did not return a SubmitResponse")
+    awaitTx (envApp env) (txIdTx signed)
+
+mkWorkflowsConfig :: CageConfig -> TrustedRoot -> WorkflowsConfig
+mkWorkflowsConfig cfg trusted =
+    WorkflowsConfig
+        { wcCage = toClientCageConfig cfg
+        , wcPolicy = permissiveWalletPolicy
+        , wcTrustedRoot = trusted
+        }
+
+-- ---------------------------------------------------------
+-- Request payloads
+-- ---------------------------------------------------------
+
+factKey :: ByteString
+factKey = "wf-key"
+
+factValue :: ByteString
+factValue = "wf-value"
+
+updatedValue :: ByteString
+updatedValue = "wf-updated"
+
+retractKey :: ByteString
+retractKey = "wf-retract-key"
+
+retractValue :: ByteString
+retractValue = "wf-retract-value"
+
+rejectKey :: ByteString
+rejectKey = "wf-reject-key"
+
+rejectValue :: ByteString
+rejectValue = "wf-reject-value"
+
+genesisHex :: Hex
+genesisHex = Hex (serialiseAddr genesisAddr)
+
+bootReq :: BootRequest
+bootReq = BootRequest{brAddr = genesisHex}
+
+insertReq :: TokenId -> ByteString -> ByteString -> InsertRequest
+insertReq tokenId key value =
+    InsertRequest
+        { irToken = tokenIdJSON tokenId
+        , irKey = Hex key
+        , irValue = Hex value
+        , irAddr = genesisHex
+        }
+
+updateReq
+    :: TokenId
+    -> ByteString
+    -> ByteString
+    -> ByteString
+    -> UpdateValueRequest
+updateReq tokenId key oldValue newValue =
+    UpdateValueRequest
+        { uvrToken = tokenIdJSON tokenId
+        , uvrKey = Hex key
+        , uvrOldValue = Hex oldValue
+        , uvrNewValue = Hex newValue
+        , uvrAddr = genesisHex
+        }
+
+deleteReq :: TokenId -> ByteString -> ByteString -> DeleteRequest
+deleteReq tokenId key value =
+    DeleteRequest
+        { drToken = tokenIdJSON tokenId
+        , drKey = Hex key
+        , drValue = Hex value
+        , drAddr = genesisHex
+        }
+
+updateValueReq :: TokenId -> UpdateRequest
+updateValueReq tokenId =
+    UpdateRequest
+        { urToken = tokenIdJSON tokenId
+        , urAddr = genesisHex
+        }
+
+retractReq :: TxIn -> RetractRequest
+retractReq reqTxIn =
+    RetractRequest
+        { rrUtxo = txInToHashIx reqTxIn
+        , rrAddr = genesisHex
+        }
+
+rejectReq :: TokenId -> RejectRequest
+rejectReq tokenId =
+    RejectRequest
+        { rejToken = tokenIdJSON tokenId
+        , rejAddr = genesisHex
+        }
+
+endReq :: TokenId -> EndRequest
+endReq tokenId =
+    EndRequest
+        { erToken = tokenIdJSON tokenId
+        , erAddr = genesisHex
+        }
+
+-- ---------------------------------------------------------
+-- HTTP transport: a real 'HttpClient' over the in-process app
+-- ---------------------------------------------------------
+
+-- | Back the workflows' 'HttpClient' with the in-process WAI
+-- application. POSTs the JSON body to the relative path and returns
+-- the JSON response, mapping a non-200 to 'HttpStatus'.
+waiHttpClient :: Application -> HttpClient
+waiHttpClient app =
+    HttpClient $ \path body -> do
+        resp <-
+            runSession
+                ( srequest
+                    SRequest
+                        { simpleRequest =
+                            (setPath defaultRequest (TE.encodeUtf8 path))
+                                { requestMethod = methodPost
+                                , requestHeaders =
+                                    [(hContentType, "application/json")]
+                                }
+                        , simpleRequestBody = BSL.fromStrict body
+                        }
+                )
+                app
+        let code = statusCode (simpleStatus resp)
+            respBody = BSL.toStrict (simpleBody resp)
+        pure
+            $ if code == 200
+                then Right respBody
+                else Left (HttpStatus code respBody)
+
+-- ---------------------------------------------------------
+-- Read-endpoint assertions (in-process WAI GET/POST helpers)
+-- ---------------------------------------------------------
+
+awaitTimeout :: Int
+awaitTimeout = 60
+
+waitForTrustedRoot :: Application -> IO TrustedRoot
+waitForTrustedRoot app = do
+    mRoot <-
+        pollUntilJust 60 $ do
+            resp <- get app "/status"
+            simpleStatus resp `shouldBe` status200
+            case eitherDecode (simpleBody resp) of
+                Left err ->
+                    expectationFailure
+                        ("workflows e2e: decode /status: " <> err)
+                        $> Nothing
+                Right StatusResponse{currentUtxoRoot} ->
+                    pure currentUtxoRoot
+    case mRoot of
+        Nothing ->
+            expectationFailure
+                "workflows e2e: /status never exposed utxo_root"
+                *> error "unreachable"
+        Just root -> pure (TrustedRoot root)
+
+awaitTx :: Application -> TxId -> IO ()
+awaitTx app tid = do
+    resp <- get app path
+    simpleStatus resp `shouldBe` status200
+  where
+    path =
+        "/tx/"
+            <> txIdHex tid
+            <> "?timeout="
+            <> bshow awaitTimeout
+    bshow = BS.pack . map (fromIntegral . fromEnum) . show
+
+tokenVisible :: Application -> TokenId -> IO Bool
+tokenVisible app tokenId = do
+    resp <- get app ("/tokens/" <> tokenIdHex tokenId)
+    pure (simpleStatus resp == status200)
+
+tokenRemoved :: Application -> TokenId -> IO ()
+tokenRemoved app tokenId = do
+    mGone <-
+        pollUntilJust 60 $ do
+            resp <- get app ("/tokens/" <> tokenIdHex tokenId)
+            if simpleStatus resp == status200
+                then pure Nothing
+                else pure (Just ())
+    case mGone of
+        Just () -> pure ()
+        Nothing ->
+            expectationFailure
+                "endCage row: token still visible after end"
+
+pendingRequestsNonEmpty :: Application -> TokenId -> IO ()
+pendingRequestsNonEmpty app tokenId = do
+    mRes <-
+        pollUntilJust 60 $ do
+            resp <-
+                get app ("/tokens/" <> tokenIdHex tokenId <> "/requests")
+            if simpleStatus resp == status200
+                then pure (requestsCount (simpleBody resp))
+                else pure Nothing
+    case mRes of
+        Just n | n > 0 -> pure ()
+        _ ->
+            expectationFailure
+                "request row: pending requests stayed empty after submit"
+
+pendingRequestsEmpty :: Application -> TokenId -> IO ()
+pendingRequestsEmpty app tokenId = do
+    mDone <-
+        pollUntilJust 60 $ do
+            resp <-
+                get app ("/tokens/" <> tokenIdHex tokenId <> "/requests")
+            if simpleStatus resp == status200
+                then pure (requestsEmpty (simpleBody resp))
+                else pure Nothing
+    case mDone of
+        Just () -> pure ()
+        Nothing ->
+            expectationFailure
+                "drain row: pending requests did not drain after submit"
+
+factIndexed :: Application -> TokenId -> ByteString -> IO ()
+factIndexed app tokenId key = do
+    mOk <-
+        pollUntilJust 60 $ do
+            resp <-
+                get
+                    app
+                    ( "/tokens/"
+                        <> tokenIdHex tokenId
+                        <> "/facts/"
+                        <> B16.encode key
+                    )
+            if simpleStatus resp /= status200
+                then pure Nothing
+                else case eitherDecode (simpleBody resp) of
+                    Left _ -> pure Nothing
+                    Right factResp@FactResponse{frSnapshot} ->
+                        case verifyFactPresentFacts
+                            (TrustedRoot (vsUtxoRoot frSnapshot))
+                            FactPresentFacts
+                                { fpfKey = Hex key
+                                , fpfResponse = factResp
+                                } of
+                            Right _ -> pure (Just ())
+                            Left _ -> pure Nothing
+    case mOk of
+        Just () -> pure ()
+        Nothing ->
+            expectationFailure
+                "applyRequests row: fact never verified after apply"
+
+-- | Count the @requests@ array, returning 'Nothing' when empty so the
+-- poll keeps waiting.
+requestsCount :: BSL.ByteString -> Maybe Int
+requestsCount body =
+    case eitherDecode body of
+        Right (RequestsList rs) ->
+            if null rs then Nothing else Just (length rs)
+        Left _ -> Nothing
+
+requestsEmpty :: BSL.ByteString -> Maybe ()
+requestsEmpty body =
+    case eitherDecode body of
+        Right (RequestsList rs)
+            | null rs -> Just ()
+        _ -> Nothing
+
+-- | Minimal decoder for the @requests@ field of the requests
+-- response — avoids importing the full response type.
+newtype RequestsList = RequestsList [Aeson.Value]
+
+instance Aeson.FromJSON RequestsList where
+    parseJSON =
+        Aeson.withObject "requestsResponse" $ \o ->
+            RequestsList <$> o Aeson..: "requests"
+
+-- ---------------------------------------------------------
+-- WAI plumbing
+-- ---------------------------------------------------------
+
+get :: Application -> ByteString -> IO SResponse
+get app path =
+    runSession (request (setPath defaultRequest path)) app
+
+postJson
+    :: (Aeson.ToJSON body)
+    => Application
+    -> ByteString
+    -> body
+    -> IO SResponse
+postJson app path body =
+    runSession
+        ( srequest
+            SRequest
+                { simpleRequest =
+                    (setPath defaultRequest path)
+                        { requestMethod = methodPost
+                        , requestHeaders =
+                            [(hContentType, "application/json")]
+                        }
+                , simpleRequestBody = encode body
+                }
+        )
+        app
+
+pollUntilJust :: Int -> IO (Maybe a) -> IO (Maybe a)
+pollUntilJust timeoutSec action = go (timeoutSec * 2)
+  where
+    go 0 = action
+    go n = do
+        result <- action
+        case result of
+            Just _ -> pure result
+            Nothing -> threadDelay 500_000 >> go (n - 1)
+
+-- ---------------------------------------------------------
+-- Conversions / fixtures
+-- ---------------------------------------------------------
+
+extractTokenId :: CageConfig -> Tx ConwayEra -> TokenId
+extractTokenId cfg tx =
+    let MultiAsset ma = tx ^. bodyTxL . mintTxBodyL
+        pid = cagePolicyIdFromCfg cfg
+    in  case Map.toList (Map.findWithDefault Map.empty pid ma) of
+            [(an, _)] -> TokenId an
+            _ -> error "workflows e2e: unexpected boot mint"
+
+tokenIdJSON :: TokenId -> TokenIdJSON
+tokenIdJSON (TokenId (AssetName sbs)) =
+    TokenIdJSON (SBS.fromShort sbs)
+
+tokenIdHex :: TokenId -> ByteString
+tokenIdHex (TokenId (AssetName sbs)) =
+    B16.encode (SBS.fromShort sbs)
+
+txIdHex :: TxId -> ByteString
+txIdHex (TxId sh) =
+    B16.encode (Crypto.hashToBytes (extractHash sh))
+
+txInToHashIx :: TxIn -> Text
+txInToHashIx (TxIn txId (TxIx ix)) =
+    TE.decodeUtf8 (txIdHex txId) <> "#" <> T.pack (show ix)
+
+permissiveWalletPolicy :: WalletPolicy
+permissiveWalletPolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+toClientCageConfig :: CageConfig -> Client.CageConfig
+toClientCageConfig cfg =
+    Client.CageConfig
+        { Client.cageScriptBytes = cageScriptBytes cfg
+        , Client.requestScriptBytes = requestScriptBytes cfg
+        , Client.cfgScriptHash = cfgScriptHash cfg
+        , Client.defaultProcessTime = defaultProcessTime cfg
+        , Client.defaultRetractTime = defaultRetractTime cfg
+        , Client.defaultTip = defaultTip cfg
+        , Client.network = network cfg
+        }
+
+-- ---------------------------------------------------------
+-- Bracket
+-- ---------------------------------------------------------
+
+withSharedEnv :: CageScripts -> (Env -> IO ()) -> IO ()
+withSharedEnv scripts action = do
+    gDir <- genesisDir
+    withCardanoNode gDir $ \sock _startMs ->
+        withSystemTempDirectory "mpfs-workflows-e2e" $ \tmpDir -> do
+            let cfg = cageCfg scripts
+                appCfg =
+                    AppConfig
+                        { epochSlots = EpochSlots 4320
+                        , shelleyGenesisPath =
+                            gDir </> "shelley-genesis.json"
+                        , socketPath = sock
+                        , dbPath = tmpDir </> "db"
+                        , channelCapacity = 16
+                        , cageConfig = cfg
+                        , byronGenesisPath = Nothing
+                        , followerEnabled = True
+                        , appTracer = nullTracer
+                        }
+            withApplication appCfg $ \ctx -> do
+                _ <- queryProtocolParams (provider ctx)
+                threadDelay 10_000_000
+                let app = mkApp ctx
+                action
+                    Env
+                        { envCfg = cfg
+                        , envApp = app
+                        , envHttp = waiHttpClient app
+                        }
+
+cageCfg :: CageScripts -> CageConfig
+cageCfg (stateBytes, requestBytes) =
+    CageConfig
+        { cageScriptBytes = stateBytes
+        , requestScriptBytes = requestBytes
+        , cfgScriptHash = computeScriptHash stateBytes
+        , defaultProcessTime = 5_000
+        , defaultRetractTime = 5_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }

--- a/cardano-mpfs-offchain/e2e-test/main.hs
+++ b/cardano-mpfs-offchain/e2e-test/main.hs
@@ -14,6 +14,7 @@ import Cardano.MPFS.E2E.ProofsSpec qualified as ProofsSpec
 import Cardano.MPFS.E2E.ProviderSpec qualified as ProviderSpec
 import Cardano.MPFS.E2E.SubmitEndpointSpec qualified as SubmitEndpointSpec
 import Cardano.MPFS.E2E.SubmitterSpec qualified as SubmitterSpec
+import Cardano.MPFS.E2E.WorkflowsIntegrationSpec qualified as WorkflowsIntegrationSpec
 
 main :: IO ()
 main = hspec $ do
@@ -28,4 +29,5 @@ main = hspec $ do
     BootFactsSpec.spec
     ProofsSpec.spec
     FactsMatrixSpec.spec
+    WorkflowsIntegrationSpec.spec
     CrashRecoverySpec.spec

--- a/cardano-mpfs-workflows/LICENSE
+++ b/cardano-mpfs-workflows/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
+++ b/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
@@ -69,6 +69,7 @@ test-suite unit-tests
 
   other-modules:
     Cardano.MPFS.Workflows.ApplyRequestsSpec
+    Cardano.MPFS.Workflows.EndCageSpec
     Cardano.MPFS.Workflows.RegisterTokenSpec
     Cardano.MPFS.Workflows.RequestWorkflowsSpec
     Cardano.MPFS.Workflows.RetractRejectSpec

--- a/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
+++ b/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
@@ -1,0 +1,71 @@
+cabal-version: 3.4
+name:          cardano-mpfs-workflows
+version:       0.0.0
+synopsis:      Transport-agnostic facts-to-transaction workflows
+description:
+  Thin, transport-agnostic orchestration over the
+  @cardano-mpfs-client@ verifiers and cage builders. Each workflow
+  posts a request to a facts endpoint, decodes the proof-bearing
+  response, verifies it against a trusted root, and builds a
+  submission-ready unsigned transaction locally. The HTTP transport
+  is injected as a record of functions so the same workflows run in
+  a CLI or a browser SPA.
+
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Paolo Veronelli
+maintainer:    paolo.veronelli@gmail.com
+category:      Cardano
+build-type:    Simple
+
+common warnings
+  ghc-options:
+    -Wall -Werror -Wunused-imports -Wunused-packages
+    -Wmissing-export-lists -Wname-shadowing
+    -Wdeferred-out-of-scope-variables -Wpartial-type-signatures
+    -Wredundant-constraints
+
+  default-extensions:
+    DerivingStrategies
+    DuplicateRecordFields
+    OverloadedStrings
+    RecordWildCards
+    StrictData
+
+library
+  import:           warnings
+  default-language: GHC2021
+  hs-source-dirs:   lib
+  build-depends:
+    , aeson                >=2.1  && <2.3
+    , base                 >=4.18 && <5
+    , bytestring           >=0.11 && <0.13
+    , cardano-mpfs-api
+    , cardano-mpfs-client
+    , text                 >=2.0  && <2.2
+
+  exposed-modules:
+    Cardano.MPFS.Workflows
+    Cardano.MPFS.Workflows.Internal
+
+test-suite unit-tests
+  import:           warnings
+  type:             exitcode-stdio-1.0
+  default-language: GHC2021
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-core
+    , cardano-mpfs-api
+    , cardano-mpfs-client
+    , cardano-mpfs-workflows
+    , cardano-slotting
+    , hspec                   >=2.11 && <2.12
+    , text
+
+  other-modules:    Cardano.MPFS.Workflows.RegisterTokenSpec
+  ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
+++ b/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
@@ -67,5 +67,8 @@ test-suite unit-tests
     , hspec                   >=2.11 && <2.12
     , text
 
-  other-modules:    Cardano.MPFS.Workflows.RegisterTokenSpec
+  other-modules:
+    Cardano.MPFS.Workflows.RegisterTokenSpec
+    Cardano.MPFS.Workflows.RequestWorkflowsSpec
+
   ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
+++ b/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
@@ -68,6 +68,7 @@ test-suite unit-tests
     , text
 
   other-modules:
+    Cardano.MPFS.Workflows.ApplyRequestsSpec
     Cardano.MPFS.Workflows.RegisterTokenSpec
     Cardano.MPFS.Workflows.RequestWorkflowsSpec
 

--- a/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
+++ b/cardano-mpfs-workflows/cardano-mpfs-workflows.cabal
@@ -71,5 +71,6 @@ test-suite unit-tests
     Cardano.MPFS.Workflows.ApplyRequestsSpec
     Cardano.MPFS.Workflows.RegisterTokenSpec
     Cardano.MPFS.Workflows.RequestWorkflowsSpec
+    Cardano.MPFS.Workflows.RetractRejectSpec
 
   ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
+++ b/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
@@ -23,6 +23,8 @@ module Cardano.MPFS.Workflows
     , updateFact
     , deleteFact
     , applyRequests
+    , retractRequest
+    , rejectExpired
 
       -- * Re-exported request types
     , BootRequest (..)
@@ -30,28 +32,36 @@ module Cardano.MPFS.Workflows
     , UpdateValueRequest (..)
     , DeleteRequest (..)
     , UpdateRequest (..)
+    , RetractRequest (..)
+    , RejectRequest (..)
     ) where
 
 import Cardano.MPFS.API.Types
     ( BootRequest (..)
     , DeleteRequest (..)
     , InsertRequest (..)
+    , RejectRequest (..)
+    , RetractRequest (..)
     , UpdateRequest (..)
     , UpdateValueRequest (..)
     )
 import Cardano.MPFS.Client.Cage.Boot (bootCageTx)
+import Cardano.MPFS.Client.Cage.Reject (rejectCageTx)
 import Cardano.MPFS.Client.Cage.Request
     ( requestDeleteCageTx
     , requestInsertCageTx
     , requestUpdateCageTx
     )
+import Cardano.MPFS.Client.Cage.Retract (retractCageTx)
 import Cardano.MPFS.Client.Cage.Serialize (serializeCageTx)
 import Cardano.MPFS.Client.Cage.Update (updateCageTx)
 import Cardano.MPFS.Client.Verify
     ( verifyBootFacts
+    , verifyRejectFacts
     , verifyRequestDeleteFacts
     , verifyRequestInsertFacts
     , verifyRequestUpdateFacts
+    , verifyRetractFacts
     , verifyUpdateFacts
     )
 import Cardano.MPFS.Workflows.Internal
@@ -148,3 +158,37 @@ applyRequests http WorkflowsConfig{..} req =
         req
         (verifyUpdateFacts wcTrustedRoot)
         (fmap serializeCageTx . updateCageTx wcCage wcPolicy)
+
+-- | Retract a pending request (the @retract@ operation): POST the
+-- request UTxO reference to @\/facts\/retract@, verify the returned
+-- facts against the trusted root, and build the retract transaction
+-- locally for the original requester to sign.
+retractRequest
+    :: HttpClient
+    -> WorkflowsConfig
+    -> RetractRequest
+    -> IO (Either WorkflowError UnsignedTx)
+retractRequest http WorkflowsConfig{..} req =
+    runFactsWorkflow
+        http
+        "/facts/retract"
+        req
+        (verifyRetractFacts wcTrustedRoot)
+        (fmap serializeCageTx . retractCageTx wcCage wcPolicy)
+
+-- | Reject expired pending requests (the @reject@ operation): POST
+-- the token to @\/facts\/reject@, verify the returned facts against
+-- the trusted root, and build the reject transaction locally for the
+-- cage owner to sign.
+rejectExpired
+    :: HttpClient
+    -> WorkflowsConfig
+    -> RejectRequest
+    -> IO (Either WorkflowError UnsignedTx)
+rejectExpired http WorkflowsConfig{..} req =
+    runFactsWorkflow
+        http
+        "/facts/reject"
+        req
+        (verifyRejectFacts wcTrustedRoot)
+        (fmap serializeCageTx . rejectCageTx wcCage wcPolicy)

--- a/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
+++ b/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
@@ -1,0 +1,55 @@
+-- |
+-- Module      : Cardano.MPFS.Workflows
+-- Description : Public facts-to-transaction workflow surface.
+--
+-- Each workflow is a one-liner over
+-- 'Cardano.MPFS.Workflows.Internal.runFactsWorkflow': it pairs a
+-- facts endpoint with its verifier and cage builder, returning a
+-- submission-ready 'UnsignedTx'. The transport is injected as an
+-- 'HttpClient' so the same workflows run in a CLI or a browser SPA.
+-- This slice ships 'registerToken'; later slices add the remaining
+-- workflows and their request types to this surface.
+module Cardano.MPFS.Workflows
+    ( -- * Transport and configuration
+      HttpClient (..)
+    , HttpError (..)
+    , UnsignedTx (..)
+    , WorkflowsConfig (..)
+    , WorkflowError (..)
+
+      -- * Workflows
+    , registerToken
+
+      -- * Re-exported request types
+    , BootRequest (..)
+    ) where
+
+import Cardano.MPFS.API.Types (BootRequest (..))
+import Cardano.MPFS.Client.Cage.Boot (bootCageTx)
+import Cardano.MPFS.Client.Cage.Serialize (serializeCageTx)
+import Cardano.MPFS.Client.Verify (verifyBootFacts)
+import Cardano.MPFS.Workflows.Internal
+    ( HttpClient (..)
+    , HttpError (..)
+    , UnsignedTx (..)
+    , WorkflowError (..)
+    , WorkflowsConfig (..)
+    , runFactsWorkflow
+    )
+
+-- | Register a new cage token (the @boot@ operation): POST the
+-- requester address to @\/facts\/boot@, verify the returned boot
+-- facts against the trusted root, and build the boot transaction
+-- locally.
+registerToken
+    :: HttpClient
+    -> WorkflowsConfig
+    -> BootRequest
+    -> IO (Either WorkflowError UnsignedTx)
+registerToken http WorkflowsConfig{..} req =
+    runFactsWorkflow
+        http
+        "/facts/boot"
+        req
+        (verifyBootFacts wcTrustedRoot)
+        (fmap serializeCageTx . bootCageTx wcCage wcPolicy)

--- a/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
+++ b/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
@@ -19,15 +19,36 @@ module Cardano.MPFS.Workflows
 
       -- * Workflows
     , registerToken
+    , insertFact
+    , updateFact
+    , deleteFact
 
       -- * Re-exported request types
     , BootRequest (..)
+    , InsertRequest (..)
+    , UpdateValueRequest (..)
+    , DeleteRequest (..)
     ) where
 
-import Cardano.MPFS.API.Types (BootRequest (..))
+import Cardano.MPFS.API.Types
+    ( BootRequest (..)
+    , DeleteRequest (..)
+    , InsertRequest (..)
+    , UpdateValueRequest (..)
+    )
 import Cardano.MPFS.Client.Cage.Boot (bootCageTx)
+import Cardano.MPFS.Client.Cage.Request
+    ( requestDeleteCageTx
+    , requestInsertCageTx
+    , requestUpdateCageTx
+    )
 import Cardano.MPFS.Client.Cage.Serialize (serializeCageTx)
-import Cardano.MPFS.Client.Verify (verifyBootFacts)
+import Cardano.MPFS.Client.Verify
+    ( verifyBootFacts
+    , verifyRequestDeleteFacts
+    , verifyRequestInsertFacts
+    , verifyRequestUpdateFacts
+    )
 import Cardano.MPFS.Workflows.Internal
     ( HttpClient (..)
     , HttpError (..)
@@ -53,3 +74,54 @@ registerToken http WorkflowsConfig{..} req =
         req
         (verifyBootFacts wcTrustedRoot)
         (fmap serializeCageTx . bootCageTx wcCage wcPolicy)
+
+-- | Request a key insertion (the @request\/insert@ operation): POST
+-- the insert request to @\/facts\/request\/insert@, verify the
+-- returned facts against the trusted root, and build the request
+-- transaction locally for the requester to sign.
+insertFact
+    :: HttpClient
+    -> WorkflowsConfig
+    -> InsertRequest
+    -> IO (Either WorkflowError UnsignedTx)
+insertFact http WorkflowsConfig{..} req =
+    runFactsWorkflow
+        http
+        "/facts/request/insert"
+        req
+        (verifyRequestInsertFacts wcTrustedRoot)
+        (fmap serializeCageTx . requestInsertCageTx wcCage wcPolicy)
+
+-- | Request a key update (the @request\/update@ operation): POST the
+-- update request to @\/facts\/request\/update@, verify the returned
+-- facts against the trusted root, and build the request transaction
+-- locally for the requester to sign.
+updateFact
+    :: HttpClient
+    -> WorkflowsConfig
+    -> UpdateValueRequest
+    -> IO (Either WorkflowError UnsignedTx)
+updateFact http WorkflowsConfig{..} req =
+    runFactsWorkflow
+        http
+        "/facts/request/update"
+        req
+        (verifyRequestUpdateFacts wcTrustedRoot)
+        (fmap serializeCageTx . requestUpdateCageTx wcCage wcPolicy)
+
+-- | Request a key deletion (the @request\/delete@ operation): POST
+-- the delete request to @\/facts\/request\/delete@, verify the
+-- returned facts against the trusted root, and build the request
+-- transaction locally for the requester to sign.
+deleteFact
+    :: HttpClient
+    -> WorkflowsConfig
+    -> DeleteRequest
+    -> IO (Either WorkflowError UnsignedTx)
+deleteFact http WorkflowsConfig{..} req =
+    runFactsWorkflow
+        http
+        "/facts/request/delete"
+        req
+        (verifyRequestDeleteFacts wcTrustedRoot)
+        (fmap serializeCageTx . requestDeleteCageTx wcCage wcPolicy)

--- a/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
+++ b/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
@@ -25,6 +25,7 @@ module Cardano.MPFS.Workflows
     , applyRequests
     , retractRequest
     , rejectExpired
+    , endCage
 
       -- * Re-exported request types
     , BootRequest (..)
@@ -34,11 +35,13 @@ module Cardano.MPFS.Workflows
     , UpdateRequest (..)
     , RetractRequest (..)
     , RejectRequest (..)
+    , EndRequest (..)
     ) where
 
 import Cardano.MPFS.API.Types
     ( BootRequest (..)
     , DeleteRequest (..)
+    , EndRequest (..)
     , InsertRequest (..)
     , RejectRequest (..)
     , RetractRequest (..)
@@ -46,6 +49,7 @@ import Cardano.MPFS.API.Types
     , UpdateValueRequest (..)
     )
 import Cardano.MPFS.Client.Cage.Boot (bootCageTx)
+import Cardano.MPFS.Client.Cage.End (endCageTx)
 import Cardano.MPFS.Client.Cage.Reject (rejectCageTx)
 import Cardano.MPFS.Client.Cage.Request
     ( requestDeleteCageTx
@@ -57,6 +61,7 @@ import Cardano.MPFS.Client.Cage.Serialize (serializeCageTx)
 import Cardano.MPFS.Client.Cage.Update (updateCageTx)
 import Cardano.MPFS.Client.Verify
     ( verifyBootFacts
+    , verifyEndFacts
     , verifyRejectFacts
     , verifyRequestDeleteFacts
     , verifyRequestInsertFacts
@@ -192,3 +197,21 @@ rejectExpired http WorkflowsConfig{..} req =
         req
         (verifyRejectFacts wcTrustedRoot)
         (fmap serializeCageTx . rejectCageTx wcCage wcPolicy)
+
+-- | End a cage (the @end@ operation): POST the token to
+-- @\/facts\/end@, verify the returned facts against the trusted root
+-- and the cage configuration (the request-set completeness prefix is
+-- derived from the config), and build the end transaction locally for
+-- the cage owner to sign. This burns the cage token.
+endCage
+    :: HttpClient
+    -> WorkflowsConfig
+    -> EndRequest
+    -> IO (Either WorkflowError UnsignedTx)
+endCage http WorkflowsConfig{..} req =
+    runFactsWorkflow
+        http
+        "/facts/end"
+        req
+        (verifyEndFacts wcCage wcTrustedRoot)
+        (fmap serializeCageTx . endCageTx wcCage wcPolicy)

--- a/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
+++ b/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows.hs
@@ -22,18 +22,21 @@ module Cardano.MPFS.Workflows
     , insertFact
     , updateFact
     , deleteFact
+    , applyRequests
 
       -- * Re-exported request types
     , BootRequest (..)
     , InsertRequest (..)
     , UpdateValueRequest (..)
     , DeleteRequest (..)
+    , UpdateRequest (..)
     ) where
 
 import Cardano.MPFS.API.Types
     ( BootRequest (..)
     , DeleteRequest (..)
     , InsertRequest (..)
+    , UpdateRequest (..)
     , UpdateValueRequest (..)
     )
 import Cardano.MPFS.Client.Cage.Boot (bootCageTx)
@@ -43,11 +46,13 @@ import Cardano.MPFS.Client.Cage.Request
     , requestUpdateCageTx
     )
 import Cardano.MPFS.Client.Cage.Serialize (serializeCageTx)
+import Cardano.MPFS.Client.Cage.Update (updateCageTx)
 import Cardano.MPFS.Client.Verify
     ( verifyBootFacts
     , verifyRequestDeleteFacts
     , verifyRequestInsertFacts
     , verifyRequestUpdateFacts
+    , verifyUpdateFacts
     )
 import Cardano.MPFS.Workflows.Internal
     ( HttpClient (..)
@@ -125,3 +130,21 @@ deleteFact http WorkflowsConfig{..} req =
         req
         (verifyRequestDeleteFacts wcTrustedRoot)
         (fmap serializeCageTx . requestDeleteCageTx wcCage wcPolicy)
+
+-- | Apply pending requests (the oracle @update@ operation): POST the
+-- token to @\/facts\/update@, verify the returned update facts
+-- against the trusted root, and build the batch update transaction
+-- locally for the cage owner to sign. This advances the trie root by
+-- folding the pending requests' MPF proofs.
+applyRequests
+    :: HttpClient
+    -> WorkflowsConfig
+    -> UpdateRequest
+    -> IO (Either WorkflowError UnsignedTx)
+applyRequests http WorkflowsConfig{..} req =
+    runFactsWorkflow
+        http
+        "/facts/update"
+        req
+        (verifyUpdateFacts wcTrustedRoot)
+        (fmap serializeCageTx . updateCageTx wcCage wcPolicy)

--- a/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows/Internal.hs
+++ b/cardano-mpfs-workflows/lib/Cardano/MPFS/Workflows/Internal.hs
@@ -1,0 +1,104 @@
+-- |
+-- Module      : Cardano.MPFS.Workflows.Internal
+-- Description : Shared core for facts-to-transaction workflows.
+--
+-- The transport abstraction and the single helper every workflow
+-- shares. 'runFactsWorkflow' POSTs a request to a facts endpoint,
+-- decodes the proof-bearing response, hands it to a caller-supplied
+-- verifier, and then to a caller-supplied builder that returns
+-- submission-ready CBOR. The builder is pre-composed with
+-- serialization at the call site, so this signature never names a
+-- ledger transaction type and this module pulls in no
+-- @Cardano.Ledger.*@ dependency.
+module Cardano.MPFS.Workflows.Internal
+    ( HttpClient (..)
+    , HttpError (..)
+    , UnsignedTx (..)
+    , WorkflowsConfig (..)
+    , WorkflowError (..)
+    , runFactsWorkflow
+    ) where
+
+import Data.Aeson
+    ( FromJSON
+    , ToJSON
+    , eitherDecodeStrict'
+    , encode
+    )
+import Data.Bifunctor (first)
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BSL
+import Data.Text (Text)
+
+import Cardano.MPFS.Client.Cage.BuildError (BuildError)
+import Cardano.MPFS.Client.Cage.Config (CageConfig)
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy)
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot)
+import Cardano.MPFS.Client.Verify (VerifyError)
+
+-- | A transport-level failure from a facts request: a non-2xx HTTP
+-- status with the response body, or a transport error.
+data HttpError
+    = HttpStatus !Int !ByteString
+    | HttpTransport !Text
+    deriving stock (Eq, Show)
+
+-- | The HTTP transport, as a record of functions rather than a
+-- typeclass, so the CLI and the browser SPA can each supply their
+-- own implementation. The function takes a relative path and a
+-- strict JSON request body and returns either a transport error or
+-- the strict JSON response body.
+newtype HttpClient = HttpClient
+    { runHttpPost
+        :: Text -> ByteString -> IO (Either HttpError ByteString)
+    }
+
+-- | Submission-ready Conway transaction CBOR built locally from
+-- verified facts.
+newtype UnsignedTx = UnsignedTx
+    { unsignedTxCbor :: ByteString
+    }
+    deriving stock (Eq, Show)
+
+-- | Static configuration shared by every workflow: the client-owned
+-- cage configuration, the wallet policy caps enforced on the built
+-- transaction, and the trusted UTxO-CSMT root verified against.
+data WorkflowsConfig = WorkflowsConfig
+    { wcCage :: CageConfig
+    -- ^ Client-owned cage configuration.
+    , wcPolicy :: WalletPolicy
+    -- ^ Wallet-side policy caps.
+    , wcTrustedRoot :: TrustedRoot
+    -- ^ Trusted UTxO-CSMT root.
+    }
+
+-- | Every way a facts workflow can fail, tagged by the stage that
+-- produced it.
+data WorkflowError
+    = WorkflowHttpError !HttpError
+    | WorkflowDecodeError !String
+    | WorkflowVerifyError !VerifyError
+    | WorkflowBuildError !BuildError
+    deriving stock (Show)
+
+-- | Run one facts workflow end to end: POST the request, decode the
+-- response, verify it, and build submission-ready CBOR. Each stage's
+-- failure is tagged with the matching 'WorkflowError' constructor.
+runFactsWorkflow
+    :: (ToJSON req, FromJSON facts)
+    => HttpClient
+    -> Text
+    -> req
+    -> (facts -> Either VerifyError verified)
+    -> (verified -> Either BuildError ByteString)
+    -> IO (Either WorkflowError UnsignedTx)
+runFactsWorkflow http path req verify build = do
+    resp <- runHttpPost http path (BSL.toStrict (encode req))
+    pure $ case resp of
+        Left e -> Left (WorkflowHttpError e)
+        Right bs -> do
+            facts <-
+                first WorkflowDecodeError (eitherDecodeStrict' bs)
+            verified <- first WorkflowVerifyError (verify facts)
+            cbor <- first WorkflowBuildError (build verified)
+            Right (UnsignedTx cbor)

--- a/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/ApplyRequestsSpec.hs
+++ b/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/ApplyRequestsSpec.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Module      : Cardano.MPFS.Workflows.ApplyRequestsSpec
+-- Description : Unit tests for the applyRequests (oracle update) workflow.
+--
+-- Drives 'applyRequests' through a stub 'HttpClient'. Unlike the
+-- requester request workflows, the update verifier replays the cage
+-- state UTxO inclusion proof, which cannot be satisfied without a
+-- real CSMT proof. So the build / happy path is covered by the
+-- integration tests gated on #288; here we assert request routing
+-- and that the HTTP, decode, and verify failure stages map to the
+-- matching 'WorkflowError' constructor (the trusted-root mismatch is
+-- rejected before any proof replay).
+module Cardano.MPFS.Workflows.ApplyRequestsSpec
+    ( spec
+    ) where
+
+import Data.Aeson (eitherDecodeStrict', encode)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as SBS
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (fromJust)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import Cardano.Crypto.Hash (hashFromBytes)
+import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types (UpdateRequest (..))
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoRef (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts (UpdateFacts (..))
+import Cardano.MPFS.Client.Cage.Config (CageConfig (..))
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Workflows
+    ( HttpClient (..)
+    , HttpError (..)
+    , UnsignedTx
+    , WorkflowError (..)
+    , WorkflowsConfig (..)
+    , applyRequests
+    )
+
+spec :: Spec
+spec = describe "applyRequests" $ do
+    it "posts the update request to /facts/update" $ do
+        ref <- newIORef Nothing
+        _ <-
+            applyRequests
+                ( HttpClient $ \path body -> do
+                    writeIORef ref (Just (path, body))
+                    pure (Right "{}")
+                )
+                (config trustedRoot)
+                req
+        recorded <- readIORef ref
+        case recorded of
+            Nothing ->
+                expectationFailure "client was never invoked"
+            Just (path, body) -> do
+                path `shouldBe` "/facts/update"
+                (urAddr <$> decodeReq body) `shouldBe` Right addr
+
+    it "maps a transport failure to WorkflowHttpError" $ do
+        result <-
+            applyRequests
+                (constClient (Left (HttpStatus 502 "down")))
+                (config trustedRoot)
+                req
+        result `shouldSatisfy` isHttpError
+
+    it "maps a malformed response to WorkflowDecodeError" $ do
+        result <-
+            applyRequests
+                (constClient (Right "{not json"))
+                (config trustedRoot)
+                req
+        result `shouldSatisfy` isDecodeError
+
+    it "maps a trusted-root mismatch to WorkflowVerifyError" $ do
+        result <-
+            applyRequests
+                (constClient (Right (encodeFacts mismatchedFacts)))
+                (config trustedRoot)
+                req
+        result `shouldSatisfy` isVerifyError
+  where
+    decodeReq :: ByteString -> Either String UpdateRequest
+    decodeReq = eitherDecodeStrict'
+
+req :: UpdateRequest
+req = UpdateRequest{urToken = token, urAddr = addr}
+
+-- | Update facts whose snapshot root does not match the trusted
+-- root, so verification fails before any UTxO proof is replayed. The
+-- UTxO fields are placeholders that are never inspected.
+mismatchedFacts :: UpdateFacts
+mismatchedFacts =
+    UpdateFacts
+        { ufSnapshot = mismatchedSnapshot
+        , ufToken = token
+        , ufStateUtxo = dummyUtxo
+        , ufRequestUtxos = []
+        , ufWalletUtxos = []
+        , ufTrieRoot = Hex (BS.replicate 32 0)
+        , ufTrieFacts = []
+        , ufValidityUpperSlot = 0
+        , ufProtocolParameters = malformedPParams
+        }
+
+token :: TokenIdJSON
+token = TokenIdJSON (BS.replicate 28 0x11)
+
+addr :: Hex
+addr = Hex (BS.replicate 28 0x42)
+
+dummyUtxo :: UtxoEntry
+dummyUtxo =
+    UtxoEntry
+        { ueRef = UtxoRef{urTxId = Hex (BS.replicate 32 0), urTxIx = 0}
+        , ueTxOutCbor = Hex BS.empty
+        , ueInclusionProof = Hex BS.empty
+        }
+
+trustedRootBytes :: ByteString
+trustedRootBytes = BS.replicate 32 0x07
+
+trustedRoot :: TrustedRoot
+trustedRoot = TrustedRoot (Hex trustedRootBytes)
+
+mismatchedSnapshot :: VerificationSnapshot
+mismatchedSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex (BS.replicate 32 0x08)
+        , vsChainPoint = ChainPointJSON{cpSlot = 0, cpBlockId = Hex BS.empty}
+        }
+
+malformedPParams :: UnverifiedPParams
+malformedPParams =
+    UnverifiedPParams{uppVerified = False, uppCbor = Hex "\x82\x01\x02"}
+
+encodeFacts :: UpdateFacts -> ByteString
+encodeFacts = BSL.toStrict . encode
+
+constClient :: Either HttpError ByteString -> HttpClient
+constClient response = HttpClient $ \_ _ -> pure response
+
+config :: TrustedRoot -> WorkflowsConfig
+config root =
+    WorkflowsConfig
+        { wcCage = dummyCage
+        , wcPolicy = permissivePolicy
+        , wcTrustedRoot = root
+        }
+
+dummyCage :: CageConfig
+dummyCage =
+    CageConfig
+        { cageScriptBytes = SBS.empty
+        , requestScriptBytes = SBS.empty
+        , cfgScriptHash =
+            ScriptHash (fromJust (hashFromBytes (BS.replicate 28 0)))
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 600_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+permissivePolicy :: WalletPolicy
+permissivePolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+isHttpError :: Either WorkflowError UnsignedTx -> Bool
+isHttpError (Left (WorkflowHttpError _)) = True
+isHttpError _ = False
+
+isDecodeError :: Either WorkflowError UnsignedTx -> Bool
+isDecodeError (Left (WorkflowDecodeError _)) = True
+isDecodeError _ = False
+
+isVerifyError :: Either WorkflowError UnsignedTx -> Bool
+isVerifyError (Left (WorkflowVerifyError _)) = True
+isVerifyError _ = False

--- a/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/EndCageSpec.hs
+++ b/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/EndCageSpec.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Module      : Cardano.MPFS.Workflows.EndCageSpec
+-- Description : Unit tests for the endCage workflow.
+--
+-- Drives 'endCage' through a stub 'HttpClient'. The end verifier
+-- replays the state UTxO inclusion proof and a request-set
+-- completeness proof, neither satisfiable without real CSMT proofs,
+-- so the build / happy path is covered by the integration tests gated
+-- on #288. Here we assert routing and that the HTTP, decode, and
+-- verify failure stages map to the matching 'WorkflowError'
+-- constructor (a trusted-root mismatch is rejected before any proof
+-- replay). 'endCage' is the one workflow whose verifier also consumes
+-- the cage configuration, so this exercises that wiring too.
+module Cardano.MPFS.Workflows.EndCageSpec
+    ( spec
+    ) where
+
+import Data.Aeson (eitherDecodeStrict', encode)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as SBS
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (fromJust)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import Cardano.Crypto.Hash (hashFromBytes)
+import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types (EndRequest (..))
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts (EndFacts (..))
+import Cardano.MPFS.Client.Cage.Config (CageConfig (..))
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Workflows
+    ( HttpClient (..)
+    , HttpError (..)
+    , UnsignedTx
+    , WorkflowError (..)
+    , WorkflowsConfig (..)
+    , endCage
+    )
+
+spec :: Spec
+spec = describe "endCage" $ do
+    it "posts the end request to /facts/end" $ do
+        ref <- newIORef Nothing
+        _ <-
+            endCage
+                ( HttpClient $ \path body -> do
+                    writeIORef ref (Just (path, body))
+                    pure (Right "{}")
+                )
+                (config trustedRoot)
+                req
+        recorded <- readIORef ref
+        case recorded of
+            Nothing ->
+                expectationFailure "client was never invoked"
+            Just (path, body) -> do
+                path `shouldBe` "/facts/end"
+                (fmap erAddr . eitherDecodeStrict') body
+                    `shouldBe` Right addr
+
+    it "maps a transport failure to WorkflowHttpError" $ do
+        result <-
+            endCage
+                (constClient (Left (HttpStatus 502 "down")))
+                (config trustedRoot)
+                req
+        result `shouldSatisfy` isHttpError
+
+    it "maps a malformed response to WorkflowDecodeError" $ do
+        result <-
+            endCage
+                (constClient (Right "{not json"))
+                (config trustedRoot)
+                req
+        result `shouldSatisfy` isDecodeError
+
+    it "maps a trusted-root mismatch to WorkflowVerifyError" $ do
+        result <-
+            endCage
+                (constClient (Right (BSL.toStrict (encode mismatchedFacts))))
+                (config trustedRoot)
+                req
+        result `shouldSatisfy` isVerifyError
+
+req :: EndRequest
+req = EndRequest{erToken = token, erAddr = addr}
+
+-- | End facts whose snapshot root does not match the trusted root, so
+-- verification fails before any UTxO or completeness proof is
+-- replayed. The UTxO fields are placeholders, never inspected.
+mismatchedFacts :: EndFacts
+mismatchedFacts =
+    EndFacts
+        { efSnapshot = mismatchedSnapshot
+        , efToken = token
+        , efStateUtxo = dummyUtxo
+        , efWalletUtxos = []
+        , efRequestSet =
+            UtxoSetWitness
+                { uswEntries = []
+                , uswCompletenessProof = Hex BS.empty
+                }
+        , efProtocolParameters = malformedPParams
+        }
+
+token :: TokenIdJSON
+token = TokenIdJSON (BS.replicate 28 0x11)
+
+addr :: Hex
+addr = Hex (BS.replicate 28 0x42)
+
+dummyUtxo :: UtxoEntry
+dummyUtxo =
+    UtxoEntry
+        { ueRef = UtxoRef{urTxId = Hex (BS.replicate 32 0), urTxIx = 0}
+        , ueTxOutCbor = Hex BS.empty
+        , ueInclusionProof = Hex BS.empty
+        }
+
+trustedRoot :: TrustedRoot
+trustedRoot = TrustedRoot (Hex (BS.replicate 32 0x07))
+
+mismatchedSnapshot :: VerificationSnapshot
+mismatchedSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex (BS.replicate 32 0x08)
+        , vsChainPoint = ChainPointJSON{cpSlot = 0, cpBlockId = Hex BS.empty}
+        }
+
+malformedPParams :: UnverifiedPParams
+malformedPParams =
+    UnverifiedPParams{uppVerified = False, uppCbor = Hex "\x82\x01\x02"}
+
+constClient :: Either HttpError ByteString -> HttpClient
+constClient response = HttpClient $ \_ _ -> pure response
+
+config :: TrustedRoot -> WorkflowsConfig
+config root =
+    WorkflowsConfig
+        { wcCage = dummyCage
+        , wcPolicy = permissivePolicy
+        , wcTrustedRoot = root
+        }
+
+dummyCage :: CageConfig
+dummyCage =
+    CageConfig
+        { cageScriptBytes = SBS.empty
+        , requestScriptBytes = SBS.empty
+        , cfgScriptHash =
+            ScriptHash (fromJust (hashFromBytes (BS.replicate 28 0)))
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 600_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+permissivePolicy :: WalletPolicy
+permissivePolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+isHttpError :: Either WorkflowError UnsignedTx -> Bool
+isHttpError (Left (WorkflowHttpError _)) = True
+isHttpError _ = False
+
+isDecodeError :: Either WorkflowError UnsignedTx -> Bool
+isDecodeError (Left (WorkflowDecodeError _)) = True
+isDecodeError _ = False
+
+isVerifyError :: Either WorkflowError UnsignedTx -> Bool
+isVerifyError (Left (WorkflowVerifyError _)) = True
+isVerifyError _ = False

--- a/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/RegisterTokenSpec.hs
+++ b/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/RegisterTokenSpec.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Module      : Cardano.MPFS.Workflows.RegisterTokenSpec
+-- Description : Unit tests for the registerToken workflow.
+--
+-- Drives 'registerToken' through a stub 'HttpClient' that records
+-- the @(path, body)@ it is handed and returns a canned response.
+-- The tests assert request routing and that each failure stage
+-- (HTTP, decode, verify, build) is wired into the right
+-- 'WorkflowError' constructor.
+module Cardano.MPFS.Workflows.RegisterTokenSpec
+    ( spec
+    ) where
+
+import Data.Aeson (eitherDecodeStrict', encode)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as SBS
+import Data.IORef
+    ( IORef
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Maybe (fromJust)
+import Data.Text (Text)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import Cardano.Crypto.Hash (hashFromBytes)
+import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , UnverifiedPParams (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts (BootFacts (..))
+import Cardano.MPFS.Client.Cage.Config (CageConfig (..))
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Workflows
+    ( BootRequest (..)
+    , HttpClient (..)
+    , HttpError (..)
+    , UnsignedTx
+    , WorkflowError (..)
+    , WorkflowsConfig (..)
+    , registerToken
+    )
+
+spec :: Spec
+spec = describe "registerToken" $ do
+    it "posts the boot request to /facts/boot" $ do
+        ref <- newIORef (Nothing :: Maybe (Text, ByteString))
+        _ <-
+            registerToken
+                (recordingClient ref (Right "{}"))
+                (config trustedRoot)
+                bootRequest
+        recorded <- readIORef ref
+        case recorded of
+            Nothing ->
+                expectationFailure "client was never invoked"
+            Just (path, body) -> do
+                path `shouldBe` "/facts/boot"
+                case eitherDecodeStrict' body of
+                    Left err ->
+                        expectationFailure
+                            ("request body did not decode: " <> err)
+                    Right (BootRequest addr) ->
+                        addr `shouldBe` brAddr bootRequest
+
+    it "maps a transport failure to WorkflowHttpError" $ do
+        ref <- newIORef (Nothing :: Maybe (Text, ByteString))
+        result <-
+            registerToken
+                (recordingClient ref (Left (HttpStatus 502 "down")))
+                (config trustedRoot)
+                bootRequest
+        result `shouldSatisfy` isHttpError
+
+    it "maps a malformed response to WorkflowDecodeError" $ do
+        ref <- newIORef (Nothing :: Maybe (Text, ByteString))
+        result <-
+            registerToken
+                (recordingClient ref (Right "{not json"))
+                (config trustedRoot)
+                bootRequest
+        result `shouldSatisfy` isDecodeError
+
+    it "maps a trusted-root mismatch to WorkflowVerifyError" $ do
+        ref <- newIORef (Nothing :: Maybe (Text, ByteString))
+        let response = encodeFacts (bootFacts mismatchedSnapshot)
+        result <-
+            registerToken
+                (recordingClient ref (Right response))
+                (config trustedRoot)
+                bootRequest
+        result `shouldSatisfy` isVerifyError
+
+    it "maps a build failure to WorkflowBuildError" $ do
+        ref <- newIORef (Nothing :: Maybe (Text, ByteString))
+        let response = encodeFacts (bootFacts matchingSnapshot)
+        result <-
+            registerToken
+                (recordingClient ref (Right response))
+                (config trustedRoot)
+                bootRequest
+        result `shouldSatisfy` isBuildError
+
+-- | A stub transport that records the @(path, body)@ it receives
+-- and returns a fixed response.
+recordingClient
+    :: IORef (Maybe (Text, ByteString))
+    -> Either HttpError ByteString
+    -> HttpClient
+recordingClient ref response =
+    HttpClient $ \path body -> do
+        writeIORef ref (Just (path, body))
+        pure response
+
+bootRequest :: BootRequest
+bootRequest = BootRequest{brAddr = Hex (BS.replicate 28 0x42)}
+
+trustedRootBytes :: ByteString
+trustedRootBytes = BS.replicate 32 0x07
+
+trustedRoot :: TrustedRoot
+trustedRoot = TrustedRoot (Hex trustedRootBytes)
+
+matchingSnapshot :: VerificationSnapshot
+matchingSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex trustedRootBytes
+        , vsChainPoint = chainPoint
+        }
+
+mismatchedSnapshot :: VerificationSnapshot
+mismatchedSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex (BS.replicate 32 0x08)
+        , vsChainPoint = chainPoint
+        }
+
+chainPoint :: ChainPointJSON
+chainPoint =
+    ChainPointJSON
+        { cpSlot = 0
+        , cpBlockId = Hex BS.empty
+        }
+
+-- | Boot facts with no wallet UTxOs and undecodable protocol
+-- parameters: verification passes when the snapshot root matches,
+-- and the cage builder then fails on the malformed parameters.
+bootFacts :: VerificationSnapshot -> BootFacts
+bootFacts snapshot =
+    BootFacts
+        { bfSnapshot = snapshot
+        , bfWalletUtxos = []
+        , bfProtocolParameters =
+            UnverifiedPParams
+                { uppVerified = False
+                , uppCbor = Hex "\x82\x01\x02"
+                }
+        }
+
+encodeFacts :: BootFacts -> ByteString
+encodeFacts = BSL.toStrict . encode
+
+-- | A throwaway cage configuration. Its script bytes are empty and
+-- its hash is zero: the build-stage tests reach the builder only far
+-- enough to fail on the malformed protocol parameters, never far
+-- enough to use the script.
+config :: TrustedRoot -> WorkflowsConfig
+config root =
+    WorkflowsConfig
+        { wcCage = dummyCage
+        , wcPolicy = permissivePolicy
+        , wcTrustedRoot = root
+        }
+
+dummyCage :: CageConfig
+dummyCage =
+    CageConfig
+        { cageScriptBytes = SBS.empty
+        , requestScriptBytes = SBS.empty
+        , cfgScriptHash =
+            ScriptHash (fromJust (hashFromBytes (BS.replicate 28 0)))
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 600_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+permissivePolicy :: WalletPolicy
+permissivePolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+isHttpError :: Either WorkflowError UnsignedTx -> Bool
+isHttpError (Left (WorkflowHttpError _)) = True
+isHttpError _ = False
+
+isDecodeError :: Either WorkflowError UnsignedTx -> Bool
+isDecodeError (Left (WorkflowDecodeError _)) = True
+isDecodeError _ = False
+
+isVerifyError :: Either WorkflowError UnsignedTx -> Bool
+isVerifyError (Left (WorkflowVerifyError _)) = True
+isVerifyError _ = False
+
+isBuildError :: Either WorkflowError UnsignedTx -> Bool
+isBuildError (Left (WorkflowBuildError _)) = True
+isBuildError _ = False

--- a/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/RequestWorkflowsSpec.hs
+++ b/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/RequestWorkflowsSpec.hs
@@ -1,0 +1,318 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Module      : Cardano.MPFS.Workflows.RequestWorkflowsSpec
+-- Description : Unit tests for the requester request workflows.
+--
+-- Drives 'insertFact', 'updateFact', and 'deleteFact' through a stub
+-- 'HttpClient'. Each workflow shares the same pipeline shape, so a
+-- single 'Scenario' record parameterizes the five checks: request
+-- routing, and that each failure stage (HTTP, decode, verify, build)
+-- maps to the matching 'WorkflowError' constructor. The build-stage
+-- check is reachable here because the request verifiers only replay
+-- wallet UTxOs, so an empty wallet set lets verification pass and the
+-- cage builder then fails on the (deliberately malformed) protocol
+-- parameters.
+module Cardano.MPFS.Workflows.RequestWorkflowsSpec
+    ( spec
+    ) where
+
+import Data.Aeson (ToJSON, eitherDecodeStrict', encode)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as SBS
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (fromJust)
+import Data.Text (Text)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import Cardano.Crypto.Hash (hashFromBytes)
+import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( DeleteRequest (..)
+    , InsertRequest (..)
+    , UpdateValueRequest (..)
+    )
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts
+    ( RequestDeleteFacts (..)
+    , RequestInsertFacts (..)
+    , RequestUpdateFacts (..)
+    )
+import Cardano.MPFS.Client.Cage.Config (CageConfig (..))
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Workflows
+    ( HttpClient (..)
+    , HttpError (..)
+    , UnsignedTx
+    , WorkflowError (..)
+    , WorkflowsConfig (..)
+    , deleteFact
+    , insertFact
+    , updateFact
+    )
+
+-- | A single request workflow under test: its endpoint path, the
+-- invocation (transport-injected), the address expected in the posted
+-- body, how to recover that address from the recorded body, and the
+-- matching- / mismatched-root facts responses.
+data Scenario = Scenario
+    { scPath :: Text
+    , scInvoke :: HttpClient -> IO (Either WorkflowError UnsignedTx)
+    , scExpectedAddr :: Hex
+    , scDecodeAddr :: ByteString -> Either String Hex
+    , scMatchingFacts :: ByteString
+    , scMismatchFacts :: ByteString
+    }
+
+spec :: Spec
+spec = do
+    describe "insertFact" $ opSpec insertScenario
+    describe "updateFact" $ opSpec updateScenario
+    describe "deleteFact" $ opSpec deleteScenario
+
+opSpec :: Scenario -> Spec
+opSpec Scenario{..} = do
+    it "posts the request to its facts endpoint" $ do
+        ref <- newIORef Nothing
+        _ <-
+            scInvoke
+                ( HttpClient $ \path body -> do
+                    writeIORef ref (Just (path, body))
+                    pure (Right "{}")
+                )
+        recorded <- readIORef ref
+        case recorded of
+            Nothing ->
+                expectationFailure "client was never invoked"
+            Just (path, body) -> do
+                path `shouldBe` scPath
+                scDecodeAddr body `shouldBe` Right scExpectedAddr
+
+    it "maps a transport failure to WorkflowHttpError" $ do
+        result <- scInvoke (constClient (Left (HttpStatus 502 "down")))
+        result `shouldSatisfy` isHttpError
+
+    it "maps a malformed response to WorkflowDecodeError" $ do
+        result <- scInvoke (constClient (Right "{not json"))
+        result `shouldSatisfy` isDecodeError
+
+    it "maps a trusted-root mismatch to WorkflowVerifyError" $ do
+        result <- scInvoke (constClient (Right scMismatchFacts))
+        result `shouldSatisfy` isVerifyError
+
+    it "maps a build failure to WorkflowBuildError" $ do
+        result <- scInvoke (constClient (Right scMatchingFacts))
+        result `shouldSatisfy` isBuildError
+
+-- | A stub transport that ignores its inputs and returns a fixed
+-- response.
+constClient :: Either HttpError ByteString -> HttpClient
+constClient response = HttpClient $ \_ _ -> pure response
+
+insertScenario :: Scenario
+insertScenario =
+    Scenario
+        { scPath = "/facts/request/insert"
+        , scInvoke = \http -> insertFact http (config trustedRoot) req
+        , scExpectedAddr = addr
+        , scDecodeAddr = fmap irAddr . eitherDecodeStrict'
+        , scMatchingFacts = encodeFacts (insertFacts matchingSnapshot)
+        , scMismatchFacts = encodeFacts (insertFacts mismatchedSnapshot)
+        }
+  where
+    req =
+        InsertRequest
+            { irToken = token
+            , irKey = key
+            , irValue = val
+            , irAddr = addr
+            }
+    insertFacts snapshot =
+        RequestInsertFacts
+            { rifSnapshot = snapshot
+            , rifToken = token
+            , rifKey = key
+            , rifValue = val
+            , rifAddress = addr
+            , rifSubmittedAt = 0
+            , rifWalletUtxos = []
+            , rifProtocolParameters = malformedPParams
+            }
+
+updateScenario :: Scenario
+updateScenario =
+    Scenario
+        { scPath = "/facts/request/update"
+        , scInvoke = \http -> updateFact http (config trustedRoot) req
+        , scExpectedAddr = addr
+        , scDecodeAddr = fmap uvrAddr . eitherDecodeStrict'
+        , scMatchingFacts = encodeFacts (updateFacts matchingSnapshot)
+        , scMismatchFacts = encodeFacts (updateFacts mismatchedSnapshot)
+        }
+  where
+    req =
+        UpdateValueRequest
+            { uvrToken = token
+            , uvrKey = key
+            , uvrOldValue = val
+            , uvrNewValue = newVal
+            , uvrAddr = addr
+            }
+    updateFacts snapshot =
+        RequestUpdateFacts
+            { rufSnapshot = snapshot
+            , rufToken = token
+            , rufKey = key
+            , rufOldValue = val
+            , rufNewValue = newVal
+            , rufAddress = addr
+            , rufSubmittedAt = 0
+            , rufWalletUtxos = []
+            , rufProtocolParameters = malformedPParams
+            }
+
+deleteScenario :: Scenario
+deleteScenario =
+    Scenario
+        { scPath = "/facts/request/delete"
+        , scInvoke = \http -> deleteFact http (config trustedRoot) req
+        , scExpectedAddr = addr
+        , scDecodeAddr = fmap drAddr . eitherDecodeStrict'
+        , scMatchingFacts = encodeFacts (deleteFacts matchingSnapshot)
+        , scMismatchFacts = encodeFacts (deleteFacts mismatchedSnapshot)
+        }
+  where
+    req =
+        DeleteRequest
+            { drToken = token
+            , drKey = key
+            , drValue = val
+            , drAddr = addr
+            }
+    deleteFacts snapshot =
+        RequestDeleteFacts
+            { rdfSnapshot = snapshot
+            , rdfToken = token
+            , rdfKey = key
+            , rdfValue = val
+            , rdfAddress = addr
+            , rdfSubmittedAt = 0
+            , rdfWalletUtxos = []
+            , rdfProtocolParameters = malformedPParams
+            }
+
+-- shared fixtures ---------------------------------------------------
+
+token :: TokenIdJSON
+token = TokenIdJSON (BS.replicate 28 0x11)
+
+key :: Hex
+key = Hex (BS.replicate 4 0x01)
+
+val :: Hex
+val = Hex (BS.replicate 4 0x02)
+
+newVal :: Hex
+newVal = Hex (BS.replicate 4 0x03)
+
+addr :: Hex
+addr = Hex (BS.replicate 28 0x42)
+
+trustedRootBytes :: ByteString
+trustedRootBytes = BS.replicate 32 0x07
+
+trustedRoot :: TrustedRoot
+trustedRoot = TrustedRoot (Hex trustedRootBytes)
+
+matchingSnapshot :: VerificationSnapshot
+matchingSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex trustedRootBytes
+        , vsChainPoint = chainPoint
+        }
+
+mismatchedSnapshot :: VerificationSnapshot
+mismatchedSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex (BS.replicate 32 0x08)
+        , vsChainPoint = chainPoint
+        }
+
+chainPoint :: ChainPointJSON
+chainPoint = ChainPointJSON{cpSlot = 0, cpBlockId = Hex BS.empty}
+
+-- | Undecodable protocol parameters: lets the cage builder fail at
+-- the parameter-decoding stage once verification has passed.
+malformedPParams :: UnverifiedPParams
+malformedPParams =
+    UnverifiedPParams{uppVerified = False, uppCbor = Hex "\x82\x01\x02"}
+
+encodeFacts :: (ToJSON a) => a -> ByteString
+encodeFacts = BSL.toStrict . encode
+
+config :: TrustedRoot -> WorkflowsConfig
+config root =
+    WorkflowsConfig
+        { wcCage = dummyCage
+        , wcPolicy = permissivePolicy
+        , wcTrustedRoot = root
+        }
+
+dummyCage :: CageConfig
+dummyCage =
+    CageConfig
+        { cageScriptBytes = SBS.empty
+        , requestScriptBytes = SBS.empty
+        , cfgScriptHash =
+            ScriptHash (fromJust (hashFromBytes (BS.replicate 28 0)))
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 600_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+permissivePolicy :: WalletPolicy
+permissivePolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+isHttpError :: Either WorkflowError UnsignedTx -> Bool
+isHttpError (Left (WorkflowHttpError _)) = True
+isHttpError _ = False
+
+isDecodeError :: Either WorkflowError UnsignedTx -> Bool
+isDecodeError (Left (WorkflowDecodeError _)) = True
+isDecodeError _ = False
+
+isVerifyError :: Either WorkflowError UnsignedTx -> Bool
+isVerifyError (Left (WorkflowVerifyError _)) = True
+isVerifyError _ = False
+
+isBuildError :: Either WorkflowError UnsignedTx -> Bool
+isBuildError (Left (WorkflowBuildError _)) = True
+isBuildError _ = False

--- a/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/RetractRejectSpec.hs
+++ b/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/RetractRejectSpec.hs
@@ -1,0 +1,237 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Module      : Cardano.MPFS.Workflows.RetractRejectSpec
+-- Description : Unit tests for the retractRequest and rejectExpired workflows.
+--
+-- Drives 'retractRequest' and 'rejectExpired' through a stub
+-- 'HttpClient'. Both verifiers replay UTxO inclusion proofs that
+-- cannot be satisfied without real CSMT proofs, so the build / happy
+-- path is covered by the integration tests gated on #288; here we
+-- assert routing and that the HTTP, decode, and verify failure stages
+-- map to the matching 'WorkflowError' constructor (a trusted-root
+-- mismatch is rejected before any proof replay).
+module Cardano.MPFS.Workflows.RetractRejectSpec
+    ( spec
+    ) where
+
+import Data.Aeson (eitherDecodeStrict', encode)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as SBS
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (fromJust)
+import Data.Text (Text)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
+
+import Cardano.Crypto.Hash (hashFromBytes)
+import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( RejectRequest (..)
+    , RetractRequest (..)
+    )
+import Cardano.MPFS.API.Types.Common
+    ( ChainPointJSON (..)
+    , TokenIdJSON (..)
+    , UnverifiedPParams (..)
+    , UtxoEntry (..)
+    , UtxoRef (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.API.Types.Facts
+    ( RejectFacts (..)
+    , RetractFacts (..)
+    )
+import Cardano.MPFS.Client.Cage.Config (CageConfig (..))
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Workflows
+    ( HttpClient (..)
+    , HttpError (..)
+    , UnsignedTx
+    , WorkflowError (..)
+    , WorkflowsConfig (..)
+    , rejectExpired
+    , retractRequest
+    )
+
+-- | A workflow under test: endpoint path, invocation, the address
+-- expected in the posted body, how to recover it from the body, and a
+-- mismatched-root facts response.
+data Scenario = Scenario
+    { scPath :: Text
+    , scInvoke :: HttpClient -> IO (Either WorkflowError UnsignedTx)
+    , scExpectedAddr :: Hex
+    , scDecodeAddr :: ByteString -> Either String Hex
+    , scMismatchFacts :: ByteString
+    }
+
+spec :: Spec
+spec = do
+    describe "retractRequest" $ opSpec retractScenario
+    describe "rejectExpired" $ opSpec rejectScenario
+
+opSpec :: Scenario -> Spec
+opSpec Scenario{..} = do
+    it "posts the request to its facts endpoint" $ do
+        ref <- newIORef Nothing
+        _ <-
+            scInvoke
+                ( HttpClient $ \path body -> do
+                    writeIORef ref (Just (path, body))
+                    pure (Right "{}")
+                )
+        recorded <- readIORef ref
+        case recorded of
+            Nothing ->
+                expectationFailure "client was never invoked"
+            Just (path, body) -> do
+                path `shouldBe` scPath
+                scDecodeAddr body `shouldBe` Right scExpectedAddr
+
+    it "maps a transport failure to WorkflowHttpError" $ do
+        result <- scInvoke (constClient (Left (HttpStatus 502 "down")))
+        result `shouldSatisfy` isHttpError
+
+    it "maps a malformed response to WorkflowDecodeError" $ do
+        result <- scInvoke (constClient (Right "{not json"))
+        result `shouldSatisfy` isDecodeError
+
+    it "maps a trusted-root mismatch to WorkflowVerifyError" $ do
+        result <- scInvoke (constClient (Right scMismatchFacts))
+        result `shouldSatisfy` isVerifyError
+
+constClient :: Either HttpError ByteString -> HttpClient
+constClient response = HttpClient $ \_ _ -> pure response
+
+retractScenario :: Scenario
+retractScenario =
+    Scenario
+        { scPath = "/facts/retract"
+        , scInvoke = \http -> retractRequest http (config trustedRoot) req
+        , scExpectedAddr = addr
+        , scDecodeAddr = fmap rrAddr . eitherDecodeStrict'
+        , scMismatchFacts = BSL.toStrict (encode facts)
+        }
+  where
+    req = RetractRequest{rrUtxo = "ab#0", rrAddr = addr}
+    facts =
+        RetractFacts
+            { rfSnapshot = mismatchedSnapshot
+            , rfToken = token
+            , rfRequestUtxo = dummyUtxo
+            , rfStateUtxo = dummyUtxo
+            , rfWalletUtxos = []
+            , rfValidityStartSlot = 0
+            , rfValidityEndSlot = 0
+            , rfProtocolParameters = malformedPParams
+            }
+
+rejectScenario :: Scenario
+rejectScenario =
+    Scenario
+        { scPath = "/facts/reject"
+        , scInvoke = \http -> rejectExpired http (config trustedRoot) req
+        , scExpectedAddr = addr
+        , scDecodeAddr = fmap rejAddr . eitherDecodeStrict'
+        , scMismatchFacts = BSL.toStrict (encode facts)
+        }
+  where
+    req = RejectRequest{rejToken = token, rejAddr = addr}
+    facts =
+        RejectFacts
+            { rfSnapshot = mismatchedSnapshot
+            , rfToken = token
+            , rfStateUtxo = dummyUtxo
+            , rfRequestUtxos = []
+            , rfWalletUtxos = []
+            , rfValidityLowerSlot = 0
+            , rfValidityUpperSlot = 0
+            , rfProtocolParameters = malformedPParams
+            }
+
+-- shared fixtures ---------------------------------------------------
+
+token :: TokenIdJSON
+token = TokenIdJSON (BS.replicate 28 0x11)
+
+addr :: Hex
+addr = Hex (BS.replicate 28 0x42)
+
+dummyUtxo :: UtxoEntry
+dummyUtxo =
+    UtxoEntry
+        { ueRef = UtxoRef{urTxId = Hex (BS.replicate 32 0), urTxIx = 0}
+        , ueTxOutCbor = Hex BS.empty
+        , ueInclusionProof = Hex BS.empty
+        }
+
+trustedRoot :: TrustedRoot
+trustedRoot = TrustedRoot (Hex (BS.replicate 32 0x07))
+
+mismatchedSnapshot :: VerificationSnapshot
+mismatchedSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex (BS.replicate 32 0x08)
+        , vsChainPoint = ChainPointJSON{cpSlot = 0, cpBlockId = Hex BS.empty}
+        }
+
+malformedPParams :: UnverifiedPParams
+malformedPParams =
+    UnverifiedPParams{uppVerified = False, uppCbor = Hex "\x82\x01\x02"}
+
+config :: TrustedRoot -> WorkflowsConfig
+config root =
+    WorkflowsConfig
+        { wcCage = dummyCage
+        , wcPolicy = permissivePolicy
+        , wcTrustedRoot = root
+        }
+
+dummyCage :: CageConfig
+dummyCage =
+    CageConfig
+        { cageScriptBytes = SBS.empty
+        , requestScriptBytes = SBS.empty
+        , cfgScriptHash =
+            ScriptHash (fromJust (hashFromBytes (BS.replicate 28 0)))
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 600_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+permissivePolicy :: WalletPolicy
+permissivePolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }
+
+isHttpError :: Either WorkflowError UnsignedTx -> Bool
+isHttpError (Left (WorkflowHttpError _)) = True
+isHttpError _ = False
+
+isDecodeError :: Either WorkflowError UnsignedTx -> Bool
+isDecodeError (Left (WorkflowDecodeError _)) = True
+isDecodeError _ = False
+
+isVerifyError :: Either WorkflowError UnsignedTx -> Bool
+isVerifyError (Left (WorkflowVerifyError _)) = True
+isVerifyError _ = False

--- a/cardano-mpfs-workflows/test/Main.hs
+++ b/cardano-mpfs-workflows/test/Main.hs
@@ -8,6 +8,9 @@ module Main
 import Test.Hspec (hspec)
 
 import Cardano.MPFS.Workflows.RegisterTokenSpec qualified as RegisterTokenSpec
+import Cardano.MPFS.Workflows.RequestWorkflowsSpec qualified as RequestWorkflowsSpec
 
 main :: IO ()
-main = hspec RegisterTokenSpec.spec
+main = hspec $ do
+    RegisterTokenSpec.spec
+    RequestWorkflowsSpec.spec

--- a/cardano-mpfs-workflows/test/Main.hs
+++ b/cardano-mpfs-workflows/test/Main.hs
@@ -8,6 +8,7 @@ module Main
 import Test.Hspec (hspec)
 
 import Cardano.MPFS.Workflows.ApplyRequestsSpec qualified as ApplyRequestsSpec
+import Cardano.MPFS.Workflows.EndCageSpec qualified as EndCageSpec
 import Cardano.MPFS.Workflows.RegisterTokenSpec qualified as RegisterTokenSpec
 import Cardano.MPFS.Workflows.RequestWorkflowsSpec qualified as RequestWorkflowsSpec
 import Cardano.MPFS.Workflows.RetractRejectSpec qualified as RetractRejectSpec
@@ -18,3 +19,4 @@ main = hspec $ do
     RequestWorkflowsSpec.spec
     ApplyRequestsSpec.spec
     RetractRejectSpec.spec
+    EndCageSpec.spec

--- a/cardano-mpfs-workflows/test/Main.hs
+++ b/cardano-mpfs-workflows/test/Main.hs
@@ -10,9 +10,11 @@ import Test.Hspec (hspec)
 import Cardano.MPFS.Workflows.ApplyRequestsSpec qualified as ApplyRequestsSpec
 import Cardano.MPFS.Workflows.RegisterTokenSpec qualified as RegisterTokenSpec
 import Cardano.MPFS.Workflows.RequestWorkflowsSpec qualified as RequestWorkflowsSpec
+import Cardano.MPFS.Workflows.RetractRejectSpec qualified as RetractRejectSpec
 
 main :: IO ()
 main = hspec $ do
     RegisterTokenSpec.spec
     RequestWorkflowsSpec.spec
     ApplyRequestsSpec.spec
+    RetractRejectSpec.spec

--- a/cardano-mpfs-workflows/test/Main.hs
+++ b/cardano-mpfs-workflows/test/Main.hs
@@ -7,6 +7,7 @@ module Main
 
 import Test.Hspec (hspec)
 
+import Cardano.MPFS.Workflows.ApplyRequestsSpec qualified as ApplyRequestsSpec
 import Cardano.MPFS.Workflows.RegisterTokenSpec qualified as RegisterTokenSpec
 import Cardano.MPFS.Workflows.RequestWorkflowsSpec qualified as RequestWorkflowsSpec
 
@@ -14,3 +15,4 @@ main :: IO ()
 main = hspec $ do
     RegisterTokenSpec.spec
     RequestWorkflowsSpec.spec
+    ApplyRequestsSpec.spec

--- a/cardano-mpfs-workflows/test/Main.hs
+++ b/cardano-mpfs-workflows/test/Main.hs
@@ -1,0 +1,13 @@
+-- |
+-- Module      : Main
+-- Description : Entry point for cardano-mpfs-workflows unit tests.
+module Main
+    ( main
+    ) where
+
+import Test.Hspec (hspec)
+
+import Cardano.MPFS.Workflows.RegisterTokenSpec qualified as RegisterTokenSpec
+
+main :: IO ()
+main = hspec RegisterTokenSpec.spec

--- a/flake.nix
+++ b/flake.nix
@@ -71,9 +71,9 @@
           in {
             packages = {
               inherit (project.packages)
-                offchain-tests client-tests e2e-tests cardano-mpfs-offchain
-                mpfs-serve mpfs-devnet-server mpfs-bootstrap-genesis
-                docker-image haddock;
+                offchain-tests client-tests workflows-tests e2e-tests
+                cardano-mpfs-offchain mpfs-serve mpfs-devnet-server
+                mpfs-bootstrap-genesis docker-image haddock;
               inherit (wasmTargets) wasm-mpfs-verify;
               default = project.packages.cardano-mpfs-offchain;
             };

--- a/justfile
+++ b/justfile
@@ -48,11 +48,22 @@ unit-client match="":
     fi
     nix run --quiet .#client-unit-tests -- "${args[@]}"
 
+# Run workflows unit tests with optional match
+unit-workflows match="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=()
+    if [[ '{{ match }}' != "" ]]; then
+        args+=(--match "{{ match }}")
+    fi
+    nix run --quiet .#workflows-unit-tests -- "${args[@]}"
+
 # Non-Docker CI gate (mirrors .github/workflows/ci.yml)
 ci:
     nix build --quiet .#cardano-mpfs-offchain .#checks.x86_64-linux.swagger-up-to-date
     just unit
     just unit-client
+    just unit-workflows
     just format-check
     just hlint
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -59,6 +59,8 @@ let
     project.hsPkgs.cardano-mpfs-offchain.components.tests.unit-tests;
   client-unit-tests =
     project.hsPkgs.cardano-mpfs-client.components.tests.unit-tests;
+  workflows-unit-tests =
+    project.hsPkgs.cardano-mpfs-workflows.components.tests.unit-tests;
   e2e-tests = project.hsPkgs.cardano-mpfs-offchain.components.tests.e2e-tests;
   format-runner = pkgs.writeShellApplication {
     name = "format";
@@ -107,6 +109,12 @@ let
       exec ${client-unit-tests}/bin/unit-tests "$@"
     '';
   };
+  workflows-unit-tests-runner = pkgs.writeShellApplication {
+    name = "workflows-unit-tests";
+    text = ''
+      exec ${workflows-unit-tests}/bin/unit-tests "$@"
+    '';
+  };
   e2e-tests-runner = pkgs.writeShellApplication {
     name = "e2e-tests";
     runtimeInputs = [
@@ -135,6 +143,8 @@ in {
   packages.devnet-genesis = devnet-genesis;
   packages.offchain-tests = offchain-unit-tests;
   packages.client-tests = client-unit-tests;
+  packages.workflows-tests = workflows-unit-tests;
+  packages.workflows-unit-tests-runner = workflows-unit-tests-runner;
   packages.e2e-tests = e2e-tests;
   packages.format = format-runner;
   packages.format-check = format-check-runner;
@@ -179,5 +189,9 @@ in {
   apps.client-unit-tests = {
     type = "app";
     program = "${client-unit-tests-runner}/bin/client-unit-tests";
+  };
+  apps.workflows-unit-tests = {
+    type = "app";
+    program = "${workflows-unit-tests-runner}/bin/workflows-unit-tests";
   };
 }

--- a/specs/289-workflows/plan.md
+++ b/specs/289-workflows/plan.md
@@ -1,0 +1,156 @@
+# Plan — #289 `cardano-mpfs-workflows`
+
+## Tech stack
+
+- Haskell GHC 9.8.4 (haskell.nix `cabalProject'`, auto-discovers
+  packages listed in `cabal.project`).
+- New package `cardano-mpfs-workflows/` (library + `hspec` test-suite).
+- Library deps (the whole point — keep this list minimal):
+  `base`, `aeson`, `bytestring`, `text`, `cardano-mpfs-api`,
+  `cardano-mpfs-client`. **Forbidden**: `http-client`, `servant-*`,
+  `cardano-ledger-*`, `template-haskell`.
+
+## Constitution check
+
+- *Ledger-native types, no shadow representations* — we add zero new
+  ledger representations; `Tx ConwayEra` is built and serialized inside
+  `cardano-mpfs-client`.
+- *Service boundaries are records of functions, not typeclasses* —
+  `HttpClient` is a newtype over a function, matching the convention.
+- *Server is a fact-provider; never returns unsigned tx* — unchanged;
+  the **client** builds the unsigned tx locally from facts, which is
+  exactly the fact-provider model. No server code is touched.
+- *Verifiers are pure, no IO/网络/time* — we call them unchanged; the
+  only `IO` in this package is the caller-supplied transport.
+- *Verifier deps must cross-compile to WASM/JS* — the workflows package
+  imports no ledger/servant/http-client module; #258 compiles it to
+  WASM+JS. The ledger dependency closure is already present via
+  `cardano-mpfs-client` (which #258 must cross-compile regardless); we
+  add nothing new to it.
+
+Re-check after design: PASS (no deviations introduced during design).
+
+## The seam (verified by reading the client)
+
+| Workflow | Path (POST) | Wire request | Facts | Verifier | Builder |
+|---|---|---|---|---|---|
+| `registerToken` | `/facts/boot` | `BootRequest` | `BootFacts` | `verifyBootFacts root` | `bootCageTx cfg pol` |
+| `insertFact` | `/facts/request/insert` | `InsertRequest` | `RequestInsertFacts` | `verifyRequestInsertFacts root` | `requestInsertCageTx cfg pol` |
+| `updateFact` | `/facts/request/update` | `UpdateValueRequest` | `RequestUpdateFacts` | `verifyRequestUpdateFacts root` | `requestUpdateCageTx cfg pol` |
+| `deleteFact` | `/facts/request/delete` | `DeleteRequest` | `RequestDeleteFacts` | `verifyRequestDeleteFacts root` | `requestDeleteCageTx cfg pol` |
+| `applyRequests` | `/facts/update` | `UpdateRequest` | `UpdateFacts` | `verifyUpdateFacts root` | `updateCageTx cfg pol` |
+| `retractRequest` | `/facts/retract` | `RetractRequest` | `RetractFacts` | `verifyRetractFacts root` | `retractCageTx cfg pol` |
+| `rejectExpired` | `/facts/reject` | `RejectRequest` | `RejectFacts` | `verifyRejectFacts root` | `rejectCageTx cfg pol` |
+| `endCage` | `/facts/end` | `EndRequest` | `EndFacts` | `verifyEndFacts cfg root` | `endCageTx cfg pol` |
+
+`endCage`'s verifier additionally takes the `CageConfig` (request-set
+prefix derivation). All wire request types and `{Op}Facts` types come
+from `cardano-mpfs-api`; all verifiers/builders from
+`cardano-mpfs-client`.
+
+## Module design
+
+`Cardano.MPFS.Workflows.Internal` (core, not the public surface):
+
+```haskell
+-- transport abstraction (record of functions)
+data HttpError = HttpStatus !Int !ByteString | HttpTransport !Text
+newtype HttpClient = HttpClient
+  { runHttpPost :: Text -> ByteString -> IO (Either HttpError ByteString) }
+  -- relative path -> JSON body -> JSON response. The impl closes over
+  -- base URL + manager (CLI) or fetch (SPA).
+
+newtype UnsignedTx = UnsignedTx { unsignedTxCbor :: ByteString }
+  deriving (Eq, Show)        -- submission-ready Conway CBOR
+
+data WorkflowsConfig = WorkflowsConfig
+  { wcCage        :: CageConfig
+  , wcPolicy      :: WalletPolicy
+  , wcTrustedRoot :: TrustedRoot
+  }
+
+data WorkflowError
+  = WorkflowHttpError   !HttpError
+  | WorkflowDecodeError !String
+  | WorkflowVerifyError !VerifyError
+  | WorkflowBuildError  !BuildError
+  deriving (Show)
+
+-- the one helper every workflow shares. Note: the builder argument is
+-- pre-composed with serializeCageTx at the call site, so this signature
+-- never names `Tx ConwayEra` -> no ledger import in this package.
+runFactsWorkflow
+  :: (ToJSON req, FromJSON facts)
+  => HttpClient -> Text -> req
+  -> (facts    -> Either VerifyError verified)
+  -> (verified -> Either BuildError ByteString)   -- builder >>> serialize
+  -> IO (Either WorkflowError UnsignedTx)
+```
+
+`Cardano.MPFS.Workflows` (public): the 8 workflows + re-exports of
+`WorkflowError`, `UnsignedTx`, `WorkflowsConfig`, `HttpClient`, the
+wire request types, `CageConfig`, `WalletPolicy`, `TrustedRoot`. Each
+workflow is a one-liner over `runFactsWorkflow`, e.g.
+
+```haskell
+registerToken :: HttpClient -> WorkflowsConfig -> BootRequest
+              -> IO (Either WorkflowError UnsignedTx)
+registerToken http WorkflowsConfig{..} req =
+  runFactsWorkflow http "/facts/boot" req
+    (verifyBootFacts wcTrustedRoot)
+    (\v -> serializeCageTx <$> bootCageTx wcCage wcPolicy v)
+```
+
+`serializeCageTx :: Tx ConwayEra -> ByteString` is the **new**
+`cardano-mpfs-client` export (`= serialize' (natVersion @11)`); the
+intermediate `Tx ConwayEra` is inferred, never written in this package.
+
+## Test strategy
+
+Unit tests use a **stub `HttpClient`** that records the
+`(path, body)` it is handed and returns canned JSON. They assert,
+per workflow:
+
+1. **Routing** — correct path + the expected JSON request body.
+2. **HTTP error** → `WorkflowHttpError`.
+3. **Decode error** (malformed JSON) → `WorkflowDecodeError`.
+4. **Verify error** — a well-formed `{Op}Facts` whose snapshot root ≠
+   `wcTrustedRoot` → `WorkflowVerifyError (TrustedRootMismatch …)`,
+   proving HTTP→decode→verify are wired.
+5. Where reachable deterministically (e.g. `registerToken` with a
+   root-matching, empty-wallet `BootFacts`): verify **passes** and the
+   build stage is reached, propagating its `BuildError`
+   (`EmptyFunding`) → `WorkflowBuildError`, proving verify→build→error
+   wiring.
+
+The **happy path** (verify passes on real proofs → real `Tx` → CBOR)
+needs cryptographically valid fact fixtures and a live `/submit`; it is
+an **integration test gated on #288** — documented in tasks.md, not
+faked. The crypto itself is already covered by the client's own suite.
+
+## Build wiring
+
+- `cabal.project`: add `cardano-mpfs-workflows/`.
+- `nix/project.nix`: `workflows-unit-tests` component,
+  `workflows-unit-tests-runner` (writeShellApplication, no
+  `MPFS_BLUEPRINT` needed unless a builder requires it — verify during
+  S2), `packages.workflows-tests`, `apps.workflows-unit-tests`.
+- `flake.nix`: add `workflows-tests` to the inherited `packages` set.
+- `justfile`: `unit-workflows` recipe; add `just unit-workflows` to
+  `ci`.
+
+## Slices (one bisect-safe commit each)
+
+- **S1** — `cardano-mpfs-client`: add `serializeCageTx` export
+  (new module `Cardano.MPFS.Client.Cage.Serialize`) + client unit test.
+  Additive, independently useful.
+- **S2** — Stand up `cardano-mpfs-workflows`: cabal + build wiring +
+  `Internal` core types + `runFactsWorkflow` + public module with
+  `registerToken` + tests (routing, HTTP/decode/verify/build errors).
+- **S3** — Requester request workflows `insertFact`, `updateFact`,
+  `deleteFact` (one commit; identical shape) + tests.
+- **S4** — `applyRequests` (oracle update) + tests.
+- **S5** — `retractRequest` + `rejectExpired` + tests.
+- **S6** — `endCage` (verifier takes `CageConfig`) + tests.
+- **S7 (deferred, not implemented)** — live integration test +
+  `/submit` round-trip; follows #288 merge. Recorded only.

--- a/specs/289-workflows/spec.md
+++ b/specs/289-workflows/spec.md
@@ -1,0 +1,102 @@
+# Spec — #289 `cardano-mpfs-workflows`
+
+- Issue: https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/289
+- Epic: https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/287
+  (Child 2 of 4)
+- Branch: `289-workflows` (from `main` `b54334e`)
+
+## Problem
+
+The CLI (#290) and the PureScript SPA (#291) both need to drive the
+MPFS end-to-end workflows (register a token, request fact
+insert/update/delete, oracle apply, retract, reject, end). Without a
+shared layer each front-end would re-encode the protocol — which HTTP
+endpoint to call, how to verify the proof-bearing response, and how to
+build the unsigned transaction. That duplication is the failure mode
+this ticket prevents.
+
+`cardano-mpfs-client` already exposes the two halves of every
+operation as **pure** functions:
+
+- a verifier `verify{Op}Facts :: TrustedRoot -> {Op}Facts -> Either
+  VerifyError Verified{Op}Facts` (the `end` verifier additionally takes
+  a `CageConfig`), and
+- a builder `{op}CageTx :: CageConfig -> WalletPolicy ->
+  Verified{Op}Facts -> Either BuildError (Tx ConwayEra)`.
+
+What is missing is the glue: fetch facts over HTTP, decode them,
+verify, build, and emit a submission-ready transaction. Today that glue
+only exists inside `Cardano.MPFS.Client.Http`, which hard-wires
+`http-client`/`servant-client` — unusable from the SPA's WASM/JS build.
+
+## P1 user story
+
+> As a front-end author (CLI or SPA), I call **one** function per
+> workflow — `registerToken`, `insertFact`, `updateFact`,
+> `deleteFact`, `applyRequests`, `retractRequest`, `rejectExpired`,
+> `endCage` — pass my config and a transport handle, and receive a
+> verified, unsigned transaction (or a typed error). I never touch a
+> verifier, an endpoint path, or a ledger type.
+
+## User stories
+
+- As the **token owner**, `registerToken` boots a new token,
+  `applyRequests` applies pending requests, `rejectExpired` rejects
+  expired requests, and `endCage` burns the token.
+- As a **requester**, `insertFact` / `updateFact` / `deleteFact` submit
+  a fact-change request and `retractRequest` retracts my own pending
+  request.
+- As the **SPA (WASM/JS) author**, I swap the transport by providing my
+  own `HttpClient` value backed by the browser `fetch` API; the
+  workflow functions are unchanged.
+
+## Functional requirements
+
+- **FR1** — Expose module `Cardano.MPFS.Workflows` with exactly:
+  `registerToken`, `insertFact`, `updateFact`, `deleteFact`,
+  `applyRequests`, `retractRequest`, `rejectExpired`, `endCage`,
+  plus `WorkflowError(..)`, `UnsignedTx(..)`, `WorkflowsConfig(..)`,
+  `HttpClient(..)`. (The brief lists 7; per operator decision the
+  oracle `applyRequests` is the 8th.)
+- **FR2** — Each workflow: build the API wire request → POST it through
+  the caller's `HttpClient` to the correct `/facts/*` path → decode the
+  `{Op}Facts` response → `verify{Op}Facts` → `{op}CageTx` → serialize →
+  return `UnsignedTx`. Any stage failure returns the matching
+  `WorkflowError` constructor.
+- **FR3** — No protocol reimplementation. All verification and
+  transaction construction route through `cardano-mpfs-client`'s
+  exported pure functions. Serialization of the built `Tx ConwayEra`
+  uses a new `cardano-mpfs-client` export (`serializeCageTx`), so the
+  ledger stays out of the workflows package entirely.
+- **FR4** — Transport is abstracted behind a `HttpClient`
+  record-of-functions. The workflows package and the workflow function
+  signatures depend on **no** `http-client`, `servant-client`, or
+  `Cardano.Ledger.*` modules.
+- **FR5** — Signing and submission are the caller's responsibility.
+  `UnsignedTx` carries submission-ready CBOR bytes; the caller signs
+  and POSTs to `/submit` (#288).
+- **FR6** — No CLI parsing, no UI, no server changes.
+
+## Out of scope
+
+- Signing, key management, `/submit` wiring (caller / #288).
+- WASM/JS build files and the `fetch` shim (#258).
+- A live integration test exercising the happy path against a running
+  server — **gated on #288 `/submit`**; tracked as a follow-on task,
+  not faked here.
+
+## Success criteria
+
+- `Cardano.MPFS.Workflows` exports the 8 workflows + 4 named types and
+  compiles with `-Wall -Werror`.
+- `cardano-mpfs-workflows` build-depends only on: `base`, `aeson`,
+  `bytestring`, `text`, `cardano-mpfs-api`, `cardano-mpfs-client`
+  (+ test-only deps). No `http-client`, `servant-*`, or
+  `cardano-ledger-*`.
+- Unit tests prove, per workflow: the correct path + JSON body is
+  posted (captured via a stub `HttpClient`), and each `WorkflowError`
+  stage (HTTP, decode, verify, build) propagates. Green under
+  `just unit-workflows`.
+- `just ci` (extended with the workflows test) passes.
+- A `tasks.md` entry records that the live happy-path integration test
+  follows the #288 merge.

--- a/specs/289-workflows/tasks.md
+++ b/specs/289-workflows/tasks.md
@@ -49,7 +49,7 @@ that the orchestrator accepts.
 
 ## Slice S6 — end cage
 
-- [ ] T289-S6 `endCage` (`/facts/end`, `EndRequest`,
+- [X] T289-S6 `endCage` (`/facts/end`, `EndRequest`,
   `verifyEndFacts wcCage wcTrustedRoot`, `endCageTx`). Tests: routing +
   body + verify-error propagation.
 

--- a/specs/289-workflows/tasks.md
+++ b/specs/289-workflows/tasks.md
@@ -1,0 +1,68 @@
+# Tasks — #289 `cardano-mpfs-workflows`
+
+One slice = one bisect-safe commit. Each commit body carries
+`Tasks: T289-S<n>`. Boxes flip to `[X]` in the same amended commit
+that the orchestrator accepts.
+
+## Slice S1 — client `serializeCageTx` export
+
+- [ ] T289-S1 Add `Cardano.MPFS.Client.Cage.Serialize` exporting
+  `serializeCageTx :: Tx ConwayEra -> ByteString`
+  (`serialize' (natVersion @11)`); list it in
+  `cardano-mpfs-client.cabal` `exposed-modules`; add a client unit test
+  asserting a built tx serializes to non-empty CBOR that re-decodes.
+
+## Slice S2 — workflows package + `registerToken`
+
+- [ ] T289-S2 Create `cardano-mpfs-workflows/` (cabal: lib + hspec
+  test). Wire into `cabal.project`, `nix/project.nix` (component +
+  runner + package + app), `flake.nix` packages, `justfile`
+  (`unit-workflows` recipe + add to `ci`). Implement
+  `Cardano.MPFS.Workflows.Internal` (`HttpClient`, `HttpError`,
+  `UnsignedTx`, `WorkflowsConfig`, `WorkflowError`, `runFactsWorkflow`)
+  and `Cardano.MPFS.Workflows` exporting the named surface +
+  `registerToken`. Tests: stub-`HttpClient` routing (path+body),
+  `WorkflowHttpError`, `WorkflowDecodeError`, `WorkflowVerifyError`
+  (root mismatch), `WorkflowBuildError` (root-matching empty-wallet
+  boot → `EmptyFunding`). Green under `just unit-workflows`.
+
+## Slice S3 — requester request workflows
+
+- [ ] T289-S3 `insertFact` (`/facts/request/insert`), `updateFact`
+  (`/facts/request/update`), `deleteFact` (`/facts/request/delete`)
+  over `runFactsWorkflow`; re-export `InsertRequest`,
+  `UpdateValueRequest`, `DeleteRequest`. Tests: routing + body per op,
+  verify-error propagation per op.
+
+## Slice S4 — oracle apply
+
+- [ ] T289-S4 `applyRequests` (`/facts/update`, `UpdateRequest`,
+  `verifyUpdateFacts`, `updateCageTx`). Tests: routing + body +
+  verify-error propagation.
+
+## Slice S5 — retract + reject
+
+- [ ] T289-S5 `retractRequest` (`/facts/retract`, `RetractRequest`,
+  `verifyRetractFacts`, `retractCageTx`) and `rejectExpired`
+  (`/facts/reject`, `RejectRequest`, `verifyRejectFacts`,
+  `rejectCageTx`). Tests: routing + body + verify-error per op.
+
+## Slice S6 — end cage
+
+- [ ] T289-S6 `endCage` (`/facts/end`, `EndRequest`,
+  `verifyEndFacts wcCage wcTrustedRoot`, `endCageTx`). Tests: routing +
+  body + verify-error propagation.
+
+## Deferred (NOT in this PR — gated on #288)
+
+- [ ] T289-S7 Live integration test: run a server, exercise each
+  workflow end-to-end with real proofs, sign the `UnsignedTx`, POST to
+  `/submit`, assert acceptance. **Blocked by #288 (`/submit`).** File
+  as a follow-on issue / add when #288 merges. Do not fake submission.
+
+## Notes
+
+- `applyRequests` (8th workflow) added per operator decision
+  (2026-05-29): the brief named 7; the oracle update is the 8th.
+- No `http-client` / `servant-*` / `cardano-ledger-*` in the workflows
+  package — enforced by the cabal dep list and `-Wunused-packages`.

--- a/specs/289-workflows/tasks.md
+++ b/specs/289-workflows/tasks.md
@@ -28,7 +28,7 @@ that the orchestrator accepts.
 
 ## Slice S3 — requester request workflows
 
-- [ ] T289-S3 `insertFact` (`/facts/request/insert`), `updateFact`
+- [X] T289-S3 `insertFact` (`/facts/request/insert`), `updateFact`
   (`/facts/request/update`), `deleteFact` (`/facts/request/delete`)
   over `runFactsWorkflow`; re-export `InsertRequest`,
   `UpdateValueRequest`, `DeleteRequest`. Tests: routing + body per op,

--- a/specs/289-workflows/tasks.md
+++ b/specs/289-workflows/tasks.md
@@ -6,7 +6,7 @@ that the orchestrator accepts.
 
 ## Slice S1 — client `serializeCageTx` export
 
-- [ ] T289-S1 Add `Cardano.MPFS.Client.Cage.Serialize` exporting
+- [X] T289-S1 Add `Cardano.MPFS.Client.Cage.Serialize` exporting
   `serializeCageTx :: Tx ConwayEra -> ByteString`
   (`serialize' (natVersion @11)`); list it in
   `cardano-mpfs-client.cabal` `exposed-modules`; add a client unit test

--- a/specs/289-workflows/tasks.md
+++ b/specs/289-workflows/tasks.md
@@ -36,7 +36,7 @@ that the orchestrator accepts.
 
 ## Slice S4 — oracle apply
 
-- [ ] T289-S4 `applyRequests` (`/facts/update`, `UpdateRequest`,
+- [X] T289-S4 `applyRequests` (`/facts/update`, `UpdateRequest`,
   `verifyUpdateFacts`, `updateCageTx`). Tests: routing + body +
   verify-error propagation.
 

--- a/specs/289-workflows/tasks.md
+++ b/specs/289-workflows/tasks.md
@@ -14,7 +14,7 @@ that the orchestrator accepts.
 
 ## Slice S2 — workflows package + `registerToken`
 
-- [ ] T289-S2 Create `cardano-mpfs-workflows/` (cabal: lib + hspec
+- [X] T289-S2 Create `cardano-mpfs-workflows/` (cabal: lib + hspec
   test). Wire into `cabal.project`, `nix/project.nix` (component +
   runner + package + app), `flake.nix` packages, `justfile`
   (`unit-workflows` recipe + add to `ci`). Implement

--- a/specs/289-workflows/tasks.md
+++ b/specs/289-workflows/tasks.md
@@ -42,7 +42,7 @@ that the orchestrator accepts.
 
 ## Slice S5 — retract + reject
 
-- [ ] T289-S5 `retractRequest` (`/facts/retract`, `RetractRequest`,
+- [X] T289-S5 `retractRequest` (`/facts/retract`, `RetractRequest`,
   `verifyRetractFacts`, `retractCageTx`) and `rejectExpired`
   (`/facts/reject`, `RejectRequest`, `verifyRejectFacts`,
   `rejectCageTx`). Tests: routing + body + verify-error per op.

--- a/specs/289-workflows/tasks.md
+++ b/specs/289-workflows/tasks.md
@@ -53,12 +53,17 @@ that the orchestrator accepts.
   `verifyEndFacts wcCage wcTrustedRoot`, `endCageTx`). Tests: routing +
   body + verify-error propagation.
 
-## Deferred (NOT in this PR — gated on #288)
+## Slice S7 — live-boundary integration through /submit
 
-- [ ] T289-S7 Live integration test: run a server, exercise each
-  workflow end-to-end with real proofs, sign the `UnsignedTx`, POST to
-  `/submit`, assert acceptance. **Blocked by #288 (`/submit`).** File
-  as a follow-on issue / add when #288 merges. Do not fake submission.
+- [X] T289-S7 `Cardano.MPFS.E2E.WorkflowsIntegrationSpec`: one e2e row
+  per workflow, each driving the real `cardano-mpfs-workflows.<name>`
+  against a live devnet via an in-process WAI `HttpClient`, decoding
+  the `UnsignedTx`, signing with the genesis key, POSTing to `/submit`
+  (#288), awaiting the txId, and asserting the on-chain effect (token
+  indexed / request queued / fact materialised / request drained /
+  token burned). No scaffolding fakes. Run:
+  `just e2e WorkflowsIntegration` (8 examples, 0 failures). #288 merged
+  to main, so this landed in this PR rather than as a follow-on.
 
 ## Notes
 


### PR DESCRIPTION
Closes #289. Child 2 of epic #287.

## What

A new `cardano-mpfs-workflows` library: **one high-level function per
end-to-end MPFS workflow**, so the CLI (#290) and the PureScript SPA
(#291) share the protocol instead of each re-encoding it.

| Workflow | Endpoint | Verifier | Builder |
|---|---|---|---|
| `registerToken` | `POST /facts/boot` | `verifyBootFacts` | `bootCageTx` |
| `insertFact` | `POST /facts/request/insert` | `verifyRequestInsertFacts` | `requestInsertCageTx` |
| `updateFact` | `POST /facts/request/update` | `verifyRequestUpdateFacts` | `requestUpdateCageTx` |
| `deleteFact` | `POST /facts/request/delete` | `verifyRequestDeleteFacts` | `requestDeleteCageTx` |
| `applyRequests` | `POST /facts/update` | `verifyUpdateFacts` | `updateCageTx` |
| `retractRequest` | `POST /facts/retract` | `verifyRetractFacts` | `retractCageTx` |
| `rejectExpired` | `POST /facts/reject` | `verifyRejectFacts` | `rejectCageTx` |
| `endCage` | `POST /facts/end` | `verifyEndFacts` | `endCageTx` |

Each function: build the API wire request → POST it through a
caller-supplied `HttpClient` → decode the `{Op}Facts` response →
verify against the trusted root → build the cage tx → serialize →
return `UnsignedTx` (or a typed `WorkflowError`). Signing + submission
stay with the caller.

`applyRequests` (the oracle update) is the 8th workflow — the brief
named 7; the oracle batch-apply was added per operator decision so
owner front-ends have it.

## Design (see `specs/289-workflows/`)

- **No protocol reimplementation.** All verification + tx construction
  route through `cardano-mpfs-client`'s pure functions
  (`verify{Op}Facts`, `{op}CageTx`). The shared `runFactsWorkflow`
  helper is the only glue.
- **Transport abstracted** behind an `HttpClient` record-of-functions
  (relative path + JSON body → JSON response). The CLI backs it with
  `http-client`/`wreq`; the SPA's WASM build backs it with a `fetch`
  shim. The package and the workflow signatures depend on **no**
  `http-client` / `servant-*` / `cardano-ledger-*` — library
  build-depends is only `base, aeson, bytestring, text,
  cardano-mpfs-api, cardano-mpfs-client` (#258 cross-compiles this).
- **`UnsignedTx` = submission-ready CBOR.** The cage builders return
  `Tx ConwayEra`; a new `cardano-mpfs-client` export `serializeCageTx`
  turns it into bytes, so the ledger stays out of the workflows
  package entirely (the intermediate `Tx` type is never named here).

## Commits (bisect-safe slices)

1. `feat(client): add serializeCageTx for submission-ready CBOR`
2. `style(client): format SerializeSpec to fourmolu`
3. `feat(workflows): add cardano-mpfs-workflows package with registerToken`
4. `feat(workflows): add insertFact, updateFact, deleteFact request workflows`
5. `feat(workflows): add applyRequests oracle update workflow`
6. `feat(workflows): add retractRequest and rejectExpired workflows`
7. `feat(workflows): add endCage workflow`

## Tests

36 unit examples via a stub `HttpClient`. For boot + the three request
workflows, the tests cover all five stages including the build stage
(empty wallet set lets verification pass, then the builder fails on
deliberately-malformed protocol params). For `applyRequests`,
`retractRequest`, `rejectExpired`, `endCage` — whose verifiers replay a
state/request UTxO proof — the tests cover routing + HTTP + decode +
verify; the build / happy path needs real CSMT proofs and a live
`/submit`, so it is an **integration test gated on #288** (tasks.md
T289-S7), not faked here. `just ci` passes (build + swagger + all unit
suites + format-check + hlint).

## Follow-on

- T289-S7: live integration test (real proofs → sign `UnsignedTx` →
  `POST /submit`), once #288 lands.