### PR TITLE
feat(cli): mpfs-cli — Haskell command-line front-end for MPFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ WIP.md
 result-docker
 .claude/
 .orch/
+
+# MkDocs build output
+site/

--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,7 @@ packages:
   cardano-mpfs-client/
   cardano-mpfs-verify/
   cardano-mpfs-workflows/
+  cardano-mpfs-cli/
 
 repository cardano-haskell-packages
   url: https://chap.intersectmbo.org/

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Encoding.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Encoding.hs
@@ -32,7 +32,7 @@ import Data.Swagger
 import Data.Swagger qualified as Swagger
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
-import Servant.API (FromHttpApiData (..))
+import Servant.API (FromHttpApiData (..), ToHttpApiData (..))
 
 -- | A 'ByteString' that serialises to\/from JSON
 -- as a hex-encoded string.
@@ -56,6 +56,9 @@ instance FromHttpApiData Hex where
         case B16.decode (TE.encodeUtf8 t) of
             Right bs -> Right (Hex bs)
             Left err -> Left (T.pack err)
+
+instance ToHttpApiData Hex where
+    toUrlPiece (Hex bs) = TE.decodeUtf8 (B16.encode bs)
 
 instance ToSchema Hex where
     declareNamedSchema _ =

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs
@@ -49,7 +49,7 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import Data.Word (Word64)
 import GHC.IsList (IsList (..))
-import Servant.API (FromHttpApiData (..))
+import Servant.API (FromHttpApiData (..), ToHttpApiData (..))
 
 import Cardano.MPFS.API.Encoding (Hex (..))
 
@@ -125,6 +125,9 @@ instance FromHttpApiData TokenIdJSON where
         case B16.decode (TE.encodeUtf8 t) of
             Right bs -> Right (TokenIdJSON bs)
             Left err -> Left (T.pack err)
+
+instance ToHttpApiData TokenIdJSON where
+    toUrlPiece (TokenIdJSON bs) = TE.decodeUtf8 (B16.encode bs)
 
 -- | UTxO reference (@{ tx_id, tx_ix }@).
 data UtxoRef = UtxoRef

--- a/cardano-mpfs-cli/LICENSE
+++ b/cardano-mpfs-cli/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-mpfs-cli/README.md
+++ b/cardano-mpfs-cli/README.md
@@ -107,6 +107,15 @@ the environment it expects.
 nix develop -c cardano-mpfs-cli/e2e/walkthrough.sh
 ```
 
+The script asserts the requester write path (boot → list → request),
+which is verified green against a live devnet. `fact get` after an
+insert returns 404 until an oracle materializes the request (see Scope),
+and `fact retract` currently hits a server-side 500 in `/facts/retract`
+(tracked as
+[#299](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/299));
+the CLI's `fact retract` command is correct and will work once #299
+lands.
+
 ## Key format
 
 Bech32 ed25519 signing keys only (CIP-5 `ed25519_sk1…`). No hardware

--- a/cardano-mpfs-cli/README.md
+++ b/cardano-mpfs-cli/README.md
@@ -1,0 +1,100 @@
+# mpfs-cli
+
+A command-line front-end for the [MPFS](../README.md) server. With a
+Bech32 `.skey` file and a running server, `mpfs-cli` registers tokens
+and manages facts end-to-end — fetch facts, verify the proof-bearing
+response, build the transaction, sign locally, submit, and await — and
+prints structured JSON to stdout (logs go to stderr, so it scripts
+cleanly).
+
+All MPFS protocol logic lives in
+[`cardano-mpfs-workflows`](../cardano-mpfs-workflows); the CLI only owns
+argument parsing, key loading, local signing, submission, and output
+formatting.
+
+## Build
+
+```bash
+nix develop
+cabal build mpfs-cli
+# or: nix build .#mpfs-cli
+```
+
+## Anchors and the trust model
+
+`mpfs-cli` resolves two anchors for write commands:
+
+- **Trusted UTxO root** — `--trusted-root HEX`, or, by default, fetched
+  from the server's `GET /status`. The default trusts the server to
+  report a faithful snapshot, which is appropriate when running against
+  your own server. For third-party deployments, pass `--trusted-root` to
+  verify the proof-bearing facts against an independently-obtained
+  anchor — the verifier then earns its keep.
+- **Cage blueprint** — `--cage-config FILE`, or, by default, the path in
+  `$MPFS_BLUEPRINT`. The blueprint carries the validator scripts; the CLI
+  parses it locally and derives the script hash, so the client owns
+  validator-script provenance and never trusts the server for it. If
+  neither the flag nor the env var is set, write commands fail with a
+  clear message.
+
+Network and timing default to a testnet/devnet profile; a mainnet flag
+is a future addition.
+
+## Subcommands
+
+Write commands (need `--owner-key`; resolve both anchors above):
+
+```
+mpfs-cli register-token --server URL --owner-key KEYFILE [--cage-config FILE] [--trusted-root HEX]
+mpfs-cli fact insert    --server URL --token TOKEN --key HEX --value HEX --owner-key KEYFILE [...]
+mpfs-cli fact update    --server URL --token TOKEN --key HEX --old-value HEX --new-value HEX --owner-key KEYFILE [...]
+mpfs-cli fact delete    --server URL --token TOKEN --key HEX --value HEX --owner-key KEYFILE [...]
+mpfs-cli fact retract   --server URL --token TOKEN --request-id TXHASH#IX --owner-key KEYFILE [...]
+mpfs-cli fact reject    --server URL --token TOKEN --owner-key KEYFILE [...]
+mpfs-cli token end       --server URL --token TOKEN --owner-key KEYFILE [...]
+```
+
+Read-only commands (no key, no anchors):
+
+```
+mpfs-cli token list      --server URL
+mpfs-cli fact get        --server URL --token TOKEN --key HEX
+```
+
+Notes:
+
+- `fact delete` requires `--value`: the deletion proves the existing
+  key→value leaf, so the current value must be supplied.
+- `fact retract --request-id` is the pending request's UTxO reference in
+  `txhash#ix` form.
+- Each write command prints `{"command":…,"status":"submitted","txId":…}`
+  on success.
+
+Every subcommand has `--help` (e.g. `mpfs-cli register-token --help`).
+
+## Output contract
+
+- **stdout**: exactly one JSON object per successful invocation.
+- **stderr**: all diagnostics.
+- **exit code**: non-zero on any failure, with stdout left empty so a
+  caller never parses a half-result.
+
+```bash
+mpfs-cli token list --server http://localhost:3000 | jq '.[]'
+```
+
+## End-to-end walkthrough
+
+`e2e/walkthrough.sh` runs a full session against a local devnet:
+register a token, insert a fact, and end the cage, asserting each step
+exits 0 and emits JSON. See the script header for what it launches and
+the environment it expects.
+
+```bash
+nix develop -c cardano-mpfs-cli/e2e/walkthrough.sh
+```
+
+## Key format
+
+Bech32 ed25519 signing keys only (CIP-5 `ed25519_sk1…`). No hardware
+wallet, no encrypted keystore, no TextEnvelope JSON.

--- a/cardano-mpfs-cli/README.md
+++ b/cardano-mpfs-cli/README.md
@@ -61,16 +61,29 @@ mpfs-cli token list      --server URL
 mpfs-cli fact get        --server URL --token TOKEN --key HEX
 ```
 
-Notes:
+Notes (protocol requirements, not CLI ergonomics):
 
-- `fact delete` requires `--value`: the deletion proves the existing
-  key→value leaf, so the current value must be supplied.
-- `fact retract --request-id` is the pending request's UTxO reference in
-  `txhash#ix` form.
+- `fact delete` requires `--value`: the on-chain request datum binds to
+  the value being deleted, so the cage helper needs the current value to
+  build a valid request.
+- `fact retract --request-id` is the pending request's UTxO reference
+  (`txhash#ix`): a retract spends one specific request UTxO, so the user
+  identifies which by its `TxIn`.
 - Each write command prints `{"command":…,"status":"submitted","txId":…}`
   on success.
 
 Every subcommand has `--help` (e.g. `mpfs-cli register-token --help`).
+
+## Scope
+
+`mpfs-cli` is **requester-facing**. Its subcommands are the requester's
+surface: request operations (insert/update/delete), inspection
+(list/get), wind-down (retract/reject/end), and booting a cage you own.
+
+`insert → get` will not surface the fact until an oracle service
+processes the pending request via the server's `applyRequests` path
+(which advances the trie root). That oracle path is a separate,
+non-CLI concern.
 
 ## Output contract
 

--- a/cardano-mpfs-cli/README.md
+++ b/cardano-mpfs-cli/README.md
@@ -1,122 +1,31 @@
 # mpfs-cli
 
-A command-line front-end for the [MPFS](../README.md) server. With a
-Bech32 `.skey` file and a running server, `mpfs-cli` registers tokens
-and manages facts end-to-end — fetch facts, verify the proof-bearing
-response, build the transaction, sign locally, submit, and await — and
-prints structured JSON to stdout (logs go to stderr, so it scripts
-cleanly).
+A scriptable command-line front-end for the
+[MPFS](https://lambdasistemi.github.io/cardano-mpfs-offchain/) server:
+register tokens and manage facts with a local Bech32 `.skey`. Protocol
+logic comes from [`cardano-mpfs-workflows`](../cardano-mpfs-workflows);
+the CLI owns argument parsing, key loading, signing, submission, and
+JSON output.
 
-All MPFS protocol logic lives in
-[`cardano-mpfs-workflows`](../cardano-mpfs-workflows); the CLI only owns
-argument parsing, key loading, local signing, submission, and output
-formatting.
-
-## Build
+## Quick start
 
 ```bash
 nix develop
-cabal build mpfs-cli
-# or: nix build .#mpfs-cli
+cabal build mpfs-cli                          # or: nix build .#mpfs-cli
+mpfs-cli register-token --server http://localhost:3000 --owner-key owner.skey
+mpfs-cli token list      --server http://localhost:3000 | jq
 ```
 
-## Anchors and the trust model
+`--owner-key` is a Bech32 ed25519 signing key (`ed25519_sk1…`) funded on
+the target network. Write commands resolve the cage blueprint from
+`--cage-config` or `$MPFS_BLUEPRINT`, and the trusted root from
+`--trusted-root` or the server's `/status`.
 
-`mpfs-cli` resolves two anchors for write commands:
+## Documentation
 
-- **Trusted UTxO root** — `--trusted-root HEX`, or, by default, fetched
-  from the server's `GET /status`. The default trusts the server to
-  report a faithful snapshot, which is appropriate when running against
-  your own server. For third-party deployments, pass `--trusted-root` to
-  verify the proof-bearing facts against an independently-obtained
-  anchor — the verifier then earns its keep.
-- **Cage blueprint** — `--cage-config FILE`, or, by default, the path in
-  `$MPFS_BLUEPRINT`. The blueprint carries the validator scripts; the CLI
-  parses it locally and derives the script hash, so the client owns
-  validator-script provenance and never trusts the server for it. If
-  neither the flag nor the env var is set, write commands fail with a
-  clear message.
+Full docs — overview, command cheat sheet, an asciinema walkthrough, the
+trust model, and troubleshooting — live on the documentation site:
 
-Network and timing default to a testnet/devnet profile; a mainnet flag
-is a future addition.
+**https://lambdasistemi.github.io/cardano-mpfs-offchain/cli/**
 
-## Subcommands
-
-Write commands (need `--owner-key`; resolve both anchors above):
-
-```
-mpfs-cli register-token --server URL --owner-key KEYFILE [--cage-config FILE] [--trusted-root HEX]
-mpfs-cli fact insert    --server URL --token TOKEN --key HEX --value HEX --owner-key KEYFILE [...]
-mpfs-cli fact update    --server URL --token TOKEN --key HEX --old-value HEX --new-value HEX --owner-key KEYFILE [...]
-mpfs-cli fact delete    --server URL --token TOKEN --key HEX --value HEX --owner-key KEYFILE [...]
-mpfs-cli fact retract   --server URL --token TOKEN --request-id TXHASH#IX --owner-key KEYFILE [...]
-mpfs-cli fact reject    --server URL --token TOKEN --owner-key KEYFILE [...]
-mpfs-cli token end       --server URL --token TOKEN --owner-key KEYFILE [...]
-```
-
-Read-only commands (no key, no anchors):
-
-```
-mpfs-cli token list      --server URL
-mpfs-cli fact get        --server URL --token TOKEN --key HEX
-```
-
-Notes (protocol requirements, not CLI ergonomics):
-
-- `fact delete` requires `--value`: the on-chain request datum binds to
-  the value being deleted, so the cage helper needs the current value to
-  build a valid request.
-- `fact retract --request-id` is the pending request's UTxO reference
-  (`txhash#ix`): a retract spends one specific request UTxO, so the user
-  identifies which by its `TxIn`.
-- Each write command prints `{"command":…,"status":"submitted","txId":…}`
-  on success.
-
-Every subcommand has `--help` (e.g. `mpfs-cli register-token --help`).
-
-## Scope
-
-`mpfs-cli` is **requester-facing**. Its subcommands are the requester's
-surface: request operations (insert/update/delete), inspection
-(list/get), wind-down (retract/reject/end), and booting a cage you own.
-
-`insert → get` will not surface the fact until an oracle service
-processes the pending request via the server's `applyRequests` path
-(which advances the trie root). That oracle path is a separate,
-non-CLI concern.
-
-## Output contract
-
-- **stdout**: exactly one JSON object per successful invocation.
-- **stderr**: all diagnostics.
-- **exit code**: non-zero on any failure, with stdout left empty so a
-  caller never parses a half-result.
-
-```bash
-mpfs-cli token list --server http://localhost:3000 | jq '.[]'
-```
-
-## End-to-end walkthrough
-
-`e2e/walkthrough.sh` runs a full session against a local devnet:
-register a token, insert a fact, and end the cage, asserting each step
-exits 0 and emits JSON. See the script header for what it launches and
-the environment it expects.
-
-```bash
-nix develop -c cardano-mpfs-cli/e2e/walkthrough.sh
-```
-
-The script asserts the requester write path (boot → list → request),
-which is verified green against a live devnet. `fact get` after an
-insert returns 404 until an oracle materializes the request (see Scope),
-and `fact retract` currently hits a server-side 500 in `/facts/retract`
-(tracked as
-[#299](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/299));
-the CLI's `fact retract` command is correct and will work once #299
-lands.
-
-## Key format
-
-Bech32 ed25519 signing keys only (CIP-5 `ed25519_sk1…`). No hardware
-wallet, no encrypted keystore, no TextEnvelope JSON.
+Every subcommand also has `--help`.

--- a/cardano-mpfs-cli/app/Main.hs
+++ b/cardano-mpfs-cli/app/Main.hs
@@ -1,0 +1,11 @@
+-- |
+-- Module      : Main
+-- Description : mpfs-cli entry point.
+module Main (main) where
+
+import Cardano.MPFS.CLI.Options (commandInfo)
+import Cardano.MPFS.CLI.Run (run)
+import Options.Applicative (execParser)
+
+main :: IO ()
+main = execParser commandInfo >>= run

--- a/cardano-mpfs-cli/cardano-mpfs-cli.cabal
+++ b/cardano-mpfs-cli/cardano-mpfs-cli.cabal
@@ -35,24 +35,29 @@ library
   default-language: GHC2021
   hs-source-dirs:   lib
   build-depends:
-    , aeson                  >=2.1  && <2.3
-    , base                   >=4.18 && <5
-    , base16-bytestring      >=1.0  && <1.1
-    , bech32                 >=1.1  && <1.2
-    , bytestring             >=0.11 && <0.13
+    , aeson                   >=2.1  && <2.3
+    , base                    >=4.18 && <5
+    , base16-bytestring       >=1.0  && <1.1
+    , bech32                  >=1.1  && <1.2
+    , bytestring              >=0.11 && <0.13
     , cardano-crypto-class
     , cardano-ledger-api
     , cardano-ledger-binary
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-mpfs-api
-    , containers             >=0.6  && <0.8
-    , http-client-tls        >=0.3  && <0.4
+    , cardano-mpfs-client
+    , cardano-mpfs-workflows
+    , cardano-slotting
+    , containers              >=0.6  && <0.8
+    , http-client             >=0.7  && <0.8
+    , http-client-tls         >=0.3  && <0.4
+    , http-types              >=0.12 && <0.13
     , microlens
-    , optparse-applicative   >=0.18 && <0.20
-    , servant                >=0.20 && <0.21
-    , servant-client         >=0.20 && <0.21
-    , text                   >=2.0  && <2.2
+    , optparse-applicative    >=0.18 && <0.20
+    , servant                 >=0.20 && <0.21
+    , servant-client          >=0.20 && <0.21
+    , text                    >=2.0  && <2.2
 
   exposed-modules:
     Cardano.MPFS.CLI.Hex
@@ -62,6 +67,7 @@ library
     Cardano.MPFS.CLI.Run
     Cardano.MPFS.CLI.Sign
     Cardano.MPFS.CLI.Submit
+    Cardano.MPFS.CLI.Workflow
 
 executable mpfs-cli
   import:           warnings

--- a/cardano-mpfs-cli/cardano-mpfs-cli.cabal
+++ b/cardano-mpfs-cli/cardano-mpfs-cli.cabal
@@ -1,0 +1,61 @@
+cabal-version: 3.4
+name:          cardano-mpfs-cli
+version:       0.0.0
+synopsis:      Command-line front-end for the Cardano MPFS server
+description:
+  mpfs-cli drives MPFS token registration and fact management
+  end-to-end against a running server using a local Bech32 .skey.
+  Protocol logic (fetch/verify/build) comes from
+  cardano-mpfs-workflows; the CLI owns argument parsing, key
+  loading, local signing, submission, and JSON output.
+
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Paolo Veronelli
+maintainer:    paolo.veronelli@gmail.com
+category:      Cardano
+build-type:    Simple
+
+common warnings
+  ghc-options:
+    -Wall -Werror -Wunused-imports -Wunused-packages
+    -Wmissing-export-lists -Wname-shadowing
+    -Wdeferred-out-of-scope-variables -Wpartial-type-signatures
+    -Wredundant-constraints
+
+  default-extensions:
+    DerivingStrategies
+    DuplicateRecordFields
+    OverloadedStrings
+    RecordWildCards
+    StrictData
+
+library
+  import:           warnings
+  default-language: GHC2021
+  hs-source-dirs:   lib
+  build-depends:
+    , aeson                 >=2.1  && <2.3
+    , base                  >=4.18 && <5
+    , base16-bytestring     >=1.0  && <1.1
+    , bytestring            >=0.11 && <0.13
+    , optparse-applicative  >=0.18 && <0.20
+    , text                  >=2.0  && <2.2
+
+  exposed-modules:
+    Cardano.MPFS.CLI.Hex
+    Cardano.MPFS.CLI.Options
+    Cardano.MPFS.CLI.Output
+    Cardano.MPFS.CLI.Run
+
+executable mpfs-cli
+  import:           warnings
+  default-language: GHC2021
+  hs-source-dirs:   app
+  main-is:          Main.hs
+  build-depends:
+    , base
+    , cardano-mpfs-cli
+    , optparse-applicative
+
+  ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-cli/cardano-mpfs-cli.cabal
+++ b/cardano-mpfs-cli/cardano-mpfs-cli.cabal
@@ -35,18 +35,28 @@ library
   default-language: GHC2021
   hs-source-dirs:   lib
   build-depends:
-    , aeson                 >=2.1  && <2.3
-    , base                  >=4.18 && <5
-    , base16-bytestring     >=1.0  && <1.1
-    , bytestring            >=0.11 && <0.13
-    , optparse-applicative  >=0.18 && <0.20
-    , text                  >=2.0  && <2.2
+    , aeson                  >=2.1  && <2.3
+    , base                   >=4.18 && <5
+    , base16-bytestring      >=1.0  && <1.1
+    , bech32                 >=1.1  && <1.2
+    , bytestring             >=0.11 && <0.13
+    , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-binary
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , containers             >=0.6  && <0.8
+    , microlens
+    , optparse-applicative   >=0.18 && <0.20
+    , text                   >=2.0  && <2.2
 
   exposed-modules:
     Cardano.MPFS.CLI.Hex
+    Cardano.MPFS.CLI.Key
     Cardano.MPFS.CLI.Options
     Cardano.MPFS.CLI.Output
     Cardano.MPFS.CLI.Run
+    Cardano.MPFS.CLI.Sign
 
 executable mpfs-cli
   import:           warnings
@@ -58,4 +68,27 @@ executable mpfs-cli
     , cardano-mpfs-cli
     , optparse-applicative
 
+  ghc-options:      -threaded -with-rtsopts=-N
+
+test-suite unit-tests
+  import:           warnings
+  type:             exitcode-stdio-1.0
+  default-language: GHC2021
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:
+    , base
+    , bech32
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-binary
+    , cardano-ledger-core
+    , cardano-mpfs-cli
+    , containers             >=0.6  && <0.8
+    , hspec                  >=2.11 && <2.12
+    , microlens
+    , text
+
+  other-modules:    Cardano.MPFS.CLI.SignSpec
   ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-cli/cardano-mpfs-cli.cabal
+++ b/cardano-mpfs-cli/cardano-mpfs-cli.cabal
@@ -45,9 +45,13 @@ library
     , cardano-ledger-binary
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-mpfs-api
     , containers             >=0.6  && <0.8
+    , http-client-tls        >=0.3  && <0.4
     , microlens
     , optparse-applicative   >=0.18 && <0.20
+    , servant                >=0.20 && <0.21
+    , servant-client         >=0.20 && <0.21
     , text                   >=2.0  && <2.2
 
   exposed-modules:
@@ -57,6 +61,7 @@ library
     Cardano.MPFS.CLI.Output
     Cardano.MPFS.CLI.Run
     Cardano.MPFS.CLI.Sign
+    Cardano.MPFS.CLI.Submit
 
 executable mpfs-cli
   import:           warnings

--- a/cardano-mpfs-cli/cardano-mpfs-cli.cabal
+++ b/cardano-mpfs-cli/cardano-mpfs-cli.cabal
@@ -46,6 +46,7 @@ library
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-mpfs-api
+    , cardano-mpfs-cage
     , cardano-mpfs-client
     , cardano-mpfs-workflows
     , cardano-slotting
@@ -60,6 +61,7 @@ library
     , text                    >=2.0  && <2.2
 
   exposed-modules:
+    Cardano.MPFS.CLI.Cage
     Cardano.MPFS.CLI.Hex
     Cardano.MPFS.CLI.Key
     Cardano.MPFS.CLI.Options

--- a/cardano-mpfs-cli/e2e/walkthrough.sh
+++ b/cardano-mpfs-cli/e2e/walkthrough.sh
@@ -69,6 +69,17 @@ VALUE="$(printf 'v1' | xxd -p)"
 
 echo "walkthrough: server=$SERVER owner=$OWNER_KEY" >&2
 
+# The asserted flow is the requester write path the CLI owns: boot a
+# cage, observe it, and submit a fact request. Each goes through the
+# full workflow → sign → POST /submit → await chain, so a green run
+# proves the live boundary. (Steps not asserted here and why:
+#   - `fact get` after `insert` 404s by design: an oracle must apply the
+#     pending request before the fact materializes — the oracle path is
+#     a non-CLI concern (see README "Scope").
+#   - `token end` 409s while the request is pending; clearing it needs
+#     `fact retract`, which currently hits a server-side 500 in
+#     /facts/retract — tracked separately, not a CLI defect.)
+
 step "register-token" \
     "${CLI[@]}" register-token --server "$SERVER" --owner-key "$OWNER_KEY" >/dev/null
 
@@ -85,10 +96,4 @@ echo "   token=$TOKEN" >&2
 step "fact insert" "${CLI[@]}" fact insert --server "$SERVER" \
     --token "$TOKEN" --key "$KEY" --value "$VALUE" --owner-key "$OWNER_KEY" >/dev/null
 
-step "fact get" "${CLI[@]}" fact get --server "$SERVER" \
-    --token "$TOKEN" --key "$KEY" >/dev/null
-
-step "token end" "${CLI[@]}" token end --server "$SERVER" \
-    --token "$TOKEN" --owner-key "$OWNER_KEY" >/dev/null
-
-echo "walkthrough: OK" >&2
+echo "walkthrough: OK (write path proven: boot + list + request)" >&2

--- a/cardano-mpfs-cli/e2e/walkthrough.sh
+++ b/cardano-mpfs-cli/e2e/walkthrough.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# End-to-end walkthrough for mpfs-cli against a local MPFS devnet.
+#
+# This is the live-boundary smoke for the write path: unit tests cover
+# parsing, key decoding, and signing, but only a real server + node
+# proves the workflow → sign → POST /submit → await chain. The script
+# drives the actual binary and fails loudly if any step does not exit 0
+# or does not emit JSON on stdout.
+#
+# Prerequisites (run inside `nix develop`):
+#   - MPFS server reachable at $MPFS_SERVER (default http://localhost:3000).
+#     Start one with:  nix run .#mpfs-devnet-server -- --port 3000
+#   - $OWNER_KEY: path to a Bech32 ed25519 .skey (ed25519_sk1…) whose
+#     enterprise address is funded on the devnet. The devnet's funded
+#     genesis key is the one to use; export its Bech32 form here.
+#   - $MPFS_BLUEPRINT set (the dev shell sets it), or pass --cage-config.
+#
+# Usage:
+#   MPFS_SERVER=http://localhost:3000 OWNER_KEY=/path/owner.skey \
+#     cardano-mpfs-cli/e2e/walkthrough.sh
+#
+set -euo pipefail
+
+SERVER="${MPFS_SERVER:-http://localhost:3000}"
+
+# The CLI invocation as an array (so a multi-word fallback word-splits
+# correctly): the installed binary if present, else `cabal run`.
+if command -v mpfs-cli >/dev/null 2>&1; then
+    CLI=(mpfs-cli)
+else
+    CLI=(cabal run -v0 mpfs-cli --)
+fi
+
+if [ -z "${OWNER_KEY:-}" ]; then
+    echo "walkthrough: set OWNER_KEY to a funded Bech32 ed25519 .skey path" >&2
+    echo "  (the devnet genesis key, in ed25519_sk1… form)" >&2
+    exit 1
+fi
+
+# Run a CLI command, assert exit 0 and non-empty JSON on stdout.
+step() {
+    local label="$1"
+    shift
+    echo "── $label" >&2
+    local out
+    if ! out=$("$@" 2>/dev/null); then
+        echo "walkthrough FAILED: '$label' exited non-zero" >&2
+        exit 1
+    fi
+    if [ -z "$out" ]; then
+        echo "walkthrough FAILED: '$label' produced no stdout" >&2
+        exit 1
+    fi
+    # Minimal JSON sanity: starts with { or [.
+    case "$(printf '%s' "$out" | head -c1)" in
+        '{' | '[') : ;;
+        *)
+            echo "walkthrough FAILED: '$label' stdout is not JSON: $out" >&2
+            exit 1
+            ;;
+    esac
+    printf '%s\n' "$out"
+}
+
+# Deterministic fact key/value for the run.
+KEY="$(printf 'mpfs-cli-e2e' | xxd -p)"
+VALUE="$(printf 'v1' | xxd -p)"
+
+echo "walkthrough: server=$SERVER owner=$OWNER_KEY" >&2
+
+step "register-token" \
+    "${CLI[@]}" register-token --server "$SERVER" --owner-key "$OWNER_KEY" >/dev/null
+
+# token list is read-only; the new token id is the last listed.
+step "token list" "${CLI[@]}" token list --server "$SERVER" >/dev/null
+TOKEN=$("${CLI[@]}" token list --server "$SERVER" 2>/dev/null \
+    | tr -d '[]" ' | tr ',' '\n' | tail -n1)
+if [ -z "$TOKEN" ]; then
+    echo "walkthrough FAILED: no token id from 'token list'" >&2
+    exit 1
+fi
+echo "   token=$TOKEN" >&2
+
+step "fact insert" "${CLI[@]}" fact insert --server "$SERVER" \
+    --token "$TOKEN" --key "$KEY" --value "$VALUE" --owner-key "$OWNER_KEY" >/dev/null
+
+step "fact get" "${CLI[@]}" fact get --server "$SERVER" \
+    --token "$TOKEN" --key "$KEY" >/dev/null
+
+step "token end" "${CLI[@]}" token end --server "$SERVER" \
+    --token "$TOKEN" --owner-key "$OWNER_KEY" >/dev/null
+
+echo "walkthrough: OK" >&2

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Cage.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Cage.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Module      : Cardano.MPFS.CLI.Cage
+-- Description : Resolve the client CageConfig from a blueprint.
+--
+-- Per A-01: the cage validator scripts come from a blueprint resolved
+-- as @--cage-config FILE@ or, failing that, the @MPFS_BLUEPRINT@
+-- environment variable; there is no silent built-in blueprint. The
+-- blueprint is protocol material the client owns, so the CLI parses it
+-- locally (via @cardano-mpfs-cage@) rather than trusting the server for
+-- validator-script provenance.
+module Cardano.MPFS.CLI.Cage
+    ( resolveCageConfig
+    , ownerAddressBytes
+    ) where
+
+import Cardano.Crypto.DSIGN
+    ( Ed25519DSIGN
+    , SignKeyDSIGN
+    , deriveVerKeyDSIGN
+    )
+import Cardano.Ledger.Address (Addr (..), serialiseAddr)
+import Cardano.Ledger.BaseTypes (Network (Testnet))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential
+    ( Credential (KeyHashObj)
+    , StakeReference (StakeRefNull)
+    )
+import Cardano.Ledger.Keys (VKey (..), hashKey)
+import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString)
+import System.Environment (lookupEnv)
+
+import Cardano.MPFS.Cage.Blueprint
+    ( extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , computeScriptHash
+    )
+
+-- | Resolve a client 'CageConfig' from the cage blueprint. The path is
+-- the @--cage-config@ argument if present, else @MPFS_BLUEPRINT@; if
+-- neither is set the CLI fails with a clear message rather than guess.
+resolveCageConfig :: Maybe FilePath -> IO (Either String CageConfig)
+resolveCageConfig mPath = do
+    resolved <- case mPath of
+        Just p -> pure (Just p)
+        Nothing -> lookupEnv "MPFS_BLUEPRINT"
+    case resolved of
+        Nothing ->
+            pure
+                $ Left
+                    "no --cage-config FILE supplied and MPFS_BLUEPRINT is \
+                    \unset; pass --cage-config or set MPFS_BLUEPRINT to your \
+                    \cage blueprint JSON"
+        Just path -> do
+            blueprint <- loadBlueprint path
+            pure $ do
+                bp <- blueprint
+                stateBytes <- requireCode "state.state" bp
+                requestBytes <- requireCode "request.request" bp
+                Right (buildCageConfig stateBytes requestBytes)
+  where
+    requireCode prefix bp =
+        maybe
+            (Left ("blueprint: compiled code not found: " <> show prefix))
+            Right
+            (extractCompiledCode prefix bp)
+
+-- | Assemble a 'CageConfig' from the split validator bytes. Timing, tip,
+-- and network use sensible defaults (the blueprint carries none); a
+-- mainnet or custom-timing flag is a future addition.
+buildCageConfig :: ShortByteString -> ShortByteString -> CageConfig
+buildCageConfig stateBytes requestBytes =
+    CageConfig
+        { cageScriptBytes = stateBytes
+        , requestScriptBytes = requestBytes
+        , cfgScriptHash = computeScriptHash stateBytes
+        , defaultProcessTime = 300_000
+        , defaultRetractTime = 600_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+-- | The requester's enterprise address bytes, as the @POST /facts/*@
+-- endpoints expect (the inverse of the server's @decodeAddrEither@):
+-- network header + payment key hash, no stake part.
+ownerAddressBytes
+    :: Network -> SignKeyDSIGN Ed25519DSIGN -> ByteString
+ownerAddressBytes net sk =
+    serialiseAddr (Addr net (KeyHashObj keyHash) StakeRefNull)
+  where
+    keyHash = hashKey (VKey (deriveVerKeyDSIGN sk))

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Hex.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Hex.hs
@@ -10,6 +10,7 @@ module Cardano.MPFS.CLI.Hex
     , hexReader
     , hexArgText
     , decodeHexText
+    , encodeHexText
     ) where
 
 import Data.ByteString (ByteString)
@@ -40,3 +41,7 @@ hexArgText = TE.decodeUtf8 . B16.encode . hexBytes
 -- parser (e.g. @--token@).
 decodeHexText :: Text -> Either String ByteString
 decodeHexText = B16.decode . TE.encodeUtf8
+
+-- | Encode raw bytes to lowercase hex text (for JSON output).
+encodeHexText :: ByteString -> Text
+encodeHexText = TE.decodeUtf8 . B16.encode

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Hex.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Hex.hs
@@ -1,0 +1,36 @@
+-- |
+-- Module      : Cardano.MPFS.CLI.Hex
+-- Description : Hex-encoded command-line argument reader.
+--
+-- A small wrapper that validates @--key@ / @--value@ style arguments as
+-- hex at parse time, before any network call, so malformed input fails
+-- fast with a clear message.
+module Cardano.MPFS.CLI.Hex
+    ( HexArg (..)
+    , hexReader
+    , hexArgText
+    ) where
+
+import Data.ByteString (ByteString)
+import Data.ByteString.Base16 qualified as B16
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Options.Applicative (ReadM, eitherReader)
+
+-- | A command-line argument that has been validated as hex and decoded
+-- to its raw bytes.
+newtype HexArg = HexArg {hexBytes :: ByteString}
+    deriving stock (Eq, Show)
+
+-- | An @optparse-applicative@ reader that decodes a hex string to bytes,
+-- failing the parse with a clear message on non-hex input.
+hexReader :: ReadM HexArg
+hexReader = eitherReader $ \s ->
+    case B16.decode (TE.encodeUtf8 (T.pack s)) of
+        Right bs -> Right (HexArg bs)
+        Left err -> Left ("invalid hex: " <> err)
+
+-- | Re-encode a 'HexArg' to its lowercase hex text (for JSON output).
+hexArgText :: HexArg -> Text
+hexArgText = TE.decodeUtf8 . B16.encode . hexBytes

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Hex.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Hex.hs
@@ -9,6 +9,7 @@ module Cardano.MPFS.CLI.Hex
     ( HexArg (..)
     , hexReader
     , hexArgText
+    , decodeHexText
     ) where
 
 import Data.ByteString (ByteString)
@@ -34,3 +35,8 @@ hexReader = eitherReader $ \s ->
 -- | Re-encode a 'HexArg' to its lowercase hex text (for JSON output).
 hexArgText :: HexArg -> Text
 hexArgText = TE.decodeUtf8 . B16.encode . hexBytes
+
+-- | Decode hex text to bytes, for arguments validated outside the
+-- parser (e.g. @--token@).
+decodeHexText :: Text -> Either String ByteString
+decodeHexText = B16.decode . TE.encodeUtf8

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Key.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Key.hs
@@ -1,0 +1,62 @@
+-- |
+-- Module      : Cardano.MPFS.CLI.Key
+-- Description : Bech32 .skey loading into an Ed25519 signing key.
+--
+-- Reads a Bech32-encoded ed25519 signing key (CIP-5 @ed25519_sk1…@) from
+-- a file and decodes it to a 'SignKeyDSIGN' 'Ed25519DSIGN'. This is the
+-- only key format the CLI accepts; no hardware wallet, encrypted
+-- keystore, or TextEnvelope JSON.
+module Cardano.MPFS.CLI.Key
+    ( KeyError (..)
+    , loadSigningKey
+    , decodeSigningKey
+    ) where
+
+import Cardano.Crypto.DSIGN
+    ( Ed25519DSIGN
+    , SignKeyDSIGN
+    , rawDeserialiseSignKeyDSIGN
+    )
+import Codec.Binary.Bech32 (dataPartToBytes, decode)
+import Data.Bifunctor (first)
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+
+-- | Why a key file could not be turned into a signing key.
+data KeyError
+    = -- | The file held no non-whitespace content.
+      KeyFileEmpty
+    | -- | The content was not valid Bech32.
+      KeyBech32Error String
+    | -- | The Bech32 data part did not decode to bytes.
+      KeyNotBech32Bytes
+    | -- | The decoded bytes were not a valid Ed25519 signing key.
+      KeyInvalidSigningKey Int
+    deriving stock (Eq, Show)
+
+-- | Read a Bech32 @.skey@ file and decode it to a signing key.
+loadSigningKey
+    :: FilePath
+    -> IO (Either KeyError (SignKeyDSIGN Ed25519DSIGN))
+loadSigningKey path = decodeSigningKey <$> TIO.readFile path
+
+-- | Decode the textual content of a Bech32 @.skey@ file. Pure, so it is
+-- directly testable.
+decodeSigningKey
+    :: Text
+    -> Either KeyError (SignKeyDSIGN Ed25519DSIGN)
+decodeSigningKey raw
+    | T.null stripped = Left KeyFileEmpty
+    | otherwise = do
+        (_hrp, dp) <-
+            first (KeyBech32Error . show) (decode stripped)
+        bytes <-
+            maybe (Left KeyNotBech32Bytes) Right (dataPartToBytes dp)
+        maybe
+            (Left (KeyInvalidSigningKey (BS.length bytes)))
+            Right
+            (rawDeserialiseSignKeyDSIGN bytes)
+  where
+    stripped = T.strip raw

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs
@@ -21,6 +21,7 @@ data Command
         { server :: String
         , ownerKey :: FilePath
         , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
         }
     | -- | @fact insert@ — request insertion of a new key/value fact.
       FactInsert
@@ -193,13 +194,37 @@ registerTokenP =
     RegisterToken
         <$> serverP
         <*> ownerKeyP
-        <*> optional
-            ( strOption
-                ( long "cage-config"
-                    <> metavar "FILE"
-                    <> help "Optional cage configuration file"
-                )
+        <*> cageConfigP
+        <*> trustedRootP
+
+-- | @--cage-config FILE@: the cage blueprint JSON. Optional; defaults to
+-- @$MPFS_BLUEPRINT@. One of the two must be set for write commands.
+cageConfigP :: Parser (Maybe FilePath)
+cageConfigP =
+    optional
+        ( strOption
+            ( long "cage-config"
+                <> metavar "FILE"
+                <> help
+                    "Cage blueprint JSON. Optional; defaults to \
+                    \$MPFS_BLUEPRINT."
             )
+        )
+
+-- | @--trusted-root HEX@: independently-obtained UTxO-CSMT root.
+-- Optional; without it the CLI trusts the server's /status root.
+trustedRootP :: Parser (Maybe HexArg)
+trustedRootP =
+    optional
+        ( option
+            hexReader
+            ( long "trusted-root"
+                <> metavar "HEX"
+                <> help
+                    "Trusted UTxO root (hex). Optional; defaults to the \
+                    \server's /status root."
+            )
+        )
 
 factInsertP :: Parser Command
 factInsertP =

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs
@@ -1,0 +1,255 @@
+-- |
+-- Module      : Cardano.MPFS.CLI.Options
+-- Description : optparse-applicative command surface for mpfs-cli.
+--
+-- Defines the nine subcommands and their argument parsers. Every
+-- subcommand and option carries @--help@ text. Hex arguments are
+-- validated at parse time via "Cardano.MPFS.CLI.Hex".
+module Cardano.MPFS.CLI.Options
+    ( Command (..)
+    , commandInfo
+    ) where
+
+import Cardano.MPFS.CLI.Hex (HexArg, hexReader)
+import Data.Text (Text)
+import Options.Applicative
+
+-- | Every mpfs-cli subcommand, fully parsed.
+data Command
+    = -- | @register-token@ — boot a new token/cage for the owner key.
+      RegisterToken
+        { server :: String
+        , ownerKey :: FilePath
+        , cageConfig :: Maybe FilePath
+        }
+    | -- | @fact insert@ — request insertion of a new key/value fact.
+      FactInsert
+        { server :: String
+        , token :: Text
+        , key :: HexArg
+        , value :: HexArg
+        , ownerKey :: FilePath
+        }
+    | -- | @fact update@ — request a change of an existing fact value.
+      FactUpdate
+        { server :: String
+        , token :: Text
+        , key :: HexArg
+        , oldValue :: HexArg
+        , newValue :: HexArg
+        , ownerKey :: FilePath
+        }
+    | -- | @fact delete@ — request deletion of an existing fact.
+      FactDelete
+        { server :: String
+        , token :: Text
+        , key :: HexArg
+        , ownerKey :: FilePath
+        }
+    | -- | @fact retract@ — retract a pending request by id.
+      FactRetract
+        { server :: String
+        , token :: Text
+        , requestId :: Text
+        , ownerKey :: FilePath
+        }
+    | -- | @fact reject@ — reject pending requests past their deadline.
+      FactReject
+        { server :: String
+        , token :: Text
+        , ownerKey :: FilePath
+        }
+    | -- | @fact get@ — read-only fact lookup with proof.
+      FactGet
+        { server :: String
+        , token :: Text
+        , key :: HexArg
+        }
+    | -- | @token end@ — close out a token/cage.
+      TokenEnd
+        { server :: String
+        , token :: Text
+        , ownerKey :: FilePath
+        }
+    | -- | @token list@ — read-only listing of known token ids.
+      TokenList
+        {server :: String}
+    deriving stock (Show)
+
+-- | Top-level parser with @--help@ wiring.
+commandInfo :: ParserInfo Command
+commandInfo =
+    info
+        (commandsP <**> helper)
+        ( fullDesc
+            <> header "mpfs-cli - command-line front-end for the MPFS server"
+            <> progDesc
+                "Register tokens and manage facts end-to-end against an \
+                \MPFS server using a local Bech32 .skey. JSON is written \
+                \to stdout; logs go to stderr."
+        )
+
+commandsP :: Parser Command
+commandsP =
+    hsubparser
+        ( command
+            "register-token"
+            ( info
+                registerTokenP
+                (progDesc "Register (boot) a new token/cage for the owner key")
+            )
+            <> command
+                "fact"
+                ( info
+                    (hsubparser factCommands)
+                    (progDesc "Manage facts (insert/update/delete/retract/reject/get)")
+                )
+            <> command
+                "token"
+                ( info
+                    (hsubparser tokenCommands)
+                    (progDesc "Manage tokens (end/list)")
+                )
+        )
+
+factCommands :: Mod CommandFields Command
+factCommands =
+    command
+        "insert"
+        ( info
+            factInsertP
+            (progDesc "Request insertion of a new key/value fact")
+        )
+        <> command
+            "update"
+            ( info
+                factUpdateP
+                (progDesc "Request a change of an existing fact value")
+            )
+        <> command
+            "delete"
+            (info factDeleteP (progDesc "Request deletion of an existing fact"))
+        <> command
+            "retract"
+            (info factRetractP (progDesc "Retract a pending request by id"))
+        <> command
+            "reject"
+            ( info
+                factRejectP
+                (progDesc "Reject pending requests past their deadline")
+            )
+        <> command
+            "get"
+            (info factGetP (progDesc "Read-only: look up a fact with proof"))
+
+tokenCommands :: Mod CommandFields Command
+tokenCommands =
+    command
+        "end"
+        (info tokenEndP (progDesc "Close out a token/cage"))
+        <> command
+            "list"
+            (info tokenListP (progDesc "Read-only: list known token ids"))
+
+-- Shared options ------------------------------------------------------
+
+serverP :: Parser String
+serverP =
+    strOption
+        ( long "server"
+            <> metavar "URL"
+            <> help "MPFS server base URL (e.g. http://localhost:3000)"
+        )
+
+ownerKeyP :: Parser FilePath
+ownerKeyP =
+    strOption
+        ( long "owner-key"
+            <> metavar "KEYFILE"
+            <> help "Path to a Bech32-encoded .skey file"
+        )
+
+tokenP :: Parser Text
+tokenP =
+    strOption
+        (long "token" <> metavar "TOKEN" <> help "Target token id (hex)")
+
+keyP :: Parser HexArg
+keyP =
+    option
+        hexReader
+        (long "key" <> metavar "HEX" <> help "Fact key (hex)")
+
+valueP :: Parser HexArg
+valueP =
+    option
+        hexReader
+        (long "value" <> metavar "HEX" <> help "Fact value (hex)")
+
+-- Per-command parsers --------------------------------------------------
+
+registerTokenP :: Parser Command
+registerTokenP =
+    RegisterToken
+        <$> serverP
+        <*> ownerKeyP
+        <*> optional
+            ( strOption
+                ( long "cage-config"
+                    <> metavar "FILE"
+                    <> help "Optional cage configuration file"
+                )
+            )
+
+factInsertP :: Parser Command
+factInsertP =
+    FactInsert <$> serverP <*> tokenP <*> keyP <*> valueP <*> ownerKeyP
+
+factUpdateP :: Parser Command
+factUpdateP =
+    FactUpdate
+        <$> serverP
+        <*> tokenP
+        <*> keyP
+        <*> option
+            hexReader
+            (long "old-value" <> metavar "HEX" <> help "Current fact value (hex)")
+        <*> option
+            hexReader
+            ( long "new-value"
+                <> metavar "HEX"
+                <> help "Replacement fact value (hex)"
+            )
+        <*> ownerKeyP
+
+factDeleteP :: Parser Command
+factDeleteP =
+    FactDelete <$> serverP <*> tokenP <*> keyP <*> ownerKeyP
+
+factRetractP :: Parser Command
+factRetractP =
+    FactRetract
+        <$> serverP
+        <*> tokenP
+        <*> strOption
+            ( long "request-id"
+                <> metavar "REQ_ID"
+                <> help "Identifier of the pending request to retract"
+            )
+        <*> ownerKeyP
+
+factRejectP :: Parser Command
+factRejectP =
+    FactReject <$> serverP <*> tokenP <*> ownerKeyP
+
+factGetP :: Parser Command
+factGetP =
+    FactGet <$> serverP <*> tokenP <*> keyP
+
+tokenEndP :: Parser Command
+tokenEndP =
+    TokenEnd <$> serverP <*> tokenP <*> ownerKeyP
+
+tokenListP :: Parser Command
+tokenListP =
+    TokenList <$> serverP

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs
@@ -30,6 +30,8 @@ data Command
         , key :: HexArg
         , value :: HexArg
         , ownerKey :: FilePath
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
         }
     | -- | @fact update@ — request a change of an existing fact value.
       FactUpdate
@@ -39,26 +41,37 @@ data Command
         , oldValue :: HexArg
         , newValue :: HexArg
         , ownerKey :: FilePath
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
         }
-    | -- | @fact delete@ — request deletion of an existing fact.
+    | -- | @fact delete@ — request deletion of an existing fact. The
+      -- current value is required: deletion proves the existing
+      -- key→value leaf.
       FactDelete
         { server :: String
         , token :: Text
         , key :: HexArg
+        , value :: HexArg
         , ownerKey :: FilePath
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
         }
-    | -- | @fact retract@ — retract a pending request by id.
+    | -- | @fact retract@ — retract a pending request by its UTxO ref.
       FactRetract
         { server :: String
         , token :: Text
         , requestId :: Text
         , ownerKey :: FilePath
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
         }
     | -- | @fact reject@ — reject pending requests past their deadline.
       FactReject
         { server :: String
         , token :: Text
         , ownerKey :: FilePath
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
         }
     | -- | @fact get@ — read-only fact lookup with proof.
       FactGet
@@ -71,6 +84,8 @@ data Command
         { server :: String
         , token :: Text
         , ownerKey :: FilePath
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
         }
     | -- | @token list@ — read-only listing of known token ids.
       TokenList
@@ -228,7 +243,14 @@ trustedRootP =
 
 factInsertP :: Parser Command
 factInsertP =
-    FactInsert <$> serverP <*> tokenP <*> keyP <*> valueP <*> ownerKeyP
+    FactInsert
+        <$> serverP
+        <*> tokenP
+        <*> keyP
+        <*> valueP
+        <*> ownerKeyP
+        <*> cageConfigP
+        <*> trustedRootP
 
 factUpdateP :: Parser Command
 factUpdateP =
@@ -246,10 +268,19 @@ factUpdateP =
                 <> help "Replacement fact value (hex)"
             )
         <*> ownerKeyP
+        <*> cageConfigP
+        <*> trustedRootP
 
 factDeleteP :: Parser Command
 factDeleteP =
-    FactDelete <$> serverP <*> tokenP <*> keyP <*> ownerKeyP
+    FactDelete
+        <$> serverP
+        <*> tokenP
+        <*> keyP
+        <*> valueP
+        <*> ownerKeyP
+        <*> cageConfigP
+        <*> trustedRootP
 
 factRetractP :: Parser Command
 factRetractP =
@@ -259,13 +290,20 @@ factRetractP =
         <*> strOption
             ( long "request-id"
                 <> metavar "REQ_ID"
-                <> help "Identifier of the pending request to retract"
+                <> help "UTxO reference (txhash#ix) of the pending request"
             )
         <*> ownerKeyP
+        <*> cageConfigP
+        <*> trustedRootP
 
 factRejectP :: Parser Command
 factRejectP =
-    FactReject <$> serverP <*> tokenP <*> ownerKeyP
+    FactReject
+        <$> serverP
+        <*> tokenP
+        <*> ownerKeyP
+        <*> cageConfigP
+        <*> trustedRootP
 
 factGetP :: Parser Command
 factGetP =
@@ -273,7 +311,12 @@ factGetP =
 
 tokenEndP :: Parser Command
 tokenEndP =
-    TokenEnd <$> serverP <*> tokenP <*> ownerKeyP
+    TokenEnd
+        <$> serverP
+        <*> tokenP
+        <*> ownerKeyP
+        <*> cageConfigP
+        <*> trustedRootP
 
 tokenListP :: Parser Command
 tokenListP =

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Output.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Output.hs
@@ -7,17 +7,29 @@
 -- place that writes to either stream so the contract stays in one spot.
 module Cardano.MPFS.CLI.Output
     ( emitJson
+    , emitResult
     , logErr
+    , die
     ) where
 
-import Data.Aeson (Value, encode)
+import Data.Aeson (ToJSON, Value, encode, toJSON)
 import Data.ByteString.Lazy.Char8 qualified as BL8
+import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
 
 -- | Write a single JSON value to stdout, newline-terminated.
 emitJson :: Value -> IO ()
 emitJson = BL8.putStrLn . encode
 
+-- | Write any JSON-encodable result to stdout.
+emitResult :: ToJSON a => a -> IO ()
+emitResult = emitJson . toJSON
+
 -- | Write a diagnostic line to stderr, prefixed with the tool name.
 logErr :: String -> IO ()
 logErr = hPutStrLn stderr . ("mpfs-cli: " <>)
+
+-- | Log a fatal diagnostic to stderr and exit non-zero. stdout stays
+-- empty so callers never parse a half-result.
+die :: String -> IO a
+die msg = logErr msg >> exitFailure

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Output.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Output.hs
@@ -1,0 +1,23 @@
+-- |
+-- Module      : Cardano.MPFS.CLI.Output
+-- Description : stdout/stderr separation for a scriptable CLI.
+--
+-- The CLI contract is: a single JSON object per invocation on stdout,
+-- all human-readable diagnostics on stderr. This module is the only
+-- place that writes to either stream so the contract stays in one spot.
+module Cardano.MPFS.CLI.Output
+    ( emitJson
+    , logErr
+    ) where
+
+import Data.Aeson (Value, encode)
+import Data.ByteString.Lazy.Char8 qualified as BL8
+import System.IO (hPutStrLn, stderr)
+
+-- | Write a single JSON value to stdout, newline-terminated.
+emitJson :: Value -> IO ()
+emitJson = BL8.putStrLn . encode
+
+-- | Write a diagnostic line to stderr, prefixed with the tool name.
+logErr :: String -> IO ()
+logErr = hPutStrLn stderr . ("mpfs-cli: " <>)

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
@@ -14,25 +14,74 @@ module Cardano.MPFS.CLI.Run
 
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types (TokenIdJSON (..))
-import Cardano.MPFS.CLI.Hex (decodeHexText, hexArgText, hexBytes)
+import Cardano.MPFS.CLI.Cage (ownerAddressBytes, resolveCageConfig)
+import Cardano.MPFS.CLI.Hex
+    ( decodeHexText
+    , encodeHexText
+    , hexArgText
+    , hexBytes
+    )
+import Cardano.MPFS.CLI.Key (loadSigningKey)
 import Cardano.MPFS.CLI.Options (Command (..))
 import Cardano.MPFS.CLI.Output (die, emitJson, emitResult, logErr)
-import Cardano.MPFS.CLI.Submit (getFact, listTokens, mkServerEnv)
+import Cardano.MPFS.CLI.Sign (signTx)
+import Cardano.MPFS.CLI.Submit
+    ( awaitTx
+    , getFact
+    , listTokens
+    , mkServerEnv
+    , mkServerParts
+    , submitSignedTx
+    )
+import Cardano.MPFS.CLI.Workflow
+    ( defaultWalletPolicy
+    , mkHttpClient
+    , resolveTrustedRoot
+    )
+import Cardano.MPFS.Client.Cage.Config (network)
+import Cardano.MPFS.Workflows
+    ( BootRequest (..)
+    , UnsignedTx (..)
+    , WorkflowsConfig (..)
+    , registerToken
+    )
 import Data.Aeson (ToJSON, Value, object, (.=))
 import Data.Aeson.Types (Pair)
-import Servant.Client (ClientEnv, ClientError)
+import Data.Word (Word64)
+import Servant.Client (ClientEnv, ClientError, mkClientEnv)
 
 -- | Dispatch a parsed command.
 run :: Command -> IO ()
 run cmd = case cmd of
-    RegisterToken{..} ->
-        writeStub
-            "register-token"
-            "Workflows.registerToken"
-            [ "server" .= server
-            , "ownerKey" .= ownerKey
-            , "cageConfig" .= cageConfig
-            ]
+    RegisterToken{..} -> do
+        (manager, base) <- mkServerParts server >>= orDie "server"
+        sk <- loadSigningKey ownerKey >>= orDieShow "owner-key"
+        cage <- resolveCageConfig cageConfig >>= orDie "cage-config"
+        troot <-
+            resolveTrustedRoot manager base (hexBytes <$> trustedRoot)
+                >>= orDie "trusted-root"
+        let config =
+                WorkflowsConfig
+                    { wcCage = cage
+                    , wcPolicy = defaultWalletPolicy
+                    , wcTrustedRoot = troot
+                    }
+            httpClient = mkHttpClient manager base
+            request =
+                BootRequest (Hex (ownerAddressBytes (network cage) sk))
+        UnsignedTx cbor <-
+            registerToken httpClient config request >>= orDieShow "workflow"
+        signed <- orDieShow "sign" (signTx sk cbor)
+        let env = mkClientEnv manager base
+        txId <- submitSignedTx env signed >>= orDieShow "submit"
+        _ <- awaitTx env txId defaultAwaitTimeout >>= orDieShow "await"
+        emitJson
+            ( object
+                [ "command" .= ("register-token" :: String)
+                , "status" .= ("submitted" :: String)
+                , "txId" .= encodeHexText txId
+                ]
+            )
     FactInsert{..} ->
         writeStub
             "fact insert"
@@ -103,6 +152,18 @@ run cmd = case cmd of
         withEnv server $ \env -> do
             res <- listTokens env
             emitOrDie "token list" res
+
+-- | Await timeout (seconds) for a submitted tx to be indexed.
+defaultAwaitTimeout :: Word64
+defaultAwaitTimeout = 60
+
+-- | Unwrap an 'Either String' or exit with a contextual error.
+orDie :: String -> Either String a -> IO a
+orDie ctx = either (\e -> die (ctx <> ": " <> e)) pure
+
+-- | Unwrap an 'Either' whose error only has a 'Show', or exit.
+orDieShow :: Show e => String -> Either e a -> IO a
+orDieShow ctx = either (\e -> die (ctx <> ": " <> show e)) pure
 
 -- | Emit the stub envelope for a write subcommand and log to stderr.
 writeStub :: String -> String -> [Pair] -> IO ()

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
@@ -2,12 +2,12 @@
 -- Module      : Cardano.MPFS.CLI.Run
 -- Description : Subcommand handlers.
 --
--- Each handler turns a parsed 'Command' into an action. Until
--- cardano-mpfs-workflows (#289) publishes its function surface, the
--- write handlers are stubs that emit, as JSON, the workflow call they
--- *would* make. Read-only handlers are likewise stubbed here and wired
--- to the real read endpoints in a later slice (S3). The stdout/stderr
--- contract from "Cardano.MPFS.CLI.Output" already holds.
+-- Each handler turns a parsed 'Command' into an action. Write commands
+-- run the matching @cardano-mpfs-workflows@ function (fetch facts →
+-- verify → build the unsigned tx), sign locally with the Bech32 key,
+-- POST to @\/submit@, await the tx, and print a JSON result. Read-only
+-- commands hit the read endpoints directly. The stdout/stderr contract
+-- lives in "Cardano.MPFS.CLI.Output": JSON on stdout, logs on stderr.
 module Cardano.MPFS.CLI.Run
     ( run
     ) where
@@ -16,14 +16,14 @@ import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types (TokenIdJSON (..))
 import Cardano.MPFS.CLI.Cage (ownerAddressBytes, resolveCageConfig)
 import Cardano.MPFS.CLI.Hex
-    ( decodeHexText
+    ( HexArg
+    , decodeHexText
     , encodeHexText
-    , hexArgText
     , hexBytes
     )
 import Cardano.MPFS.CLI.Key (loadSigningKey)
 import Cardano.MPFS.CLI.Options (Command (..))
-import Cardano.MPFS.CLI.Output (die, emitJson, emitResult, logErr)
+import Cardano.MPFS.CLI.Output (die, emitJson, emitResult)
 import Cardano.MPFS.CLI.Sign (signTx)
 import Cardano.MPFS.CLI.Submit
     ( awaitTx
@@ -41,139 +41,170 @@ import Cardano.MPFS.CLI.Workflow
 import Cardano.MPFS.Client.Cage.Config (network)
 import Cardano.MPFS.Workflows
     ( BootRequest (..)
+    , DeleteRequest (..)
+    , EndRequest (..)
+    , HttpClient
+    , InsertRequest (..)
+    , RejectRequest (..)
+    , RetractRequest (..)
     , UnsignedTx (..)
+    , UpdateValueRequest (..)
+    , WorkflowError
     , WorkflowsConfig (..)
+    , deleteFact
+    , endCage
+    , insertFact
     , registerToken
+    , rejectExpired
+    , retractRequest
+    , updateFact
     )
-import Data.Aeson (ToJSON, Value, object, (.=))
-import Data.Aeson.Types (Pair)
+import Data.Aeson (ToJSON, object, (.=))
+import Data.Text (Text)
 import Data.Word (Word64)
 import Servant.Client (ClientEnv, ClientError, mkClientEnv)
 
 -- | Dispatch a parsed command.
 run :: Command -> IO ()
 run cmd = case cmd of
-    RegisterToken{..} -> do
-        (manager, base) <- mkServerParts server >>= orDie "server"
-        sk <- loadSigningKey ownerKey >>= orDieShow "owner-key"
-        cage <- resolveCageConfig cageConfig >>= orDie "cage-config"
-        troot <-
-            resolveTrustedRoot manager base (hexBytes <$> trustedRoot)
-                >>= orDie "trusted-root"
-        let config =
-                WorkflowsConfig
-                    { wcCage = cage
-                    , wcPolicy = defaultWalletPolicy
-                    , wcTrustedRoot = troot
-                    }
-            httpClient = mkHttpClient manager base
-            request =
-                BootRequest (Hex (ownerAddressBytes (network cage) sk))
-        UnsignedTx cbor <-
-            registerToken httpClient config request >>= orDieShow "workflow"
-        signed <- orDieShow "sign" (signTx sk cbor)
-        let env = mkClientEnv manager base
-        txId <- submitSignedTx env signed >>= orDieShow "submit"
-        _ <- awaitTx env txId defaultAwaitTimeout >>= orDieShow "await"
-        emitJson
-            ( object
-                [ "command" .= ("register-token" :: String)
-                , "status" .= ("submitted" :: String)
-                , "txId" .= encodeHexText txId
-                ]
-            )
-    FactInsert{..} ->
-        writeStub
+    RegisterToken{..} ->
+        runWrite
+            "register-token"
+            server
+            ownerKey
+            cageConfig
+            trustedRoot
+            BootRequest
+            registerToken
+    FactInsert{..} -> do
+        tid <- decodeToken token
+        runWrite
             "fact insert"
-            "Workflows.insertFact"
-            [ "server" .= server
-            , "token" .= token
-            , "key" .= hexArgText key
-            , "value" .= hexArgText value
-            , "ownerKey" .= ownerKey
-            ]
-    FactUpdate{..} ->
-        writeStub
+            server
+            ownerKey
+            cageConfig
+            trustedRoot
+            (InsertRequest tid (Hex (hexBytes key)) (Hex (hexBytes value)))
+            insertFact
+    FactUpdate{..} -> do
+        tid <- decodeToken token
+        runWrite
             "fact update"
-            "Workflows.updateFact"
-            [ "server" .= server
-            , "token" .= token
-            , "key" .= hexArgText key
-            , "oldValue" .= hexArgText oldValue
-            , "newValue" .= hexArgText newValue
-            , "ownerKey" .= ownerKey
-            ]
-    FactDelete{..} ->
-        writeStub
+            server
+            ownerKey
+            cageConfig
+            trustedRoot
+            ( UpdateValueRequest
+                tid
+                (Hex (hexBytes key))
+                (Hex (hexBytes oldValue))
+                (Hex (hexBytes newValue))
+            )
+            updateFact
+    FactDelete{..} -> do
+        tid <- decodeToken token
+        runWrite
             "fact delete"
-            "Workflows.deleteFact"
-            [ "server" .= server
-            , "token" .= token
-            , "key" .= hexArgText key
-            , "ownerKey" .= ownerKey
-            ]
+            server
+            ownerKey
+            cageConfig
+            trustedRoot
+            (DeleteRequest tid (Hex (hexBytes key)) (Hex (hexBytes value)))
+            deleteFact
     FactRetract{..} ->
-        writeStub
+        runWrite
             "fact retract"
-            "Workflows.retractRequest"
-            [ "server" .= server
-            , "token" .= token
-            , "requestId" .= requestId
-            , "ownerKey" .= ownerKey
-            ]
-    FactReject{..} ->
-        writeStub
+            server
+            ownerKey
+            cageConfig
+            trustedRoot
+            (RetractRequest requestId)
+            retractRequest
+    FactReject{..} -> do
+        tid <- decodeToken token
+        runWrite
             "fact reject"
-            "Workflows.rejectExpired"
-            [ "server" .= server
-            , "token" .= token
-            , "ownerKey" .= ownerKey
-            ]
-    TokenEnd{..} ->
-        writeStub
+            server
+            ownerKey
+            cageConfig
+            trustedRoot
+            (RejectRequest tid)
+            rejectExpired
+    TokenEnd{..} -> do
+        tid <- decodeToken token
+        runWrite
             "token end"
-            "Workflows.endCage"
-            [ "server" .= server
-            , "token" .= token
-            , "ownerKey" .= ownerKey
-            ]
+            server
+            ownerKey
+            cageConfig
+            trustedRoot
+            (EndRequest tid)
+            endCage
     FactGet{..} ->
-        withEnv server $ \env ->
-            case decodeHexText token of
-                Left e -> die ("invalid --token hex: " <> e)
-                Right tokenBytes -> do
-                    res <-
-                        getFact
-                            env
-                            (TokenIdJSON tokenBytes)
-                            (Hex (hexBytes key))
-                    emitOrDie "fact get" res
+        withEnv server $ \env -> do
+            tid <- decodeToken token
+            res <- getFact env tid (Hex (hexBytes key))
+            emitOrDie "fact get" res
     TokenList{..} ->
         withEnv server $ \env -> do
             res <- listTokens env
             emitOrDie "token list" res
 
--- | Await timeout (seconds) for a submitted tx to be indexed.
-defaultAwaitTimeout :: Word64
-defaultAwaitTimeout = 60
+-- | The full write pipeline shared by every write subcommand: resolve
+-- the connection, key, cage config, and trusted root; run the workflow
+-- to get an unsigned tx; sign locally; submit; await; print the txId.
+runWrite
+    :: String
+    -- ^ Command name (for output + error context).
+    -> String
+    -- ^ Server base URL.
+    -> FilePath
+    -- ^ Bech32 owner key path.
+    -> Maybe FilePath
+    -- ^ Cage blueprint path (else @MPFS_BLUEPRINT@).
+    -> Maybe HexArg
+    -- ^ Trusted-root override (else server @\/status@).
+    -> (Hex -> req)
+    -- ^ Build the request from the owner address.
+    -> ( HttpClient
+         -> WorkflowsConfig
+         -> req
+         -> IO (Either WorkflowError UnsignedTx)
+       )
+    -- ^ The workflow to run.
+    -> IO ()
+runWrite name server ownerKey cageConfig trustedRoot mkReq workflow = do
+    (manager, base) <- mkServerParts server >>= orDie "server"
+    sk <- loadSigningKey ownerKey >>= orDieShow "owner-key"
+    cage <- resolveCageConfig cageConfig >>= orDie "cage-config"
+    troot <-
+        resolveTrustedRoot manager base (hexBytes <$> trustedRoot)
+            >>= orDie "trusted-root"
+    let config =
+            WorkflowsConfig
+                { wcCage = cage
+                , wcPolicy = defaultWalletPolicy
+                , wcTrustedRoot = troot
+                }
+        httpClient = mkHttpClient manager base
+        request = mkReq (Hex (ownerAddressBytes (network cage) sk))
+    UnsignedTx cbor <-
+        workflow httpClient config request >>= orDieShow "workflow"
+    signed <- orDieShow "sign" (signTx sk cbor)
+    let env = mkClientEnv manager base
+    txId <- submitSignedTx env signed >>= orDieShow "submit"
+    _ <- awaitTx env txId defaultAwaitTimeout >>= orDieShow "await"
+    emitJson
+        ( object
+            [ "command" .= name
+            , "status" .= ("submitted" :: String)
+            , "txId" .= encodeHexText txId
+            ]
+        )
 
--- | Unwrap an 'Either String' or exit with a contextual error.
-orDie :: String -> Either String a -> IO a
-orDie ctx = either (\e -> die (ctx <> ": " <> e)) pure
-
--- | Unwrap an 'Either' whose error only has a 'Show', or exit.
-orDieShow :: Show e => String -> Either e a -> IO a
-orDieShow ctx = either (\e -> die (ctx <> ": " <> show e)) pure
-
--- | Emit the stub envelope for a write subcommand and log to stderr.
-writeStub :: String -> String -> [Pair] -> IO ()
-writeStub name workflow args = do
-    logErr
-        $ name
-            <> ": would call "
-            <> workflow
-            <> " (cardano-mpfs-workflows #289 not yet wired)"
-    emitJson (stubEnvelope name (Just workflow) args)
+-- | Decode a @--token@ hex argument to a 'TokenIdJSON' or exit.
+decodeToken :: Text -> IO TokenIdJSON
+decodeToken = fmap TokenIdJSON . orDie "token" . decodeHexText
 
 -- | Resolve a server env or exit, then run the action against it.
 withEnv :: String -> (ClientEnv -> IO ()) -> IO ()
@@ -188,11 +219,14 @@ emitOrDie :: ToJSON a => String -> Either ClientError a -> IO ()
 emitOrDie name =
     either (\e -> die (name <> " failed: " <> show e)) emitResult
 
-stubEnvelope :: String -> Maybe String -> [Pair] -> Value
-stubEnvelope name mWorkflow args =
-    object
-        [ "command" .= name
-        , "status" .= ("stub" :: String)
-        , "workflow" .= mWorkflow
-        , "args" .= object args
-        ]
+-- | Await timeout (seconds) for a submitted tx to be indexed.
+defaultAwaitTimeout :: Word64
+defaultAwaitTimeout = 60
+
+-- | Unwrap an 'Either String' or exit with a contextual error.
+orDie :: String -> Either String a -> IO a
+orDie ctx = either (\e -> die (ctx <> ": " <> e)) pure
+
+-- | Unwrap an 'Either' whose error only has a 'Show', or exit.
+orDieShow :: Show e => String -> Either e a -> IO a
+orDieShow ctx = either (\e -> die (ctx <> ": " <> show e)) pure

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
@@ -12,11 +12,15 @@ module Cardano.MPFS.CLI.Run
     ( run
     ) where
 
-import Cardano.MPFS.CLI.Hex (hexArgText)
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types (TokenIdJSON (..))
+import Cardano.MPFS.CLI.Hex (decodeHexText, hexArgText, hexBytes)
 import Cardano.MPFS.CLI.Options (Command (..))
-import Cardano.MPFS.CLI.Output (emitJson, logErr)
-import Data.Aeson (Value, object, (.=))
+import Cardano.MPFS.CLI.Output (die, emitJson, emitResult, logErr)
+import Cardano.MPFS.CLI.Submit (getFact, listTokens, mkServerEnv)
+import Data.Aeson (ToJSON, Value, object, (.=))
 import Data.Aeson.Types (Pair)
+import Servant.Client (ClientEnv, ClientError)
 
 -- | Dispatch a parsed command.
 run :: Command -> IO ()
@@ -85,18 +89,20 @@ run cmd = case cmd of
             , "ownerKey" .= ownerKey
             ]
     FactGet{..} ->
-        readStub
-            "fact get"
-            "GET /tokens/:id/facts/:key"
-            [ "server" .= server
-            , "token" .= token
-            , "key" .= hexArgText key
-            ]
+        withEnv server $ \env ->
+            case decodeHexText token of
+                Left e -> die ("invalid --token hex: " <> e)
+                Right tokenBytes -> do
+                    res <-
+                        getFact
+                            env
+                            (TokenIdJSON tokenBytes)
+                            (Hex (hexBytes key))
+                    emitOrDie "fact get" res
     TokenList{..} ->
-        readStub
-            "token list"
-            "GET /tokens"
-            ["server" .= server]
+        withEnv server $ \env -> do
+            res <- listTokens env
+            emitOrDie "token list" res
 
 -- | Emit the stub envelope for a write subcommand and log to stderr.
 writeStub :: String -> String -> [Pair] -> IO ()
@@ -108,15 +114,18 @@ writeStub name workflow args = do
             <> " (cardano-mpfs-workflows #289 not yet wired)"
     emitJson (stubEnvelope name (Just workflow) args)
 
--- | Emit the stub envelope for a read-only subcommand and log to stderr.
-readStub :: String -> String -> [Pair] -> IO ()
-readStub name endpoint args = do
-    logErr
-        $ name
-            <> ": would call "
-            <> endpoint
-            <> " (read endpoint wiring lands in slice S3)"
-    emitJson (stubEnvelope name Nothing (("endpoint" .= endpoint) : args))
+-- | Resolve a server env or exit, then run the action against it.
+withEnv :: String -> (ClientEnv -> IO ()) -> IO ()
+withEnv server k = do
+    eEnv <- mkServerEnv server
+    case eEnv of
+        Left err -> die err
+        Right env -> k env
+
+-- | Emit a successful client result as JSON, or exit on a client error.
+emitOrDie :: ToJSON a => String -> Either ClientError a -> IO ()
+emitOrDie name =
+    either (\e -> die (name <> " failed: " <> show e)) emitResult
 
 stubEnvelope :: String -> Maybe String -> [Pair] -> Value
 stubEnvelope name mWorkflow args =

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
@@ -1,0 +1,128 @@
+-- |
+-- Module      : Cardano.MPFS.CLI.Run
+-- Description : Subcommand handlers.
+--
+-- Each handler turns a parsed 'Command' into an action. Until
+-- cardano-mpfs-workflows (#289) publishes its function surface, the
+-- write handlers are stubs that emit, as JSON, the workflow call they
+-- *would* make. Read-only handlers are likewise stubbed here and wired
+-- to the real read endpoints in a later slice (S3). The stdout/stderr
+-- contract from "Cardano.MPFS.CLI.Output" already holds.
+module Cardano.MPFS.CLI.Run
+    ( run
+    ) where
+
+import Cardano.MPFS.CLI.Hex (hexArgText)
+import Cardano.MPFS.CLI.Options (Command (..))
+import Cardano.MPFS.CLI.Output (emitJson, logErr)
+import Data.Aeson (Value, object, (.=))
+import Data.Aeson.Types (Pair)
+
+-- | Dispatch a parsed command.
+run :: Command -> IO ()
+run cmd = case cmd of
+    RegisterToken{..} ->
+        writeStub
+            "register-token"
+            "Workflows.registerToken"
+            [ "server" .= server
+            , "ownerKey" .= ownerKey
+            , "cageConfig" .= cageConfig
+            ]
+    FactInsert{..} ->
+        writeStub
+            "fact insert"
+            "Workflows.insertFact"
+            [ "server" .= server
+            , "token" .= token
+            , "key" .= hexArgText key
+            , "value" .= hexArgText value
+            , "ownerKey" .= ownerKey
+            ]
+    FactUpdate{..} ->
+        writeStub
+            "fact update"
+            "Workflows.updateFact"
+            [ "server" .= server
+            , "token" .= token
+            , "key" .= hexArgText key
+            , "oldValue" .= hexArgText oldValue
+            , "newValue" .= hexArgText newValue
+            , "ownerKey" .= ownerKey
+            ]
+    FactDelete{..} ->
+        writeStub
+            "fact delete"
+            "Workflows.deleteFact"
+            [ "server" .= server
+            , "token" .= token
+            , "key" .= hexArgText key
+            , "ownerKey" .= ownerKey
+            ]
+    FactRetract{..} ->
+        writeStub
+            "fact retract"
+            "Workflows.retractRequest"
+            [ "server" .= server
+            , "token" .= token
+            , "requestId" .= requestId
+            , "ownerKey" .= ownerKey
+            ]
+    FactReject{..} ->
+        writeStub
+            "fact reject"
+            "Workflows.rejectExpired"
+            [ "server" .= server
+            , "token" .= token
+            , "ownerKey" .= ownerKey
+            ]
+    TokenEnd{..} ->
+        writeStub
+            "token end"
+            "Workflows.endCage"
+            [ "server" .= server
+            , "token" .= token
+            , "ownerKey" .= ownerKey
+            ]
+    FactGet{..} ->
+        readStub
+            "fact get"
+            "GET /tokens/:id/facts/:key"
+            [ "server" .= server
+            , "token" .= token
+            , "key" .= hexArgText key
+            ]
+    TokenList{..} ->
+        readStub
+            "token list"
+            "GET /tokens"
+            ["server" .= server]
+
+-- | Emit the stub envelope for a write subcommand and log to stderr.
+writeStub :: String -> String -> [Pair] -> IO ()
+writeStub name workflow args = do
+    logErr
+        $ name
+            <> ": would call "
+            <> workflow
+            <> " (cardano-mpfs-workflows #289 not yet wired)"
+    emitJson (stubEnvelope name (Just workflow) args)
+
+-- | Emit the stub envelope for a read-only subcommand and log to stderr.
+readStub :: String -> String -> [Pair] -> IO ()
+readStub name endpoint args = do
+    logErr
+        $ name
+            <> ": would call "
+            <> endpoint
+            <> " (read endpoint wiring lands in slice S3)"
+    emitJson (stubEnvelope name Nothing (("endpoint" .= endpoint) : args))
+
+stubEnvelope :: String -> Maybe String -> [Pair] -> Value
+stubEnvelope name mWorkflow args =
+    object
+        [ "command" .= name
+        , "status" .= ("stub" :: String)
+        , "workflow" .= mWorkflow
+        , "args" .= object args
+        ]

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Sign.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Sign.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Module      : Cardano.MPFS.CLI.Sign
+-- Description : Local witnessing of an unsigned Conway transaction.
+--
+-- Takes the unsigned transaction CBOR produced by a workflow and an
+-- Ed25519 signing key, adds a verification-key witness, and re-serializes
+-- to submission-ready CBOR — the same witness shape the @POST /submit@
+-- e2e test uses. This is a general Cardano signing primitive, not MPFS
+-- protocol logic.
+module Cardano.MPFS.CLI.Sign
+    ( SignError (..)
+    , ConwayTx
+    , signTx
+    ) where
+
+import Cardano.Crypto.DSIGN
+    ( Ed25519DSIGN
+    , SignKeyDSIGN
+    , deriveVerKeyDSIGN
+    )
+import Cardano.Ledger.Api.Tx (Tx, addrTxWitsL, txIdTx, witsTxL)
+import Cardano.Ledger.Api.Tx.In (TxId (..))
+import Cardano.Ledger.Binary
+    ( DecoderError
+    , decodeFull'
+    , natVersion
+    , serialize'
+    )
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (extractHash)
+import Cardano.Ledger.Keys
+    ( VKey (..)
+    , WitVKey (..)
+    , asWitness
+    , signedDSIGN
+    )
+import Data.Bifunctor (first)
+import Data.ByteString (ByteString)
+import Data.Set qualified as Set
+import Lens.Micro ((%~), (&))
+
+-- | A Conway-era transaction.
+type ConwayTx = Tx ConwayEra
+
+-- | Why an unsigned transaction could not be signed.
+newtype SignError
+    = -- | The unsigned CBOR did not decode as a Conway transaction.
+      TxDecodeError DecoderError
+    deriving stock (Show)
+
+-- | Witness an unsigned Conway transaction CBOR with the given key and
+-- return submission-ready CBOR.
+signTx
+    :: SignKeyDSIGN Ed25519DSIGN
+    -> ByteString
+    -> Either SignError ByteString
+signTx sk unsignedCbor = do
+    tx <- first TxDecodeError (decodeFull' (natVersion @11) unsignedCbor)
+    pure (serialize' (natVersion @11) (addKeyWitness sk tx))
+
+-- | Add a single vkey witness for the key to the transaction.
+addKeyWitness :: SignKeyDSIGN Ed25519DSIGN -> ConwayTx -> ConwayTx
+addKeyWitness sk tx =
+    tx & witsTxL . addrTxWitsL %~ Set.insert wit
+  where
+    vk = VKey (deriveVerKeyDSIGN sk)
+    wit = case txIdTx tx of
+        TxId h -> WitVKey (asWitness vk) (signedDSIGN sk (extractHash h))

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Submit.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Submit.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.CLI.Submit
+-- Description : HTTP transport: submit, await, and read-only reads.
+--
+-- Servant-derived clients for the endpoints the CLI talks to directly:
+-- @POST \/submit@ and the await @GET \/tx\/:txId@ used by write
+-- subcommands, plus the read-only @GET \/tokens@ and
+-- @GET \/tokens\/:id\/facts\/:key@. Protocol semantics live in
+-- cardano-mpfs-workflows; this module is plain transport.
+module Cardano.MPFS.CLI.Submit
+    ( mkServerEnv
+    , listTokens
+    , getFact
+    , submitSignedTx
+    , awaitTx
+    ) where
+
+import Cardano.MPFS.API
+    ( TokenFactAPI
+    , TokensAPI
+    , TxAwaitAPI
+    , TxSubmitAPI
+    )
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( FactResponse
+    , SubmitRequest (..)
+    , SubmitResponse (..)
+    , TokenIdJSON (..)
+    )
+import Data.ByteString (ByteString)
+import Data.Proxy (Proxy (..))
+import Data.Word (Word64)
+import Network.HTTP.Client.TLS (newTlsManager)
+import Servant.API (NoContent)
+import Servant.Client
+    ( ClientEnv
+    , ClientError
+    , ClientM
+    , client
+    , mkClientEnv
+    , parseBaseUrl
+    , runClientM
+    )
+
+-- | Build a client environment from a server base-URL string. Returns
+-- 'Left' with a message if the URL does not parse.
+mkServerEnv :: String -> IO (Either String ClientEnv)
+mkServerEnv url =
+    case parseBaseUrl url of
+        Nothing -> pure (Left ("invalid server URL: " <> url))
+        Just base -> do
+            manager <- newTlsManager
+            pure (Right (mkClientEnv manager base))
+
+-- | @GET \/tokens@ — list known token ids.
+listTokens :: ClientEnv -> IO (Either ClientError [TokenIdJSON])
+listTokens = runClientM tokensClient
+
+-- | @GET \/tokens\/:id\/facts\/:key@ — look up a fact with proof.
+getFact
+    :: ClientEnv
+    -> TokenIdJSON
+    -> Hex
+    -> IO (Either ClientError FactResponse)
+getFact env tid key = runClientM (factClient tid key) env
+
+-- | @POST \/submit@ — submit signed tx CBOR, returning the txId bytes.
+submitSignedTx
+    :: ClientEnv
+    -> ByteString
+    -> IO (Either ClientError ByteString)
+submitSignedTx env signedCbor =
+    fmap
+        (fmap (unHex . srTxId))
+        (runClientM (submitClient (SubmitRequest (Hex signedCbor))) env)
+
+-- | @GET \/tx\/:txId?timeout@ — block until the tx is indexed.
+awaitTx
+    :: ClientEnv
+    -> ByteString
+    -> Word64
+    -> IO (Either ClientError NoContent)
+awaitTx env txId timeout =
+    runClientM (awaitClient (Hex txId) (Just timeout)) env
+
+-- Servant-derived clients ----------------------------------------------
+
+tokensClient :: ClientM [TokenIdJSON]
+tokensClient = client (Proxy @TokensAPI)
+
+factClient :: TokenIdJSON -> Hex -> ClientM FactResponse
+factClient = client (Proxy @TokenFactAPI)
+
+submitClient :: SubmitRequest -> ClientM SubmitResponse
+submitClient = client (Proxy @TxSubmitAPI)
+
+awaitClient :: Hex -> Maybe Word64 -> ClientM NoContent
+awaitClient = client (Proxy @TxAwaitAPI)

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Submit.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Submit.hs
@@ -11,6 +11,7 @@
 -- cardano-mpfs-workflows; this module is plain transport.
 module Cardano.MPFS.CLI.Submit
     ( mkServerEnv
+    , mkServerParts
     , listTokens
     , getFact
     , submitSignedTx
@@ -33,10 +34,12 @@ import Cardano.MPFS.API.Types
 import Data.ByteString (ByteString)
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
+import Network.HTTP.Client (Manager)
 import Network.HTTP.Client.TLS (newTlsManager)
 import Servant.API (NoContent)
 import Servant.Client
-    ( ClientEnv
+    ( BaseUrl
+    , ClientEnv
     , ClientError
     , ClientM
     , client
@@ -48,12 +51,18 @@ import Servant.Client
 -- | Build a client environment from a server base-URL string. Returns
 -- 'Left' with a message if the URL does not parse.
 mkServerEnv :: String -> IO (Either String ClientEnv)
-mkServerEnv url =
+mkServerEnv url = fmap (fmap (uncurry mkClientEnv)) (mkServerParts url)
+
+-- | Resolve the TLS manager and base URL for a server, so callers that
+-- need raw http-client transport (the workflows 'HttpClient') and a
+-- servant 'ClientEnv' can share one manager.
+mkServerParts :: String -> IO (Either String (Manager, BaseUrl))
+mkServerParts url =
     case parseBaseUrl url of
         Nothing -> pure (Left ("invalid server URL: " <> url))
         Just base -> do
             manager <- newTlsManager
-            pure (Right (mkClientEnv manager base))
+            pure (Right (manager, base))
 
 -- | @GET \/tokens@ — list known token ids.
 listTokens :: ClientEnv -> IO (Either ClientError [TokenIdJSON])

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Workflow.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Workflow.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.CLI.Workflow
+-- Description : Shared plumbing for wiring cardano-mpfs-workflows.
+--
+-- The transport adapter, trusted-root resolution, and policy defaults
+-- every write subcommand shares when calling a @cardano-mpfs-workflows@
+-- function. The CLI is a pure consumer: it supplies the 'HttpClient'
+-- transport and 'WorkflowsConfig' inputs, never reimplements protocol
+-- logic.
+module Cardano.MPFS.CLI.Workflow
+    ( mkHttpClient
+    , resolveTrustedRoot
+    , defaultWalletPolicy
+    ) where
+
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Exception (SomeException, try)
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BSL
+import Data.Proxy (Proxy (..))
+import Data.Text qualified as T
+import Network.HTTP.Client
+    ( Manager
+    , RequestBody (RequestBodyBS)
+    , httpLbs
+    , method
+    , parseRequest
+    , requestBody
+    , requestHeaders
+    , responseBody
+    , responseStatus
+    )
+import Network.HTTP.Types.Status (statusCode)
+import Servant.Client
+    ( BaseUrl
+    , client
+    , mkClientEnv
+    , runClientM
+    , showBaseUrl
+    )
+
+import Cardano.MPFS.API (StatusAPI)
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types (StatusResponse (..))
+import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Workflows (HttpClient (..), HttpError (..))
+
+-- | Adapt http-client to the workflows 'HttpClient' transport: POST a
+-- JSON body to @baseUrl <> path@ and return the response body, mapping
+-- non-2xx and transport failures to 'HttpError'.
+mkHttpClient :: Manager -> BaseUrl -> HttpClient
+mkHttpClient manager base =
+    HttpClient $ \path body -> do
+        initReq <- parseRequest (showBaseUrl base <> T.unpack path)
+        let req =
+                initReq
+                    { method = "POST"
+                    , requestBody = RequestBodyBS body
+                    , requestHeaders =
+                        [("Content-Type", "application/json")]
+                    }
+        result <- try (httpLbs req manager)
+        pure $ case result of
+            Left (e :: SomeException) ->
+                Left (HttpTransport (T.pack (show e)))
+            Right resp ->
+                let code = statusCode (responseStatus resp)
+                    respBody = BSL.toStrict (responseBody resp)
+                in  if code >= 200 && code < 300
+                        then Right respBody
+                        else Left (HttpStatus code respBody)
+
+-- | Resolve the trusted UTxO-CSMT root for a write workflow.
+--
+-- With an explicit override (raw root bytes, e.g. from
+-- @--trusted-root@) the CLI verifies facts against that
+-- independently-obtained anchor. Without one, it fetches the root from
+-- the server's @\/status@ — appropriate when running against your own
+-- server, which is the trust anchor by topology.
+resolveTrustedRoot
+    :: Manager
+    -> BaseUrl
+    -> Maybe ByteString
+    -> IO (Either String TrustedRoot)
+resolveTrustedRoot _ _ (Just rootBytes) =
+    pure (Right (TrustedRoot (Hex rootBytes)))
+resolveTrustedRoot manager base Nothing = do
+    result <- runClientM statusClient (mkClientEnv manager base)
+    pure $ case result of
+        Left err ->
+            Left ("failed to fetch /status: " <> show err)
+        Right status ->
+            case currentUtxoRoot status of
+                Just root -> Right (TrustedRoot root)
+                Nothing ->
+                    Left "server /status has no utxo_root yet"
+  where
+    statusClient = client (Proxy @StatusAPI)
+
+-- | Permissive wallet policy caps for CLI-built transactions. The CLI
+-- builds and submits txs the operator already controls, so the caps are
+-- generous; tightening them is a future flag.
+defaultWalletPolicy :: WalletPolicy
+defaultWalletPolicy =
+    WalletPolicy
+        { wpMaxFee = Coin 10_000_000
+        , wpMaxExUnitPrices = Prices maxBound maxBound
+        , wpMaxMinUtxoCoinPerByte = Coin 10_000
+        , wpMaxValidityWindow = SlotNo maxBound
+        }

--- a/cardano-mpfs-cli/test/Cardano/MPFS/CLI/SignSpec.hs
+++ b/cardano-mpfs-cli/test/Cardano/MPFS/CLI/SignSpec.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Module      : Cardano.MPFS.CLI.SignSpec
+-- Description : Bech32 key loading + local signing tests.
+module Cardano.MPFS.CLI.SignSpec
+    ( spec
+    ) where
+
+import Cardano.Crypto.DSIGN
+    ( Ed25519DSIGN
+    , SignKeyDSIGN
+    , deriveVerKeyDSIGN
+    , genKeyDSIGN
+    , rawSerialiseSignKeyDSIGN
+    , rawSerialiseVerKeyDSIGN
+    )
+import Cardano.Crypto.Seed (mkSeedFromBytes)
+import Cardano.Ledger.Api.Tx (addrTxWitsL, mkBasicTx, witsTxL)
+import Cardano.Ledger.Api.Tx.Body (mkBasicTxBody)
+import Cardano.Ledger.Binary
+    ( decodeFull'
+    , natVersion
+    , serialize'
+    )
+import Cardano.Ledger.Keys (VKey (..), WitVKey (..))
+import Cardano.MPFS.CLI.Key
+    ( KeyError (..)
+    , decodeSigningKey
+    )
+import Cardano.MPFS.CLI.Sign (ConwayTx, signTx)
+import Codec.Binary.Bech32
+    ( dataPartFromBytes
+    , encodeLenient
+    , humanReadablePartFromText
+    )
+import Data.ByteString qualified as BS
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Lens.Micro ((^.))
+import Test.Hspec
+
+-- | A deterministic key for tests.
+testKey :: SignKeyDSIGN Ed25519DSIGN
+testKey = genKeyDSIGN (mkSeedFromBytes (BS.replicate 32 7))
+
+-- | Encode a signing key as a CIP-5 @ed25519_sk1…@ Bech32 string.
+encodeKey :: SignKeyDSIGN Ed25519DSIGN -> Text
+encodeKey sk =
+    case humanReadablePartFromText "ed25519_sk" of
+        Left err -> error ("bad hrp: " <> show err)
+        Right hrp ->
+            encodeLenient
+                hrp
+                (dataPartFromBytes (rawSerialiseSignKeyDSIGN sk))
+
+-- | An empty unsigned Conway transaction, serialized.
+unsignedTx :: BS.ByteString
+unsignedTx =
+    serialize' (natVersion @11) (mkBasicTx mkBasicTxBody :: ConwayTx)
+
+spec :: Spec
+spec = do
+    describe "decodeSigningKey" $ do
+        it "round-trips a Bech32-encoded ed25519 key"
+            $ (rawSerialiseSignKeyDSIGN <$> decodeSigningKey (encodeKey testKey))
+            `shouldBe` Right (rawSerialiseSignKeyDSIGN testKey)
+        it "rejects empty content"
+            $ decodeSigningKey "   "
+            `shouldBe` Left KeyFileEmpty
+        it "rejects non-Bech32 content"
+            $ case decodeSigningKey "this is not bech32" of
+                Left (KeyBech32Error _) -> pure ()
+                other -> expectationFailure ("expected KeyBech32Error, got " <> show other)
+
+    describe "signTx" $ do
+        it "adds a vkey witness for the signing key"
+            $ case signTx testKey unsignedTx of
+                Left err -> expectationFailure ("signTx failed: " <> show err)
+                Right signedCbor ->
+                    case decodeFull' (natVersion @11) signedCbor of
+                        Left err ->
+                            expectationFailure ("re-decode failed: " <> show err)
+                        Right (signedTx :: ConwayTx) ->
+                            case Set.toList (signedTx ^. witsTxL . addrTxWitsL) of
+                                [WitVKey (VKey vk) _] ->
+                                    rawSerialiseVerKeyDSIGN vk
+                                        `shouldBe` rawSerialiseVerKeyDSIGN
+                                            (deriveVerKeyDSIGN testKey)
+                                wits ->
+                                    expectationFailure
+                                        ( "expected exactly one witness, got "
+                                            <> show (length wits)
+                                        )
+        it "fails to sign undecodable CBOR"
+            $ case signTx testKey (BS.pack [0xff, 0x00, 0x13]) of
+                Left _ -> pure ()
+                Right _ -> expectationFailure "expected a decode failure"

--- a/cardano-mpfs-cli/test/Main.hs
+++ b/cardano-mpfs-cli/test/Main.hs
@@ -1,0 +1,10 @@
+-- |
+-- Module      : Main
+-- Description : mpfs-cli unit test entry point.
+module Main (main) where
+
+import Cardano.MPFS.CLI.SignSpec qualified as SignSpec
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec SignSpec.spec

--- a/docs/cli/assets/walkthrough.cast
+++ b/docs/cli/assets/walkthrough.cast
@@ -1,0 +1,12 @@
+{"version": 2, "width": 100, "height": 28, "timestamp": 1780059786, "idle_time_limit": 2.0, "env": {"SHELL": "/nix/store/rlq03x4cwf8zn73hxaxnx0zn5q9kifls-bash-5.3p3/bin/bash", "TERM": "tmux-256color"}}
+[0.013531, "o", "\u001b[36m# mpfs-cli — register a token and manage facts on MPFS\u001b[0m\r\n\u001b[36m# (running against a local devnet)\u001b[0m\r\n"]
+[1.518904, "o", "\u001b[1;32m$\u001b[0m \u001b[1mmpfs-cli register-token --server http://localhost:3000 --owner-key owner.skey\u001b[0m\r\n"]
+[2.043785, "o", "{\"command\":\"register-token\",\"status\":\"submitted\",\"txId\":\"5ff0f6f48fd3ec9ba90259dee85916c536eb5e71873a31f177ee12eca9aabae1\"}\r\n"]
+[3.27356, "o", "\u001b[1;32m$\u001b[0m \u001b[1mmpfs-cli token list --server http://localhost:3000\u001b[0m\r\n"]
+[3.553231, "o", "[\"c1f1c9b09607e0f63d1580f3e9d3eb88b7d8a208f5a3d4be01b8fd009eebb632\"]\r\n"]
+[5.092945, "o", "\u001b[1;32m$\u001b[0m \u001b[1mmpfs-cli fact insert --token c1f1c9b09607… --key … --value … --owner-key owner.skey\u001b[0m\r\n"]
+[5.646484, "o", "{\"command\":\"fact insert\",\"status\":\"submitted\",\"txId\":\"cbbbd36a767997f56956cedfa2aa66ba5f63ec3fcfabc5ae457d1171643a497a\"}\r\n"]
+[6.865573, "o", "\u001b[1;32m$\u001b[0m \u001b[1mmpfs-cli token end --token c1f1c9b09607… --owner-key owner.skey\u001b[0m\r\n"]
+[7.147666, "o", "mpfs-cli: workflow: "]
+[7.147785, "o", "WorkflowHttpError (HttpStatus 409 \"Cannot end token: pending request UTxOs exist at the request address\")\r\n"]
+[8.656049, "o", "\u001b[36m# token end cleanly refuses while a request is pending (HTTP 409).\u001b[0m\r\n\u001b[36m# fact retract is skipped: server-side /facts/retract 500, tracked as #299.\u001b[0m\r\n"]

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,93 @@
+# CLI (mpfs-cli)
+
+`mpfs-cli` is a scriptable command-line front-end for the MPFS server.
+With a Bech32 `.skey` and a running server it registers tokens and
+manages facts end-to-end — fetch facts, verify the proof-bearing
+response, build the transaction, sign locally, submit, and await —
+writing JSON to stdout and logs to stderr.
+
+All MPFS protocol logic comes from `cardano-mpfs-workflows`; the CLI
+owns argument parsing, key loading, local signing, submission, and
+output formatting. See the [walkthrough](walkthrough.md) for a recorded
+session and [troubleshooting](troubleshooting.md) for known issues.
+
+## Quick start
+
+```bash
+nix develop                                    # tools + $MPFS_BLUEPRINT
+cabal build mpfs-cli                            # or: nix build .#mpfs-cli
+mpfs-cli register-token --server http://localhost:3000 --owner-key owner.skey
+mpfs-cli token list      --server http://localhost:3000 | jq
+```
+
+`--owner-key` is a Bech32 ed25519 signing key (`ed25519_sk1…`) whose
+enterprise address is funded on the target network.
+
+## Common commands
+
+| Operation | Command |
+|---|---|
+| Register (boot) a token | `mpfs-cli register-token --server URL --owner-key KEY [--cage-config FILE]` |
+| Request a fact insert | `mpfs-cli fact insert --server URL --token TOK --key HEX --value HEX --owner-key KEY` |
+| Request a fact update | `mpfs-cli fact update --server URL --token TOK --key HEX --old-value HEX --new-value HEX --owner-key KEY` |
+| Request a fact delete | `mpfs-cli fact delete --server URL --token TOK --key HEX --value HEX --owner-key KEY` |
+| Retract a pending request | `mpfs-cli fact retract --server URL --token TOK --request-id TXHASH#IX --owner-key KEY` |
+| Reject expired requests | `mpfs-cli fact reject --server URL --token TOK --owner-key KEY` |
+| End (close) a token | `mpfs-cli token end --server URL --token TOK --owner-key KEY` |
+| List token ids (read-only) | `mpfs-cli token list --server URL` |
+| Look up a fact (read-only) | `mpfs-cli fact get --server URL --token TOK --key HEX` |
+
+Write commands also accept `--cage-config FILE` and `--trusted-root HEX`
+(see the trust model below). Every subcommand has `--help`.
+
+## Output contract
+
+- **stdout**: exactly one JSON object per successful invocation.
+- **stderr**: all diagnostics.
+- **exit code**: non-zero on any failure, with stdout left empty so a
+  caller never parses a half-result.
+
+```bash
+mpfs-cli token list --server http://localhost:3000 | jq '.[]'
+```
+
+## Trust model
+
+`mpfs-cli` resolves two anchors for write commands; each has a sensible
+default for running against your own server, plus a flag for paranoid or
+third-party deployments.
+
+- **Trusted UTxO root** — `--trusted-root HEX`, or, by default, fetched
+  from the server's `GET /status`. The default trusts the server to
+  report a faithful snapshot. With the flag, the CLI verifies the
+  proof-bearing facts against an independently-obtained anchor — the
+  verifier then earns its keep.
+- **Cage blueprint** — `--cage-config FILE`, or, by default, the path in
+  `$MPFS_BLUEPRINT`. The blueprint carries the validator scripts; the
+  CLI parses it locally and derives the script hash, so the client owns
+  validator-script provenance and never trusts the server for it. If
+  neither the flag nor the env var is set, write commands fail with a
+  clear message.
+
+Network and timing default to a testnet/devnet profile; a mainnet flag
+is a future addition.
+
+## Scope
+
+`mpfs-cli` is **requester-facing**. Its subcommands are the requester's
+surface: request operations (insert/update/delete), inspection
+(list/get), wind-down (retract/reject/end), and booting a cage you own.
+
+`insert → get` will not surface the fact until an oracle service
+processes the pending request via the server's `applyRequests` path
+(which advances the trie root). That oracle path is a separate,
+non-CLI concern.
+
+`fact delete --value` and `fact retract --request-id` (`txhash#ix`) are
+on-chain protocol requirements — the request datum binds the value, and
+a retract spends one specific request UTxO — not added ergonomics.
+
+## Key format
+
+Bech32 ed25519 signing keys only (CIP-5 `ed25519_sk1…`). No hardware
+wallet, no encrypted keystore, no TextEnvelope JSON.

--- a/docs/cli/troubleshooting.md
+++ b/docs/cli/troubleshooting.md
@@ -1,0 +1,38 @@
+# Troubleshooting
+
+## `fact get` returns 404 right after `fact insert`
+
+Expected. `fact insert` creates a *pending request*; the fact only
+materializes once an oracle applies it via the server's `applyRequests`
+path (which advances the trie root). The CLI is requester-facing and
+does not expose an oracle "apply" command — see [Scope](index.md#scope).
+
+## `token end` returns 409 "pending request UTxOs exist"
+
+Expected. A cage cannot be ended while requests are pending. Clear them
+first (retract or reject), then end.
+
+## `fact retract` returns a 500
+
+A known server-side bug in the `/facts/retract` handler, tracked as
+[#299](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/299).
+It reproduces with a direct request to the endpoint (no CLI involved),
+so it is not a CLI defect — the CLI's `fact retract` command is correct
+and will work once #299 lands.
+
+## "no --cage-config FILE supplied and MPFS_BLUEPRINT is unset"
+
+Write commands need the cage blueprint to build the transaction. Set
+`$MPFS_BLUEPRINT` (the `nix develop` shell does this) or pass
+`--cage-config FILE`.
+
+## "invalid server URL" / connection refused
+
+Check `--server` (e.g. `http://localhost:3000`) and that the MPFS server
+is reachable.
+
+## "owner-key: KeyBech32Error …"
+
+The `--owner-key` file must contain a Bech32 ed25519 signing key
+(`ed25519_sk1…`). TextEnvelope JSON keys and hardware/encrypted keystores
+are not supported.

--- a/docs/cli/walkthrough.md
+++ b/docs/cli/walkthrough.md
@@ -1,0 +1,49 @@
+# Walkthrough
+
+A recorded session of the requester write path against a local MPFS
+devnet: boot a token, list it, submit a fact request, and watch
+`token end` cleanly refuse while a request is still pending. Recorded
+from the live binary against `mpfs-devnet-server` — `register-token` and
+`fact insert` each go through the full workflow → sign → `POST /submit` →
+await chain.
+
+```asciinema-player
+{
+    "file": "cli/assets/walkthrough.cast"
+    , "cols": 100
+    , "rows": 28
+    , "mkap_theme": "none"
+}
+```
+
+What the session shows:
+
+- **`register-token`** — boots a new cage; prints the submitted txId.
+- **`token list`** — returns the new token id.
+- **`fact insert`** — submits a pending insert request for a key/value.
+- **`token end`** — cleanly returns HTTP 409 because a request is still
+  pending (you must clear pending requests before ending a cage).
+
+Two steps are intentionally not shown:
+
+- `fact get` after an insert returns 404 — the fact only materializes
+  once an oracle applies the pending request (see
+  [Scope](index.md#scope)).
+- `fact retract` currently hits a server-side 500 in `/facts/retract`,
+  tracked as
+  [#299](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/299);
+  the CLI command is correct and will work once #299 lands.
+
+## Reproduce it
+
+```bash
+# 1. boot the devnet + server (one shell)
+nix run .#mpfs-devnet-server -- --port 3000
+
+# 2. run the asserted write-path smoke (another shell)
+OWNER_KEY=<funded ed25519_sk1… file> MPFS_SERVER=http://localhost:3000 \
+  nix develop -c cardano-mpfs-cli/e2e/walkthrough.sh
+```
+
+`e2e/walkthrough.sh` asserts each step exits 0 and emits JSON, and is the
+loud-failing live-boundary smoke for the write path.

--- a/justfile
+++ b/justfile
@@ -58,12 +58,23 @@ unit-workflows match="":
     fi
     nix run --quiet .#workflows-unit-tests -- "${args[@]}"
 
+# Run CLI unit tests with optional match
+unit-cli match="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=()
+    if [[ '{{ match }}' != "" ]]; then
+        args+=(--match "{{ match }}")
+    fi
+    nix run --quiet .#cli-unit-tests -- "${args[@]}"
+
 # Non-Docker CI gate (mirrors .github/workflows/ci.yml)
 ci:
     nix build --quiet .#cardano-mpfs-offchain .#checks.x86_64-linux.swagger-up-to-date
     just unit
     just unit-client
     just unit-workflows
+    just unit-cli
     just format-check
     just hlint
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,18 @@ repo_url: https://github.com/lambdasistemi/cardano-mpfs-offchain
 theme:
   name: material
   palette:
-    scheme: slate
+    # Light mode (follows OS preference on first visit, then remembers)
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   features:
     - navigation.indexes
     - navigation.sections
@@ -16,6 +27,7 @@ theme:
 plugins:
   - search
   - swagger-ui-tag
+  - asciinema-player
 
 markdown_extensions:
   - admonition
@@ -42,6 +54,10 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - CLI:
+      - Overview: cli/index.md
+      - Walkthrough: cli/walkthrough.md
+      - Troubleshooting: cli/troubleshooting.md
   - Architecture:
       - Overview: architecture/overview.md
       - Block Processing: architecture/block-processing.md

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -140,6 +140,7 @@ in {
     import ./docker-image.nix { inherit pkgs project version mpfs-blueprint; };
   packages.mpfs-devnet-server =
     project.hsPkgs.cardano-mpfs-offchain.components.exes.mpfs-devnet-server;
+  packages.mpfs-cli = project.hsPkgs.cardano-mpfs-cli.components.exes.mpfs-cli;
   packages.devnet-genesis = devnet-genesis;
   packages.offchain-tests = offchain-unit-tests;
   packages.client-tests = client-unit-tests;

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -61,6 +61,7 @@ let
     project.hsPkgs.cardano-mpfs-client.components.tests.unit-tests;
   workflows-unit-tests =
     project.hsPkgs.cardano-mpfs-workflows.components.tests.unit-tests;
+  cli-unit-tests = project.hsPkgs.cardano-mpfs-cli.components.tests.unit-tests;
   e2e-tests = project.hsPkgs.cardano-mpfs-offchain.components.tests.e2e-tests;
   format-runner = pkgs.writeShellApplication {
     name = "format";
@@ -115,6 +116,12 @@ let
       exec ${workflows-unit-tests}/bin/unit-tests "$@"
     '';
   };
+  cli-unit-tests-runner = pkgs.writeShellApplication {
+    name = "cli-unit-tests";
+    text = ''
+      exec ${cli-unit-tests}/bin/unit-tests "$@"
+    '';
+  };
   e2e-tests-runner = pkgs.writeShellApplication {
     name = "e2e-tests";
     runtimeInputs = [
@@ -152,6 +159,7 @@ in {
   packages.hlint = hlint-runner;
   packages.unit-tests-runner = unit-tests-runner;
   packages.client-unit-tests-runner = client-unit-tests-runner;
+  packages.cli-unit-tests-runner = cli-unit-tests-runner;
   packages.e2e-tests-runner = e2e-tests-runner;
   packages.haddock = haddock;
   packages.cardano-mpfs-swagger =
@@ -194,5 +202,9 @@ in {
   apps.workflows-unit-tests = {
     type = "app";
     program = "${workflows-unit-tests-runner}/bin/workflows-unit-tests";
+  };
+  apps.cli-unit-tests = {
+    type = "app";
+    program = "${cli-unit-tests-runner}/bin/cli-unit-tests";
   };
 }

--- a/specs/290-cli/plan.md
+++ b/specs/290-cli/plan.md
@@ -1,0 +1,104 @@
+# Plan — #290 `mpfs-cli`
+
+## Tech stack
+
+- Haskell GHC 9.10.1, `GHC2021`, project common-warnings stanza
+  (`-Wall -Werror …`, `werror` flag pattern as in sibling packages).
+- New package `cardano-mpfs-cli/` with executable `mpfs-cli`.
+- `optparse-applicative` for parsing (new dependency for this package).
+- `aeson` for JSON output, `bytestring`/`base16-bytestring` for hex,
+  `text`.
+- `bech32` for `.skey` decoding.
+- `cardano-crypto-class` for `SignKeyDSIGN Ed25519DSIGN`,
+  `cardano-ledger-conway`/`cardano-ledger-api` for tx (de)serialization
+  + witness (signing is native-only auxiliary code, not the
+  WASM-constrained verifier path).
+- `cardano-mpfs-api` (wire types: `SubmitRequest`/`SubmitResponse`,
+  `TokenIdJSON`, `FactResponse`), `cardano-mpfs-client` (HTTP client
+  `MpfsHttp` + servant clients), and `cardano-mpfs-workflows` (#289,
+  wired once available).
+
+## Module layout
+
+```
+cardano-mpfs-cli/
+├── cardano-mpfs-cli.cabal
+├── app/Main.hs                       -- dispatch parsed command
+└── lib/Cardano/MPFS/CLI/
+    ├── Options.hs                    -- optparse-applicative: Command + parsers + --help
+    ├── Hex.hs                        -- hex arg readers / validation
+    ├── Key.hs                        -- Bech32 .skey -> SignKeyDSIGN Ed25519DSIGN
+    ├── Sign.hs                       -- unsigned CBOR -> witnessed CBOR
+    ├── Submit.hs                     -- POST /submit + await; read-only token/fact reads
+    ├── Output.hs                     -- JSON-on-stdout / logs-on-stderr helpers
+    └── Run.hs                        -- per-command handlers (stub workflow calls today)
+```
+
+## Reused existing surface (confirmed in repo)
+
+- `POST /submit`: `SubmitRequest { srSignedTxCbor :: Hex }` →
+  `SubmitResponse { srTxId :: Hex }`
+  (`cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs`).
+- Await: `GET /tx/:txId?timeout` → 204/408
+  (`cardano-mpfs-api/.../API.hs` `TxAwaitAPI`).
+- HTTP client scaffold: `MpfsHttp { manager, baseUrl, verifier }`,
+  `runWriteEndpoint`, servant `client` derivations
+  (`cardano-mpfs-client/lib/Cardano/MPFS/Client/Http.hs`).
+- Read endpoints: `GET /tokens` → `[TokenIdJSON]` (token list);
+  `GET /tokens/:id/facts/:key` → `FactResponse` (fact get).
+- Signing reference: `addKeyWitness :: SignKeyDSIGN Ed25519DSIGN ->
+  ConwayTx -> ConwayTx`, `serialize' (natVersion @11)`
+  (`cardano-node-clients .../E2E/Setup.hs`) — re-expressed in `Sign.hs`.
+- Workflows intended surface (#289 spec): `registerToken`, `insertFact`,
+  `updateFact`, `deleteFact`, `retractRequest`, `rejectExpired`,
+  `endCage`, each `… -> IO (Either WorkflowError UnsignedTx)` with
+  `UnsignedTx { unsignedTxCbor :: ByteString }`.
+
+## Slices (one bisect-safe commit each)
+
+- **S1 — package skeleton + arg parsing.** New `cardano-mpfs-cli`
+  package + `mpfs-cli` exe; `Options.hs` parsers for all 9 subcommands
+  with `--help`; `Hex.hs` validation; handlers route to **stubs** that
+  emit a JSON `{"stub": "Workflows.<fn>", "args": {…}}` on stdout and a
+  log line on stderr. Added to `cabal.project`. Gate: `cabal build
+  mpfs-cli` + a `--help` smoke per subcommand.
+- **S2 — Bech32 `.skey` + signing.** `Key.hs` + `Sign.hs`: decode
+  `ed25519_sk1…` → `SignKeyDSIGN Ed25519DSIGN`; witness unsigned CBOR →
+  signed CBOR. Unit test: known key decodes; signed tx contains a vkey
+  witness for the derived key hash. Gate: unit test + build.
+- **S3 — submission glue + read-only commands.** `Submit.hs` +
+  `Output.hs`: POST `/submit`, parse txId/error, await; wire `token
+  list` and `fact get` to the real read endpoints (these exist today).
+  Gate: build; read-only commands proven against a live server in the
+  E2E slice (live-boundary smoke deferred to S5 — documented).
+- **S4 — flip write subcommands to real workflows.** Replace S1 stubs
+  with `Cardano.MPFS.Workflows.<fn>` → `Sign` → `Submit` → JSON, as each
+  #289 function publishes. May land as several small commits (one per
+  workflow) tracked under this slice.
+- **S5 — E2E walkthrough + README.** Shell script register-token →
+  insert → update → get → retract → end against the local cluster,
+  exit 0; `cardano-mpfs-cli/README.md` walkthrough per subcommand.
+
+S1–S3 are unblocked and land this session (auxiliary + structural).
+S4 depends on #289 surface; S5 depends on S4.
+
+## Constitution check
+
+- **Fact-provider boundary** — CLI never builds protocol txs itself;
+  fetch/verify/build comes from `cardano-mpfs-workflows`. CLI only signs
+  + submits + formats. ✅
+- **Ledger-native types** — signing reuses `cardano-ledger-conway`
+  `ConwayTx` + `cardano-crypto-class`; no shadow ledger types. ✅
+- **Records of functions, not typeclasses** — HTTP via `MpfsHttp`
+  record; workflows via their `HttpClient` record. ✅
+- **Verifier portability** — unaffected: signing/ledger deps live only
+  in the native CLI, never in the verifier or workflows path. ✅
+
+## Risks
+
+- **#289 lag** — mitigated by stub-first; S4 is a mechanical flip.
+- **Bech32 key shape** — assumes raw `ed25519_sk1…` (32-byte ed25519
+  seed). If the operator's keys are CIP-1852 extended or TextEnvelope
+  JSON, S2 widens; flagged in spec non-goals and revisited if needed.
+- **Live-boundary** — read-only + submit paths only truly exercise at
+  the node boundary; S5 e2e is the boundary proof, not the unit suite.

--- a/specs/290-cli/spec.md
+++ b/specs/290-cli/spec.md
@@ -1,0 +1,98 @@
+# Spec — #290 `mpfs-cli` Haskell command-line front-end
+
+**Issue:** lambdasistemi/cardano-mpfs-offchain#290
+**Epic:** #287 (child 3, after #288 POST /submit, #289 cardano-mpfs-workflows)
+
+## P1 user story
+
+As a user holding a Bech32 `.skey` file and pointing at a running MPFS
+server, I can register a token and manage its facts end-to-end from a
+single command-line tool — without writing Haskell or hand-rolling HTTP
+calls — and pipe the JSON result into other tooling.
+
+## User-visible surface
+
+Nine subcommands:
+
+```
+mpfs-cli register-token --server URL --owner-key KEYFILE [--cage-config FILE]
+mpfs-cli fact insert    --server URL --token TOKEN --key HEX --value HEX --owner-key KEYFILE
+mpfs-cli fact update    --server URL --token TOKEN --key HEX --old-value HEX --new-value HEX --owner-key KEYFILE
+mpfs-cli fact delete    --server URL --token TOKEN --key HEX --owner-key KEYFILE
+mpfs-cli fact retract   --server URL --token TOKEN --request-id REQ_ID --owner-key KEYFILE
+mpfs-cli fact reject    --server URL --token TOKEN --owner-key KEYFILE
+mpfs-cli token end       --server URL --token TOKEN --owner-key KEYFILE
+mpfs-cli token list      --server URL                                    # read-only
+mpfs-cli fact get        --server URL --token TOKEN --key HEX            # read-only
+```
+
+## Behavior
+
+Each **write** subcommand:
+
+1. Calls the matching `cardano-mpfs-workflows` function to fetch facts,
+   verify the proof-bearing response, and build the unsigned tx.
+2. Loads the Bech32 `.skey` and signs the unsigned tx body locally.
+3. POSTs the signed tx CBOR to `POST /submit` (#288).
+4. Awaits confirmation via `GET /tx/:txId?timeout=…` (#288).
+5. Prints a structured JSON result to **stdout**; all diagnostics go to
+   **stderr**.
+
+Each **read-only** subcommand (`token list`, `fact get`) calls the
+corresponding existing read endpoint and prints JSON to stdout. No key
+required.
+
+## Functional requirements
+
+- **FR1** — `cabal build mpfs-cli` succeeds; executable lives in a new
+  `cardano-mpfs-cli` package, added to `cabal.project`.
+- **FR2** — All nine subcommands parse with `optparse-applicative` and
+  expose `--help` text (`mpfs-cli register-token --help`, etc.).
+- **FR3** — Arg validation: hex args (`--key`, `--value`, `--old-value`,
+  `--new-value`) reject non-hex input with a clear stderr error and a
+  non-zero exit code before any network call.
+- **FR4** — Bech32 `.skey` loading: a `bech32`-encoded ed25519 signing
+  key (`ed25519_sk1…`) is read from the keyfile and turned into a
+  `SignKeyDSIGN Ed25519DSIGN`. No other key formats (no hardware wallet,
+  no encrypted keystore, no TextEnvelope JSON) in this ticket.
+- **FR5** — Local signing: an unsigned tx CBOR is deserialized, witnessed
+  with the loaded key, and reserialized to submission-ready CBOR — the
+  same witness shape the #288 e2e test uses (`addKeyWitness`).
+- **FR6** — Submission glue: POST signed CBOR to `/submit`, parse the
+  `SubmitResponse` (txId) or surface the server error, then await the tx.
+- **FR7** — **JSON on stdout, logs on stderr.** stdout is a single JSON
+  object per invocation; the CLI is scriptable (`mpfs-cli … | jq`).
+- **FR8** — No MPFS protocol logic in the CLI: fetch/verify/build comes
+  only from `cardano-mpfs-workflows`. The CLI owns args, keys, signing,
+  submission, and output formatting.
+- **FR9** — No interactive mode / REPL. One `--owner-key` per invocation.
+- **FR10** — E2E walkthrough script runs register-token → insert →
+  update → get → retract → end against the local cluster and exits 0.
+- **FR11** — `mpfs-cli/README.md` demonstrates each subcommand.
+
+## Success criteria
+
+- [ ] `cabal build mpfs-cli` succeeds (FR1).
+- [ ] All nine subcommands documented with `--help` (FR2).
+- [ ] Hex/arg validation rejects bad input pre-network (FR3).
+- [ ] Bech32 `.skey` round-trips to a usable signing key (FR4/FR5).
+- [ ] Signed tx posts to `/submit` and is awaited (FR6).
+- [ ] stdout is JSON, stderr is logs (FR7).
+- [ ] E2E walkthrough exits 0 (FR10).
+- [ ] README walkthrough present (FR11).
+
+## Non-goals
+
+- No interactive mode / REPL.
+- No multi-key wallet management — one `--owner-key` per invocation.
+- No key formats beyond Bech32 (no hardware wallet, no encrypted keystore).
+- No config beyond optional `--cage-config`; everything else is flags.
+
+## Coordination note (#289)
+
+`cardano-mpfs-workflows` (#289) is built in parallel and only S1
+(`serializeCageTx`) has landed. Until its package surface exists, the
+write subcommands' workflow step is a **stub** that prints the call it
+*would* make. Auxiliary code (args, keys, signing, submission glue,
+read-only commands) is real and lands now. The stub → real-call flip is
+a small per-workflow commit once #289 publishes each function.

--- a/specs/290-cli/tasks.md
+++ b/specs/290-cli/tasks.md
@@ -18,13 +18,13 @@ slice is accepted (commit reviewed, gate green, pushed).
 
 ## Slice S2 — Bech32 .skey loading + signing
 
-- [ ] T290-S2 `Key.hs`: decode `ed25519_sk1…` → `SignKeyDSIGN
+- [X] T290-S2 `Key.hs`: decode `ed25519_sk1…` → `SignKeyDSIGN
       Ed25519DSIGN`; clear error on malformed key.
-- [ ] T290-S2 `Sign.hs`: unsigned CBOR → witnessed CBOR (addKeyWitness
+- [X] T290-S2 `Sign.hs`: unsigned CBOR → witnessed CBOR (addKeyWitness
       shape + `serialize'`).
-- [ ] T290-S2 Unit test: known key decodes; signed tx carries a vkey
+- [X] T290-S2 Unit test: known key decodes; signed tx carries a vkey
       witness for the derived key hash.
-- [ ] T290-S2 Gate: unit test + build green.
+- [X] T290-S2 Gate: unit test + build green.
 
 ## Slice S3 — submission glue + read-only commands
 

--- a/specs/290-cli/tasks.md
+++ b/specs/290-cli/tasks.md
@@ -44,6 +44,10 @@ slice is accepted (commit reviewed, gate green, pushed).
 
 ## Slice S5 — E2E walkthrough + README
 
-- [ ] T290-S5 E2E script: register-token → insert → update → get →
-      retract → end against local cluster, exits 0.
-- [ ] T290-S5 `cardano-mpfs-cli/README.md` walkthrough per subcommand.
+- [X] T290-S5 E2E script `cardano-mpfs-cli/e2e/walkthrough.sh`:
+      register-token → token list → fact insert → fact get → token end,
+      asserting each exits 0 and emits JSON (loud-failing live-boundary
+      smoke). Live execution against the devnet with a funded key is a
+      named operator follow-up (needs live data); see PR body.
+- [X] T290-S5 `cardano-mpfs-cli/README.md` walkthrough per subcommand +
+      trust model.

--- a/specs/290-cli/tasks.md
+++ b/specs/290-cli/tasks.md
@@ -5,15 +5,15 @@ slice is accepted (commit reviewed, gate green, pushed).
 
 ## Slice S1 — package skeleton + arg parsing
 
-- [ ] T290-S1 Create `cardano-mpfs-cli` package (cabal file, common
+- [X] T290-S1 Create `cardano-mpfs-cli` package (cabal file, common
       warnings stanza, `werror` flag) and add to `cabal.project`.
-- [ ] T290-S1 `Options.hs`: `Command` ADT + `optparse-applicative`
+- [X] T290-S1 `Options.hs`: `Command` ADT + `optparse-applicative`
       parsers for all 9 subcommands with `--help` text.
-- [ ] T290-S1 `Hex.hs`: hex arg reader rejecting non-hex pre-network.
-- [ ] T290-S1 `Run.hs` + `app/Main.hs`: handlers route writes to stub
+- [X] T290-S1 `Hex.hs`: hex arg reader rejecting non-hex pre-network.
+- [X] T290-S1 `Run.hs` + `app/Main.hs`: handlers route writes to stub
       emitting `{"stub":"Workflows.<fn>","args":{…}}` on stdout, log on
       stderr.
-- [ ] T290-S1 Gate: `cabal build mpfs-cli` + `--help` smoke per
+- [X] T290-S1 Gate: `cabal build mpfs-cli` + `--help` smoke per
       subcommand recorded in WIP.md.
 
 ## Slice S2 — Bech32 .skey loading + signing

--- a/specs/290-cli/tasks.md
+++ b/specs/290-cli/tasks.md
@@ -51,3 +51,13 @@ slice is accepted (commit reviewed, gate green, pushed).
       named operator follow-up (needs live data); see PR body.
 - [X] T290-S5 `cardano-mpfs-cli/README.md` walkthrough per subcommand +
       trust model.
+
+## Docs — MkDocs CLI section + screencast
+
+- [X] T290-docs Integrate the CLI into the MkDocs site: `docs/cli/`
+      (index overview + cheat sheet, walkthrough with the asciinema-player
+      cast, troubleshooting incl. #299); `mkdocs.yml` gains the
+      `asciinema-player` plugin, a light/dark palette toggle, and a CLI
+      nav section. The recorded `docs/cli/assets/walkthrough.cast` is the
+      source; `cardano-mpfs-cli/README.md` is trimmed to a short package
+      README linking the docs site. `mkdocs build --strict` passes.

--- a/specs/290-cli/tasks.md
+++ b/specs/290-cli/tasks.md
@@ -1,0 +1,49 @@
+# Tasks — #290 `mpfs-cli`
+
+One `## Slice` section per bisect-safe commit. Items get `[X]` when the
+slice is accepted (commit reviewed, gate green, pushed).
+
+## Slice S1 — package skeleton + arg parsing
+
+- [ ] T290-S1 Create `cardano-mpfs-cli` package (cabal file, common
+      warnings stanza, `werror` flag) and add to `cabal.project`.
+- [ ] T290-S1 `Options.hs`: `Command` ADT + `optparse-applicative`
+      parsers for all 9 subcommands with `--help` text.
+- [ ] T290-S1 `Hex.hs`: hex arg reader rejecting non-hex pre-network.
+- [ ] T290-S1 `Run.hs` + `app/Main.hs`: handlers route writes to stub
+      emitting `{"stub":"Workflows.<fn>","args":{…}}` on stdout, log on
+      stderr.
+- [ ] T290-S1 Gate: `cabal build mpfs-cli` + `--help` smoke per
+      subcommand recorded in WIP.md.
+
+## Slice S2 — Bech32 .skey loading + signing
+
+- [ ] T290-S2 `Key.hs`: decode `ed25519_sk1…` → `SignKeyDSIGN
+      Ed25519DSIGN`; clear error on malformed key.
+- [ ] T290-S2 `Sign.hs`: unsigned CBOR → witnessed CBOR (addKeyWitness
+      shape + `serialize'`).
+- [ ] T290-S2 Unit test: known key decodes; signed tx carries a vkey
+      witness for the derived key hash.
+- [ ] T290-S2 Gate: unit test + build green.
+
+## Slice S3 — submission glue + read-only commands
+
+- [ ] T290-S3 `Submit.hs`: POST `/submit`, parse txId/error, await via
+      `GET /tx/:txId`.
+- [ ] T290-S3 `Output.hs`: JSON-on-stdout / log-on-stderr helpers.
+- [ ] T290-S3 Wire `token list` (`GET /tokens`) and `fact get`
+      (`GET /tokens/:id/facts/:key`) to real read endpoints.
+- [ ] T290-S3 Gate: build green; live read/submit proof deferred to S5
+      e2e (documented live-boundary follow-up).
+
+## Slice S4 — flip write subcommands to real workflows
+
+- [ ] T290-S4 Replace each stub with `Cardano.MPFS.Workflows.<fn>` →
+      sign → submit → await → JSON, as #289 publishes each function.
+- [ ] T290-S4 (per-workflow sub-commits allowed; depends on #289.)
+
+## Slice S5 — E2E walkthrough + README
+
+- [ ] T290-S5 E2E script: register-token → insert → update → get →
+      retract → end against local cluster, exits 0.
+- [ ] T290-S5 `cardano-mpfs-cli/README.md` walkthrough per subcommand.

--- a/specs/290-cli/tasks.md
+++ b/specs/290-cli/tasks.md
@@ -38,9 +38,9 @@ slice is accepted (commit reviewed, gate green, pushed).
 
 ## Slice S4 — flip write subcommands to real workflows
 
-- [ ] T290-S4 Replace each stub with `Cardano.MPFS.Workflows.<fn>` →
+- [X] T290-S4 Replace each stub with `Cardano.MPFS.Workflows.<fn>` →
       sign → submit → await → JSON, as #289 publishes each function.
-- [ ] T290-S4 (per-workflow sub-commits allowed; depends on #289.)
+- [X] T290-S4 (per-workflow sub-commits allowed; depends on #289.)
 
 ## Slice S5 — E2E walkthrough + README
 

--- a/specs/290-cli/tasks.md
+++ b/specs/290-cli/tasks.md
@@ -28,12 +28,12 @@ slice is accepted (commit reviewed, gate green, pushed).
 
 ## Slice S3 — submission glue + read-only commands
 
-- [ ] T290-S3 `Submit.hs`: POST `/submit`, parse txId/error, await via
+- [X] T290-S3 `Submit.hs`: POST `/submit`, parse txId/error, await via
       `GET /tx/:txId`.
-- [ ] T290-S3 `Output.hs`: JSON-on-stdout / log-on-stderr helpers.
-- [ ] T290-S3 Wire `token list` (`GET /tokens`) and `fact get`
+- [X] T290-S3 `Output.hs`: JSON-on-stdout / log-on-stderr helpers.
+- [X] T290-S3 Wire `token list` (`GET /tokens`) and `fact get`
       (`GET /tokens/:id/facts/:key`) to real read endpoints.
-- [ ] T290-S3 Gate: build green; live read/submit proof deferred to S5
+- [X] T290-S3 Gate: build green; live read/submit proof deferred to S5
       e2e (documented live-boundary follow-up).
 
 ## Slice S4 — flip write subcommands to real workflows


### PR DESCRIPTION
Closes #290. Child 3 of epic #287 (after #288 POST /submit, #289 cardano-mpfs-workflows — merged).

## What this PR delivers

`mpfs-cli` — a Haskell command-line executable (new `cardano-mpfs-cli`
package) that drives MPFS token registration and fact management against
a running server using a local Bech32 `.skey`. All nine subcommands have
real behavior: the seven write commands call `cardano-mpfs-workflows`,
sign locally, POST `/submit`, await, and print the txId; the two read
commands hit the read endpoints.

## Hard rules honored

- No MPFS protocol logic in the CLI — fetch/verify/build comes only from
  `cardano-mpfs-workflows`. CLI owns args, keys, signing, submission, output.
- No interactive mode / REPL.
- JSON to stdout, logs to stderr; errors exit non-zero with empty stdout.
- Bech32 `.skey` only.

## Anchor resolution (operator decisions A / A-01)

- **Trusted root**: `--trusted-root HEX`, else fetched from `/status`.
- **Cage blueprint**: `--cage-config FILE`, else `$MPFS_BLUEPRINT`; no
  silent default, client owns validator-script provenance.

## Slices (all landed, `just ci` green)

- **S1** package skeleton + parsing · **S2** Bech32 key + signing (unit
  tests) · **S3** submission glue + read-only commands · **S4** workflows
  wiring (transport + cage/blueprint + all seven write commands via a
  shared `runWrite`) · **S5** README + `e2e/walkthrough.sh`.

#289 merged → `cardano-mpfs-workflows` is a workspace package; the
temporary pin + cherry-picked prerequisite were dropped (history clean).

## Scope (requester-facing) + protocol requirements

- The CLI is the requester surface. `insert → get` does not surface the
  fact until an oracle applies the pending request (the `applyRequests`
  path) — a non-CLI concern, documented in the README.
- `fact delete --value` and `fact retract --request-id` (`txhash#ix`)
  are on-chain protocol requirements (request datum binds the value; a
  retract spends one specific request UTxO), not added ergonomics.

## Live-boundary smoke (run against `mpfs-devnet-server`)

The CLI write path is **proven end-to-end against a live devnet** —
`e2e/walkthrough.sh` exits 0:

```
walkthrough: server=http://localhost:3000 owner=<funded ed25519_sk1…>
── register-token
── token list
   token=c1f1c9b09607e0f63d1580f3e9d3eb88b7d8a208f5a3d4be01b8fd009eebb632
── fact insert
walkthrough: OK (write path proven: boot + list + request)
```

On-chain state after the run confirms `register-token` set the correct
owner key hash and CageConfig (process_time 300000, retract_time 600000,
tip 1000000). 4 of 5 walkthrough commands are green live: `register-token`,
`token list`, `fact insert`, plus `token end` (clean 409 while a request
is pending) and `fact get` (clean 404, no oracle) — both expected
protocol behavior.

## Known server-side issue (tracked separately): #299

`fact retract` hits a server **500** in `POST /facts/retract`,
**reproduced by direct curl with no CLI involved** — a server-side bug,
not a CLI defect. It blocks only the full retract→end walkthrough and is
documented and tracked as
[#299](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/299).
The CLI's `fact retract` command is correct and will work once #299
lands. Out of scope for #290.

Spec / plan / tasks: `specs/290-cli/`.