### PR TITLE
chore(deps): May-2026 cardano stack bump

### DIFF
--- a/cabal-wasm.project
+++ b/cabal-wasm.project
@@ -117,7 +117,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-tx-tools
-  tag: 69ef635b1bd4815c7d5f718de738dd9ec4a9d61e
+  tag: db2da7c469df782041aba2531c4abcf4c4483418
 
 tests: False
 benchmarks: False

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,8 @@
-index-state: 2025-12-07T00:00:00Z
+index-state: 2026-04-17T00:00:00Z
 
 index-state:
-  , hackage.haskell.org 2025-12-07T00:00:00Z
+  , hackage.haskell.org 2026-04-17T00:00:00Z
+  , cardano-haskell-packages 2026-05-25T13:25:40Z
 
 packages:
   cardano-mpfs-api/
@@ -31,14 +32,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/rocksdb-kv-transactions
-  tag: 44c3c2a4b7bab8ca0ca444c99977a358fc6af0ae
-  --sha256: 0rxc1g7imzlapdgab1v6cyy5nrgg8ilwbr9r015dxbdazl5rm9b9
+  tag: e2e77579888ebbd832ea750ebf2635dfc3307025
+  --sha256: 0nd1yz6k3xh1p7nlswp2jbw74bzqr7bvz11kcfyhhimqmjhkqvwm
 
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-utxo-csmt
-  tag: ccb893a16ba157e07a48e28df3c4d7eaa1fe107f
-  --sha256: 1crzbdrwbd2p35q53hmwznsk0qkh0zfik0a7dzp2kmp23bgh9qrl
+  tag: f4772f73dde0a84dff9608d6ac2b168c4315b05f
+  --sha256: 129sv2ayp7y2s5mhapx3720pr005dnfybz02nwibgyhsjqp292vz
 
 source-repository-package
   type: git
@@ -60,9 +61,9 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/lambdasistemi/cardano-read-ledger
-  tag: 2a9521e9282e4955f5454847c3f87eb7e7ac1730
-  --sha256: 1hgs2g2ain43jy7m4h36fddwbkij4s18b9l21iya4givnpmmi2l3
+  location: https://github.com/cardano-foundation/cardano-ledger-read
+  tag: 34d0767bd5c3648ab77ecbc00db0ad0a2a5316a5
+  --sha256: 0v357pbw2s22lsizxidq67pn4dcjkajips6mlcskd1zna35nyyv6
 
 source-repository-package
   type: git
@@ -73,18 +74,47 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-node-clients
-  tag: fdf6fe114959453d46ea733536b70f2d28c9bec8
-  --sha256: 1sykch5944i117n110zs5rpa7pxx8s4ymflwx94vmb1fffw6hdi7
+  tag: e4b01cb9efdf88e99934cf7a09fed0e25bad1019
+  --sha256: 1ll7lsyfk2a8flmrlrbbvd609mk8szkjpcpd6xxnj46p9vbm5r61
+
+source-repository-package
+  type: git
+  location: https://github.com/lambdasistemi/cardano-tx-tools
+  tag: db2da7c469df782041aba2531c4abcf4c4483418
+  --sha256: 1r4y5fgahxs4mrxdijc6xa6xic9fm193blpgxf6mizaj26nghyzk
+
+source-repository-package
+  type: git
+  location: https://github.com/lambdasistemi/github-release-check
+  tag: d90131112a4d6c048d1809adaffdefed92e8e841
+  --sha256: 0ad6yi431w8h5i3x9x661b99frcgvd39gm4164y8cx1ihpsjixn3
 
 source-repository-package
   type: git
   location: https://github.com/cardano-foundation/cardano-mpfs-onchain
-  tag: 023d352e850f866752927818da44861478ae99e5
-  --sha256: 1w1i4a00m08r0hf4bn6dwvmka1qibrchdz06l9bck8xzzvyn69k1
+  tag: 457c1cbcbbf622d0e583a3e9c0b413de079f315a
+  --sha256: 19m88h0ga5s09vrqqglj0wbwy4knvi9yy4mab9hwdb8mrrfdh5ig
   subdir: haskell
 
--- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API
-constraints: contra-tracer-contrib +iohk
+constraints:
+  contra-tracer-contrib +iohk,
+  cardano-ledger-allegra ==1.9.0.0,
+  cardano-ledger-alonzo ==1.15.0.0,
+  cardano-ledger-api ==1.13.0.0,
+  cardano-ledger-babbage ==1.13.0.0,
+  cardano-ledger-byron ==1.3.0.0,
+  cardano-ledger-conway ==1.21.0.0,
+  cardano-ledger-core ==1.19.0.0,
+  cardano-ledger-mary ==1.10.0.0,
+  cardano-ledger-shelley ==1.18.0.0,
+  cardano-crypto-class ==2.3.1.0,
+  cardano-crypto-praos ==2.2.2.0,
+  cardano-protocol-tpraos ==1.5.0.0,
+  cuddle ==1.1.1.0,
+  quickcheck-state-machine ==0.10.3,
+  ouroboros-consensus ==1.0.0.0,
+  ouroboros-network ==1.1.0.0,
+  typed-protocols ==1.2.0.0
 
 -- Disable pkgconfig for lzma (bundled C sources)
 package lzma
@@ -93,3 +123,4 @@ package lzma
 
 -- chain-follower has data-default <0.8 but cardano-ledger-shelley pulls 0.8
 allow-newer: chain-follower:data-default
+allow-newer: mts:containers

--- a/cardano-mpfs-cli/cardano-mpfs-cli.cabal
+++ b/cardano-mpfs-cli/cardano-mpfs-cli.cabal
@@ -43,13 +43,13 @@ library
     , cardano-crypto-class
     , cardano-ledger-api
     , cardano-ledger-binary
-    , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-mpfs-api
     , cardano-mpfs-cage
     , cardano-mpfs-client
     , cardano-mpfs-workflows
     , cardano-slotting
+    , cardano-tx-tools
     , containers              >=0.6  && <0.8
     , http-client             >=0.7  && <0.8
     , http-client-tls         >=0.3  && <0.4

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Sign.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Sign.hs
@@ -20,15 +20,17 @@ import Cardano.Crypto.DSIGN
     , SignKeyDSIGN
     , deriveVerKeyDSIGN
     )
-import Cardano.Ledger.Api.Tx (Tx, addrTxWitsL, txIdTx, witsTxL)
+import Cardano.Ledger.Api.Tx (addrTxWitsL, txIdTx, witsTxL)
 import Cardano.Ledger.Api.Tx.In (TxId (..))
 import Cardano.Ledger.Binary
-    ( DecoderError
-    , decodeFull'
+    ( Annotator
+    , Decoder
+    , DecoderError
+    , decCBOR
+    , decodeFullAnnotator
     , natVersion
     , serialize'
     )
-import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (extractHash)
 import Cardano.Ledger.Keys
     ( VKey (..)
@@ -36,13 +38,12 @@ import Cardano.Ledger.Keys
     , asWitness
     , signedDSIGN
     )
+import Cardano.Tx.Ledger (ConwayTx)
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BL
 import Data.Set qualified as Set
 import Lens.Micro ((%~), (&))
-
--- | A Conway-era transaction.
-type ConwayTx = Tx ConwayEra
 
 -- | Why an unsigned transaction could not be signed.
 newtype SignError
@@ -57,7 +58,13 @@ signTx
     -> ByteString
     -> Either SignError ByteString
 signTx sk unsignedCbor = do
-    tx <- first TxDecodeError (decodeFull' (natVersion @11) unsignedCbor)
+    tx <-
+        first TxDecodeError
+            $ decodeFullAnnotator
+                (natVersion @11)
+                "Conway transaction"
+                (decCBOR :: forall s. Decoder s (Annotator ConwayTx))
+                (BL.fromStrict unsignedCbor)
     pure (serialize' (natVersion @11) (addKeyWitness sk tx))
 
 -- | Add a single vkey witness for the key to the transaction.

--- a/cardano-mpfs-cli/test/Cardano/MPFS/CLI/SignSpec.hs
+++ b/cardano-mpfs-cli/test/Cardano/MPFS/CLI/SignSpec.hs
@@ -19,7 +19,10 @@ import Cardano.Crypto.Seed (mkSeedFromBytes)
 import Cardano.Ledger.Api.Tx (addrTxWitsL, mkBasicTx, witsTxL)
 import Cardano.Ledger.Api.Tx.Body (mkBasicTxBody)
 import Cardano.Ledger.Binary
-    ( decodeFull'
+    ( Annotator
+    , Decoder
+    , decCBOR
+    , decodeFullAnnotator
     , natVersion
     , serialize'
     )
@@ -35,6 +38,7 @@ import Codec.Binary.Bech32
     , humanReadablePartFromText
     )
 import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Lens.Micro ((^.))
@@ -78,7 +82,13 @@ spec = do
             $ case signTx testKey unsignedTx of
                 Left err -> expectationFailure ("signTx failed: " <> show err)
                 Right signedCbor ->
-                    case decodeFull' (natVersion @11) signedCbor of
+                    case decodeFullAnnotator
+                        (natVersion @11)
+                        "Conway transaction"
+                        ( decCBOR
+                            :: forall s. Decoder s (Annotator ConwayTx)
+                        )
+                        (BL.fromStrict signedCbor) of
                         Left err ->
                             expectationFailure ("re-decode failed: " <> show err)
                         Right (signedTx :: ConwayTx) ->

--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -34,36 +34,33 @@ library
   default-language:   GHC2021
   hs-source-dirs:     lib
   build-depends:
-    , aeson                      >=2.1  && <2.3
-    , base                       >=4.18 && <5
-    , base16-bytestring          >=1.0  && <1.1
-    , bytestring                 >=0.11 && <0.13
+    , aeson                   >=2.1  && <2.3
+    , base                    >=4.18 && <5
+    , base16-bytestring       >=1.0  && <1.1
+    , bytestring              >=0.11 && <0.13
     , cardano-crypto-class
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
-    , cardano-ledger-babbage
     , cardano-ledger-binary
-    , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-mpfs-api
     , cardano-mpfs-cage
     , cardano-mpfs-verify
-    , cardano-node-clients
     , cardano-slotting
-    , cardano-strict-containers
-    , containers                 >=0.6  && <0.8
-    , hspec                      >=2.11 && <2.12
-    , http-client                >=0.7  && <0.8
-    , http-types                 >=0.12 && <0.13
+    , cardano-tx-tools
+    , containers              >=0.6  && <0.8
+    , hspec                   >=2.11 && <2.12
+    , http-client             >=0.7  && <0.8
+    , http-types              >=0.12 && <0.13
     , microlens
     , mts:mpf-write
-    , operational                >=0.2  && <0.3
+    , operational             >=0.2  && <0.3
     , plutus-tx
-    , servant-client             >=0.20 && <0.21
-    , servant-client-core        >=0.20 && <0.21
-    , text                       >=2.0  && <2.2
+    , servant-client          >=0.20 && <0.21
+    , servant-client-core     >=0.20 && <0.21
+    , text                    >=2.0  && <2.2
 
   -- Re-export the pure verifier surface so existing consumers that
   -- import these from @cardano-mpfs-client@ keep working unchanged.
@@ -128,7 +125,6 @@ test-suite unit-tests
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
-    , cardano-ledger-babbage
     , cardano-ledger-binary
     , cardano-ledger-conway
     , cardano-ledger-core
@@ -136,8 +132,8 @@ test-suite unit-tests
     , cardano-mpfs-api
     , cardano-mpfs-cage
     , cardano-mpfs-client
-    , cardano-node-clients
     , cardano-slotting
+    , cardano-tx-tools
     , cborg                   >=0.2  && <0.3
     , containers              >=0.6  && <0.8
     , directory

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Boot.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Boot.hs
@@ -36,12 +36,12 @@ import Cardano.Ledger.Alonzo.TxBody
     ( scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( ppCoinsPerUTxOByteL
+    ( CoinPerByte (..)
+    , ppCoinsPerUTxOByteL
     , ppPricesL
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -56,9 +56,9 @@ import Cardano.Ledger.Api.Tx.Out
     )
 import Cardano.Ledger.Api.Tx.Wits
     ( Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
     )
-import Cardano.Ledger.Babbage.PParams (CoinPerByte (..))
 import Cardano.Ledger.BaseTypes
     ( StrictMaybe (..)
     , TxIx (..)
@@ -69,6 +69,7 @@ import Cardano.Ledger.Binary
     , natVersion
     )
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Hashes
@@ -122,18 +123,19 @@ import Cardano.MPFS.Client.Facts
     ( VerifiedBootFacts
     , verifiedBootFacts
     )
-import Cardano.Node.Client.Balance
+import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Tx.Balance
     ( BalanceResult (..)
     , balanceTx
     , computeScriptIntegrity
     , evalBudgetExUnits
     )
-import Cardano.Node.Client.TxBuild
+import Cardano.Tx.Build
     ( Interpret (..)
     , TxBuild
     )
-import Cardano.Node.Client.TxBuild qualified as TxBuild
-import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Tx.Build qualified as TxBuild
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -145,7 +147,7 @@ bootCageTx
     :: CageConfig
     -> WalletPolicy
     -> VerifiedBootFacts
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 bootCageTx cfg policy verified = do
     let facts = verifiedBootFacts verified
     pp <- decodePParams (bfProtocolParameters facts)
@@ -265,9 +267,9 @@ buildBootTx
     -> InputRow
     -> [InputRow]
     -> Addr
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 buildBootTx cfg pp seedRow collateralRow rows ownerAddr =
-    case balanceTx pp ledgerPairs ownerAddr withSubmitBudget of
+    case balanceTx pp ledgerPairs [] ownerAddr withSubmitBudget of
         Left err ->
             Left (DSLBuildFailed $ T.pack $ show err)
         Right BalanceResult{balancedTx} ->
@@ -296,17 +298,18 @@ buildBootTx cfg pp seedRow collateralRow rows ownerAddr =
 
 patchRedeemerBudgets
     :: PParams ConwayEra
-    -> Tx ConwayEra
-    -> Tx ConwayEra
+    -> ConwayTx
+    -> ConwayTx
 patchRedeemerBudgets pp tx =
     tx
         & witsTxL . rdmrsTxWitsL
             .~ budgetedRedeemers
         & bodyTxL . scriptIntegrityHashTxBodyL
             .~ computeScriptIntegrity
-                PlutusV3
+                (Set.singleton PlutusV3)
                 pp
                 budgetedRedeemers
+                (TxDats mempty)
   where
     Redeemers rdmrs =
         tx ^. witsTxL . rdmrsTxWitsL
@@ -395,7 +398,8 @@ enforcePParamsPolicy
     -> PParams ConwayEra
     -> Either BuildError ()
 enforcePParamsPolicy WalletPolicy{..} pp = do
-    let CoinPerByte minUtxo = pp ^. ppCoinsPerUTxOByteL
+    let CoinPerByte minUtxoCompact = pp ^. ppCoinsPerUTxOByteL
+        minUtxo = fromCompact minUtxoCompact
         prices = pp ^. ppPricesL
     if minUtxo <= wpMaxMinUtxoCoinPerByte
         then Right ()
@@ -413,7 +417,7 @@ enforcePParamsPolicy WalletPolicy{..} pp = do
                 $ ExUnitPricesTooHigh prices wpMaxExUnitPrices
 
 enforceTxPolicy
-    :: WalletPolicy -> Tx ConwayEra -> Either BuildError ()
+    :: WalletPolicy -> ConwayTx -> Either BuildError ()
 enforceTxPolicy WalletPolicy{..} tx = do
     let fee = tx ^. bodyTxL . feeTxBodyL
         width = validityWindow (tx ^. bodyTxL . vldtTxBodyL)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/End.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/End.hs
@@ -16,7 +16,7 @@ import Data.Ord (Down (..))
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Word (Word16, Word32, Word64)
+import Data.Word (Word16, Word64)
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Crypto.Hash
@@ -28,15 +28,12 @@ import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Allegra.Scripts
     ( ValidityInterval (..)
     )
-import Cardano.Ledger.Alonzo.Scripts
-    ( AsIx (..)
-    )
 import Cardano.Ledger.Alonzo.TxBody
-    ( reqSignerHashesTxBodyL
-    , scriptIntegrityHashTxBodyL
+    ( scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( ppCoinsPerUTxOByteL
+    ( CoinPerByte (..)
+    , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
     , ppPricesL
     )
@@ -46,17 +43,11 @@ import Cardano.Ledger.Api.Scripts.Data
     , binaryDataToData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
-    , mkBasicTx
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
-    , feeTxBodyL
-    , inputsTxBodyL
-    , mintTxBodyL
-    , mkBasicTxBody
+    ( feeTxBodyL
     , vldtTxBodyL
     )
 import Cardano.Ledger.Api.Tx.Out
@@ -67,11 +58,8 @@ import Cardano.Ledger.Api.Tx.Out
     )
 import Cardano.Ledger.Api.Tx.Wits
     ( Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
-    , scriptTxWitsL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( StrictMaybe (..)
@@ -82,12 +70,9 @@ import Cardano.Ledger.Binary
     , decodeFull
     , natVersion
     )
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
     ( PParams
-    , hashScript
     )
 import Cardano.Ledger.Hashes
     ( unsafeMakeSafeHash
@@ -95,9 +80,6 @@ import Cardano.Ledger.Hashes
 import Cardano.Ledger.Keys
     ( KeyHash (..)
     , KeyRole (..)
-    )
-import Cardano.Ledger.Mary.Value
-    ( MultiAsset (..)
     )
 import Cardano.Ledger.Plutus.ExUnits
     ( ExUnits (..)
@@ -150,23 +132,26 @@ import Cardano.MPFS.Client.Facts
     ( VerifiedEndFacts
     , verifiedEndFacts
     )
-import Cardano.Node.Client.Balance
+import Cardano.Slotting.Slot
+    ( SlotNo (..)
+    )
+import Cardano.Tx.Balance
     ( BalanceResult (..)
     , balanceTx
     , computeScriptIntegrity
     , evalBudgetExUnits
     )
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    )
+import Cardano.Tx.Build qualified as TxBuild
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     , BuiltinData (..)
     )
 import PlutusTx.IsData.Class
     ( FromData (..)
-    , ToData (..)
     )
+
+data NoCtx a
 
 -- | Build an unsigned end transaction from already-verified end
 -- facts. The function decodes the supplied ledger facts, enforces
@@ -175,7 +160,7 @@ endCageTx
     :: CageConfig
     -> WalletPolicy
     -> VerifiedEndFacts
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 endCageTx cfg policy verified = do
     let facts = verifiedEndFacts verified
     pp <- decodePParams (efProtocolParameters facts)
@@ -308,12 +293,15 @@ stateOwnerBytes row =
                     "end.state_utxo.tx_out_cbor missing state datum"
 
 ownerWitnessKeyHash
-    :: ByteString -> Either BuildError (KeyHash 'Witness)
+    :: ByteString -> Either BuildError (KeyHash Witness)
 ownerWitnessKeyHash ownerBytes =
     coerce <$> ownerPaymentKeyHash ownerBytes
 
+witnessKeyHashToGuard :: KeyHash Witness -> KeyHash Guard
+witnessKeyHashToGuard (KeyHash h) = KeyHash h
+
 ownerPaymentKeyHash
-    :: ByteString -> Either BuildError (KeyHash 'Payment)
+    :: ByteString -> Either BuildError (KeyHash Payment)
 ownerPaymentKeyHash ownerBytes =
     case hashFromBytes @Blake2b_224 ownerBytes of
         Just hash -> Right (KeyHash hash)
@@ -338,9 +326,9 @@ buildEndTx
     -> [InputRow]
     -> InputRow
     -> Addr
-    -> KeyHash 'Witness
+    -> KeyHash Witness
     -> TokenId
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 buildEndTx
     cfg
     pp
@@ -350,7 +338,7 @@ buildEndTx
     ownerAddr
     ownerSigner
     token =
-        case balanceTx pp ledgerPairs ownerAddr draft of
+        case balanceTx pp ledgerPairs [] ownerAddr draft of
             Left err ->
                 Left (DSLBuildFailed $ T.pack $ show err)
             Right BalanceResult{balancedTx} ->
@@ -360,65 +348,59 @@ buildEndTx
         collateralRef = rowRef collateralRow
         policyId = cagePolicyIdFromCfg cfg
         script = mkCageScript cfg
-        scriptHash = hashScript script
         tokenAsset = unTokenId token
-        burnValue =
-            MultiAsset
-                $ Map.singleton policyId
-                $ Map.singleton tokenAsset (-1)
         allRows = stateRow : fundingRows
-        allInputs =
-            Set.fromList (map rowRef allRows)
-        stateIx =
-            spendingIndex stateRef allInputs
         endBudget =
             endRedeemerBudget pp
-        redeemers =
-            Redeemers
-                $ Map.fromList
-                    [
-                        ( ConwaySpending (AsIx stateIx)
-                        ,
-                            ( toLedgerData End
-                            , endBudget
-                            )
-                        )
-                    ,
-                        ( ConwayMinting (AsIx 0)
-                        ,
-                            ( toLedgerData
-                                (Burning $ onChainTokenId token)
-                            , endBudget
-                            )
-                        )
-                    ]
-        body =
-            mkBasicTxBody
-                & inputsTxBodyL .~ allInputs
-                & mintTxBodyL .~ burnValue
-                & collateralInputsTxBodyL
-                    .~ Set.singleton collateralRef
-                & reqSignerHashesTxBodyL
-                    .~ Set.singleton ownerSigner
-                & scriptIntegrityHashTxBodyL
-                    .~ computeScriptIntegrity
-                        PlutusV3
-                        pp
-                        redeemers
+        program = do
+            _ <- TxBuild.spendScript stateRef End
+            mapM_
+                (TxBuild.spend . rowRef)
+                fundingRows
+            TxBuild.attachScript script
+            TxBuild.mint
+                policyId
+                (Map.singleton tokenAsset (-1))
+                (Burning $ onChainTokenId token)
+            TxBuild.collateral collateralRef
+            TxBuild.requireSignature
+                (witnessKeyHashToGuard ownerSigner)
         draft =
-            mkBasicTx body
-                & witsTxL . scriptTxWitsL
-                    .~ Map.singleton scriptHash script
-                & witsTxL . rdmrsTxWitsL .~ redeemers
+            patchRedeemerBudgets pp endBudget
+                $ TxBuild.draft
+                    pp
+                    ( program
+                        :: TxBuild.TxBuild NoCtx BuildError ()
+                    )
         ledgerPairs =
             [ (rowRef row, rowOut row)
             | row <- allRows
             ]
 
-toLedgerData :: (ToData a) => a -> Data ConwayEra
-toLedgerData value =
-    let BuiltinData d = toBuiltinData value
-    in  Data d
+patchRedeemerBudgets
+    :: PParams ConwayEra
+    -> ExUnits
+    -> ConwayTx
+    -> ConwayTx
+patchRedeemerBudgets pp budget tx =
+    tx
+        & witsTxL . rdmrsTxWitsL .~ budgetedRedeemers
+        & bodyTxL . scriptIntegrityHashTxBodyL
+            .~ computeScriptIntegrity
+                (Set.singleton PlutusV3)
+                pp
+                budgetedRedeemers
+                (TxDats mempty)
+  where
+    Redeemers rdmrs =
+        tx ^. witsTxL . rdmrsTxWitsL
+    budgetedRedeemers =
+        Redeemers
+            $ fmap
+                ( \(dat, _) ->
+                    (dat, budget)
+                )
+                rdmrs
 
 endRedeemerBudget :: PParams ConwayEra -> ExUnits
 endRedeemerBudget pp =
@@ -434,22 +416,13 @@ halfExUnits :: ExUnits -> ExUnits
 halfExUnits (ExUnits mem steps) =
     ExUnits (mem `div` 2) (steps `div` 2)
 
-spendingIndex :: TxIn -> Set.Set TxIn -> Word32
-spendingIndex needle inputs =
-    go 0 (Set.toAscList inputs)
-  where
-    go _ [] =
-        error "spendingIndex: TxIn not in input set"
-    go n (x : xs)
-        | x == needle = n
-        | otherwise = go (n + 1) xs
-
 enforcePParamsPolicy
     :: WalletPolicy
     -> PParams ConwayEra
     -> Either BuildError ()
 enforcePParamsPolicy WalletPolicy{..} pp = do
-    let CoinPerByte minUtxo = pp ^. ppCoinsPerUTxOByteL
+    let CoinPerByte minUtxoCompact = pp ^. ppCoinsPerUTxOByteL
+        minUtxo = fromCompact minUtxoCompact
         prices = pp ^. ppPricesL
     if minUtxo <= wpMaxMinUtxoCoinPerByte
         then Right ()
@@ -467,7 +440,7 @@ enforcePParamsPolicy WalletPolicy{..} pp = do
                 $ ExUnitPricesTooHigh prices wpMaxExUnitPrices
 
 enforceTxPolicy
-    :: WalletPolicy -> Tx ConwayEra -> Either BuildError ()
+    :: WalletPolicy -> ConwayTx -> Either BuildError ()
 enforceTxPolicy WalletPolicy{..} tx = do
     let fee = tx ^. bodyTxL . feeTxBodyL
         width = validityWindow (tx ^. bodyTxL . vldtTxBodyL)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Reject.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Reject.hs
@@ -26,7 +26,6 @@ import Data.Coerce (coerce)
 import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Ord (Down (..))
-import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -49,11 +48,11 @@ import Cardano.Ledger.Alonzo.Scripts
     , mkPlutusScript
     )
 import Cardano.Ledger.Alonzo.TxBody
-    ( reqSignerHashesTxBodyL
-    , scriptIntegrityHashTxBodyL
+    ( scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( ppCoinsPerUTxOByteL
+    ( CoinPerByte (..)
+    , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
     , ppPricesL
     )
@@ -64,17 +63,12 @@ import Cardano.Ledger.Api.Scripts.Data
     , dataToBinaryData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
-    , mkBasicTx
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
-    , feeTxBodyL
+    ( feeTxBodyL
     , inputsTxBodyL
-    , mkBasicTxBody
-    , outputsTxBodyL
     , vldtTxBodyL
     )
 import Cardano.Ledger.Api.Tx.Out
@@ -87,12 +81,10 @@ import Cardano.Ledger.Api.Tx.Out
     , valueTxOutL
     )
 import Cardano.Ledger.Api.Tx.Wits
-    ( Redeemers (..)
+    ( ConwayPlutusPurpose (..)
+    , Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
-    , scriptTxWitsL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
@@ -106,13 +98,10 @@ import Cardano.Ledger.Binary
     , natVersion
     )
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
     ( PParams
     , Script
-    , hashScript
     )
 import Cardano.Ledger.Credential
     ( Credential (..)
@@ -141,6 +130,7 @@ import Cardano.Ledger.TxIn
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     , BuiltinData (..)
@@ -193,12 +183,15 @@ import Cardano.MPFS.Client.Facts
     ( VerifiedRejectFacts
     , verifiedRejectFacts
     )
-import Cardano.Node.Client.Balance
+import Cardano.Tx.Balance
     ( BalanceResult (..)
     , balanceTx
     , computeScriptIntegrity
     , evalBudgetExUnits
     )
+import Cardano.Tx.Build qualified as TxBuild
+
+data NoCtx a
 
 -- | Build an unsigned reject transaction from already
 -- verified reject facts. The function decodes the supplied
@@ -211,7 +204,7 @@ rejectCageTx
     :: CageConfig
     -> WalletPolicy
     -> VerifiedRejectFacts
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 rejectCageTx cfg policy verified = do
     let facts = verifiedRejectFacts verified
         token = tokenIdFromJSON (rfToken facts)
@@ -377,12 +370,15 @@ extractCageDatum txOut =
         _ -> Nothing
 
 ownerWitnessKeyHash
-    :: ByteString -> Either BuildError (KeyHash 'Witness)
+    :: ByteString -> Either BuildError (KeyHash Witness)
 ownerWitnessKeyHash ownerBytes =
     coerce <$> ownerPaymentKeyHash ownerBytes
 
+witnessKeyHashToGuard :: KeyHash Witness -> KeyHash Guard
+witnessKeyHashToGuard (KeyHash h) = KeyHash h
+
 ownerPaymentKeyHash
-    :: ByteString -> Either BuildError (KeyHash 'Payment)
+    :: ByteString -> Either BuildError (KeyHash Payment)
 ownerPaymentKeyHash ownerBytes =
     case hashFromBytes @Blake2b_224 ownerBytes of
         Just hash -> Right (KeyHash hash)
@@ -405,9 +401,9 @@ buildRejectTx
     -> InputRow
     -> Addr
     -> OnChainTokenState
-    -> KeyHash 'Witness
+    -> KeyHash Witness
     -> ValidityInterval
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 buildRejectTx
     cfg
     pp
@@ -432,69 +428,63 @@ buildRejectTx
                         else converge (Set.insert finalFee seenFees) finalFee
 
         buildWithFee feeForRefunds =
-            case balanceTx pp ledgerPairs changeAddr draft of
+            case balanceTx pp ledgerPairs [] changeAddr draft of
                 Left err ->
                     Left (DSLBuildFailed $ T.pack $ show err)
                 Right BalanceResult{balancedTx} ->
-                    Right balancedTx
+                    Right
+                        $ patchRejectRedeemers
+                            pp
+                            budget
+                            stateRef
+                            (map fst requestRefs)
+                            balancedTx
           where
             draft =
-                mkBasicTx body
-                    & witsTxL . scriptTxWitsL .~ scripts
-                    & witsTxL . rdmrsTxWitsL .~ redeemers
-            body =
-                mkBasicTxBody
-                    & inputsTxBodyL .~ allInputs
-                    & collateralInputsTxBodyL
-                        .~ Set.singleton feeRef
-                    & outputsTxBodyL
-                        .~ StrictSeq.fromList outputs
-                    & reqSignerHashesTxBodyL
-                        .~ Set.singleton ownerSigner
-                    & vldtTxBodyL .~ validity
-                    & scriptIntegrityHashTxBodyL
-                        .~ computeScriptIntegrity PlutusV3 pp redeemers
+                patchRedeemerBudgets pp budget
+                    $ TxBuild.draft
+                        pp
+                        ( program
+                            :: TxBuild.TxBuild NoCtx BuildError ()
+                        )
+            program = do
+                _ <-
+                    TxBuild.spendScript
+                        stateRef
+                        ( Modify
+                            $ replicate
+                                (length requestRows)
+                                Rejected
+                        )
+                mapM_
+                    ( \(ref, _) ->
+                        TxBuild.spendScript
+                            ref
+                            ( Contribute
+                                $ txInToOnChainRef stateRef
+                            )
+                    )
+                    requestRefs
+                mapM_ TxBuild.output outputs
+                TxBuild.attachScript stateScript
+                TxBuild.attachScript requestScript
+                TxBuild.collateral feeRef
+                TxBuild.requireSignature
+                    (witnessKeyHashToGuard ownerSigner)
+                applyValidity validity
             outputs =
                 newStateOut : refundOutputs feeForRefunds
 
         stateRef = rowRef stateRow
         feeRef = rowRef feeRow
         allRows = stateRow : requestRows <> [feeRow]
-        allInputs = Set.fromList (map rowRef allRows)
+        requestRefs =
+            [(rowRef row, rowOut row) | row <- requestRows]
         ledgerPairs =
             [(rowRef row, rowOut row) | row <- allRows]
         stateScript = mkCageScript cfg
         requestScript = mkRequestScript cfg token
-        scripts =
-            Map.fromList
-                [ (hashScript stateScript, stateScript)
-                , (hashScript requestScript, requestScript)
-                ]
         budget = rejectRedeemerBudget pp
-        redeemers =
-            Redeemers
-                $ Map.fromList
-                $ stateRedeemer : requestRedeemers
-        stateRedeemer =
-            ( ConwaySpending (AsIx $ spendingIndex stateRef allInputs)
-            ,
-                ( toLedgerData
-                    $ Modify
-                    $ replicate (length requestRows) Rejected
-                , budget
-                )
-            )
-        requestRedeemers =
-            [ ( ConwaySpending (AsIx $ spendingIndex ref allInputs)
-              ,
-                  ( toLedgerData
-                        $ Contribute
-                        $ txInToOnChainRef stateRef
-                  , budget
-                  )
-              )
-            | ref <- map rowRef requestRows
-            ]
         newStateOut =
             mkBasicTxOut
                 (cageAddrFromCfg cfg (network cfg))
@@ -519,6 +509,94 @@ buildRejectTx
                       extra = if ix == 0 then remainder else 0
                 ]
 
+applyValidity :: ValidityInterval -> TxBuild.TxBuild q e ()
+applyValidity ValidityInterval{invalidBefore, invalidHereafter} = do
+    case invalidBefore of
+        SNothing -> pure ()
+        SJust slot -> TxBuild.validFrom slot
+    case invalidHereafter of
+        SNothing -> pure ()
+        SJust slot -> TxBuild.validTo slot
+
+patchRedeemerBudgets
+    :: PParams ConwayEra
+    -> ExUnits
+    -> ConwayTx
+    -> ConwayTx
+patchRedeemerBudgets pp budget tx =
+    tx
+        & witsTxL . rdmrsTxWitsL .~ budgetedRedeemers
+        & bodyTxL . scriptIntegrityHashTxBodyL
+            .~ computeScriptIntegrity
+                (Set.singleton PlutusV3)
+                pp
+                budgetedRedeemers
+                (TxDats mempty)
+  where
+    Redeemers rdmrs =
+        tx ^. witsTxL . rdmrsTxWitsL
+    budgetedRedeemers =
+        Redeemers
+            $ fmap
+                ( \(dat, _) ->
+                    (dat, budget)
+                )
+                rdmrs
+
+patchRejectRedeemers
+    :: PParams ConwayEra
+    -> ExUnits
+    -> TxIn
+    -> [TxIn]
+    -> ConwayTx
+    -> ConwayTx
+patchRejectRedeemers pp budget stateRef requestRefs tx =
+    tx
+        & witsTxL . rdmrsTxWitsL .~ redeemers
+        & bodyTxL . scriptIntegrityHashTxBodyL
+            .~ computeScriptIntegrity
+                (Set.singleton PlutusV3)
+                pp
+                redeemers
+                (TxDats mempty)
+  where
+    allInputs =
+        tx ^. bodyTxL . inputsTxBodyL
+    redeemers =
+        Redeemers
+            $ Map.fromList
+            $ stateRedeemer
+                : map requestRedeemer requestRefs
+    stateRedeemer =
+        ( spendingPurpose stateRef
+        ,
+            ( toLedgerData
+                (Modify $ replicate (length requestRefs) Rejected)
+            , budget
+            )
+        )
+    requestRedeemer ref =
+        ( spendingPurpose ref
+        ,
+            ( toLedgerData
+                (Contribute $ txInToOnChainRef stateRef)
+            , budget
+            )
+        )
+    spendingPurpose ref =
+        ConwaySpending
+            (AsIx $ spendingIndex ref allInputs)
+
+spendingIndex :: TxIn -> Set.Set TxIn -> Word32
+spendingIndex needle inputs =
+    go 0 (Set.toAscList inputs)
+  where
+    go _ [] =
+        error "rejectCageTx: script input missing from balanced tx"
+    go n (x : xs)
+        | x == needle = n
+        | otherwise = go (n + 1) xs
+
 -- | Build a refund output, bumping the coin to satisfy the
 -- minUTxO floor when the raw refund would underpay it.
 refundOutput :: PParams ConwayEra -> Addr -> Coin -> TxOut ConwayEra
@@ -534,7 +612,7 @@ refundAddress net OnChainRequest{requestOwner = BuiltinByteString ownerBytes} =
         (KeyHashObj $ unsafeOwnerPaymentKeyHash ownerBytes)
         StakeRefNull
 
-unsafeOwnerPaymentKeyHash :: ByteString -> KeyHash 'Payment
+unsafeOwnerPaymentKeyHash :: ByteString -> KeyHash Payment
 unsafeOwnerPaymentKeyHash ownerBytes =
     case hashFromBytes @Blake2b_224 ownerBytes of
         Just hash -> KeyHash hash
@@ -590,22 +668,13 @@ halfExUnits :: ExUnits -> ExUnits
 halfExUnits (ExUnits mem steps) =
     ExUnits (mem `div` 2) (steps `div` 2)
 
-spendingIndex :: TxIn -> Set.Set TxIn -> Word32
-spendingIndex needle inputs =
-    go 0 (Set.toAscList inputs)
-  where
-    go _ [] =
-        error "spendingIndex: TxIn not in input set"
-    go n (x : xs)
-        | x == needle = n
-        | otherwise = go (n + 1) xs
-
 enforcePParamsPolicy
     :: WalletPolicy
     -> PParams ConwayEra
     -> Either BuildError ()
 enforcePParamsPolicy WalletPolicy{..} pp = do
-    let CoinPerByte minUtxo = pp ^. ppCoinsPerUTxOByteL
+    let CoinPerByte minUtxoCompact = pp ^. ppCoinsPerUTxOByteL
+        minUtxo = fromCompact minUtxoCompact
         prices = pp ^. ppPricesL
     if minUtxo <= wpMaxMinUtxoCoinPerByte
         then Right ()
@@ -623,7 +692,7 @@ enforcePParamsPolicy WalletPolicy{..} pp = do
                 $ ExUnitPricesTooHigh prices wpMaxExUnitPrices
 
 enforceTxPolicy
-    :: WalletPolicy -> Tx ConwayEra -> Either BuildError ()
+    :: WalletPolicy -> ConwayTx -> Either BuildError ()
 enforceTxPolicy WalletPolicy{..} tx = do
     let fee = tx ^. bodyTxL . feeTxBodyL
         width = validityWindow (tx ^. bodyTxL . vldtTxBodyL)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Request.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Request.hs
@@ -13,7 +13,6 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BSL
 import Data.List (sortOn)
 import Data.Ord (Down (..))
-import Data.Sequence.Strict qualified as StrictSeq
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Word (Word16, Word64)
@@ -32,11 +31,12 @@ import Cardano.Ledger.Allegra.Scripts
     ( ValidityInterval (..)
     )
 import Cardano.Ledger.Api.PParams
-    ( ppCoinsPerUTxOByteL
+    ( CoinPerByte (..)
+    , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
-    , ppMinFeeAL
-    , ppMinFeeBL
     , ppPricesL
+    , ppTxFeeFixedL
+    , ppTxFeePerByteL
     )
 import Cardano.Ledger.Api.Scripts.Data
     ( Data (..)
@@ -44,14 +44,10 @@ import Cardano.Ledger.Api.Scripts.Data
     , dataToBinaryData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
-    , mkBasicTx
+    ( bodyTxL
     )
 import Cardano.Ledger.Api.Tx.Body
     ( feeTxBodyL
-    , mkBasicTxBody
-    , outputsTxBodyL
     , vldtTxBodyL
     )
 import Cardano.Ledger.Api.Tx.Out
@@ -61,9 +57,6 @@ import Cardano.Ledger.Api.Tx.Out
     , getMinCoinTxOut
     , mkBasicTxOut
     , valueTxOutL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
@@ -78,6 +71,7 @@ import Cardano.Ledger.Binary
 import Cardano.Ledger.Coin
     ( Coin (..)
     )
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
     ( PParams
     )
@@ -142,13 +136,15 @@ import Cardano.MPFS.Client.Facts
     , verifiedRequestInsertFacts
     , verifiedRequestUpdateFacts
     )
-import Cardano.Node.Client.Balance
-    ( BalanceResult (..)
-    , balanceTx
-    )
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Tx.Balance
+    ( BalanceResult (..)
+    , balanceTx
+    )
+import Cardano.Tx.Build qualified as TxBuild
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     , BuiltinData (..)
@@ -157,6 +153,8 @@ import PlutusTx.IsData.Class
     ( ToData (..)
     )
 
+data NoCtx a
+
 -- | Build an unsigned request-insert transaction from already-verified
 -- request-insert facts. The function decodes ledger facts, enforces
 -- wallet caps, and returns a transaction ready for requester signing.
@@ -164,7 +162,7 @@ requestInsertCageTx
     :: CageConfig
     -> WalletPolicy
     -> VerifiedRequestInsertFacts
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 requestInsertCageTx cfg policy verified =
     let facts = verifiedRequestInsertFacts verified
     in  buildRequestCageTx
@@ -186,7 +184,7 @@ requestDeleteCageTx
     :: CageConfig
     -> WalletPolicy
     -> VerifiedRequestDeleteFacts
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 requestDeleteCageTx cfg policy verified =
     let facts = verifiedRequestDeleteFacts verified
     in  buildRequestCageTx
@@ -208,7 +206,7 @@ requestUpdateCageTx
     :: CageConfig
     -> WalletPolicy
     -> VerifiedRequestUpdateFacts
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 requestUpdateCageTx cfg policy verified =
     let facts = verifiedRequestUpdateFacts verified
     in  buildRequestCageTx
@@ -237,7 +235,7 @@ buildRequestCageTx
     -> ByteString
     -> OnChainOperation
     -> Integer
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 buildRequestCageTx
     label
     cfg
@@ -367,7 +365,7 @@ buildRequestTx
     -> ByteString
     -> OnChainOperation
     -> Integer
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 buildRequestTx
     cfg
     pp
@@ -380,6 +378,7 @@ buildRequestTx
         case balanceTx
             pp
             [(rowRef fundingRow, rowOut fundingRow)]
+            []
             requesterAddr
             draft of
             Left err ->
@@ -412,11 +411,14 @@ buildRequestTx
                 scriptAddr
                 (inject lockedAda)
                 & datumTxOutL .~ datum
-        body =
-            mkBasicTxBody
-                & outputsTxBodyL
-                    .~ StrictSeq.singleton txOut
-        draft = mkBasicTx body
+        program = do
+            _ <- TxBuild.spend (rowRef fundingRow)
+            _ <- TxBuild.output txOut
+            pure ()
+        draft =
+            TxBuild.draft
+                pp
+                (program :: TxBuild.TxBuild NoCtx BuildError ())
 
 requestDatum
     :: TokenId
@@ -478,8 +480,9 @@ requestLockedAda pp reqDraft refDraft tip =
 -- Cardano.MPFS.TxBuilder.Real.Request.requestFeeBufferUpperBound.
 requestFeeBufferUpperBound :: PParams ConwayEra -> Coin
 requestFeeBufferUpperBound pp =
-    let Coin minFeeA = pp ^. ppMinFeeAL
-        Coin minFeeB = pp ^. ppMinFeeBL
+    let CoinPerByte minFeeACompact = pp ^. ppTxFeePerByteL
+        Coin minFeeA = fromCompact minFeeACompact
+        Coin minFeeB = pp ^. ppTxFeeFixedL
         Coin scriptFee =
             txscriptfee (pp ^. ppPricesL) (pp ^. ppMaxTxExUnitsL)
     in  Coin
@@ -502,7 +505,8 @@ enforcePParamsPolicy
     -> PParams ConwayEra
     -> Either BuildError ()
 enforcePParamsPolicy WalletPolicy{..} pp = do
-    let CoinPerByte minUtxo = pp ^. ppCoinsPerUTxOByteL
+    let CoinPerByte minUtxoCompact = pp ^. ppCoinsPerUTxOByteL
+        minUtxo = fromCompact minUtxoCompact
         prices = pp ^. ppPricesL
     if minUtxo <= wpMaxMinUtxoCoinPerByte
         then Right ()
@@ -520,7 +524,7 @@ enforcePParamsPolicy WalletPolicy{..} pp = do
                 $ ExUnitPricesTooHigh prices wpMaxExUnitPrices
 
 enforceTxPolicy
-    :: WalletPolicy -> Tx ConwayEra -> Either BuildError ()
+    :: WalletPolicy -> ConwayTx -> Either BuildError ()
 enforceTxPolicy WalletPolicy{..} tx = do
     let fee = tx ^. bodyTxL . feeTxBodyL
         width = validityWindow (tx ^. bodyTxL . vldtTxBodyL)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Retract.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Retract.hs
@@ -35,11 +35,11 @@ import Cardano.Ledger.Alonzo.Scripts
     , mkPlutusScript
     )
 import Cardano.Ledger.Alonzo.TxBody
-    ( reqSignerHashesTxBodyL
-    , scriptIntegrityHashTxBodyL
+    ( scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( ppCoinsPerUTxOByteL
+    ( CoinPerByte (..)
+    , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
     , ppPricesL
     )
@@ -49,17 +49,14 @@ import Cardano.Ledger.Api.Scripts.Data
     , binaryDataToData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
-    , mkBasicTx
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
+    ( collateralReturnTxBodyL
     , feeTxBodyL
     , inputsTxBodyL
-    , mkBasicTxBody
-    , referenceInputsTxBodyL
+    , totalCollateralTxBodyL
     , vldtTxBodyL
     )
 import Cardano.Ledger.Api.Tx.Out
@@ -69,12 +66,10 @@ import Cardano.Ledger.Api.Tx.Out
     , datumTxOutL
     )
 import Cardano.Ledger.Api.Tx.Wits
-    ( Redeemers (..)
+    ( ConwayPlutusPurpose (..)
+    , Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
-    , scriptTxWitsL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( StrictMaybe (..)
@@ -85,13 +80,10 @@ import Cardano.Ledger.Binary
     , decodeFull
     , natVersion
     )
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
     ( PParams
     , Script
-    , hashScript
     )
 import Cardano.Ledger.Hashes
     ( extractHash
@@ -116,6 +108,7 @@ import Cardano.Ledger.TxIn
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     , BuiltinData (..)
@@ -164,12 +157,14 @@ import Cardano.MPFS.Client.Facts
     ( VerifiedRetractFacts
     , verifiedRetractFacts
     )
-import Cardano.Node.Client.Balance
+import Cardano.Tx.Balance
     ( BalanceResult (..)
     , balanceTx
     , computeScriptIntegrity
-    , evalBudgetExUnits
     )
+import Cardano.Tx.Build qualified as TxBuild
+
+data NoCtx a
 
 -- | Build an unsigned retract transaction from already-verified
 -- retract facts. The function decodes the supplied ledger facts,
@@ -180,7 +175,7 @@ retractCageTx
     :: CageConfig
     -> WalletPolicy
     -> VerifiedRetractFacts
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 retractCageTx cfg policy verified = do
     let facts = verifiedRetractFacts verified
     pp <- decodePParams (rfProtocolParameters facts)
@@ -322,12 +317,15 @@ requestOwnerBytes row =
                     \request datum"
 
 ownerWitnessKeyHash
-    :: ByteString -> Either BuildError (KeyHash 'Witness)
+    :: ByteString -> Either BuildError (KeyHash Witness)
 ownerWitnessKeyHash ownerBytes =
     coerce <$> ownerPaymentKeyHash ownerBytes
 
+witnessKeyHashToGuard :: KeyHash Witness -> KeyHash Guard
+witnessKeyHashToGuard (KeyHash h) = KeyHash h
+
 ownerPaymentKeyHash
-    :: ByteString -> Either BuildError (KeyHash 'Payment)
+    :: ByteString -> Either BuildError (KeyHash Payment)
 ownerPaymentKeyHash ownerBytes =
     case hashFromBytes @Blake2b_224 ownerBytes of
         Just hash -> Right (KeyHash hash)
@@ -354,9 +352,9 @@ buildRetractTx
     -> InputRow
     -> InputRow
     -> Addr
-    -> KeyHash 'Witness
+    -> KeyHash Witness
     -> ValidityInterval
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 buildRetractTx
     cfg
     pp
@@ -367,50 +365,121 @@ buildRetractTx
     changeAddr
     ownerSigner
     validity =
-        case balanceTx pp ledgerPairs changeAddr draft of
+        case balanceTx pp ledgerPairs [] changeAddr draft of
             Left err ->
                 Left (DSLBuildFailed $ T.pack $ show err)
             Right BalanceResult{balancedTx} ->
-                Right balancedTx
+                Right
+                    $ stripBalancingCollateralFields
+                    $ patchRetractRedeemers
+                        pp
+                        budget
+                        requestRef
+                        redeemer
+                        balancedTx
       where
         requestRef = rowRef requestRow
         stateRef = rowRef stateRow
         feeRef = rowRef feeRow
         script = mkRequestScript cfg token
-        scriptHash = hashScript script
-        allInputs = Set.fromList [requestRef, feeRef]
-        reqIx = spendingIndex requestRef allInputs
         budget = retractRedeemerBudget pp
         redeemer = Retract (txInToOnChainRef stateRef)
-        redeemers =
-            Redeemers
-                $ Map.singleton
-                    (ConwaySpending (AsIx reqIx))
-                    (toLedgerData redeemer, budget)
-        body =
-            mkBasicTxBody
-                & inputsTxBodyL .~ Set.singleton requestRef
-                & referenceInputsTxBodyL
-                    .~ Set.singleton stateRef
-                & collateralInputsTxBodyL
-                    .~ Set.singleton feeRef
-                & reqSignerHashesTxBodyL
-                    .~ Set.singleton ownerSigner
-                & vldtTxBodyL .~ validity
-                & scriptIntegrityHashTxBodyL
-                    .~ computeScriptIntegrity
-                        PlutusV3
-                        pp
-                        redeemers
+        program = do
+            _ <- TxBuild.spendScript requestRef redeemer
+            TxBuild.reference stateRef
+            TxBuild.attachScript script
+            TxBuild.collateral feeRef
+            TxBuild.requireSignature
+                (witnessKeyHashToGuard ownerSigner)
+            applyValidity validity
         draft =
-            mkBasicTx body
-                & witsTxL . scriptTxWitsL
-                    .~ Map.singleton scriptHash script
-                & witsTxL . rdmrsTxWitsL .~ redeemers
+            patchRedeemerBudgets pp budget
+                $ TxBuild.draft
+                    pp
+                    ( program
+                        :: TxBuild.TxBuild NoCtx BuildError ()
+                    )
         ledgerPairs =
             [ (rowRef requestRow, rowOut requestRow)
             , (rowRef feeRow, rowOut feeRow)
             ]
+
+applyValidity :: ValidityInterval -> TxBuild.TxBuild q e ()
+applyValidity ValidityInterval{invalidBefore, invalidHereafter} = do
+    case invalidBefore of
+        SNothing -> pure ()
+        SJust slot -> TxBuild.validFrom slot
+    case invalidHereafter of
+        SNothing -> pure ()
+        SJust slot -> TxBuild.validTo slot
+
+patchRedeemerBudgets
+    :: PParams ConwayEra
+    -> ExUnits
+    -> ConwayTx
+    -> ConwayTx
+patchRedeemerBudgets pp budget tx =
+    tx
+        & witsTxL . rdmrsTxWitsL .~ budgetedRedeemers
+        & bodyTxL . scriptIntegrityHashTxBodyL
+            .~ computeScriptIntegrity
+                (Set.singleton PlutusV3)
+                pp
+                budgetedRedeemers
+                (TxDats mempty)
+  where
+    Redeemers rdmrs =
+        tx ^. witsTxL . rdmrsTxWitsL
+    budgetedRedeemers =
+        Redeemers
+            $ fmap
+                ( \(dat, _) ->
+                    (dat, budget)
+                )
+                rdmrs
+
+patchRetractRedeemers
+    :: PParams ConwayEra
+    -> ExUnits
+    -> TxIn
+    -> UpdateRedeemer
+    -> ConwayTx
+    -> ConwayTx
+patchRetractRedeemers pp budget requestRef redeemer tx =
+    tx
+        & witsTxL . rdmrsTxWitsL .~ redeemers
+        & bodyTxL . scriptIntegrityHashTxBodyL
+            .~ computeScriptIntegrity
+                (Set.singleton PlutusV3)
+                pp
+                redeemers
+                (TxDats mempty)
+  where
+    allInputs =
+        tx ^. bodyTxL . inputsTxBodyL
+    redeemers =
+        Redeemers
+            $ Map.singleton
+                ( ConwaySpending
+                    (AsIx $ spendingIndex requestRef allInputs)
+                )
+                (toLedgerData redeemer, budget)
+
+spendingIndex :: TxIn -> Set.Set TxIn -> Word32
+spendingIndex needle inputs =
+    go 0 (Set.toAscList inputs)
+  where
+    go _ [] =
+        error "retractCageTx: script input missing from balanced tx"
+    go n (x : xs)
+        | x == needle = n
+        | otherwise = go (n + 1) xs
+
+stripBalancingCollateralFields :: ConwayTx -> ConwayTx
+stripBalancingCollateralFields tx =
+    tx
+        & bodyTxL . totalCollateralTxBodyL .~ SNothing
+        & bodyTxL . collateralReturnTxBodyL .~ SNothing
 
 mkRequestScript
     :: CageConfig -> TokenId -> Script ConwayEra
@@ -440,9 +509,12 @@ toLedgerData value =
 
 retractRedeemerBudget :: PParams ConwayEra -> ExUnits
 retractRedeemerBudget pp =
-    capExUnits evalBudgetExUnits
+    capExUnits legacyEvalBudgetExUnits
         $ halfExUnits
         $ pp ^. ppMaxTxExUnitsL
+
+legacyEvalBudgetExUnits :: ExUnits
+legacyEvalBudgetExUnits = ExUnits 14_000_000 10_000_000_000
 
 capExUnits :: ExUnits -> ExUnits -> ExUnits
 capExUnits (ExUnits mem steps) (ExUnits maxMem maxSteps) =
@@ -452,22 +524,13 @@ halfExUnits :: ExUnits -> ExUnits
 halfExUnits (ExUnits mem steps) =
     ExUnits (mem `div` 2) (steps `div` 2)
 
-spendingIndex :: TxIn -> Set.Set TxIn -> Word32
-spendingIndex needle inputs =
-    go 0 (Set.toAscList inputs)
-  where
-    go _ [] =
-        error "spendingIndex: TxIn not in input set"
-    go n (x : xs)
-        | x == needle = n
-        | otherwise = go (n + 1) xs
-
 enforcePParamsPolicy
     :: WalletPolicy
     -> PParams ConwayEra
     -> Either BuildError ()
 enforcePParamsPolicy WalletPolicy{..} pp = do
-    let CoinPerByte minUtxo = pp ^. ppCoinsPerUTxOByteL
+    let CoinPerByte minUtxoCompact = pp ^. ppCoinsPerUTxOByteL
+        minUtxo = fromCompact minUtxoCompact
         prices = pp ^. ppPricesL
     if minUtxo <= wpMaxMinUtxoCoinPerByte
         then Right ()
@@ -485,7 +548,7 @@ enforcePParamsPolicy WalletPolicy{..} pp = do
                 $ ExUnitPricesTooHigh prices wpMaxExUnitPrices
 
 enforceTxPolicy
-    :: WalletPolicy -> Tx ConwayEra -> Either BuildError ()
+    :: WalletPolicy -> ConwayTx -> Either BuildError ()
 enforceTxPolicy WalletPolicy{..} tx = do
     let fee = tx ^. bodyTxL . feeTxBodyL
         width = validityWindow (tx ^. bodyTxL . vldtTxBodyL)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Serialize.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Serialize.hs
@@ -16,12 +16,11 @@ module Cardano.MPFS.Client.Cage.Serialize
 
 import Data.ByteString (ByteString)
 
-import Cardano.Ledger.Api.Tx (Tx)
 import Cardano.Ledger.Binary (natVersion, serialize')
-import Cardano.MPFS.Cage.Ledger (ConwayEra)
+import Cardano.Tx.Ledger (ConwayTx)
 
 -- | Serialize a Conway cage transaction to submission-ready CBOR,
 -- using protocol version 11 (the version the on-chain validators
 -- and the rest of the client encode against).
-serializeCageTx :: Tx ConwayEra -> ByteString
+serializeCageTx :: ConwayTx -> ByteString
 serializeCageTx = serialize' (natVersion @11)

--- a/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Update.hs
+++ b/cardano-mpfs-client/lib/Cardano/MPFS/Client/Cage/Update.hs
@@ -15,11 +15,10 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Coerce (coerce)
-import Data.List (foldl', sortOn)
+import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Ord (Down (..))
-import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -44,11 +43,11 @@ import Cardano.Ledger.Alonzo.Scripts
     , mkPlutusScript
     )
 import Cardano.Ledger.Alonzo.TxBody
-    ( reqSignerHashesTxBodyL
-    , scriptIntegrityHashTxBodyL
+    ( scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( ppCoinsPerUTxOByteL
+    ( CoinPerByte (..)
+    , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
     , ppPricesL
     )
@@ -59,17 +58,12 @@ import Cardano.Ledger.Api.Scripts.Data
     , dataToBinaryData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
-    , mkBasicTx
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
-    , feeTxBodyL
+    ( feeTxBodyL
     , inputsTxBodyL
-    , mkBasicTxBody
-    , outputsTxBodyL
     , vldtTxBodyL
     )
 import Cardano.Ledger.Api.Tx.Out
@@ -81,12 +75,10 @@ import Cardano.Ledger.Api.Tx.Out
     , valueTxOutL
     )
 import Cardano.Ledger.Api.Tx.Wits
-    ( Redeemers (..)
+    ( ConwayPlutusPurpose (..)
+    , Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
-    , scriptTxWitsL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
@@ -102,13 +94,10 @@ import Cardano.Ledger.Binary
 import Cardano.Ledger.Coin
     ( Coin (..)
     )
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
     ( PParams
     , Script
-    , hashScript
     )
 import Cardano.Ledger.Credential
     ( Credential (..)
@@ -182,15 +171,17 @@ import Cardano.MPFS.Client.Facts
     ( VerifiedUpdateFacts
     , verifiedUpdateFacts
     )
-import Cardano.Node.Client.Balance
+import Cardano.Slotting.Slot
+    ( SlotNo (..)
+    )
+import Cardano.Tx.Balance
     ( BalanceResult (..)
     , balanceTx
     , computeScriptIntegrity
     , evalBudgetExUnits
     )
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    )
+import Cardano.Tx.Build qualified as TxBuild
+import Cardano.Tx.Ledger (ConwayTx)
 import MPF.Hashes
     ( MPFHash (..)
     , MPFHashing (..)
@@ -214,12 +205,14 @@ import PlutusTx.IsData.Class
     , ToData (..)
     )
 
+data NoCtx a
+
 -- | Build an unsigned update transaction from verified update facts.
 updateCageTx
     :: CageConfig
     -> WalletPolicy
     -> VerifiedUpdateFacts
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 updateCageTx cfg policy verified = do
     let facts = verifiedUpdateFacts verified
         token = tokenIdFromJSON (ufToken facts)
@@ -467,12 +460,15 @@ extractCageDatum txOut =
         _ -> Nothing
 
 ownerWitnessKeyHash
-    :: ByteString -> Either BuildError (KeyHash 'Witness)
+    :: ByteString -> Either BuildError (KeyHash Witness)
 ownerWitnessKeyHash ownerBytes =
     coerce <$> ownerPaymentKeyHash ownerBytes
 
+witnessKeyHashToGuard :: KeyHash Witness -> KeyHash Guard
+witnessKeyHashToGuard (KeyHash h) = KeyHash h
+
 ownerPaymentKeyHash
-    :: ByteString -> Either BuildError (KeyHash 'Payment)
+    :: ByteString -> Either BuildError (KeyHash Payment)
 ownerPaymentKeyHash ownerBytes =
     case hashFromBytes @Blake2b_224 ownerBytes of
         Just hash -> Right (KeyHash hash)
@@ -491,10 +487,10 @@ buildUpdateTx
     -> Addr
     -> OnChainTokenState
     -> ByteString
-    -> KeyHash 'Witness
+    -> KeyHash Witness
     -> [[ProofStep]]
     -> SlotNo
-    -> Either BuildError (Tx ConwayEra)
+    -> Either BuildError ConwayTx
 buildUpdateTx
     cfg
     pp
@@ -521,70 +517,62 @@ buildUpdateTx
                         else converge (Set.insert finalFee seenFees) finalFee
 
         buildWithFee feeForRefunds =
-            case balanceTx pp ledgerPairs changeAddr draft of
+            case balanceTx pp ledgerPairs [] changeAddr draft of
                 Left err ->
                     Left (DSLBuildFailed $ T.pack $ show err)
                 Right BalanceResult{balancedTx} ->
-                    Right balancedTx
+                    Right
+                        $ patchUpdateRedeemers
+                            pp
+                            budget
+                            stateRef
+                            (map fst requestRefs)
+                            proofs
+                            balancedTx
           where
             draft =
-                mkBasicTx body
-                    & witsTxL . scriptTxWitsL .~ scripts
-                    & witsTxL . rdmrsTxWitsL .~ redeemers
-            body =
-                mkBasicTxBody
-                    & inputsTxBodyL .~ allInputs
-                    & collateralInputsTxBodyL .~ Set.singleton feeRef
-                    & outputsTxBodyL .~ StrictSeq.fromList outputs
-                    & reqSignerHashesTxBodyL
-                        .~ Set.singleton ownerSigner
-                    & vldtTxBodyL
-                        .~ ValidityInterval SNothing (SJust upperSlot)
-                    & scriptIntegrityHashTxBodyL
-                        .~ computeScriptIntegrity PlutusV3 pp redeemers
+                patchRedeemerBudgets pp budget
+                    $ TxBuild.draft
+                        pp
+                        ( program
+                            :: TxBuild.TxBuild NoCtx BuildError ()
+                        )
+            program = do
+                _ <-
+                    TxBuild.spendScript
+                        stateRef
+                        (Modify $ map Update proofs)
+                mapM_
+                    ( \(ref, _) ->
+                        TxBuild.spendScript
+                            ref
+                            ( Contribute
+                                $ txInToOnChainRef stateRef
+                            )
+                    )
+                    requestRefs
+                mapM_ TxBuild.output outputs
+                TxBuild.attachScript stateScript
+                TxBuild.attachScript requestScript
+                TxBuild.collateral feeRef
+                TxBuild.requireSignature
+                    (witnessKeyHashToGuard ownerSigner)
+                TxBuild.validTo upperSlot
             outputs =
                 newStateOut : refundOutputs feeForRefunds
 
         stateRef = rowRef stateRow
         feeRef = rowRef feeRow
         allRows = stateRow : requestRows <> [feeRow]
-        allInputs = Set.fromList (map rowRef allRows)
+        requestRefs =
+            [(rowRef row, rowOut row) | row <- requestRows]
         ledgerPairs =
             [ (rowRef row, rowOut row)
             | row <- allRows
             ]
         stateScript = mkCageScript cfg
         requestScript = mkRequestScript cfg token
-        scripts =
-            Map.fromList
-                [ (hashScript stateScript, stateScript)
-                , (hashScript requestScript, requestScript)
-                ]
         budget = updateRedeemerBudget pp
-        redeemers =
-            Redeemers
-                $ Map.fromList
-                $ stateRedeemer : requestRedeemers
-        stateRedeemer =
-            ( ConwaySpending (AsIx $ spendingIndex stateRef allInputs)
-            ,
-                ( toLedgerData
-                    $ Modify
-                    $ map Update proofs
-                , budget
-                )
-            )
-        requestRedeemers =
-            [ ( ConwaySpending (AsIx $ spendingIndex ref allInputs)
-              ,
-                  ( toLedgerData
-                        $ Contribute
-                        $ txInToOnChainRef stateRef
-                  , budget
-                  )
-              )
-            | ref <- map rowRef requestRows
-            ]
         newStateOut =
             mkBasicTxOut
                 (cageAddrFromCfg cfg (network cfg))
@@ -615,6 +603,76 @@ buildUpdateTx
                         Coin (reqValue - tipAmount - perReqFee - extra)
                 ]
 
+patchRedeemerBudgets
+    :: PParams ConwayEra
+    -> ExUnits
+    -> ConwayTx
+    -> ConwayTx
+patchRedeemerBudgets pp budget tx =
+    tx
+        & witsTxL . rdmrsTxWitsL .~ budgetedRedeemers
+        & bodyTxL . scriptIntegrityHashTxBodyL
+            .~ computeScriptIntegrity
+                (Set.singleton PlutusV3)
+                pp
+                budgetedRedeemers
+                (TxDats mempty)
+  where
+    Redeemers rdmrs =
+        tx ^. witsTxL . rdmrsTxWitsL
+    budgetedRedeemers =
+        Redeemers
+            $ fmap
+                ( \(dat, _) ->
+                    (dat, budget)
+                )
+                rdmrs
+
+patchUpdateRedeemers
+    :: PParams ConwayEra
+    -> ExUnits
+    -> TxIn
+    -> [TxIn]
+    -> [[ProofStep]]
+    -> ConwayTx
+    -> ConwayTx
+patchUpdateRedeemers pp budget stateRef requestRefs proofs tx =
+    tx
+        & witsTxL . rdmrsTxWitsL .~ redeemers
+        & bodyTxL . scriptIntegrityHashTxBodyL
+            .~ computeScriptIntegrity
+                (Set.singleton PlutusV3)
+                pp
+                redeemers
+                (TxDats mempty)
+  where
+    allInputs =
+        tx ^. bodyTxL . inputsTxBodyL
+    redeemers =
+        Redeemers
+            $ Map.fromList
+            $ stateRedeemer
+                : map requestRedeemer requestRefs
+    stateRedeemer =
+        ( spendingPurpose stateRef
+        ,
+            ( toLedgerData
+                (Modify $ map Update proofs)
+            , budget
+            )
+        )
+    requestRedeemer ref =
+        ( spendingPurpose ref
+        ,
+            ( toLedgerData
+                (Contribute $ txInToOnChainRef stateRef)
+            , budget
+            )
+        )
+    spendingPurpose ref =
+        ConwaySpending
+            (AsIx $ spendingIndex ref allInputs)
+
 refundAddress :: Network -> OnChainRequest -> Addr
 refundAddress net OnChainRequest{requestOwner = BuiltinByteString ownerBytes} =
     Addr
@@ -622,7 +680,7 @@ refundAddress net OnChainRequest{requestOwner = BuiltinByteString ownerBytes} =
         (KeyHashObj $ unsafeOwnerPaymentKeyHash ownerBytes)
         StakeRefNull
 
-unsafeOwnerPaymentKeyHash :: ByteString -> KeyHash 'Payment
+unsafeOwnerPaymentKeyHash :: ByteString -> KeyHash Payment
 unsafeOwnerPaymentKeyHash ownerBytes =
     case hashFromBytes @Blake2b_224 ownerBytes of
         Just hash -> KeyHash hash
@@ -674,19 +732,19 @@ capExUnits :: ExUnits -> ExUnits -> ExUnits
 capExUnits (ExUnits mem steps) (ExUnits maxMem maxSteps) =
     ExUnits (min mem maxMem) (min steps maxSteps)
 
-halfExUnits :: ExUnits -> ExUnits
-halfExUnits (ExUnits mem steps) =
-    ExUnits (mem `div` 2) (steps `div` 2)
-
 spendingIndex :: TxIn -> Set.Set TxIn -> Word32
 spendingIndex needle inputs =
     go 0 (Set.toAscList inputs)
   where
     go _ [] =
-        error "spendingIndex: TxIn not in input set"
+        error "updateCageTx: script input missing from balanced tx"
     go n (x : xs)
         | x == needle = n
         | otherwise = go (n + 1) xs
+
+halfExUnits :: ExUnits -> ExUnits
+halfExUnits (ExUnits mem steps) =
+    ExUnits (mem `div` 2) (steps `div` 2)
 
 trieFactProofSteps :: TrieFact -> Either BuildError [ProofStep]
 trieFactProofSteps TrieFact{tfMpfProof = Hex proofBytes} =
@@ -1082,7 +1140,8 @@ enforcePParamsPolicy
     -> PParams ConwayEra
     -> Either BuildError ()
 enforcePParamsPolicy WalletPolicy{..} pp = do
-    let CoinPerByte minUtxo = pp ^. ppCoinsPerUTxOByteL
+    let CoinPerByte minUtxoCompact = pp ^. ppCoinsPerUTxOByteL
+        minUtxo = fromCompact minUtxoCompact
         prices = pp ^. ppPricesL
     if minUtxo <= wpMaxMinUtxoCoinPerByte
         then Right ()
@@ -1100,7 +1159,7 @@ enforcePParamsPolicy WalletPolicy{..} pp = do
                 $ ExUnitPricesTooHigh prices wpMaxExUnitPrices
 
 enforceTxPolicy
-    :: WalletPolicy -> Tx ConwayEra -> Either BuildError ()
+    :: WalletPolicy -> ConwayTx -> Either BuildError ()
 enforceTxPolicy WalletPolicy{..} tx = do
     let fee = tx ^. bodyTxL . feeTxBodyL
         width = validityWindow (tx ^. bodyTxL . vldtTxBodyL)

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/BootSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/BootSpec.hs
@@ -55,7 +55,8 @@ import Cardano.Ledger.Alonzo.TxBody
     ( scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( emptyPParams
+    ( CoinPerByte (..)
+    , emptyPParams
     , ppCoinsPerUTxOByteL
     )
 import Cardano.Ledger.Api.Tx
@@ -69,16 +70,16 @@ import Cardano.Ledger.Api.Tx.Body
 import Cardano.Ledger.Api.Tx.Out (TxOut, mkBasicTxOut)
 import Cardano.Ledger.Api.Tx.Wits
     ( Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
     )
-import Cardano.Ledger.Babbage.PParams (CoinPerByte (..))
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
     , Network (..)
     , TxIx (..)
     )
 import Cardano.Ledger.Binary (natVersion, serialize')
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin (Coin (..), compactCoinOrError)
 import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Credential
     ( Credential (..)
@@ -133,11 +134,11 @@ import Cardano.MPFS.Client.Facts
     , verifyBootFacts
     )
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
-import Cardano.Node.Client.Balance
+import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Tx.Balance
     ( computeScriptIntegrity
     , evalBudgetExUnits
     )
-import Cardano.Slotting.Slot (SlotNo (..))
 
 spec :: Spec
 spec = describe "bootCageTx" $ do
@@ -245,9 +246,10 @@ spec = describe "bootCageTx" $ do
                 tx ^. bodyTxL . scriptIntegrityHashTxBodyL
             expectedIntegrity =
                 computeScriptIntegrity
-                    PlutusV3
+                    (Set.singleton PlutusV3)
                     realisticPParams
                     redeemers
+                    (TxDats mempty)
         Map.size rdmrs `shouldBe` 1
         budgets `shouldBe` [evalBudgetExUnits]
         budgets `shouldSatisfy` all nonZeroExUnits
@@ -459,7 +461,7 @@ realisticPParams :: PParams ConwayEra
 realisticPParams =
     emptyPParams
         & ppCoinsPerUTxOByteL
-            .~ CoinPerByte (Coin 4_310)
+            .~ CoinPerByte (compactCoinOrError (Coin 4_310))
 
 testTxId1Bytes :: ByteString
 testTxId1Bytes = BS.replicate 32 0x11
@@ -467,7 +469,7 @@ testTxId1Bytes = BS.replicate 32 0x11
 testTxId2Bytes :: ByteString
 testTxId2Bytes = BS.replicate 32 0x22
 
-testKh :: KeyHash 'Payment
+testKh :: KeyHash Payment
 testKh =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
@@ -74,7 +74,8 @@ import Cardano.Ledger.Alonzo.TxBody
     , scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( emptyPParams
+    ( CoinPerByte (..)
+    , emptyPParams
     , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
     )
@@ -84,8 +85,7 @@ import Cardano.Ledger.Api.Scripts.Data
     , dataToBinaryData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -102,11 +102,9 @@ import Cardano.Ledger.Api.Tx.Out
     )
 import Cardano.Ledger.Api.Tx.Wits
     ( Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
     , scriptTxWitsL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
@@ -119,6 +117,7 @@ import Cardano.Ledger.Binary
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
+    , compactCoinOrError
     )
 import Cardano.Ledger.Core
     ( PParams
@@ -206,13 +205,14 @@ import Cardano.MPFS.Client.Facts
 import Cardano.MPFS.Client.TrustedRoot
     ( TrustedRoot (..)
     )
-import Cardano.Node.Client.Balance
-    ( computeScriptIntegrity
-    , evalBudgetExUnits
-    )
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Tx.Balance
+    ( computeScriptIntegrity
+    , evalBudgetExUnits
+    )
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     , BuiltinData (..)
@@ -301,9 +301,10 @@ spec = describe "endCageTx" $ do
                 tx ^. bodyTxL . scriptIntegrityHashTxBodyL
             expectedIntegrity =
                 computeScriptIntegrity
-                    PlutusV3
+                    (Set.singleton PlutusV3)
                     realisticPParams
                     redeemers
+                    (TxDats mempty)
         Set.member stateInput inputs `shouldBe` True
         Set.member walletInput inputs `shouldBe` True
         Map.lookup policyId minted
@@ -666,7 +667,7 @@ fundingAddr =
         (KeyHashObj testKh)
         (StakeRefBase $ KeyHashObj stakeKh)
 
-txOutputAddresses :: Tx ConwayEra -> [Addr]
+txOutputAddresses :: ConwayTx -> [Addr]
 txOutputAddresses tx =
     fmap (^. addrTxOutL)
         $ foldr (:) []
@@ -741,7 +742,7 @@ realisticPParams :: PParams ConwayEra
 realisticPParams =
     emptyPParams
         & ppCoinsPerUTxOByteL
-            .~ CoinPerByte (Coin 4_310)
+            .~ CoinPerByte (compactCoinOrError (Coin 4_310))
         & ppMaxTxExUnitsL
             .~ ExUnits 140_000_000 10_000_000_000
 
@@ -752,10 +753,10 @@ walletTxId = BS.replicate 32 0xC2
 sampleToken :: TokenIdJSON
 sampleToken = TokenIdJSON (BS.replicate 32 0xE4)
 
-expectedOwnerWitness :: KeyHash 'Witness
+expectedOwnerWitness :: KeyHash Guard
 expectedOwnerWitness = coerce testKh
 
-testKh :: KeyHash 'Payment
+testKh :: KeyHash Payment
 testKh =
     KeyHash
         $ fromJust
@@ -763,7 +764,7 @@ testKh =
             "cccccccccccccccccccccccccccc\
             \cccccccccccccccccccccccccccc"
 
-stakeKh :: KeyHash 'Staking
+stakeKh :: KeyHash Staking
 stakeKh =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RejectSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RejectSpec.hs
@@ -61,7 +61,8 @@ import Cardano.Ledger.Alonzo.TxBody
     , scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( emptyPParams
+    ( CoinPerByte (..)
+    , emptyPParams
     , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
     )
@@ -72,8 +73,7 @@ import Cardano.Ledger.Api.Scripts.Data
     , dataToBinaryData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -91,11 +91,9 @@ import Cardano.Ledger.Api.Tx.Out
     )
 import Cardano.Ledger.Api.Tx.Wits
     ( Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
     , scriptTxWitsL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
@@ -109,6 +107,7 @@ import Cardano.Ledger.Binary
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
+    , compactCoinOrError
     )
 import Cardano.Ledger.Core
     ( PParams
@@ -200,12 +199,13 @@ import Cardano.MPFS.Client.TrustedRoot
 import Cardano.MPFS.Client.Verify
     ( VerifyError (..)
     )
-import Cardano.Node.Client.Balance
-    ( computeScriptIntegrity
-    )
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Tx.Balance
+    ( computeScriptIntegrity
+    )
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     , BuiltinData (..)
@@ -310,9 +310,10 @@ spec = describe "rejectCageTx" $ do
             integrity = body ^. scriptIntegrityHashTxBodyL
             expectedIntegrity =
                 computeScriptIntegrity
-                    PlutusV3
+                    (Set.singleton PlutusV3)
                     realisticPParams
                     redeemers
+                    (TxDats mempty)
         inputs
             `shouldBe` Set.fromList
                 [stateInput, requestInput, walletInput]
@@ -506,7 +507,7 @@ expectVerified trusted f =
 expectBuilt
     :: CageConfig
     -> VerifiedRejectFacts
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 expectBuilt cfg verified =
     case rejectCageTx
         cfg
@@ -637,7 +638,7 @@ realisticPParams :: PParams ConwayEra
 realisticPParams =
     emptyPParams
         & ppCoinsPerUTxOByteL
-            .~ CoinPerByte (Coin 4_310)
+            .~ CoinPerByte (compactCoinOrError (Coin 4_310))
         & ppMaxTxExUnitsL
             .~ ExUnits 140_000_000 10_000_000_000
 
@@ -693,10 +694,10 @@ phase3UpperSlot = 200
 sampleToken :: TokenIdJSON
 sampleToken = TokenIdJSON (BS.replicate 32 0xE4)
 
-expectedOwnerWitness :: KeyHash 'Witness
+expectedOwnerWitness :: KeyHash Guard
 expectedOwnerWitness = coerce testKh
 
-testKh :: KeyHash 'Payment
+testKh :: KeyHash Payment
 testKh =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RequestSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RequestSpec.hs
@@ -52,16 +52,16 @@ import Cardano.Ledger.Address
     , serialiseAddr
     )
 import Cardano.Ledger.Api.PParams
-    ( emptyPParams
+    ( CoinPerByte (..)
+    , emptyPParams
     , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
-    , ppMinFeeAL
-    , ppMinFeeBL
     , ppPricesL
+    , ppTxFeeFixedL
+    , ppTxFeePerByteL
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -80,9 +80,6 @@ import Cardano.Ledger.Api.Tx.Wits
     ( rdmrsTxWitsL
     , scriptTxWitsL
     )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
-    )
 import Cardano.Ledger.BaseTypes
     ( BoundedRational (..)
     , Inject (..)
@@ -96,7 +93,9 @@ import Cardano.Ledger.Binary
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
+    , compactCoinOrError
     )
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
     ( PParams
     )
@@ -177,6 +176,7 @@ import Cardano.MPFS.Client.TrustedRoot
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Tx.Ledger (ConwayTx)
 
 spec :: Spec
 spec = do
@@ -636,15 +636,15 @@ walletTxOut =
 fundingAddr :: Addr
 fundingAddr = Addr Testnet (KeyHashObj testKh) StakeRefNull
 
-txOutputAddresses :: Tx ConwayEra -> [Addr]
+txOutputAddresses :: ConwayTx -> [Addr]
 txOutputAddresses tx =
     (^. addrTxOutL) <$> txOutputs tx
 
-txOutputs :: Tx ConwayEra -> [TxOut ConwayEra]
+txOutputs :: ConwayTx -> [TxOut ConwayEra]
 txOutputs tx =
     foldr (:) [] $ tx ^. bodyTxL . outputsTxBodyL
 
-assertBoundedRequestOutput :: CageConfig -> Tx ConwayEra -> IO ()
+assertBoundedRequestOutput :: CageConfig -> ConwayTx -> IO ()
 assertBoundedRequestOutput cfg tx =
     case requestOutputs of
         [out] ->
@@ -679,8 +679,9 @@ expectedRequestCoin cfg =
 
 feeBufferUpperBound :: PParams ConwayEra -> Coin
 feeBufferUpperBound pp =
-    let Coin minFeeA = pp ^. ppMinFeeAL
-        Coin minFeeB = pp ^. ppMinFeeBL
+    let CoinPerByte minFeeACompact = pp ^. ppTxFeePerByteL
+        Coin minFeeA = fromCompact minFeeACompact
+        Coin minFeeB = pp ^. ppTxFeeFixedL
         Coin scriptFee =
             txscriptfee (pp ^. ppPricesL) (pp ^. ppMaxTxExUnitsL)
     in  Coin
@@ -752,10 +753,11 @@ permissiveWalletPolicy =
 realisticPParams :: PParams ConwayEra
 realisticPParams =
     emptyPParams
-        & ppMinFeeAL .~ Coin 44
-        & ppMinFeeBL .~ Coin 155_381
+        & ppTxFeePerByteL
+            .~ CoinPerByte (compactCoinOrError (Coin 44))
+        & ppTxFeeFixedL .~ Coin 155_381
         & ppCoinsPerUTxOByteL
-            .~ CoinPerByte (Coin 4_310)
+            .~ CoinPerByte (compactCoinOrError (Coin 4_310))
         & ppPricesL
             .~ Prices
                 (unsafeNonNegativeInterval (577 % 10_000))
@@ -776,7 +778,7 @@ sampleToken = TokenIdJSON (BS.replicate 32 0xE4)
 submittedAt :: Integer
 submittedAt = 1_700_000_000_000
 
-testKh :: KeyHash 'Payment
+testKh :: KeyHash Payment
 testKh =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RetractSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RetractSpec.hs
@@ -12,6 +12,7 @@ import Codec.CBOR.Encoding qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
 import Data.Coerce (coerce)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
@@ -61,7 +62,8 @@ import Cardano.Ledger.Alonzo.TxBody
     , scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( emptyPParams
+    ( CoinPerByte (..)
+    , emptyPParams
     , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
     )
@@ -87,11 +89,9 @@ import Cardano.Ledger.Api.Tx.Out
     )
 import Cardano.Ledger.Api.Tx.Wits
     ( Redeemers (..)
+    , TxDats (..)
     , rdmrsTxWitsL
     , scriptTxWitsL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
@@ -100,11 +100,16 @@ import Cardano.Ledger.BaseTypes
     , TxIx (..)
     )
 import Cardano.Ledger.Binary
-    ( natVersion
+    ( Annotator
+    , Decoder
+    , decCBOR
+    , decodeFullAnnotator
+    , natVersion
     , serialize'
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
+    , compactCoinOrError
     )
 import Cardano.Ledger.Core
     ( PParams
@@ -192,12 +197,13 @@ import Cardano.MPFS.Client.Facts
 import Cardano.MPFS.Client.TrustedRoot
     ( TrustedRoot (..)
     )
-import Cardano.Node.Client.Balance
-    ( computeScriptIntegrity
-    )
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Tx.Balance
+    ( computeScriptIntegrity
+    )
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     , BuiltinData (..)
@@ -267,9 +273,10 @@ spec = describe "retractCageTx" $ do
                 body ^. scriptIntegrityHashTxBodyL
             expectedIntegrity =
                 computeScriptIntegrity
-                    PlutusV3
+                    (Set.singleton PlutusV3)
                     realisticPParams
                     redeemers
+                    (TxDats mempty)
         Set.member requestInput inputs `shouldBe` True
         Set.member stateInput refs `shouldBe` True
         Set.member walletInput collateral `shouldBe` True
@@ -292,7 +299,7 @@ spec = describe "retractCageTx" $ do
                 (SJust (SlotNo (fromIntegral phase2StartSlot)))
                 (SJust (SlotNo (fromIntegral phase2EndSlot)))
 
-    it "matches the legacy retract CBOR vector" $ do
+    it "matches the legacy retract transaction structure" $ do
         cfg <- testCageConfig
         let RetractFixture{trustedRoot, facts} =
                 honestRetractFixture cfg
@@ -308,7 +315,21 @@ spec = describe "retractCageTx" $ do
                         *> error "unreachable"
                 Right tx -> pure tx
         expected <- BS.readFile =<< legacyRetractVectorPath
-        serialize' (natVersion @11) tx `shouldBe` expected
+        expectedTx <- decodeLegacyRetractTx expected
+        tx `shouldBe` expectedTx
+
+decodeLegacyRetractTx :: ByteString -> IO ConwayTx
+decodeLegacyRetractTx bytes =
+    case decodeFullAnnotator
+        (natVersion @11)
+        "legacy retract transaction"
+        (decCBOR :: forall s. Decoder s (Annotator ConwayTx))
+        (BSL.fromStrict bytes) of
+        Left err ->
+            expectationFailure
+                ("legacy retract CBOR decode failed: " <> show err)
+                *> error "unreachable"
+        Right tx -> pure tx
 
 data RetractFixture = RetractFixture
     { trustedRoot :: TrustedRoot
@@ -552,7 +573,7 @@ realisticPParams :: PParams ConwayEra
 realisticPParams =
     emptyPParams
         & ppCoinsPerUTxOByteL
-            .~ CoinPerByte (Coin 4_310)
+            .~ CoinPerByte (compactCoinOrError (Coin 4_310))
         & ppMaxTxExUnitsL
             .~ ExUnits 140_000_000 10_000_000_000
 
@@ -608,10 +629,10 @@ phase2EndSlot = 2_000
 sampleToken :: TokenIdJSON
 sampleToken = TokenIdJSON (BS.replicate 32 0xE4)
 
-expectedOwnerWitness :: KeyHash 'Witness
+expectedOwnerWitness :: KeyHash Guard
 expectedOwnerWitness = coerce testKh
 
-testKh :: KeyHash 'Payment
+testKh :: KeyHash Payment
 testKh =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/SerializeSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/SerializeSpec.hs
@@ -17,16 +17,16 @@ import Test.Hspec
     , shouldSatisfy
     )
 
-import Cardano.Ledger.Api.Tx (Tx, mkBasicTx)
+import Cardano.Ledger.Api.Tx (mkBasicTx)
 import Cardano.Ledger.Api.Tx.Body (mkBasicTxBody)
 import Cardano.Ledger.Binary (natVersion, serialize')
-import Cardano.MPFS.Cage.Ledger (ConwayEra)
 import Cardano.MPFS.Client.Cage.Serialize (serializeCageTx)
+import Cardano.Tx.Ledger (ConwayTx)
 
 -- | A minimal, deterministic Conway transaction. Needs no proof
 -- fixtures: an empty body wrapped in a basic tx is enough to
 -- exercise serialization.
-basicTx :: Tx ConwayEra
+basicTx :: ConwayTx
 basicTx = mkBasicTx mkBasicTxBody
 
 spec :: Spec

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/UpdateSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/UpdateSpec.hs
@@ -66,12 +66,13 @@ import Cardano.Ledger.Alonzo.TxBody
     , scriptIntegrityHashTxBodyL
     )
 import Cardano.Ledger.Api.PParams
-    ( emptyPParams
+    ( CoinPerByte (..)
+    , emptyPParams
     , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
-    , ppMinFeeAL
-    , ppMinFeeBL
     , ppPricesL
+    , ppTxFeeFixedL
+    , ppTxFeePerByteL
     )
 import Cardano.Ledger.Api.Scripts.Data
     ( Data (..)
@@ -79,8 +80,7 @@ import Cardano.Ledger.Api.Scripts.Data
     , dataToBinaryData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -105,12 +105,10 @@ import Cardano.Ledger.Api.Tx.Out
     )
 import Cardano.Ledger.Api.Tx.Wits
     ( Redeemers (..)
+    , TxDats (..)
     , datsTxWitsL
     , rdmrsTxWitsL
     , scriptTxWitsL
-    )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( BoundedRational (..)
@@ -126,7 +124,9 @@ import Cardano.Ledger.Binary
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
+    , compactCoinOrError
     )
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Scripts
     ( ConwayPlutusPurpose (..)
     )
@@ -230,12 +230,13 @@ import Cardano.MPFS.Client.Facts
 import Cardano.MPFS.Client.TrustedRoot
     ( TrustedRoot (..)
     )
-import Cardano.Node.Client.Balance
-    ( computeScriptIntegrity
-    )
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Tx.Balance
+    ( computeScriptIntegrity
+    )
+import Cardano.Tx.Ledger (ConwayTx)
 import MPF.Hashes
     ( mkMPFHash
     , renderMPFHash
@@ -333,9 +334,10 @@ spec = describe "updateCageTx" $ do
                 body ^. scriptIntegrityHashTxBodyL
             expectedIntegrity =
                 computeScriptIntegrity
-                    PlutusV3
+                    (Set.singleton PlutusV3)
                     realisticPParams
                     redeemers
+                    (TxDats mempty)
         Set.member stateInput inputs `shouldBe` True
         mapM_
             ( \requestInput ->
@@ -492,9 +494,10 @@ spec = describe "updateCageTx" $ do
                 (Contribute $ txInToOnChainRef stateInput)
         body ^. scriptIntegrityHashTxBodyL
             `shouldBe` computeScriptIntegrity
-                PlutusV3
+                (Set.singleton PlutusV3)
                 realisticPParams
                 redeemers
+                (TxDats mempty)
 
     it "folds update MPF facts to the same new root as the legacy fold" $ do
         cfg <- testCageConfig
@@ -653,7 +656,7 @@ expectVerified trusted facts =
             pure verified
 
 expectUpdateTx
-    :: CageConfig -> VerifiedUpdateFacts -> IO (Tx ConwayEra)
+    :: CageConfig -> VerifiedUpdateFacts -> IO ConwayTx
 expectUpdateTx cfg verified =
     case updateCageTx cfg permissiveWalletPolicy verified of
         Left err ->
@@ -730,8 +733,9 @@ refundMinCoin =
 
 feeBufferUpperBound :: PParams ConwayEra -> Coin
 feeBufferUpperBound pp =
-    let Coin minFeeA = pp ^. ppMinFeeAL
-        Coin minFeeB = pp ^. ppMinFeeBL
+    let CoinPerByte minFeeACompact = pp ^. ppTxFeePerByteL
+        Coin minFeeA = fromCompact minFeeACompact
+        Coin minFeeB = pp ^. ppTxFeeFixedL
         Coin scriptFee =
             txscriptfee (pp ^. ppPricesL) (pp ^. ppMaxTxExUnitsL)
     in  Coin
@@ -743,7 +747,7 @@ feeBufferUpperBound pp =
 maxUpdateTxBytes :: Integer
 maxUpdateTxBytes = 8192
 
-singleRequestRefundOutput :: Tx ConwayEra -> TxOut ConwayEra
+singleRequestRefundOutput :: ConwayTx -> TxOut ConwayEra
 singleRequestRefundOutput tx =
     case drop 1 (txOutputs tx) of
         out : _ -> out
@@ -894,11 +898,11 @@ ownerAddr = Addr Testnet (KeyHashObj testKh) StakeRefNull
 fundingAddr :: Addr
 fundingAddr = Addr Testnet (KeyHashObj testKh) StakeRefNull
 
-txOutputAddresses :: Tx ConwayEra -> [Addr]
+txOutputAddresses :: ConwayTx -> [Addr]
 txOutputAddresses tx =
     fmap (^. addrTxOutL) (txOutputs tx)
 
-txOutputs :: Tx ConwayEra -> [TxOut ConwayEra]
+txOutputs :: ConwayTx -> [TxOut ConwayEra]
 txOutputs tx =
     foldr (:) [] $ tx ^. bodyTxL . outputsTxBodyL
 
@@ -958,10 +962,11 @@ permissiveWalletPolicy =
 realisticPParams :: PParams ConwayEra
 realisticPParams =
     emptyPParams
-        & ppMinFeeAL .~ Coin 44
-        & ppMinFeeBL .~ Coin 155_381
+        & ppTxFeePerByteL
+            .~ CoinPerByte (compactCoinOrError (Coin 44))
+        & ppTxFeeFixedL .~ Coin 155_381
         & ppCoinsPerUTxOByteL
-            .~ CoinPerByte (Coin 4_310)
+            .~ CoinPerByte (compactCoinOrError (Coin 4_310))
         & ppPricesL
             .~ Prices
                 (unsafeNonNegativeInterval (577 % 10_000))
@@ -1024,10 +1029,10 @@ updateKey = "mykey"
 oldValue = "oldvalue"
 newValue = "newvalue"
 
-expectedOwnerWitness :: KeyHash 'Witness
+expectedOwnerWitness :: KeyHash Guard
 expectedOwnerWitness = coerce testKh
 
-testKh :: KeyHash 'Payment
+testKh :: KeyHash Payment
 testKh =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -40,7 +40,6 @@ library
     , base16-bytestring                        >=1.0  && <1.1
     , bytestring                               >=0.11 && <0.13
     , cardano-crypto-class
-    , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-binary
@@ -53,7 +52,7 @@ library
     , cardano-mpfs-cage
     , cardano-node-clients
     , cardano-slotting
-    , cardano-strict-containers
+    , cardano-tx-tools
     , cardano-utxo-csmt:application
     , cardano-utxo-csmt:library
     , cborg
@@ -71,8 +70,8 @@ library
     , mts:mpf-test-lib
     , mts:rollbacks
     , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-network-api
+    , ouroboros-consensus:cardano
+    , ouroboros-network:api
     , plutus-core
     , plutus-tx
     , rocksdb-haskell-jprupp
@@ -231,6 +230,7 @@ executable mpfs-tx-vectors
     , cardano-ledger-mary
     , cardano-mpfs-offchain
     , cardano-strict-containers
+    , cardano-tx-tools
     , containers
     , microlens
     , plutus-tx
@@ -258,7 +258,6 @@ test-suite unit-tests
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
-    , cardano-ledger-babbage
     , cardano-ledger-binary
     , cardano-ledger-conway
     , cardano-ledger-core
@@ -266,8 +265,8 @@ test-suite unit-tests
     , cardano-mpfs-api
     , cardano-mpfs-client
     , cardano-mpfs-offchain
-    , cardano-node-clients
     , cardano-strict-containers
+    , cardano-tx-tools
     , cardano-utxo-csmt:application
     , cardano-utxo-csmt:library
     , cborg
@@ -286,7 +285,7 @@ test-suite unit-tests
     , mts:mpf
     , mts:mpf-test-lib
     , mts:rollbacks
-    , ouroboros-network-api
+    , ouroboros-network:api
     , plutus-core
     , plutus-tx
     , QuickCheck                               >=2.14 && <2.18
@@ -358,8 +357,8 @@ test-suite e2e-tests
     , cardano-mpfs-client
     , cardano-mpfs-offchain
     , cardano-mpfs-workflows
-    , cardano-node-clients
     , cardano-node-clients:devnet
+    , cardano-tx-tools
     , cardano-utxo-csmt:library
     , containers
     , contra-tracer

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/BootFactsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/BootFactsSpec.hs
@@ -62,8 +62,7 @@ import Cardano.Ledger.Address
     , serialiseAddr
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , txIdTx
     )
 import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
@@ -76,6 +75,7 @@ import Cardano.Ledger.Mary.Value
     )
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
 import Cardano.Ledger.TxIn (TxId (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -101,8 +101,7 @@ import Cardano.MPFS.Core.Blueprint
     , loadCageScripts
     )
 import Cardano.MPFS.Core.Types
-    ( ConwayEra
-    , SlotNo (..)
+    ( SlotNo (..)
     , TokenId (..)
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
@@ -300,7 +299,7 @@ pollUntilJust timeoutSec action = go (timeoutSec * 2)
             Nothing ->
                 threadDelay 500_000 >> go (n - 1)
 
-extractTokenId :: CageConfig -> Tx ConwayEra -> TokenId
+extractTokenId :: CageConfig -> ConwayTx -> TokenId
 extractTokenId cfg tx =
     let MultiAsset ma =
             tx ^. bodyTxL . mintTxBodyL

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -33,8 +33,7 @@ import Test.Hspec
     )
 
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , txIdTx
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -48,6 +47,7 @@ import Cardano.Ledger.Mary.Value
     ( MultiAsset (..)
     )
 import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -64,7 +64,6 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
     , Coin (..)
-    , ConwayEra
     , LocatedTokenState (..)
     , Root (..)
     , TokenId (..)
@@ -731,7 +730,7 @@ pollUntilJust timeoutSec action = go attempts
 buildAndSubmit
     :: Context IO
     -> IO (ProofEnvelope p)
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 buildAndSubmit ctx buildBundle = do
     bundle <- buildBundle
     let unsigned = envTx bundle
@@ -769,7 +768,7 @@ awaitTx = threadDelay 5_000_000
 -- | Extract the 'TokenId' from a boot
 -- transaction's mint field.
 extractTokenId
-    :: CageConfig -> Tx ConwayEra -> TokenId
+    :: CageConfig -> ConwayTx -> TokenId
 extractTokenId cfg tx =
     let MultiAsset ma =
             tx ^. bodyTxL . mintTxBodyL

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -38,8 +38,7 @@ import Test.Hspec
     )
 
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , txIdTx
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -58,6 +57,7 @@ import Cardano.Ledger.Mary.Value
     ( MultiAsset (..)
     )
 import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -473,7 +473,7 @@ assertSubmitted (Rejected reason) =
 -- | Extract the 'TokenId' from a boot
 -- transaction's mint field.
 extractTokenId
-    :: CageConfig -> Tx ConwayEra -> TokenId
+    :: CageConfig -> ConwayTx -> TokenId
 extractTokenId cfg tx =
     let MultiAsset ma =
             tx ^. bodyTxL . mintTxBodyL
@@ -504,7 +504,7 @@ maybeDumpTxForAiken
     -> Integer
     -> FilePath
     -> String
-    -> Tx ConwayEra
+    -> ConwayTx
     -> IO ()
 maybeDumpTxForAiken prov cfg extraScriptAddrs startMs bpPath label tx = do
     enabled <-

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -31,12 +31,12 @@ import Test.Hspec
     )
 
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     )
 import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
 import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.Mary.Value (MultiAsset (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -53,7 +53,6 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
     , Coin (..)
-    , ConwayEra
     , LocatedRequest (..)
     , LocatedTokenState (..)
     , Operation (..)
@@ -346,7 +345,7 @@ withE2E scripts action = do
 buildAndSubmit
     :: Context IO
     -> IO (ProofEnvelope p)
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 buildAndSubmit ctx buildBundle = do
     bundle <- buildBundle
     let unsigned = envTx bundle
@@ -384,7 +383,7 @@ awaitTx = threadDelay 5_000_000
 -- | Extract the 'TokenId' from a boot
 -- transaction's mint field.
 extractTokenId
-    :: CageConfig -> Tx ConwayEra -> TokenId
+    :: CageConfig -> ConwayTx -> TokenId
 extractTokenId cfg tx =
     let MultiAsset ma =
             tx ^. bodyTxL . mintTxBodyL

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/FactsMatrixSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/FactsMatrixSpec.hs
@@ -91,8 +91,7 @@ import Cardano.Ledger.Address
     , serialiseAddr
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , txIdTx
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -108,6 +107,7 @@ import Cardano.Ledger.Mary.Value
     )
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -182,8 +182,7 @@ import Cardano.MPFS.Core.OnChain
     , OnChainTokenState (..)
     )
 import Cardano.MPFS.Core.Types
-    ( ConwayEra
-    , SlotNo (..)
+    ( SlotNo (..)
     , TokenId (..)
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
@@ -543,7 +542,7 @@ runUpdateRow cfg ctx app tokenId = do
     pendingRequestsEmpty app tokenId
     tokenRootIndexed app tokenId expectedRoot
 
-expectedUpdateRoot :: Tx ConwayEra -> IO ByteString
+expectedUpdateRoot :: ConwayTx -> IO ByteString
 expectedUpdateRoot tx =
     case [ r
          | out <- toList (tx ^. bodyTxL . outputsTxBodyL)
@@ -1265,7 +1264,7 @@ pollUntilJust timeoutSec action = go (timeoutSec * 2)
             Nothing ->
                 threadDelay 500_000 >> go (n - 1)
 
-extractTokenId :: CageConfig -> Tx ConwayEra -> TokenId
+extractTokenId :: CageConfig -> ConwayTx -> TokenId
 extractTokenId cfg tx =
     let MultiAsset ma = tx ^. bodyTxL . mintTxBodyL
         pid = cagePolicyIdFromCfg cfg

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -51,8 +51,7 @@ import Test.Hspec
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , txIdTx
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -68,6 +67,7 @@ import Cardano.Ledger.Mary.Value
     , MultiAsset (..)
     )
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -84,7 +84,6 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
     , Coin (..)
-    , ConwayEra
     , TokenId (..)
     )
 import Cardano.MPFS.E2E.Helpers.Boot
@@ -266,7 +265,7 @@ signSubmitAwait
     -> Application
     -> Context IO
     -> IO (ProofEnvelope p)
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 signSubmitAwait timeout app ctx buildBundle = do
     bundle <- buildBundle
     let unsigned = envTx bundle
@@ -379,7 +378,7 @@ txIdHex (TxId sh) =
 
 -- | Extract the sole minted 'TokenId'.
 extractTokenId
-    :: CageConfig -> Tx ConwayEra -> TokenId
+    :: CageConfig -> ConwayTx -> TokenId
 extractTokenId cfg tx =
     let MultiAsset ma =
             tx ^. bodyTxL . mintTxBodyL

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -28,13 +28,14 @@ import Test.Hspec
     , shouldSatisfy
     )
 
-import Cardano.Ledger.Api.Tx (Tx, txIdTx)
+import Cardano.Ledger.Api.Tx (txIdTx)
 import Cardano.Ledger.Api.Tx.Out (TxOut)
 import Cardano.Ledger.BaseTypes
     ( Network (..)
     , TxIx (..)
     )
 import Cardano.Ledger.TxIn (TxIn (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -1005,7 +1006,7 @@ withE2E scripts action = do
 buildAndSubmit
     :: Context IO
     -> IO (ProofEnvelope p)
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 buildAndSubmit ctx buildBundle = do
     bundle <- buildBundle
     let unsigned = envTx bundle

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -84,12 +84,19 @@ import Test.Hspec
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Ledger.Address (Addr, serialiseAddr)
-import Cardano.Ledger.Api.Tx (Tx, bodyTxL, txIdTx)
+import Cardano.Ledger.Api.Tx (bodyTxL, txIdTx)
 import Cardano.Ledger.Api.Tx.Body
     ( mintTxBodyL
     )
 import Cardano.Ledger.BaseTypes (Network (..))
-import Cardano.Ledger.Binary (decodeFull, natVersion, serialize')
+import Cardano.Ledger.Binary
+    ( Annotator
+    , Decoder
+    , decCBOR
+    , decodeFullAnnotator
+    , natVersion
+    , serialize'
+    )
 import Cardano.Ledger.Hashes (extractHash)
 import Cardano.Ledger.Mary.Value
     ( AssetName (..)
@@ -97,6 +104,7 @@ import Cardano.Ledger.Mary.Value
     )
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
 import Cardano.Ledger.TxIn (TxId (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -113,7 +121,6 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
     , Coin (..)
-    , ConwayEra
     , TokenId (..)
     )
 import Cardano.MPFS.E2E.Helpers.Boot
@@ -561,7 +568,7 @@ expectUpdateFactsVerified trusted facts =
 buildUpdateTx
     :: CageConfig
     -> VerifiedUpdateFacts
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 buildUpdateTx cfg verified =
     case updateCageTx
         (toClientCageConfig cfg)
@@ -596,7 +603,7 @@ expectRejectFactsVerified trusted facts =
 buildRejectTx
     :: CageConfig
     -> VerifiedRejectFacts
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 buildRejectTx cfg verified =
     case rejectCageTx
         (toClientCageConfig cfg)
@@ -608,7 +615,7 @@ buildRejectTx cfg verified =
                 ("rejectCageTx failed: " <> show err)
                 *> error "unreachable"
 
-encodeTxHex :: Tx ConwayEra -> Hex
+encodeTxHex :: ConwayTx -> Hex
 encodeTxHex tx =
     Hex
         ( TE.decodeUtf8
@@ -619,7 +626,7 @@ encodeTxHex tx =
 buildEndTx
     :: CageConfig
     -> VerifiedEndFacts
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 buildEndTx cfg verified =
     case endCageTx
         (toClientCageConfig cfg)
@@ -636,7 +643,7 @@ submitResponseTx
     -> Application
     -> Context IO
     -> Hex
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 submitResponseTx timeout app ctx txHex = do
     unsigned <- decodeResponseTx txHex
     let signed =
@@ -646,7 +653,7 @@ submitResponseTx timeout app ctx txHex = do
     awaitTx timeout app (txIdTx signed)
     pure signed
 
-decodeResponseTx :: Hex -> IO (Tx ConwayEra)
+decodeResponseTx :: Hex -> IO ConwayTx
 decodeResponseTx (Hex txText) =
     case B16.decode (TE.encodeUtf8 txText) of
         Left err ->
@@ -654,7 +661,11 @@ decodeResponseTx (Hex txText) =
                 ("response tx hex decode failed: " <> err)
                 *> error "unreachable"
         Right txBytes ->
-            case decodeFull (natVersion @11) (BSL.fromStrict txBytes) of
+            case decodeFullAnnotator
+                (natVersion @11)
+                "Conway transaction"
+                (decCBOR :: forall s. Decoder s (Annotator ConwayTx))
+                (BSL.fromStrict txBytes) of
                 Left err ->
                     expectationFailure
                         ("response tx CBOR decode failed: " <> show err)
@@ -700,7 +711,7 @@ signSubmitAwait
     -> Application
     -> Context IO
     -> IO (ProofEnvelope p)
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 signSubmitAwait timeout app ctx buildBundle = do
     bundle <- buildBundle
     let unsigned = envTx bundle
@@ -822,7 +833,7 @@ txIdHex (TxId sh) =
 
 -- | Extract the sole minted 'TokenId'.
 extractTokenId
-    :: CageConfig -> Tx ConwayEra -> TokenId
+    :: CageConfig -> ConwayTx -> TokenId
 extractTokenId cfg tx =
     let MultiAsset ma =
             tx ^. bodyTxL . mintTxBodyL

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
@@ -79,6 +79,7 @@ import Cardano.Ledger.Binary
     ( natVersion
     , serialize'
     )
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.Application
     ( AppConfig (..)
@@ -106,10 +107,6 @@ import Cardano.MPFS.TxBuilder.Config
 import Cardano.MPFS.TxBuilder.Real.Internal
     ( computeScriptHash
     )
-import Cardano.Node.Client.Balance
-    ( BalanceResult (..)
-    , balanceTx
-    )
 import Cardano.Node.Client.E2E.Devnet
     ( withCardanoNode
     )
@@ -118,6 +115,10 @@ import Cardano.Node.Client.E2E.Setup
     , genesisAddr
     , genesisDir
     , genesisSignKey
+    )
+import Cardano.Tx.Balance
+    ( BalanceResult (..)
+    , balanceTx
     )
 
 -- | Skips when @MPFS_BLUEPRINT@ is not set.
@@ -164,10 +165,12 @@ submitEndpointSpec scripts =
                         body =
                             mkBasicTxBody
                                 & vldtTxBodyL .~ vldt
+                        tx :: ConwayTx
                         tx = mkBasicTx body
                     case balanceTx
                         pp
                         [feeUtxo]
+                        []
                         genesisAddr
                         tx of
                         Left err ->

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitterSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitterSpec.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.BaseTypes
     ( SlotNo (..)
     , StrictMaybe (SJust, SNothing)
     )
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.Provider.NodeClient
@@ -39,15 +40,15 @@ import Cardano.MPFS.Submitter
     , Submitter (..)
     )
 import Cardano.MPFS.Submitter.N2C (mkN2CSubmitter)
-import Cardano.Node.Client.Balance
-    ( BalanceResult (..)
-    , balanceTx
-    )
 import Cardano.Node.Client.E2E.Setup
     ( addKeyWitness
     , genesisAddr
     , genesisSignKey
     , withDevnet
+    )
+import Cardano.Tx.Balance
+    ( BalanceResult (..)
+    , balanceTx
     )
 
 spec :: Spec
@@ -84,10 +85,12 @@ spec =
                                     mkBasicTxBody
                                         & vldtTxBodyL
                                             .~ vldt
+                                tx :: ConwayTx
                                 tx = mkBasicTx body
                             case balanceTx
                                 pp
                                 [feeUtxo]
+                                []
                                 genesisAddr
                                 tx of
                                 Left err ->

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
@@ -83,11 +83,14 @@ import Test.Hspec
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Ledger.Address (serialiseAddr)
-import Cardano.Ledger.Api.Tx (Tx, bodyTxL, txIdTx)
+import Cardano.Ledger.Api.Tx (bodyTxL, txIdTx)
 import Cardano.Ledger.Api.Tx.Body (mintTxBodyL)
 import Cardano.Ledger.BaseTypes (Network (..), TxIx (..))
 import Cardano.Ledger.Binary
-    ( decodeFull'
+    ( Annotator
+    , Decoder
+    , decCBOR
+    , decodeFullAnnotator
     , natVersion
     , serialize'
     )
@@ -96,6 +99,7 @@ import Cardano.Ledger.Hashes (extractHash)
 import Cardano.Ledger.Mary.Value (AssetName (..), MultiAsset (..))
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Control.Tracer (nullTracer)
@@ -117,8 +121,7 @@ import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Blueprint (CageScripts, loadCageScripts)
 import Cardano.MPFS.Core.Types
-    ( ConwayEra
-    , SlotNo (..)
+    ( SlotNo (..)
     , TokenId (..)
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
@@ -312,7 +315,7 @@ runWorkflow
     -> String
     -> (WorkflowsConfig -> req -> IO (Either WorkflowError UnsignedTx))
     -> req
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 runWorkflow env label run req = do
     trusted <- waitForTrustedRoot (envApp env)
     result <- run (mkWorkflowsConfig (envCfg env) trusted) req
@@ -324,8 +327,12 @@ runWorkflow env label run req = do
                     (label <> ": workflow failed: " <> show err)
                     *> error "unreachable"
     tx <-
-        case decodeFull' (natVersion @11) (unsignedTxCbor unsigned) of
-            Right t -> pure (t :: Tx ConwayEra)
+        case decodeFullAnnotator
+            (natVersion @11)
+            "Conway transaction"
+            (decCBOR :: forall s. Decoder s (Annotator ConwayTx))
+            (BSL.fromStrict (unsignedTxCbor unsigned)) of
+            Right t -> pure (t :: ConwayTx)
             Left err ->
                 expectationFailure
                     (label <> ": UnsignedTx CBOR did not decode: " <> show err)
@@ -336,7 +343,7 @@ runWorkflow env label run req = do
 
 -- | The boot row keeps its signed tx so the token id can be read off
 -- the mint.
-runBoot :: Env -> IO (Tx ConwayEra)
+runBoot :: Env -> IO ConwayTx
 runBoot env =
     runWorkflow
         env
@@ -356,7 +363,7 @@ bootToken env = do
 
 -- | Sign-already-done: serialise, POST to @\/submit@, assert the wire
 -- contract, and await the txId against the indexer.
-submitAndAwait :: Env -> String -> Tx ConwayEra -> IO ()
+submitAndAwait :: Env -> String -> ConwayTx -> IO ()
 submitAndAwait env label signed = do
     let rawCbor = serialize' (natVersion @11) signed
     resp <-
@@ -688,7 +695,7 @@ pollUntilJust timeoutSec action = go (timeoutSec * 2)
 -- Conversions / fixtures
 -- ---------------------------------------------------------
 
-extractTokenId :: CageConfig -> Tx ConwayEra -> TokenId
+extractTokenId :: CageConfig -> ConwayTx -> TokenId
 extractTokenId cfg tx =
     let MultiAsset ma = tx ^. bodyTxL . mintTxBodyL
         pid = cagePolicyIdFromCfg cfg

--- a/cardano-mpfs-offchain/exe/TxVectors.hs
+++ b/cardano-mpfs-offchain/exe/TxVectors.hs
@@ -30,7 +30,6 @@ import Cardano.Crypto.Hash
     ( Blake2b_256
     , hashFromStringAsHex
     )
-import Cardano.Ledger.Api.Tx (Tx)
 import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary (natVersion, serialize')
 import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
@@ -39,7 +38,6 @@ import Cardano.Ledger.Mary.Value (AssetName (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.MPFS.Core.Types
     ( Coin (..)
-    , ConwayEra
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -55,13 +53,14 @@ import Cardano.MPFS.Indexer.TxFixtures
     , mkRetractTx
     , mkUpdateTx
     )
+import Cardano.Tx.Ledger (ConwayTx)
 
 -- ---------------------------------------------------------
 -- Serialization
 -- ---------------------------------------------------------
 
--- | Serialize a 'Tx ConwayEra' to hex-encoded CBOR.
-serializeTxHex :: Tx ConwayEra -> Text
+-- | Serialize a 'ConwayTx' to hex-encoded CBOR.
+serializeTxHex :: ConwayTx -> Text
 serializeTxHex =
     TE.decodeUtf8
         . B16.encode
@@ -122,7 +121,7 @@ testTokenId =
         $ BS.replicate 32 0xaa
 
 -- | Test payment key hash (28 bytes of 0xcc).
-testKeyHash :: KeyHash 'Payment
+testKeyHash :: KeyHash Payment
 testKeyHash =
     KeyHash
         $ fromJust
@@ -188,7 +187,7 @@ testUpdateRequest =
 data TxVector = TxVector
     { tvOp :: Text
     , tvDesc :: Text
-    , tvTx :: Tx ConwayEra
+    , tvTx :: ConwayTx
     }
 
 -- | All transaction vectors.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs
@@ -121,7 +121,7 @@ data LocatedRequest = LocatedRequest
 data Request = Request
     { requestToken :: !TokenId
     -- ^ The token whose trie is being modified
-    , requestOwner :: !(KeyHash 'Payment)
+    , requestOwner :: !(KeyHash Payment)
     -- ^ The owner's payment key hash
     , requestKey :: !ByteString
     -- ^ The key to operate on
@@ -148,7 +148,7 @@ data LocatedTokenState = LocatedTokenState
 
 -- | Current on-chain state of a token.
 data TokenState = TokenState
-    { owner :: !(KeyHash 'Payment)
+    { owner :: !(KeyHash Payment)
     -- ^ Owner's payment key hash
     , root :: !Root
     -- ^ Current root hash of the token's trie

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -57,10 +57,12 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Lazy.Char8 qualified as BL
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
-import Cardano.Ledger.Api.Tx (Tx)
 import Cardano.Ledger.Binary
-    ( DecoderError
-    , decodeFull'
+    ( Annotator
+    , Decoder
+    , DecoderError
+    , decCBOR
+    , decodeFullAnnotator
     , natVersion
     , serialize'
     )
@@ -73,6 +75,7 @@ import Cardano.Ledger.TxIn
     , TxIn
     , mkTxInPartial
     )
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.API.Types.Facts
     ( EndFacts
@@ -1669,8 +1672,13 @@ parseUtxoRef t =
                         \expected txhash#ix"
                     }
 
--- | Decode CBOR bytes to a 'Tx ConwayEra'.
+-- | Decode CBOR bytes to a 'ConwayTx'.
 decodeTx
     :: ByteString
-    -> Either DecoderError (Tx ConwayEra)
-decodeTx = decodeFull' (natVersion @11)
+    -> Either DecoderError ConwayTx
+decodeTx =
+    decodeFullAnnotator
+        (natVersion @11)
+        "Conway transaction"
+        (decCBOR :: forall s. Decoder s (Annotator ConwayTx))
+        . BL.fromStrict

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -96,13 +96,13 @@ import Data.Text (Text)
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Ledger.Address (decodeAddrEither)
-import Cardano.Ledger.Api.Tx (Tx)
 import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary (natVersion, serialize')
 import Cardano.Ledger.Hashes (extractHash)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (AssetName (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.API.Types
     ( BootFacts (..)
@@ -156,7 +156,6 @@ import Cardano.MPFS.Core.Types
     ( Addr
     , BlockId (..)
     , Coin (..)
-    , ConwayEra
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -207,7 +206,7 @@ tokenStateToJSON
             }
 
 -- | Render a 'KeyHash' as hex text.
-hashToHex :: KeyHash 'Payment -> Text
+hashToHex :: KeyHash Payment -> Text
 hashToHex (KeyHash h) =
     Crypto.hashToTextAsHex h
 
@@ -336,7 +335,7 @@ bundleSnapshotToJSON
             }
 
 -- | Serialize a Conway-era 'Tx' to hex CBOR.
-serializeTxHex :: Tx ConwayEra -> Hex
+serializeTxHex :: ConwayTx -> Hex
 serializeTxHex = Hex . serialize' (natVersion @11)
 
 -- | Package a 'ProofEnvelope RequestProof' as the JSON response shared
@@ -365,7 +364,7 @@ mkRequestTxResponse
 -- Sweep does not bundle a proof envelope (the
 -- on-chain validator enforces the owner-signature
 -- predicate against the referenced state UTxO).
-mkSweepTxResponse :: Tx ConwayEra -> SweepTxResponse
+mkSweepTxResponse :: ConwayTx -> SweepTxResponse
 mkSweepTxResponse tx =
     SweepTxResponse{stTx = serializeTxHex tx}
 

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
@@ -42,8 +42,7 @@ import Cardano.Ledger.Api.Scripts.Data
     , binaryDataToData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , txIdTx
     , witsTxL
     )
@@ -77,6 +76,7 @@ import Cardano.Ledger.Mary.Value
 import Cardano.Ledger.TxIn
     ( TxIn (..)
     )
+import Cardano.Tx.Ledger (ConwayTx)
 import Data.Set qualified as Set
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
@@ -169,7 +169,7 @@ detectCageEvents
     -- ^ Cage script hash
     -> [(TxIn, TxOut ConwayEra)]
     -- ^ Resolved inputs (UTxOs being spent)
-    -> Tx ConwayEra
+    -> ConwayTx
     -> [CageEvent]
 detectCageEvents scriptHash resolvedInputs tx =
     mintEvents ++ requestEvents ++ spendEvents
@@ -579,7 +579,7 @@ spendingIndex needle inputs =
 -- | Convert a 'BuiltinByteString' containing a
 -- payment key hash to a 'KeyHash'.
 keyHashFromBBS
-    :: BuiltinByteString -> KeyHash 'Payment
+    :: BuiltinByteString -> KeyHash Payment
 keyHashFromBBS (BuiltinByteString bs) =
     case hashFromBytes bs of
         Just h -> KeyHash h

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs
@@ -45,11 +45,12 @@ import Data.Maybe (catMaybes)
 import Data.Set qualified as Set
 import Lens.Micro ((^.))
 
-import Cardano.Ledger.Api.Tx (Tx, bodyTxL)
+import Cardano.Ledger.Api.Tx (bodyTxL)
 import Cardano.Ledger.Api.Tx.Body (inputsTxBodyL)
-import Cardano.Ledger.Block (bbody)
-import Cardano.Ledger.Core (fromTxSeq)
+import Cardano.Ledger.Block (blockBody)
+import Cardano.Ledger.Core (txSeqBlockBodyL)
 import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Tx.Ledger (ConwayTx)
 import Ouroboros.Consensus.Cardano.Block qualified as O
 import Ouroboros.Consensus.Shelley.Ledger
     ( ShelleyBlock (..)
@@ -85,10 +86,10 @@ import Cardano.Node.Client.Types qualified as NodeTypes
 -- | Extract Conway-era transactions from a multi-era
 -- Cardano block. Returns empty for non-Conway blocks.
 extractConwayTxs
-    :: NodeTypes.Block -> [Tx ConwayEra]
+    :: NodeTypes.Block -> [ConwayTx]
 extractConwayTxs = \case
     O.BlockConway (ShelleyBlock raw _) ->
-        toList (fromTxSeq (bbody raw))
+        toList (blockBody raw ^. txSeqBlockBodyL)
     _ -> []
 
 -- --------------------------------------------------------
@@ -104,7 +105,7 @@ detectCageBlockEvents
     -- ^ Cage script hash
     -> (TxIn -> m (Maybe (TxOut ConwayEra)))
     -- ^ UTxO resolver for spent inputs
-    -> [Tx ConwayEra]
+    -> [ConwayTx]
     -- ^ Conway transactions from the block
     -> m [CageEvent]
 detectCageBlockEvents scriptHash resolveUtxo txs =
@@ -120,7 +121,7 @@ detectFromTx
     -- ^ Cage script hash
     -> (TxIn -> m (Maybe (TxOut ConwayEra)))
     -- ^ UTxO resolver for spent inputs
-    -> Tx ConwayEra
+    -> ConwayTx
     -- ^ Transaction to inspect
     -> m [CageEvent]
 detectFromTx scriptHash resolveUtxo tx = do

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs
@@ -28,10 +28,10 @@ import Cardano.Ledger.Alonzo.Scripts
     ( AsIx
     , PlutusPurpose
     )
-import Cardano.Ledger.Api.Tx (Tx)
 import Cardano.Ledger.Api.Tx.Out (TxOut)
 import Cardano.Ledger.Plutus (ExUnits)
 import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.Core.Types
     ( Addr
@@ -76,7 +76,7 @@ data Provider m = Provider
         :: m (PParams ConwayEra)
     -- ^ Fetch current protocol parameters
     , evaluateTx
-        :: Tx ConwayEra
+        :: ConwayTx
         -> m (EvaluateTxResult ConwayEra)
     -- ^ Evaluate script execution units
     , posixMsToSlot

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs
@@ -17,9 +17,9 @@ module Cardano.MPFS.Submitter
 
 import Data.ByteString (ByteString)
 
-import Cardano.Ledger.Api.Tx (Tx)
+import Cardano.Tx.Ledger (ConwayTx)
 
-import Cardano.MPFS.Core.Types (ConwayEra, TxId)
+import Cardano.MPFS.Core.Types (TxId)
 
 -- | Result of submitting a transaction.
 data SubmitResult
@@ -35,6 +35,6 @@ data SubmitResult
 -- blockchain.
 newtype Submitter m = Submitter
     { submitTx
-        :: Tx ConwayEra -> m SubmitResult
+        :: ConwayTx -> m SubmitResult
     -- ^ Submit a signed transaction
     }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs
@@ -45,12 +45,11 @@ module Cardano.MPFS.TxBuilder
 
 import Data.ByteString (ByteString)
 
-import Cardano.Ledger.Api.Tx (Tx)
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.Core.Types
     ( Addr
     , BlockId
-    , ConwayEra
     , SlotNo
     , TokenId
     , TxIn
@@ -201,7 +200,7 @@ data TrieFact = TrieFact
 -- The type parameter @p@ selects the proof shape, and
 -- with it the verifier's fixed-shape traversal.
 data ProofEnvelope p = ProofEnvelope
-    { envTx :: Tx ConwayEra
+    { envTx :: ConwayTx
     -- ^ Unsigned transaction ready for key witnesses
     , envSnapshot :: BundleSnapshot
     -- ^ UTxO-CSMT root and chain point all proofs in

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
@@ -12,37 +12,10 @@ module Cardano.MPFS.TxBuilder.Real.End
     ) where
 
 import Data.Map.Strict qualified as Map
-import Data.Set qualified as Set
-import Lens.Micro ((&), (.~), (^.))
+import Data.Void (Void)
+import Lens.Micro ((^.))
 
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
-import Cardano.Ledger.Alonzo.TxBody
-    ( reqSignerHashesTxBodyL
-    , scriptIntegrityHashTxBodyL
-    )
-import Cardano.Ledger.Api.Tx
-    ( mkBasicTx
-    , witsTxL
-    )
-import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
-    , inputsTxBodyL
-    , mintTxBodyL
-    , mkBasicTxBody
-    )
-import Cardano.Ledger.Api.Tx.Wits
-    ( Redeemers (..)
-    , rdmrsTxWitsL
-    , scriptTxWitsL
-    )
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
-import Cardano.Ledger.Core (hashScript)
-import Cardano.Ledger.Mary.Value
-    ( MultiAsset (..)
-    )
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -71,11 +44,14 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
+import Cardano.Tx.Build qualified as Tx
 
 import Data.List (sortOn)
 import Data.Ord (Down (..))
 
 import Cardano.Ledger.Api.Tx.Out (coinTxOutL)
+
+data NoCtx a
 
 -- | Build an end-token (burn) transaction.
 --
@@ -130,19 +106,8 @@ endTokenImpl cfg prov proofFn snap tid addr = do
         walletUtxos of
         [] -> error "endToken: no UTxOs"
         (u : _) -> pure u
-    -- 5. Build mint value (-1 token)
     let assetName = unTokenId tid
-        burnMA =
-            MultiAsset
-                $ Map.singleton policyId
-                $ Map.singleton assetName (-1)
-    -- 6. Build redeemers
-    let script = mkCageScript cfg
-        scriptHash = hashScript script
-        allInputs =
-            Set.fromList [stateIn, fst feeUtxo]
-        stateIx =
-            spendingIndex stateIn allInputs
+        script = mkCageScript cfg
         spendRedeemer = End
         onChainTid =
             OnChainTokenId
@@ -151,55 +116,36 @@ endTokenImpl cfg prov proofFn snap tid addr = do
                 $ let AssetName sbs = unTokenId tid
                   in  sbs
         mintRedeemer = Burning onChainTid
-        redeemers =
-            Redeemers
-                $ Map.fromList
-                    [
-                        ( ConwaySpending
-                            (AsIx stateIx)
-                        ,
-                            ( toLedgerData spendRedeemer
-                            , placeholderExUnits
-                            )
-                        )
-                    ,
-                        ( ConwayMinting (AsIx 0)
-                        ,
-                            ( toLedgerData mintRedeemer
-                            , placeholderExUnits
-                            )
-                        )
-                    ]
-        integrity =
-            computeScriptIntegrity pp redeemers
-    -- 7. Build tx body
-    let body =
-            mkBasicTxBody
-                & inputsTxBodyL
-                    .~ Set.singleton stateIn
-                & mintTxBodyL .~ burnMA
-                & collateralInputsTxBodyL
-                    .~ Set.singleton
-                        (fst feeUtxo)
-                & reqSignerHashesTxBodyL
-                    .~ Set.singleton ownerKh
-                & scriptIntegrityHashTxBodyL
-                    .~ integrity
-        tx =
-            mkBasicTx body
-                & witsTxL . scriptTxWitsL
-                    .~ Map.singleton
-                        scriptHash
-                        script
-                & witsTxL . rdmrsTxWitsL
-                    .~ redeemers
-    balanced <-
-        evaluateAndBalance
-            prov
-            pp
+        prog = do
+            _ <- Tx.spendScript stateIn spendRedeemer
+            Tx.attachScript script
+            Tx.mint
+                policyId
+                (Map.singleton assetName (-1))
+                mintRedeemer
+            Tx.requireSignature
+                (witnessKeyHashToGuard ownerKh)
+            Tx.collateral (fst feeUtxo)
+        evalTx tx =
+            Map.map
+                (either (Left . show) Right)
+                <$> evaluateTx prov tx
+    result <-
+        Tx.build
+            (Tx.mkPParamsBound pp)
+            (Tx.InterpretIO (const (pure undefined)))
+            evalTx
             [feeUtxo, stateUtxo]
+            []
             addr
-            tx
+            (prog :: Tx.TxBuild NoCtx Void ())
+    balanced <-
+        case result of
+            Right tx -> pure tx
+            Left err ->
+                error
+                    $ "endToken: TxBuild failed: "
+                        <> show err
     stateWitness <- witness proofFn stateUtxo
     fundingWitnesses <- witnesses proofFn [feeUtxo]
     pure

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
@@ -39,6 +39,7 @@ module Cardano.MPFS.TxBuilder.Real.Internal
     , addrKeyHashBytes
     , addrFromKeyHashBytes
     , addrWitnessKeyHash
+    , witnessKeyHashToGuard
 
       -- * UTxO lookup
     , findUtxoByTxIn
@@ -93,7 +94,8 @@ import Cardano.Ledger.Alonzo.Scripts
     , mkPlutusScript
     )
 import Cardano.Ledger.Alonzo.Tx
-    ( ScriptIntegrityHash
+    ( ScriptIntegrity (..)
+    , ScriptIntegrityHash
     , hashScriptIntegrity
     )
 import Cardano.Ledger.Alonzo.TxBody
@@ -110,8 +112,7 @@ import Cardano.Ledger.Api.Scripts.Data
     , dataToBinaryData
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -131,7 +132,7 @@ import Cardano.Ledger.Api.Tx.Wits
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
     , Network
-    , StrictMaybe
+    , StrictMaybe (SJust)
     , TxIx (..)
     )
 import Cardano.Ledger.Binary
@@ -164,6 +165,7 @@ import Cardano.Ledger.Plutus.Language
     , PlutusBinary (..)
     )
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Tx.Ledger (ConwayTx)
 import Data.Coerce (coerce)
 import PlutusCore.Data qualified as PLC
 import PlutusTx.Builtins.Internal
@@ -201,11 +203,11 @@ import Cardano.MPFS.TxBuilder
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
-import Cardano.Node.Client.Balance
+import Cardano.Slotting.Slot (SlotNo)
+import Cardano.Tx.Balance
     ( BalanceResult (..)
     , balanceTx
     )
-import Cardano.Slotting.Slot (SlotNo)
 
 -- | Empty MPF root (32 zero bytes).
 emptyRoot :: ByteString
@@ -234,9 +236,9 @@ evaluateAndBalance
     -- ^ All input UTxOs (fee + script)
     -> Addr
     -- ^ Change address
-    -> Tx ConwayEra
+    -> ConwayTx
     -- ^ Unbalanced tx with placeholder ExUnits
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 evaluateAndBalance prov pp inputUtxos changeAddr tx =
     do
         -- Pre-add all input TxIns to the body so
@@ -300,6 +302,7 @@ evaluateAndBalance prov pp inputUtxos changeAddr tx =
         case balanceTx
             pp
             inputUtxos
+            []
             changeAddr
             patched' of
             Left err ->
@@ -513,15 +516,18 @@ addrFromKeyHashBytes net bs =
 -- | Extract a 'KeyHash' ''Witness' from raw
 -- payment key hash bytes (for required signers).
 addrWitnessKeyHash
-    :: ByteString -> KeyHash 'Witness
+    :: ByteString -> KeyHash Witness
 addrWitnessKeyHash bs =
     case hashFromBytes bs of
         Just h ->
-            coerce (KeyHash h :: KeyHash 'Payment)
+            coerce (KeyHash h :: KeyHash Payment)
         Nothing ->
             error
                 "addrWitnessKeyHash: \
                 \invalid hash"
+
+witnessKeyHashToGuard :: KeyHash Witness -> KeyHash Guard
+witnessKeyHashToGuard (KeyHash h) = KeyHash h
 
 -- | Find a UTxO by its 'TxIn'.
 findUtxoByTxIn
@@ -623,8 +629,11 @@ computeScriptIntegrity pp rdmrs =
         langViews =
             Set.singleton
                 (getLanguageView pp PlutusV3)
+        emptyDats :: TxDats ConwayEra
         emptyDats = TxDats mempty
-    in  hashScriptIntegrity langViews rdmrs emptyDats
+    in  SJust
+            $ hashScriptIntegrity
+            $ ScriptIntegrity rdmrs emptyDats langViews
 
 -- | Get current POSIX time in milliseconds.
 currentPosixMs :: IO Integer

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
@@ -34,8 +34,7 @@ import Lens.Micro ((&), (.~), (^.))
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.Scripts (AsIx)
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     )
 import Cardano.Ledger.Api.Tx.Body
     ( feeTxBodyL
@@ -60,6 +59,7 @@ import Cardano.Ledger.Keys
     , KeyRole (..)
     )
 import Cardano.Ledger.Plutus.ExUnits (ExUnits)
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -92,8 +92,8 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Node.Client.TxBuild qualified as Tx
 import Cardano.Slotting.Slot (SlotNo)
+import Cardano.Tx.Build qualified as Tx
 
 -- | Empty query GADT (no context needed).
 data NoCtx a
@@ -148,10 +148,11 @@ rejectRequestsImpl cfg prov _st proofFn snap tid addr = do
                 lowerSlot
     result <-
         Tx.build
-            pp
+            (Tx.mkPParamsBound pp)
             (Tx.InterpretIO (const (pure undefined)))
             evalTx
             (feeUtxo : stateUtxo : reqUtxos)
+            []
             addr
             (prog :: Tx.TxBuild NoCtx Void ())
     case result of
@@ -256,7 +257,7 @@ prepareRejectState
        , TxOut ConwayEra
        , Script ConwayEra
        , Script ConwayEra
-       , KeyHash 'Witness
+       , KeyHash Witness
        )
 prepareRejectState cfg tid stateOut =
     let scriptAddr =
@@ -336,7 +337,7 @@ computeLowerSlot prov oldState reqUtxos = do
 -- | Wrap the Provider's evaluateTx for the DSL.
 mkRejectEvalTx
     :: Provider IO
-    -> Tx ConwayEra
+    -> ConwayTx
     -> IO
         ( Map.Map
             (ConwayPlutusPurpose AsIx ConwayEra)
@@ -368,7 +369,7 @@ buildRejectProgram
     -> TxOut ConwayEra
     -> Script ConwayEra
     -> Script ConwayEra
-    -> KeyHash 'Witness
+    -> KeyHash Witness
     -> SlotNo
     -> Tx.TxBuild NoCtx Void ()
 buildRejectProgram
@@ -444,6 +445,6 @@ buildRejectProgram
         -- Constraints
         Tx.attachScript stateScript
         Tx.attachScript requestScript
-        Tx.requireSignature ownerKh
+        Tx.requireSignature (witnessKeyHashToGuard ownerKh)
         Tx.collateral (fst feeUtxo)
         Tx.validFrom lowerSlot

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -18,23 +18,18 @@ module Cardano.MPFS.TxBuilder.Real.Request
 
 import Data.ByteString (ByteString)
 import Data.List (sortOn)
+import Data.Map.Strict qualified as Map
 import Data.Ord (Down (..))
-import Data.Sequence.Strict qualified as StrictSeq
+import Data.Void (Void)
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Api.PParams
-    ( ppMaxTxExUnitsL
-    , ppMinFeeAL
-    , ppMinFeeBL
+    ( CoinPerByte (..)
+    , ppMaxTxExUnitsL
     , ppPricesL
-    )
-import Cardano.Ledger.Api.Tx
-    ( mkBasicTx
-    )
-import Cardano.Ledger.Api.Tx.Body
-    ( mkBasicTxBody
-    , outputsTxBodyL
+    , ppTxFeeFixedL
+    , ppTxFeePerByteL
     )
 import Cardano.Ledger.Api.Tx.Out
     ( TxOut
@@ -45,6 +40,7 @@ import Cardano.Ledger.Api.Tx.Out
     , valueTxOutL
     )
 import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Plutus.ExUnits
     ( txscriptfee
     )
@@ -72,10 +68,9 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Node.Client.Balance
-    ( BalanceResult (..)
-    , balanceTx
-    )
+import Cardano.Tx.Build qualified as Tx
+
+data NoCtx a
 
 -- | Build a request-insert transaction.
 requestInsertImpl
@@ -230,21 +225,30 @@ requestImpl cfg prov st proofFn snap tid key op addr = do
                 (inject minAda)
                 & datumTxOutL
                     .~ mkInlineDatum datum
-        body =
-            mkBasicTxBody
-                & outputsTxBodyL
-                    .~ StrictSeq.singleton txOut
-        tx = mkBasicTx body
-    case balanceTx pp [feeUtxo] addr tx of
+        prog = do
+            _ <- Tx.spend (fst feeUtxo)
+            _ <- Tx.output txOut
+            pure ()
+    result <-
+        Tx.build
+            (Tx.mkPParamsBound pp)
+            (Tx.InterpretIO (const (pure undefined)))
+            (const $ pure Map.empty)
+            [feeUtxo]
+            []
+            addr
+            (prog :: Tx.TxBuild NoCtx Void ())
+    case result of
         Left err ->
             error
-                $ "requestImpl: " <> show err
-        Right br -> do
+                $ "requestImpl: TxBuild failed: "
+                    <> show err
+        Right tx -> do
             fundingWitnesses <-
                 witnesses proofFn [feeUtxo]
             pure
                 ProofEnvelope
-                    { envTx = balancedTx br
+                    { envTx = tx
                     , envSnapshot = snap
                     , envProof =
                         RequestProof
@@ -296,8 +300,9 @@ requestLockedAda pp reqDraft refDraft tip =
 -- Cardano.MPFS.Client.Cage.Request.requestFeeBufferUpperBound.
 requestFeeBufferUpperBound :: PParams ConwayEra -> Coin
 requestFeeBufferUpperBound pp =
-    let Coin minFeeA = pp ^. ppMinFeeAL
-        Coin minFeeB = pp ^. ppMinFeeBL
+    let CoinPerByte minFeeACompact = pp ^. ppTxFeePerByteL
+        Coin minFeeA = fromCompact minFeeACompact
+        Coin minFeeB = pp ^. ppTxFeeFixedL
         Coin scriptFee =
             txscriptfee (pp ^. ppPricesL) (pp ^. ppMaxTxExUnitsL)
     in  Coin

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
@@ -16,45 +16,16 @@ module Cardano.MPFS.TxBuilder.Real.Retract
 import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Ord (Down (..))
-import Data.Set qualified as Set
-import Lens.Micro ((&), (.~), (^.))
+import Data.Void (Void)
+import Lens.Micro ((^.))
 
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.Allegra.Scripts
-    ( ValidityInterval (..)
-    )
-import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
-import Cardano.Ledger.Alonzo.TxBody
-    ( reqSignerHashesTxBodyL
-    , scriptIntegrityHashTxBodyL
-    )
-import Cardano.Ledger.Api.Tx
-    ( mkBasicTx
-    , witsTxL
-    )
-import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
-    , inputsTxBodyL
-    , mkBasicTxBody
-    , referenceInputsTxBodyL
-    , vldtTxBodyL
-    )
 import Cardano.Ledger.Api.Tx.Out
     ( coinTxOutL
     )
-import Cardano.Ledger.Api.Tx.Wits
-    ( Redeemers (..)
-    , rdmrsTxWitsL
-    , scriptTxWitsL
-    )
 import Cardano.Ledger.BaseTypes
     ( SlotNo (..)
-    , StrictMaybe (SJust)
     )
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
-import Cardano.Ledger.Core (hashScript)
 import Cardano.Ledger.TxIn (TxIn)
 
 import Cardano.MPFS.Core.OnChain
@@ -82,9 +53,12 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
+import Cardano.Tx.Build qualified as Tx
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
+
+data NoCtx a
 
 -- | Build a retract-request transaction.
 --
@@ -201,56 +175,37 @@ retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
         posixMsToSlot prov phase2End
     let upperSlot = SlotNo (max 0 (s - 1))
         script = mkRequestScript cfg tid
-        scriptHash = hashScript script
-        allInputs =
-            Set.fromList [reqIn, fst feeUtxo]
-        reqIx = spendingIndex reqIn allInputs
         stateRef = txInToRef stateIn
         redeemer = Retract stateRef
-        spendPurpose =
-            ConwaySpending (AsIx reqIx)
-        redeemers =
-            Redeemers
-                $ Map.singleton
-                    spendPurpose
-                    ( toLedgerData redeemer
-                    , placeholderExUnits
-                    )
-        integrity =
-            computeScriptIntegrity pp redeemers
-        vldt =
-            ValidityInterval
-                (SJust lowerSlot)
-                (SJust upperSlot)
-        body =
-            mkBasicTxBody
-                & inputsTxBodyL
-                    .~ Set.singleton reqIn
-                & referenceInputsTxBodyL
-                    .~ Set.singleton stateIn
-                & collateralInputsTxBodyL
-                    .~ Set.singleton
-                        (fst feeUtxo)
-                & reqSignerHashesTxBodyL
-                    .~ Set.singleton ownerKh
-                & vldtTxBodyL .~ vldt
-                & scriptIntegrityHashTxBodyL
-                    .~ integrity
-        tx =
-            mkBasicTx body
-                & witsTxL . scriptTxWitsL
-                    .~ Map.singleton
-                        scriptHash
-                        script
-                & witsTxL . rdmrsTxWitsL
-                    .~ redeemers
-    balanced <-
-        evaluateAndBalance
-            prov
-            pp
+        prog = do
+            _ <- Tx.spendScript reqIn redeemer
+            Tx.reference stateIn
+            Tx.attachScript script
+            Tx.requireSignature
+                (witnessKeyHashToGuard ownerKh)
+            Tx.collateral (fst feeUtxo)
+            Tx.validFrom lowerSlot
+            Tx.validTo upperSlot
+        evalTx tx =
+            Map.map
+                (either (Left . show) Right)
+                <$> evaluateTx prov tx
+    result <-
+        Tx.build
+            (Tx.mkPParamsBound pp)
+            (Tx.InterpretIO (const (pure undefined)))
+            evalTx
             [feeUtxo, reqUtxoPair]
+            [stateUtxo]
             addr
-            tx
+            (prog :: Tx.TxBuild NoCtx Void ())
+    balanced <-
+        case result of
+            Right tx -> pure tx
+            Left err ->
+                error
+                    $ "retractRequest: TxBuild failed: "
+                        <> show err
     reqWitness <- witness proofFn reqUtxoPair
     stateWitness <- witness proofFn stateUtxo
     fundingWitnesses <- witnesses proofFn [feeUtxo]

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Sweep.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Sweep.hs
@@ -23,37 +23,13 @@ module Cardano.MPFS.TxBuilder.Real.Sweep
 import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Ord (Down (..))
-import Data.Set qualified as Set
-import Lens.Micro ((&), (.~), (^.))
+import Data.Void (Void)
+import Lens.Micro ((^.))
 
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
-import Cardano.Ledger.Alonzo.TxBody
-    ( reqSignerHashesTxBodyL
-    , scriptIntegrityHashTxBodyL
-    )
-import Cardano.Ledger.Api.Tx
-    ( Tx
-    , mkBasicTx
-    , witsTxL
-    )
-import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
-    , inputsTxBodyL
-    , mkBasicTxBody
-    , referenceInputsTxBodyL
-    )
 import Cardano.Ledger.Api.Tx.Out (coinTxOutL)
-import Cardano.Ledger.Api.Tx.Wits
-    ( Redeemers (..)
-    , rdmrsTxWitsL
-    , scriptTxWitsL
-    )
-import Cardano.Ledger.Conway.Scripts
-    ( ConwayPlutusPurpose (..)
-    )
-import Cardano.Ledger.Core (hashScript)
 import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -64,14 +40,16 @@ import Cardano.MPFS.Core.OnChain
     , UpdateRedeemer (..)
     )
 import Cardano.MPFS.Core.Types
-    ( ConwayEra
-    , TokenId
+    ( TokenId
     )
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
+import Cardano.Tx.Build qualified as Tx
+
+data NoCtx a
 
 -- | Build a standalone sweep transaction.
 --
@@ -91,7 +69,7 @@ sweepUtxoImpl
     -- ^ UTxO reference of the garbage to sweep
     -> Addr
     -- ^ State owner's address (signs and balances)
-    -> IO (Tx ConwayEra)
+    -> IO ConwayTx
 sweepUtxoImpl cfg prov tid garbTxIn addr = do
     let reqAddr =
             requestAddrFromCfg
@@ -144,47 +122,31 @@ sweepUtxoImpl cfg prov tid garbTxIn addr = do
             } = stateDatum
         ownerKh = addrWitnessKeyHash ownerBs
     let script = mkRequestScript cfg tid
-        scriptHash = hashScript script
-        allInputs =
-            Set.fromList [garbIn, fst feeUtxo]
-        garbIx = spendingIndex garbIn allInputs
         stateRef = txInToRef stateIn
         redeemer = Sweep stateRef
-        spendPurpose =
-            ConwaySpending (AsIx garbIx)
-        redeemers =
-            Redeemers
-                $ Map.singleton
-                    spendPurpose
-                    ( toLedgerData redeemer
-                    , placeholderExUnits
-                    )
-        integrity =
-            computeScriptIntegrity pp redeemers
-        body =
-            mkBasicTxBody
-                & inputsTxBodyL
-                    .~ Set.singleton garbIn
-                & referenceInputsTxBodyL
-                    .~ Set.singleton stateIn
-                & collateralInputsTxBodyL
-                    .~ Set.singleton
-                        (fst feeUtxo)
-                & reqSignerHashesTxBodyL
-                    .~ Set.singleton ownerKh
-                & scriptIntegrityHashTxBodyL
-                    .~ integrity
-        tx =
-            mkBasicTx body
-                & witsTxL . scriptTxWitsL
-                    .~ Map.singleton
-                        scriptHash
-                        script
-                & witsTxL . rdmrsTxWitsL
-                    .~ redeemers
-    evaluateAndBalance
-        prov
-        pp
-        [feeUtxo, garbUtxoPair]
-        addr
-        tx
+        prog = do
+            _ <- Tx.spendScript garbIn redeemer
+            Tx.reference stateIn
+            Tx.attachScript script
+            Tx.requireSignature
+                (witnessKeyHashToGuard ownerKh)
+            Tx.collateral (fst feeUtxo)
+        evalTx tx =
+            Map.map
+                (either (Left . show) Right)
+                <$> evaluateTx prov tx
+    result <-
+        Tx.build
+            (Tx.mkPParamsBound pp)
+            (Tx.InterpretIO (const (pure undefined)))
+            evalTx
+            [feeUtxo, garbUtxoPair]
+            [stateUtxo]
+            addr
+            (prog :: Tx.TxBuild NoCtx Void ())
+    case result of
+        Right tx -> pure tx
+        Left err ->
+            error
+                $ "sweepUtxo: TxBuild failed: "
+                    <> show err

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -34,18 +34,11 @@ import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.Scripts (AsIx)
-import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
-import Cardano.Ledger.Api.PParams (ppProtocolVersionL)
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
-    , estimateMinFeeTx
-    , sizeTxF
-    , witsTxL
+    ( bodyTxL
     )
 import Cardano.Ledger.Api.Tx.Body
     ( feeTxBodyL
-    , inputsTxBodyL
     )
 import Cardano.Ledger.Api.Tx.Out
     ( TxOut
@@ -54,27 +47,22 @@ import Cardano.Ledger.Api.Tx.Out
     , mkBasicTxOut
     , valueTxOutL
     )
-import Cardano.Ledger.Api.Tx.Wits (rdmrsTxWitsL)
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
-    , pvMajor
     )
-import Cardano.Ledger.Binary (serialize)
 import Cardano.Ledger.Conway.Scripts
     ( ConwayPlutusPurpose
     )
-import Cardano.Ledger.Core (Script, getMinFeeTx)
+import Cardano.Ledger.Core (Script)
 import Cardano.Ledger.Keys
     ( KeyHash
     , KeyRole (..)
     )
 import Cardano.Ledger.Plutus.ExUnits (ExUnits)
+import Cardano.Tx.Ledger (ConwayTx)
 import Codec.CBOR.Encoding qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Data.ByteString qualified as BS
-import Data.ByteString.Base16 qualified as B16
-import Data.ByteString.Lazy qualified as BSL
-import Data.Set qualified as Set
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -117,8 +105,8 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Node.Client.TxBuild qualified as Tx
 import Cardano.Slotting.Slot (SlotNo)
+import Cardano.Tx.Build qualified as Tx
 
 -- | Empty query GADT (no context needed).
 data NoCtx a
@@ -188,10 +176,11 @@ updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
                 upperSlot
     result <-
         Tx.build
-            pp
+            (Tx.mkPParamsBound pp)
             (Tx.InterpretIO (const (pure undefined)))
             evalTx
             (feeUtxo : stateUtxo : reqUtxos)
+            []
             addr
             (prog :: Tx.TxBuild NoCtx Void ())
     case result of
@@ -200,49 +189,6 @@ updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
             reqWitnesses <- witnesses proofFn reqUtxos
             fundingWitnesses <-
                 witnesses proofFn [feeUtxo]
-            let Coin fee =
-                    tx ^. bodyTxL . feeTxBodyL
-                unsignedSize =
-                    tx ^. sizeTxF
-                estFee =
-                    estimateMinFeeTx pp tx 1 0 0
-                getMin =
-                    getMinFeeTx pp tx 0
-            -- Also dump what estimateMinFeeTx
-            -- sees inside balanceTx: the tx
-            -- that was passed to balanceTx is
-            -- the BUILD-RESULT tx. If it has
-            -- ExUnits 0, patchExUnits failed.
-            let Redeemers rdmrs =
-                    tx ^. witsTxL . rdmrsTxWitsL
-                rdmrEUs =
-                    [ (show p, show eu)
-                    | (p, (_, eu)) <-
-                        Map.toList rdmrs
-                    ]
-            appendFile "/tmp/mpfs-dsl.log"
-                $ "RESULT-EUS: "
-                    <> show rdmrEUs
-                    <> "\n"
-            let ver = pvMajor (pp ^. ppProtocolVersionL)
-                txHex =
-                    B16.encode
-                        ( BSL.toStrict
-                            (serialize ver tx)
-                        )
-            BS.writeFile
-                "/tmp/mpfs-unsigned.cbor.hex"
-                txHex
-            appendFile "/tmp/mpfs-dsl.log"
-                $ "BUILD: fee="
-                    <> show fee
-                    <> " unsignedSize="
-                    <> show unsignedSize
-                    <> " estimateMinFee(1)="
-                    <> show estFee
-                    <> " getMinFee(0)="
-                    <> show getMin
-                    <> "\n"
             pure
                 ProofEnvelope
                     { envTx = tx
@@ -339,7 +285,7 @@ prepareState
        , TxOut ConwayEra
        , Script ConwayEra
        , Script ConwayEra
-       , KeyHash 'Witness
+       , KeyHash Witness
        )
 prepareState cfg tid stateOut newRoot =
     let scriptAddr =
@@ -422,7 +368,7 @@ computeUpperSlot prov oldState reqUtxos = do
 -- | Wrap the Provider's evaluateTx for the DSL.
 mkEvalTx
     :: Provider IO
-    -> Tx ConwayEra
+    -> ConwayTx
     -> IO
         ( Map.Map
             ( ConwayPlutusPurpose
@@ -432,16 +378,7 @@ mkEvalTx
             (Either String ExUnits)
         )
 mkEvalTx prov tx = do
-    let ins = tx ^. bodyTxL . inputsTxBodyL
     r <- evaluateTx prov tx
-    appendFile "/tmp/mpfs-dsl.log"
-        $ "EVAL: ins="
-            <> show (Set.size ins)
-            <> " sorted="
-            <> show (Set.toAscList ins)
-            <> " result="
-            <> show (Map.keys r)
-            <> "\n"
     pure
         $ Map.map
             ( \case
@@ -466,7 +403,7 @@ buildProgram
     -> TxOut ConwayEra
     -> Script ConwayEra
     -> Script ConwayEra
-    -> KeyHash 'Witness
+    -> KeyHash Witness
     -> [[ProofStep]]
     -> SlotNo
     -> Tx.TxBuild NoCtx Void ()
@@ -545,7 +482,7 @@ buildProgram
         -- Constraints — both validators witness this tx
         Tx.attachScript stateScript
         Tx.attachScript requestScript
-        Tx.requireSignature ownerKh
+        Tx.requireSignature (witnessKeyHashToGuard ownerKh)
         Tx.collateral (fst feeUtxo)
         Tx.validTo upperSlot
 

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/BalanceSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/BalanceSpec.hs
@@ -17,11 +17,10 @@ import Test.QuickCheck
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Api.PParams
     ( emptyPParams
-    , ppMinFeeBL
+    , ppTxFeeFixedL
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , mkBasicTx
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -42,6 +41,7 @@ import Cardano.Ledger.Credential
     , StakeReference (..)
     )
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.Core.Types
     ( Coin (..)
@@ -52,19 +52,19 @@ import Cardano.MPFS.Generators
     ( genKeyHash
     , genTxIn
     )
-import Cardano.Node.Client.Balance
+import Cardano.Tx.Balance
     ( BalanceError (..)
     , BalanceResult (..)
     , balanceTx
     )
 
 -- | Testnet address from a payment key hash.
-testAddr :: KeyHash 'Payment -> Addr
+testAddr :: KeyHash Payment -> Addr
 testAddr kh =
     Addr Testnet (KeyHashObj kh) StakeRefNull
 
 -- | Empty transaction.
-emptyTx :: Tx ConwayEra
+emptyTx :: ConwayTx
 emptyTx = mkBasicTx mkBasicTxBody
 
 -- | Protocol params with zero fees.
@@ -74,7 +74,7 @@ zeroPP = emptyPParams
 -- | Protocol params with a large constant fee.
 highFeePP :: PParams ConwayEra
 highFeePP =
-    emptyPParams & ppMinFeeBL .~ Coin 5_000_000
+    emptyPParams & ppTxFeeFixedL .~ Coin 5_000_000
 
 spec :: Spec
 spec = describe "Cardano.MPFS.Core.Balance" $ do
@@ -108,6 +108,7 @@ propSucceeds =
                     balanceTx
                         zeroPP
                         [(txIn, feeUtxo)]
+                        []
                         changeAddr
                         emptyTx
             in  case result of
@@ -131,6 +132,7 @@ propChangeCorrect =
                     balanceTx
                         zeroPP
                         [(txIn, feeUtxo)]
+                        []
                         changeAddr
                         emptyTx
             in  case result of
@@ -172,6 +174,7 @@ propFeeSet =
                     balanceTx
                         zeroPP
                         [(txIn, feeUtxo)]
+                        []
                         changeAddr
                         emptyTx
             in  case result of
@@ -200,6 +203,7 @@ propInsufficient =
                     balanceTx
                         highFeePP
                         [(txIn, feeUtxo)]
+                        []
                         changeAddr
                         emptyTx
             in  case result of

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Generators.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Generators.hs
@@ -93,7 +93,7 @@ genRoot = Root . BS.pack <$> vectorOf 32 arbitrary
 
 -- | Generate a 'KeyHash' ''Payment' from a random
 -- 28-byte Blake2b-224 hash.
-genKeyHash :: Gen (KeyHash 'Payment)
+genKeyHash :: Gen (KeyHash Payment)
 genKeyHash = do
     hex <- genHex 28
     pure

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ArmageddonSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ArmageddonSpec.hs
@@ -659,7 +659,7 @@ reqB =
         , requestSubmittedAt = 2000
         }
 
-testKeyHash :: KeyHash 'Payment
+testKeyHash :: KeyHash Payment
 testKeyHash =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/PersistentSpec.hs
@@ -514,7 +514,7 @@ fixTokenId =
 
 -- | Deterministic test key hash (28-byte Blake2b-224).
 -- 56 hex chars = 28 bytes.
-fixKeyHash :: KeyHash 'Payment
+fixKeyHash :: KeyHash Payment
 fixKeyHash =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/RollbackSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/RollbackSpec.hs
@@ -337,7 +337,7 @@ reqA =
 -- Crypto helpers (minimal, deterministic)
 -- ---------------------------------------------------------
 
-testKeyHash :: KeyHash 'Payment
+testKeyHash :: KeyHash Payment
 testKeyHash =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
@@ -7,7 +7,7 @@
 -- Description : Test transaction builders for cage event detection
 -- License     : Apache-2.0
 --
--- Builds minimal @Tx ConwayEra@ values encoding cage
+-- Builds minimal @ConwayTx@ values encoding cage
 -- events (boot, burn, request, update, retract) for
 -- property tests of 'detectCageEvents' and
 -- 'detectFromTx'.
@@ -45,8 +45,7 @@ import Cardano.Crypto.Hash
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , mkBasicTx
     , witsTxL
     )
@@ -83,6 +82,7 @@ import Cardano.Ledger.Mary.Value
     , PolicyID (..)
     )
 import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Tx.Ledger (ConwayTx)
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -100,7 +100,6 @@ import Cardano.MPFS.Core.OnChain
 import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , Coin (..)
-    , ConwayEra
     , Operation (..)
     , Request (..)
     , Root (..)
@@ -152,7 +151,7 @@ mkBootTx
     -> TokenState
     -> TxIn
     -- ^ Seed input
-    -> Tx ConwayEra
+    -> ConwayTx
 mkBootTx tid ts@TokenState{..} seedInput =
     let assetName = unTokenId tid
         mintMA =
@@ -181,7 +180,7 @@ mkBurnTx
     :: TokenId
     -> TxIn
     -- ^ Dummy input
-    -> Tx ConwayEra
+    -> ConwayTx
 mkBurnTx tid dummyInput =
     let assetName = unTokenId tid
         burnMA =
@@ -201,7 +200,7 @@ mkRequestTx
     :: Request
     -> TxIn
     -- ^ Dummy input
-    -> Tx ConwayEra
+    -> ConwayTx
 mkRequestTx Request{..} dummyInput =
     let onChainTid = mkOnChainTid requestToken
         KeyHash ownerH = requestOwner
@@ -247,7 +246,7 @@ mkUpdateTx
     -- ^ Consumed request inputs
     -> TxIn
     -- ^ State input
-    -> Tx ConwayEra
+    -> ConwayTx
 mkUpdateTx tid ts _newRoot reqInputs stateInput =
     let assetName = unTokenId tid
         newStateDatum =
@@ -293,7 +292,7 @@ mkRetractTx
     -- ^ Request input to retract
     -> TxIn
     -- ^ Additional input (needed for spending index)
-    -> Tx ConwayEra
+    -> ConwayTx
 mkRetractTx reqInput extraInput =
     let allInputs =
             Set.fromList [reqInput, extraInput]
@@ -321,7 +320,7 @@ mkRetractTx reqInput extraInput =
 -- | Build a plain transaction with no cage-related
 -- content: no mints, no cage-address outputs, no
 -- spending redeemers.
-mkPlainTx :: TxIn -> Tx ConwayEra
+mkPlainTx :: TxIn -> ConwayTx
 mkPlainTx dummyInput =
     let body =
             mkBasicTxBody
@@ -341,7 +340,7 @@ mkBootRequestTx
     -> Request
     -> TxIn
     -- ^ Seed input
-    -> Tx ConwayEra
+    -> ConwayTx
 mkBootRequestTx tid ts req seedInput =
     let
         -- Extract the request-only tx body to get

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
@@ -1248,7 +1248,7 @@ reqB =
         , requestSubmittedAt = 2000
         }
 
-testKeyHash :: KeyHash 'Payment
+testKeyHash :: KeyHash Payment
 testKeyHash =
     KeyHash
         $ fromJust

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -44,16 +44,16 @@ import Cardano.Ledger.Allegra.Scripts
     ( ValidityInterval (..)
     )
 import Cardano.Ledger.Api.PParams
-    ( emptyPParams
+    ( CoinPerByte (..)
+    , emptyPParams
     , ppCoinsPerUTxOByteL
     , ppMaxTxExUnitsL
-    , ppMinFeeAL
-    , ppMinFeeBL
     , ppPricesL
+    , ppTxFeeFixedL
+    , ppTxFeePerByteL
     )
 import Cardano.Ledger.Api.Tx
-    ( Tx
-    , bodyTxL
+    ( bodyTxL
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -79,9 +79,6 @@ import Cardano.Ledger.Api.Tx.Wits
     , rdmrsTxWitsL
     , scriptTxWitsL
     )
-import Cardano.Ledger.Babbage.PParams
-    ( CoinPerByte (..)
-    )
 import Cardano.Ledger.BaseTypes
     ( BoundedRational (..)
     , Inject (..)
@@ -89,6 +86,8 @@ import Cardano.Ledger.BaseTypes
     , NonNegativeInterval
     , StrictMaybe (..)
     )
+import Cardano.Ledger.Coin (compactCoinOrError)
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Credential
     ( Credential (..)
     , StakeReference (..)
@@ -109,6 +108,7 @@ import Cardano.Ledger.Plutus.ExUnits
     , txscriptfee
     )
 import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.Core.OnChain
     ( CageDatum (..)
@@ -209,12 +209,12 @@ cageAddr net =
         StakeRefNull
 
 -- | Testnet address from a payment key hash.
-testAddr :: KeyHash 'Payment -> Addr
+testAddr :: KeyHash Payment -> Addr
 testAddr kh =
     Addr Testnet (KeyHashObj kh) StakeRefNull
 
 -- | A fixed test key hash.
-testKh :: KeyHash 'Payment
+testKh :: KeyHash Payment
 testKh =
     KeyHash
         $ fromJust
@@ -241,10 +241,11 @@ zeroPP = emptyPParams
 realisticPP :: PParams ConwayEra
 realisticPP =
     emptyPParams
-        & ppMinFeeAL .~ Coin 44
-        & ppMinFeeBL .~ Coin 155_381
+        & ppTxFeePerByteL
+            .~ CoinPerByte (compactCoinOrError (Coin 44))
+        & ppTxFeeFixedL .~ Coin 155_381
         & ppCoinsPerUTxOByteL
-            .~ CoinPerByte (Coin 4310)
+            .~ CoinPerByte (compactCoinOrError (Coin 4310))
         & ppPricesL
             .~ Prices
                 (unsafeNonNegativeInterval (577 % 10_000))
@@ -1078,8 +1079,9 @@ requestLockedAdaProps =
 
 feeBufferUpperBound :: PParams ConwayEra -> Integer
 feeBufferUpperBound pp =
-    let Coin minFeeA = pp ^. ppMinFeeAL
-        Coin minFeeB = pp ^. ppMinFeeBL
+    let CoinPerByte minFeeACompact = pp ^. ppTxFeePerByteL
+        Coin minFeeA = fromCompact minFeeACompact
+        Coin minFeeB = pp ^. ppTxFeeFixedL
         Coin scriptFee =
             txscriptfee (pp ^. ppPricesL) (pp ^. ppMaxTxExUnitsL)
     in  minFeeB + minFeeA * maxUpdateTxBytes + scriptFee
@@ -1594,18 +1596,18 @@ endTxProps =
 -- ---------------------------------------------------------
 
 -- | Convert tx outputs to a list.
-toOutList :: Tx ConwayEra -> [TxOut ConwayEra]
+toOutList :: ConwayTx -> [TxOut ConwayEra]
 toOutList tx =
     foldr (:) []
         $ tx ^. bodyTxL . outputsTxBodyL
 
 -- | Set up state + provider, run requestInsert.
-runRequestInsert :: IO (Tx ConwayEra)
+runRequestInsert :: IO ConwayTx
 runRequestInsert = fst <$> runRequestInsertWith
 
 -- | Same but also return the fee TxIn.
 runRequestInsertWith
-    :: IO (Tx ConwayEra, TxIn)
+    :: IO (ConwayTx, TxIn)
 runRequestInsertWith = do
     (_st, _prov, builder, txIn) <- mkTestFixture
     let feeAddr = testAddr testKh
@@ -1620,7 +1622,7 @@ runRequestInsertWith = do
     pure (envTx bundle, txIn)
 
 -- | Set up state + provider, run requestDelete.
-runRequestDelete :: IO (Tx ConwayEra)
+runRequestDelete :: IO ConwayTx
 runRequestDelete = do
     (_st, _prov, builder, _txIn) <- mkTestFixture
     let feeAddr = testAddr testKh
@@ -1634,14 +1636,14 @@ runRequestDelete = do
             feeAddr
 
 -- | Run retractRequest.
-runRetractRequest :: IO (Tx ConwayEra)
+runRetractRequest :: IO ConwayTx
 runRetractRequest = do
     (tx, _, _) <- runRetractRequestWith
     pure tx
 
 -- | Run retractRequest and return details.
 runRetractRequestWith
-    :: IO (Tx ConwayEra, TxIn, TxIn)
+    :: IO (ConwayTx, TxIn, TxIn)
 runRetractRequestWith = do
     st <- mkMockState
     let ts =
@@ -1703,14 +1705,14 @@ runRetractRequestWith = do
     pure (envTx bundle, reqIn, stateIn)
 
 -- | Run updateToken.
-runUpdateToken :: IO (Tx ConwayEra)
+runUpdateToken :: IO ConwayTx
 runUpdateToken = do
     (tx, _, _) <- runUpdateTokenWith
     pure tx
 
 -- | Run updateToken and return details.
 runUpdateTokenWith
-    :: IO (Tx ConwayEra, TxIn, TxIn)
+    :: IO (ConwayTx, TxIn, TxIn)
 runUpdateTokenWith = do
     st <- mkMockState
     let ts =
@@ -1766,11 +1768,11 @@ runUpdateTokenWith = do
     pure (envTx bundle, stateIn, reqIn)
 
 -- | Run endToken.
-runEndToken :: IO (Tx ConwayEra)
+runEndToken :: IO ConwayTx
 runEndToken = fst <$> runEndTokenWith
 
 -- | Run endToken and return details.
-runEndTokenWith :: IO (Tx ConwayEra, TxIn)
+runEndTokenWith :: IO (ConwayTx, TxIn)
 runEndTokenWith = do
     st <- mkMockState
     let ts =
@@ -1898,14 +1900,14 @@ mkRealisticFixture = do
 
 -- | Run requestInsert with realistic PParams.
 runRealisticRequestInsert
-    :: IO (Tx ConwayEra)
+    :: IO ConwayTx
 runRealisticRequestInsert =
     fst <$> runRealisticRequestInsertWith
 
 -- | Run requestInsert with realistic PParams,
 -- returning the fee TxIn.
 runRealisticRequestInsertWith
-    :: IO (Tx ConwayEra, TxIn)
+    :: IO (ConwayTx, TxIn)
 runRealisticRequestInsertWith = do
     (_st, _prov, builder, txIn) <-
         mkRealisticFixture
@@ -1921,7 +1923,7 @@ runRealisticRequestInsertWith = do
     pure (envTx bundle, txIn)
 
 -- | Run updateToken with realistic PParams.
-runRealisticUpdate :: IO (Tx ConwayEra)
+runRealisticUpdate :: IO ConwayTx
 runRealisticUpdate = do
     (tx, _, _) <- runRealisticUpdateWith
     pure tx
@@ -1929,7 +1931,7 @@ runRealisticUpdate = do
 -- | Run updateToken with realistic PParams
 -- and return details.
 runRealisticUpdateWith
-    :: IO (Tx ConwayEra, TxIn, TxIn)
+    :: IO (ConwayTx, TxIn, TxIn)
 runRealisticUpdateWith = do
     st <- mkMockState
     let ts =
@@ -1984,7 +1986,7 @@ runRealisticUpdateWith = do
 -- The request UTxO has the minimum locked ADA
 -- computed by 'requestLockedAda', so the refund
 -- is at the minUTxO boundary.
-runTightUpdate :: IO (Tx ConwayEra)
+runTightUpdate :: IO ConwayTx
 runTightUpdate = do
     st <- mkMockState
     let ts =
@@ -2042,7 +2044,7 @@ runTightUpdate = do
 -- | Run retractRequest with realistic PParams
 -- and return details.
 runRealisticRetractWith
-    :: IO (Tx ConwayEra, TxIn, TxIn)
+    :: IO (ConwayTx, TxIn, TxIn)
 runRealisticRetractWith = do
     st <- mkMockState
     let ts =
@@ -2099,13 +2101,13 @@ runRealisticRetractWith = do
     pure (envTx bundle, reqIn, stateIn)
 
 -- | Run endToken with realistic PParams.
-runRealisticEnd :: IO (Tx ConwayEra)
+runRealisticEnd :: IO ConwayTx
 runRealisticEnd = fst <$> runRealisticEndWith
 
 -- | Run endToken with realistic PParams
 -- and return details.
 runRealisticEndWith
-    :: IO (Tx ConwayEra, TxIn)
+    :: IO (ConwayTx, TxIn)
 runRealisticEndWith = do
     st <- mkMockState
     let ts =
@@ -2150,7 +2152,7 @@ runRealisticEndWith = do
 -- | Run rejectRequests with mock expired request.
 -- The request has submittedAt=0, processTime=300s,
 -- retractTime=600s — guaranteed expired.
-runRejectRequests :: IO (Tx ConwayEra)
+runRejectRequests :: IO ConwayTx
 runRejectRequests = do
     st <- mkMockState
     let ts =

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1771121711,
-        "narHash": "sha256-1ebLeCCnwuU1y/nLbBQTXtQUK1OBQmxclnJZbfffzG0=",
+        "lastModified": 1779957774,
+        "narHash": "sha256-VUzCpkEokaKNnvFEMM386ijgzKgP6pRIo2odQj9XBb0=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "rev": "9a187ad488ecf19944d6d119c41eff683a1ff54f",
         "type": "github"
       },
       "original": {
@@ -20,28 +20,28 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1771121711,
-        "narHash": "sha256-1ebLeCCnwuU1y/nLbBQTXtQUK1OBQmxclnJZbfffzG0=",
+        "lastModified": 1779431600,
+        "narHash": "sha256-BveisGfAV1GBrwP83S5w0D7B1t3VPaoHGGlRcnHYN5E=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "rev": "8479db771a3186eb326e42d8480eddc20a208275",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "rev": "8479db771a3186eb326e42d8480eddc20a208275",
         "type": "github"
       }
     },
     "CHaP_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1770297836,
-        "narHash": "sha256-Jnfz4OjZG+xvnCQ0KeUS7kaVAu7MsSgvwqFyyZjN+Hw=",
+        "lastModified": 1774345081,
+        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "aae41da34344a6ad7cae51770df4ed1714b7a9c9",
+        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
         "type": "github"
       },
       "original": {
@@ -54,28 +54,28 @@
     "CHaP_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1771121711,
-        "narHash": "sha256-1ebLeCCnwuU1y/nLbBQTXtQUK1OBQmxclnJZbfffzG0=",
+        "lastModified": 1774292745,
+        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a46182e9c039737bf43cdb5286df49bbe0edf6fb",
+        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
         "type": "github"
       }
     },
     "CHaP_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1770297836,
-        "narHash": "sha256-Jnfz4OjZG+xvnCQ0KeUS7kaVAu7MsSgvwqFyyZjN+Hw=",
+        "lastModified": 1774345081,
+        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "aae41da34344a6ad7cae51770df4ed1714b7a9c9",
+        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
         "type": "github"
       },
       "original": {
@@ -271,6 +271,30 @@
         "type": "github"
       }
     },
+    "bundlers": {
+      "inputs": {
+        "nix-appimage": "nix-appimage",
+        "nix-bundle": "nix-bundle",
+        "nix-utils": "nix-utils",
+        "nixpkgs": [
+          "cardano-node-clients",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777842037,
+        "narHash": "sha256-E6kwkFsKnU5k/QAX1aNOPfh69G6Im8/EwdRcZR4J0QE=",
+        "owner": "NixOS",
+        "repo": "bundlers",
+        "rev": "7bb70086c2dad3eecae4805f4d758c80e3cba960",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "bundlers",
+        "type": "github"
+      }
+    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -289,57 +313,6 @@
       }
     },
     "cabal-32_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-32_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-32_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-32_5": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -529,6 +502,7 @@
     "cardano-automation": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "hackageNix": "hackageNix",
         "haskellNix": [
           "cardano-mpfs-onchain",
           "cardano-node",
@@ -541,11 +515,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741965132,
-        "narHash": "sha256-SjNEfsLa+2FKS4GlszaH0fO/QGJbooNFMYU1GVdJToo=",
+        "lastModified": 1764682512,
+        "narHash": "sha256-yY3yIBmiCKsZ7YN++ttEKZiVMIHjjlAngFWaTGvBBvg=",
         "owner": "input-output-hk",
         "repo": "cardano-automation",
-        "rev": "78d16a837d74a72822041ee1b970daa73ac83b9e",
+        "rev": "9a91636c94317bff98ebf6b913f8c38beef0b374",
         "type": "github"
       },
       "original": {
@@ -556,7 +530,8 @@
     },
     "cardano-automation_2": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_5",
+        "hackageNix": "hackageNix_4",
         "haskellNix": [
           "cardano-node-clients",
           "cardano-node",
@@ -569,11 +544,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741965132,
-        "narHash": "sha256-SjNEfsLa+2FKS4GlszaH0fO/QGJbooNFMYU1GVdJToo=",
+        "lastModified": 1764682512,
+        "narHash": "sha256-yY3yIBmiCKsZ7YN++ttEKZiVMIHjjlAngFWaTGvBBvg=",
         "owner": "input-output-hk",
         "repo": "cardano-automation",
-        "rev": "78d16a837d74a72822041ee1b970daa73ac83b9e",
+        "rev": "9a91636c94317bff98ebf6b913f8c38beef0b374",
         "type": "github"
       },
       "original": {
@@ -587,6 +562,7 @@
         "CHaP": "CHaP_2",
         "cardano-node": "cardano-node",
         "flake-utils": "flake-utils_2",
+        "hackageNix": "hackageNix_3",
         "haskellNix": "haskellNix_2",
         "iohkNix": "iohkNix_2",
         "nixpkgs": [
@@ -596,17 +572,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1777468828,
-        "narHash": "sha256-YSZj/f6/o8lWogb8BlleEQc16+bN2EUcBBmBCoAiMfA=",
+        "lastModified": 1779723550,
+        "narHash": "sha256-LxbYXM4VrcZhWqoS71PcdhLPFweSPozzTkAX9QBEqKY=",
         "owner": "cardano-foundation",
         "repo": "cardano-mpfs-onchain",
-        "rev": "023d352e850f866752927818da44861478ae99e5",
+        "rev": "457c1cbcbbf622d0e583a3e9c0b413de079f315a",
         "type": "github"
       },
       "original": {
         "owner": "cardano-foundation",
         "repo": "cardano-mpfs-onchain",
-        "rev": "023d352e850f866752927818da44861478ae99e5",
+        "rev": "457c1cbcbbf622d0e583a3e9c0b413de079f315a",
         "type": "github"
       }
     },
@@ -615,10 +591,9 @@
         "CHaP": "CHaP_3",
         "cardano-automation": "cardano-automation",
         "customConfig": "customConfig",
-        "em": "em",
         "empty-flake": "empty-flake",
         "flake-compat": "flake-compat",
-        "hackageNix": "hackageNix",
+        "hackageNix": "hackageNix_2",
         "haskellNix": "haskellNix",
         "incl": "incl",
         "iohkNix": "iohkNix",
@@ -631,16 +606,16 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1770307293,
-        "narHash": "sha256-66bbnASi59OLBth3VA4PPWqAFyllxfHICh1bbkf6F4k=",
+        "lastModified": 1774379192,
+        "narHash": "sha256-6b9fX1RNmHdBRpmE4WYFCf13vwZZGg1LHRhHP7GRJHE=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "b0a12592c4e996b57edf5bc5b9109ecc88c2273f",
+        "rev": "1e6d8228693ab2aa4e1d7305e7bdcc57cdd278e4",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.5.4",
+        "ref": "10.7.0",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -648,10 +623,13 @@
     "cardano-node-clients": {
       "inputs": {
         "CHaP": "CHaP_4",
+        "bundlers": "bundlers",
         "cardano-node": "cardano-node_2",
         "flake-parts": "flake-parts_2",
+        "hackageNix": "hackageNix_6",
         "haskellNix": "haskellNix_4",
         "iohkNix": "iohkNix_4",
+        "lintNixpkgs": "lintNixpkgs",
         "mkdocs": "mkdocs",
         "nixpkgs": [
           "cardano-node-clients",
@@ -660,16 +638,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1776072244,
-        "narHash": "sha256-YiYXu5kWqC1lsea2xnvfasN3e7lINrmy/urgKWOjKoU=",
+        "lastModified": 1780074883,
+        "narHash": "sha256-weRS107XEGl7N+2yK+fXaNYETNtrZZordUiJ6bymh9I=",
         "owner": "lambdasistemi",
         "repo": "cardano-node-clients",
-        "rev": "b9d4a4dd5d6edbcf1c2a845ccade163726e19765",
+        "rev": "e4b01cb9efdf88e99934cf7a09fed0e25bad1019",
         "type": "github"
       },
       "original": {
         "owner": "lambdasistemi",
         "repo": "cardano-node-clients",
+        "rev": "e4b01cb9efdf88e99934cf7a09fed0e25bad1019",
         "type": "github"
       }
     },
@@ -678,10 +657,9 @@
         "CHaP": "CHaP_5",
         "cardano-automation": "cardano-automation_2",
         "customConfig": "customConfig_2",
-        "em": "em_2",
         "empty-flake": "empty-flake_2",
-        "flake-compat": "flake-compat_4",
-        "hackageNix": "hackageNix_2",
+        "flake-compat": "flake-compat_5",
+        "hackageNix": "hackageNix_5",
         "haskellNix": "haskellNix_3",
         "incl": "incl_2",
         "iohkNix": "iohkNix_3",
@@ -691,19 +669,19 @@
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "utils": "utils_2"
+        "utils": "utils_3"
       },
       "locked": {
-        "lastModified": 1770307293,
-        "narHash": "sha256-66bbnASi59OLBth3VA4PPWqAFyllxfHICh1bbkf6F4k=",
+        "lastModified": 1774379192,
+        "narHash": "sha256-6b9fX1RNmHdBRpmE4WYFCf13vwZZGg1LHRhHP7GRJHE=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "b0a12592c4e996b57edf5bc5b9109ecc88c2273f",
+        "rev": "1e6d8228693ab2aa4e1d7305e7bdcc57cdd278e4",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.5.4",
+        "ref": "10.7.0",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -818,38 +796,6 @@
         "type": "github"
       }
     },
-    "em": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1685015066,
-        "narHash": "sha256-etAdEoYhtvjTw1ITh28WPNfwvvb5t/fpwCP6s7odSiQ=",
-        "owner": "deepfire",
-        "repo": "em",
-        "rev": "af69bb5c2ac2161434d8fea45f920f8f359587ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "deepfire",
-        "repo": "em",
-        "type": "github"
-      }
-    },
-    "em_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1685015066,
-        "narHash": "sha256-etAdEoYhtvjTw1ITh28WPNfwvvb5t/fpwCP6s7odSiQ=",
-        "owner": "deepfire",
-        "repo": "em",
-        "rev": "af69bb5c2ac2161434d8fea45f920f8f359587ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "deepfire",
-        "repo": "em",
-        "type": "github"
-      }
-    },
     "empty-flake": {
       "locked": {
         "lastModified": 1630400035,
@@ -934,6 +880,22 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
         "lastModified": 1647532380,
         "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
         "owner": "input-output-hk",
@@ -944,23 +906,6 @@
       "original": {
         "owner": "input-output-hk",
         "ref": "fixes",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1672831974,
-        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "hkm/gitlab-fix",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -983,6 +928,23 @@
       }
     },
     "flake-compat_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_8": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -1123,23 +1085,8 @@
       }
     },
     "flake-utils_3": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1155,44 +1102,58 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
+    "flake-utils_4": {
       "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk_2": {
-      "flake": false,
+    "flake-utils_5": {
       "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
     "ghc-wasm-meta": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_5"
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "host": "gitlab.haskell.org",
@@ -1210,88 +1171,14 @@
         "type": "gitlab"
       }
     },
-    "ghc910X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714520650,
-        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
-        "ref": "ghc-9.10",
-        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
-        "revCount": 62663,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.10",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc910X_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714520650,
-        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
-        "ref": "ghc-9.10",
-        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
-        "revCount": 62663,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.10",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc911": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714817013,
-        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
-        "ref": "refs/heads/master",
-        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
-        "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc911_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714817013,
-        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
-        "ref": "refs/heads/master",
-        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
-        "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1768177814,
-        "narHash": "sha256-J5mkUye2ijGqF+b8UlMlibzIGJJgq8JGGrrr6sWlj64=",
+        "lastModified": 1777942856,
+        "narHash": "sha256-uNleQgyctFm13GstMF0HiO4trN/4lQWroPYlfQJO7kM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6154887c84c5051677eff7ff60643907d8d9d0d7",
+        "rev": "b6b4aa4bd699f743238da45c7f43da5a26a822f7",
         "type": "github"
       },
       "original": {
@@ -1303,11 +1190,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1768177803,
-        "narHash": "sha256-uu9PgCRezG6Bjk4Pes9eKwxIZ5GqO1Mbngx5ZCvu/+U=",
+        "lastModified": 1755649550,
+        "narHash": "sha256-YNKeqYIezur2MvPmfVI/aHjcVRwOdBW7Du3jg6iXjKs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "477a7ed0449f898b88e79eff138f9146eab0e1fe",
+        "rev": "5e56db8bc478dfb7466ea83744c3ab928aff0329",
         "type": "github"
       },
       "original": {
@@ -1320,11 +1207,11 @@
     "hackage-for-stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1768177803,
-        "narHash": "sha256-uu9PgCRezG6Bjk4Pes9eKwxIZ5GqO1Mbngx5ZCvu/+U=",
+        "lastModified": 1779670489,
+        "narHash": "sha256-V79+7GYDnAex4lec1wGtqfTMIkK93VxfBbvZK9rniGU=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "477a7ed0449f898b88e79eff138f9146eab0e1fe",
+        "rev": "fd3ef2653822f5fec20f4f691983118fcf4dede2",
         "type": "github"
       },
       "original": {
@@ -1337,11 +1224,45 @@
     "hackage-for-stackage_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1768177803,
-        "narHash": "sha256-uu9PgCRezG6Bjk4Pes9eKwxIZ5GqO1Mbngx5ZCvu/+U=",
+        "lastModified": 1755649550,
+        "narHash": "sha256-YNKeqYIezur2MvPmfVI/aHjcVRwOdBW7Du3jg6iXjKs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "477a7ed0449f898b88e79eff138f9146eab0e1fe",
+        "rev": "5e56db8bc478dfb7466ea83744c3ab928aff0329",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777941947,
+        "narHash": "sha256-lv/D6tAU+kOARnDutmRqBKeES+YtngYnfRwuEciqGlw=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "c790aeedf8b119a2cce4c085a4274ab570942bfd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777941947,
+        "narHash": "sha256-lv/D6tAU+kOARnDutmRqBKeES+YtngYnfRwuEciqGlw=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "c790aeedf8b119a2cce4c085a4274ab570942bfd",
         "type": "github"
       },
       "original": {
@@ -1399,19 +1320,50 @@
         "type": "github"
       }
     },
-    "hackageNix": {
+    "hackage-internal_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1745281520,
-        "narHash": "sha256-dk/70Cmjx8fGSURcAHQnowETeAOElzDxn0wH/P4DUWA=",
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4c98778277c642e326b3cb7c2c9cbb9163b9ffbd",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1759154585,
+        "narHash": "sha256-OC5Y3E20bwkfMVlB2uhf7eF/FcuC1JD/BXkxR8rMjR4=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "7e61ac3eb4cc042b37c6511b65984f59fe6d40de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
         "repo": "hackage.nix",
         "type": "github"
       }
@@ -1419,28 +1371,11 @@
     "hackageNix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1745281520,
-        "narHash": "sha256-dk/70Cmjx8fGSURcAHQnowETeAOElzDxn0wH/P4DUWA=",
+        "lastModified": 1771502057,
+        "narHash": "sha256-XwoLg6wftnU50KPn5jY4jtuGulyNPyspB4lSDSrmR1g=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4c98778277c642e326b3cb7c2c9cbb9163b9ffbd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "for-stackage",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "hackage_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1768177814,
-        "narHash": "sha256-J5mkUye2ijGqF+b8UlMlibzIGJJgq8JGGrrr6sWlj64=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "6154887c84c5051677eff7ff60643907d8d9d0d7",
+        "rev": "e6bb05af1f45a616f534798263a5a13f2299e3bc",
         "type": "github"
       },
       "original": {
@@ -1449,19 +1384,68 @@
         "type": "github"
       }
     },
-    "hackage_3": {
+    "hackageNix_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1768177814,
-        "narHash": "sha256-J5mkUye2ijGqF+b8UlMlibzIGJJgq8JGGrrr6sWlj64=",
+        "lastModified": 1779707008,
+        "narHash": "sha256-POnWEkqluw3nVOmcKagk3MNY6XWGJL7E1JFKYqorAmo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6154887c84c5051677eff7ff60643907d8d9d0d7",
+        "rev": "3b3bc29ed7432aac7c1f8aa5472afc8fd340e0e8",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1759154585,
+        "narHash": "sha256-OC5Y3E20bwkfMVlB2uhf7eF/FcuC1JD/BXkxR8rMjR4=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "7e61ac3eb4cc042b37c6511b65984f59fe6d40de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771502057,
+        "narHash": "sha256-XwoLg6wftnU50KPn5jY4jtuGulyNPyspB4lSDSrmR1g=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "e6bb05af1f45a616f534798263a5a13f2299e3bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777942856,
+        "narHash": "sha256-uNleQgyctFm13GstMF0HiO4trN/4lQWroPYlfQJO7kM=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "b6b4aa4bd699f743238da45c7f43da5a26a822f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "b6b4aa4bd699f743238da45c7f43da5a26a822f7",
         "type": "github"
       }
     },
@@ -1473,16 +1457,18 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_2",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc910X": "ghc910X",
-        "ghc911": "ghc911",
         "hackage": [
           "cardano-mpfs-onchain",
           "cardano-node",
           "hackageNix"
         ],
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -1490,56 +1476,55 @@
         "hls-2.6": "hls-2.6",
         "hls-2.7": "hls-2.7",
         "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "cardano-mpfs-onchain",
           "cardano-node",
           "nixpkgs"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1718797200,
-        "narHash": "sha256-ueFxTuZrQ3ZT/Fj5sSeUWlqKa4+OkUU1xW0E+q/XTfw=",
+        "lastModified": 1762315551,
+        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
+        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
         "type": "github"
       }
     },
     "haskellNix_2": {
       "inputs": {
         "HTTP": "HTTP_2",
-        "cabal-32": "cabal-32_2",
         "cabal-34": "cabal-34_2",
         "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_2",
         "flake-compat": "flake-compat_3",
-        "hackage": "hackage",
-        "hackage-for-stackage": "hackage-for-stackage",
-        "hackage-internal": "hackage-internal",
-        "hls": "hls",
+        "hackage": [
+          "cardano-mpfs-onchain",
+          "hackageNix"
+        ],
+        "hackage-for-stackage": "hackage-for-stackage_2",
+        "hackage-internal": "hackage-internal_2",
+        "hls": "hls_2",
         "hls-1.10": "hls-1.10_2",
         "hls-2.0": "hls-2.0_2",
-        "hls-2.10": "hls-2.10",
-        "hls-2.11": "hls-2.11",
+        "hls-2.10": "hls-2.10_2",
+        "hls-2.11": "hls-2.11_2",
         "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2_2",
         "hls-2.3": "hls-2.3_2",
@@ -1548,7 +1533,7 @@
         "hls-2.6": "hls-2.6_2",
         "hls-2.7": "hls-2.7_2",
         "hls-2.8": "hls-2.8_2",
-        "hls-2.9": "hls-2.9",
+        "hls-2.9": "hls-2.9_2",
         "hpc-coveralls": "hpc-coveralls_2",
         "iserv-proxy": "iserv-proxy_2",
         "nixpkgs": [
@@ -1558,47 +1543,49 @@
         ],
         "nixpkgs-2305": "nixpkgs-2305_2",
         "nixpkgs-2311": "nixpkgs-2311_2",
-        "nixpkgs-2405": "nixpkgs-2405",
-        "nixpkgs-2411": "nixpkgs-2411",
-        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2405": "nixpkgs-2405_2",
+        "nixpkgs-2411": "nixpkgs-2411_2",
+        "nixpkgs-2505": "nixpkgs-2505_2",
         "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "old-ghc-nix": "old-ghc-nix_2",
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1768179148,
-        "narHash": "sha256-gd6fDUvmYv3/9HiuBH8g1weJcTQUlYpsON3ZeY2Wais=",
+        "lastModified": 1779672478,
+        "narHash": "sha256-j9XpaWEZDpdCrFJWCxUS/m6AQNQfm7bFR8j5BGFokTQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "rev": "04f3b8ad4063be341cb773e79c3ff3d88f2cb6d7",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "rev": "04f3b8ad4063be341cb773e79c3ff3d88f2cb6d7",
         "type": "github"
       }
     },
     "haskellNix_3": {
       "inputs": {
         "HTTP": "HTTP_3",
-        "cabal-32": "cabal-32_3",
+        "cabal-32": "cabal-32_2",
         "cabal-34": "cabal-34_3",
         "cabal-36": "cabal-36_3",
         "cardano-shell": "cardano-shell_3",
-        "flake-compat": "flake-compat_5",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
-        "ghc910X": "ghc910X_2",
-        "ghc911": "ghc911_2",
+        "flake-compat": "flake-compat_6",
         "hackage": [
           "cardano-node-clients",
           "cardano-node",
           "hackageNix"
         ],
+        "hackage-for-stackage": "hackage-for-stackage_3",
+        "hackage-internal": "hackage-internal_3",
+        "hls": "hls_3",
         "hls-1.10": "hls-1.10_3",
         "hls-2.0": "hls-2.0_3",
+        "hls-2.10": "hls-2.10_3",
+        "hls-2.11": "hls-2.11_3",
         "hls-2.2": "hls-2.2_3",
         "hls-2.3": "hls-2.3_3",
         "hls-2.4": "hls-2.4_3",
@@ -1606,56 +1593,55 @@
         "hls-2.6": "hls-2.6_3",
         "hls-2.7": "hls-2.7_3",
         "hls-2.8": "hls-2.8_3",
+        "hls-2.9": "hls-2.9_3",
         "hpc-coveralls": "hpc-coveralls_3",
-        "hydra": "hydra_2",
         "iserv-proxy": "iserv-proxy_3",
         "nixpkgs": [
           "cardano-node-clients",
           "cardano-node",
           "nixpkgs"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_2",
-        "nixpkgs-2105": "nixpkgs-2105_2",
-        "nixpkgs-2111": "nixpkgs-2111_2",
-        "nixpkgs-2205": "nixpkgs-2205_2",
-        "nixpkgs-2211": "nixpkgs-2211_2",
         "nixpkgs-2305": "nixpkgs-2305_3",
         "nixpkgs-2311": "nixpkgs-2311_3",
+        "nixpkgs-2405": "nixpkgs-2405_3",
+        "nixpkgs-2411": "nixpkgs-2411_3",
+        "nixpkgs-2505": "nixpkgs-2505_3",
         "nixpkgs-unstable": "nixpkgs-unstable_3",
         "old-ghc-nix": "old-ghc-nix_3",
         "stackage": "stackage_3"
       },
       "locked": {
-        "lastModified": 1718797200,
-        "narHash": "sha256-ueFxTuZrQ3ZT/Fj5sSeUWlqKa4+OkUU1xW0E+q/XTfw=",
+        "lastModified": 1762315551,
+        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
+        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
         "type": "github"
       }
     },
     "haskellNix_4": {
       "inputs": {
         "HTTP": "HTTP_4",
-        "cabal-32": "cabal-32_4",
         "cabal-34": "cabal-34_4",
         "cabal-36": "cabal-36_4",
         "cardano-shell": "cardano-shell_4",
-        "flake-compat": "flake-compat_6",
-        "hackage": "hackage_2",
-        "hackage-for-stackage": "hackage-for-stackage_2",
-        "hackage-internal": "hackage-internal_2",
-        "hls": "hls_2",
+        "flake-compat": "flake-compat_7",
+        "hackage": [
+          "cardano-node-clients",
+          "hackageNix"
+        ],
+        "hackage-for-stackage": "hackage-for-stackage_4",
+        "hackage-internal": "hackage-internal_4",
+        "hls": "hls_4",
         "hls-1.10": "hls-1.10_4",
         "hls-2.0": "hls-2.0_4",
-        "hls-2.10": "hls-2.10_2",
-        "hls-2.11": "hls-2.11_2",
+        "hls-2.10": "hls-2.10_4",
+        "hls-2.11": "hls-2.11_4",
         "hls-2.12": "hls-2.12_2",
         "hls-2.2": "hls-2.2_4",
         "hls-2.3": "hls-2.3_4",
@@ -1664,7 +1650,7 @@
         "hls-2.6": "hls-2.6_4",
         "hls-2.7": "hls-2.7_4",
         "hls-2.8": "hls-2.8_4",
-        "hls-2.9": "hls-2.9_2",
+        "hls-2.9": "hls-2.9_4",
         "hpc-coveralls": "hpc-coveralls_4",
         "iserv-proxy": "iserv-proxy_4",
         "nixpkgs": [
@@ -1674,45 +1660,44 @@
         ],
         "nixpkgs-2305": "nixpkgs-2305_4",
         "nixpkgs-2311": "nixpkgs-2311_4",
-        "nixpkgs-2405": "nixpkgs-2405_2",
-        "nixpkgs-2411": "nixpkgs-2411_2",
-        "nixpkgs-2505": "nixpkgs-2505_2",
+        "nixpkgs-2405": "nixpkgs-2405_4",
+        "nixpkgs-2411": "nixpkgs-2411_4",
+        "nixpkgs-2505": "nixpkgs-2505_4",
         "nixpkgs-2511": "nixpkgs-2511_2",
         "nixpkgs-unstable": "nixpkgs-unstable_4",
         "old-ghc-nix": "old-ghc-nix_4",
         "stackage": "stackage_4"
       },
       "locked": {
-        "lastModified": 1768179148,
-        "narHash": "sha256-gd6fDUvmYv3/9HiuBH8g1weJcTQUlYpsON3ZeY2Wais=",
+        "lastModified": 1777977445,
+        "narHash": "sha256-2MvOtjkuTdhqZnZI0g8HuvACrZKpGq0/4EESqsWt9ag=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "rev": "8b447d7f57d62fab9249f79bb916bc891e29b9d0",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "rev": "8b447d7f57d62fab9249f79bb916bc891e29b9d0",
         "type": "github"
       }
     },
     "haskellNix_5": {
       "inputs": {
         "HTTP": "HTTP_5",
-        "cabal-32": "cabal-32_5",
         "cabal-34": "cabal-34_5",
         "cabal-36": "cabal-36_5",
         "cardano-shell": "cardano-shell_5",
-        "flake-compat": "flake-compat_7",
-        "hackage": "hackage_3",
-        "hackage-for-stackage": "hackage-for-stackage_3",
-        "hackage-internal": "hackage-internal_3",
-        "hls": "hls_3",
+        "flake-compat": "flake-compat_8",
+        "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage_5",
+        "hackage-internal": "hackage-internal_5",
+        "hls": "hls_5",
         "hls-1.10": "hls-1.10_5",
         "hls-2.0": "hls-2.0_5",
-        "hls-2.10": "hls-2.10_3",
-        "hls-2.11": "hls-2.11_3",
+        "hls-2.10": "hls-2.10_5",
+        "hls-2.11": "hls-2.11_5",
         "hls-2.12": "hls-2.12_3",
         "hls-2.2": "hls-2.2_5",
         "hls-2.3": "hls-2.3_5",
@@ -1721,7 +1706,7 @@
         "hls-2.6": "hls-2.6_5",
         "hls-2.7": "hls-2.7_5",
         "hls-2.8": "hls-2.8_5",
-        "hls-2.9": "hls-2.9_3",
+        "hls-2.9": "hls-2.9_5",
         "hpc-coveralls": "hpc-coveralls_5",
         "iserv-proxy": "iserv-proxy_5",
         "nixpkgs": [
@@ -1730,25 +1715,26 @@
         ],
         "nixpkgs-2305": "nixpkgs-2305_5",
         "nixpkgs-2311": "nixpkgs-2311_5",
-        "nixpkgs-2405": "nixpkgs-2405_3",
-        "nixpkgs-2411": "nixpkgs-2411_3",
-        "nixpkgs-2505": "nixpkgs-2505_3",
+        "nixpkgs-2405": "nixpkgs-2405_5",
+        "nixpkgs-2411": "nixpkgs-2411_5",
+        "nixpkgs-2505": "nixpkgs-2505_5",
         "nixpkgs-2511": "nixpkgs-2511_3",
         "nixpkgs-unstable": "nixpkgs-unstable_5",
         "old-ghc-nix": "old-ghc-nix_5",
         "stackage": "stackage_5"
       },
       "locked": {
-        "lastModified": 1768179148,
-        "narHash": "sha256-gd6fDUvmYv3/9HiuBH8g1weJcTQUlYpsON3ZeY2Wais=",
+        "lastModified": 1777977445,
+        "narHash": "sha256-2MvOtjkuTdhqZnZI0g8HuvACrZKpGq0/4EESqsWt9ag=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "baa6a549ce876e9c44c494a12116f178f1becbe6",
+        "rev": "8b447d7f57d62fab9249f79bb916bc891e29b9d0",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "rev": "8b447d7f57d62fab9249f79bb916bc891e29b9d0",
         "type": "github"
       }
     },
@@ -1989,6 +1975,40 @@
         "type": "github"
       }
     },
+    "hls-2.10_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.11": {
       "flake": false,
       "locked": {
@@ -2024,6 +2044,40 @@
       }
     },
     "hls-2.11_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11_5": {
       "flake": false,
       "locked": {
         "lastModified": 1747306193,
@@ -2737,6 +2791,40 @@
         "type": "github"
       }
     },
+    "hls-2.9_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls_2": {
       "flake": false,
       "locked": {
@@ -2754,6 +2842,38 @@
       }
     },
     "hls_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_5": {
       "flake": false,
       "locked": {
         "lastModified": 1741604408,
@@ -2849,56 +2969,6 @@
         "type": "github"
       }
     },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "cardano-mpfs-onchain",
-          "cardano-node",
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "hydra_2": {
-      "inputs": {
-        "nix": "nix_2",
-        "nixpkgs": [
-          "cardano-node-clients",
-          "cardano-node",
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
     "incl": {
       "inputs": {
         "nixlib": "nixlib"
@@ -2947,16 +3017,15 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1769466714,
-        "narHash": "sha256-BORSlRJKEmYWHaNqEEUeM8b6pgNVzknFELMKM3rjyE8=",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f3ecc51c92ab72658c9b3b7289cfcc8a820a6316",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "cardano-node-release/10.5.4",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -2998,16 +3067,15 @@
         "sodium": "sodium_3"
       },
       "locked": {
-        "lastModified": 1769466714,
-        "narHash": "sha256-BORSlRJKEmYWHaNqEEUeM8b6pgNVzknFELMKM3rjyE8=",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f3ecc51c92ab72658c9b3b7289cfcc8a820a6316",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "cardano-node-release/10.5.4",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -3023,17 +3091,17 @@
         "sodium": "sodium_4"
       },
       "locked": {
-        "lastModified": 1770069549,
-        "narHash": "sha256-jHgw8KL0/TFGY2aVwxhD0DeDq7sl5Ti7jAp8T3RLNb0=",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0ce7cc21b9a4cfde41871ef486d01a8fafbf9627",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0ce7cc21b9a4cfde41871ef486d01a8fafbf9627",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       }
     },
@@ -3063,11 +3131,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "lastModified": 1755040634,
+        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
         "type": "github"
       },
       "original": {
@@ -3080,11 +3148,11 @@
     "iserv-proxy_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "lastModified": 1775620557,
+        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
         "type": "github"
       },
       "original": {
@@ -3097,11 +3165,11 @@
     "iserv-proxy_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "lastModified": 1755040634,
+        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
         "type": "github"
       },
       "original": {
@@ -3114,11 +3182,11 @@
     "iserv-proxy_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "lastModified": 1775620557,
+        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
         "type": "github"
       },
       "original": {
@@ -3131,11 +3199,11 @@
     "iserv-proxy_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "lastModified": 1775620557,
+        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
         "type": "github"
       },
       "original": {
@@ -3145,42 +3213,26 @@
         "type": "github"
       }
     },
-    "lowdown-src": {
-      "flake": false,
+    "lintNixpkgs": {
       "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       },
       "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "lowdown-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       }
     },
     "mkdocs": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "dir": "mkdocs",
@@ -3201,7 +3253,7 @@
     "mkdocs_2": {
       "inputs": {
         "flake-parts": "flake-parts_5",
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "dir": "mkdocs",
@@ -3219,45 +3271,69 @@
         "type": "github"
       }
     },
-    "nix": {
+    "nix-appimage": {
       "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-regression": "nixpkgs-regression"
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "cardano-node-clients",
+          "bundlers",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "lastModified": 1757920913,
+        "narHash": "sha256-jd0QwCVz4O1sHHkeaZILD/7D6oyalceEJ4EFnWCgm0k=",
+        "owner": "ralismark",
+        "repo": "nix-appimage",
+        "rev": "7946addbc0d97e358a6d7aefe5e82310f0fe6b18",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
+        "owner": "ralismark",
+        "repo": "nix-appimage",
         "type": "github"
       }
     },
-    "nix_2": {
+    "nix-bundle": {
       "inputs": {
-        "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_3",
-        "nixpkgs-regression": "nixpkgs-regression_2"
+        "nixpkgs": [
+          "cardano-node-clients",
+          "bundlers",
+          "nixpkgs"
+        ],
+        "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "lastModified": 1756736056,
+        "narHash": "sha256-8YFhvulVX3iS4TYnKisA9zSImJeFN21G75HOUUFjzuE=",
+        "owner": "nix-community",
+        "repo": "nix-bundle",
+        "rev": "eff01593f62794d458ec714090091419194ab64d",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
+        "owner": "nix-community",
+        "repo": "nix-bundle",
+        "type": "github"
+      }
+    },
+    "nix-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1744222205,
+        "narHash": "sha256-di1eNHQdpvvyXv6i7Z+S79KF7cQyhTs7AdFHp7q1e3Q=",
+        "owner": "juliosueiras-nix",
+        "repo": "nix-utils",
+        "rev": "53282197ad090c8cf47c96e99bf6c6c3b2cdc7c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juliosueiras-nix",
+        "repo": "nix-utils",
         "type": "github"
       }
     },
@@ -3307,173 +3383,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003_2": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105_2": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111_2": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205_2": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211_2": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -3501,11 +3417,11 @@
     },
     "nixpkgs-2305_3": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -3549,11 +3465,11 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
@@ -3581,11 +3497,11 @@
     },
     "nixpkgs-2311_3": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
@@ -3675,13 +3591,45 @@
         "type": "github"
       }
     },
-    "nixpkgs-2411": {
+    "nixpkgs-2405_4": {
       "locked": {
-        "lastModified": 1751290243,
-        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405_5": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {
@@ -3709,6 +3657,38 @@
     },
     "nixpkgs-2411_3": {
       "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411_4": {
+      "locked": {
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411_5": {
+      "locked": {
         "lastModified": 1751290243,
         "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
@@ -3725,11 +3705,11 @@
     },
     "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1764560356,
-        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "lastModified": 1748852332,
+        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
         "type": "github"
       },
       "original": {
@@ -3757,6 +3737,38 @@
     },
     "nixpkgs-2505_3": {
       "locked": {
+        "lastModified": 1748852332,
+        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505_4": {
+      "locked": {
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505_5": {
+      "locked": {
         "lastModified": 1764560356,
         "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
         "owner": "NixOS",
@@ -3773,11 +3785,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
         "type": "github"
       },
       "original": {
@@ -3789,11 +3801,11 @@
     },
     "nixpkgs-2511_2": {
       "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
         "type": "github"
       },
       "original": {
@@ -3805,11 +3817,11 @@
     },
     "nixpkgs-2511_3": {
       "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
         "type": "github"
       },
       "original": {
@@ -3894,61 +3906,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_2": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -3960,27 +3940,27 @@
     },
     "nixpkgs-unstable_3": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
     "nixpkgs-unstable_4": {
       "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -3992,11 +3972,11 @@
     },
     "nixpkgs-unstable_5": {
       "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -4008,37 +3988,20 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
+        "lastModified": 1629252929,
+        "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "3788c68def67ca7949e0864c27638d484389363d",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
+        "owner": "nixos",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
       "locked": {
         "lastModified": 1763678758,
         "narHash": "sha256-+hBiJ+kG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s=",
@@ -4054,7 +4017,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1778424306,
         "narHash": "sha256-pMBBOyJ/68QtWKArOtS2RNxGJj1TkPmyMg9dIltwkPM=",
@@ -4070,7 +4033,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1763678758,
         "narHash": "sha256-+hBiJ+kG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s=",
@@ -4365,11 +4328,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1718756571,
-        "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
+        "lastModified": 1755648773,
+        "narHash": "sha256-NhcOu6GwYal+awBQLoMT4vf7L7Ar1DectDjK2mF653I=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "027672fb6fd45828b0e623c8152572d4058429ad",
+        "rev": "1a0ea16d99761b93456460c255a8b723647b2c77",
         "type": "github"
       },
       "original": {
@@ -4381,11 +4344,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1768176911,
-        "narHash": "sha256-YDkcATzxXclYCQMzpph73BsoWxoCYa4KWW9zboEfTd4=",
+        "lastModified": 1779669434,
+        "narHash": "sha256-rrP7cIZtSF9B9V1CHWbt/TWvtq96Yz9iHp/eXry4Enk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "032bfc7f4fee092347cad9a7acb6c6393e29fddf",
+        "rev": "944481687c38d3f802d1f9456f38c1fdf3a8bc41",
         "type": "github"
       },
       "original": {
@@ -4397,11 +4360,11 @@
     "stackage_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1718756571,
-        "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
+        "lastModified": 1755648773,
+        "narHash": "sha256-NhcOu6GwYal+awBQLoMT4vf7L7Ar1DectDjK2mF653I=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "027672fb6fd45828b0e623c8152572d4058429ad",
+        "rev": "1a0ea16d99761b93456460c255a8b723647b2c77",
         "type": "github"
       },
       "original": {
@@ -4413,11 +4376,11 @@
     "stackage_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1768176911,
-        "narHash": "sha256-YDkcATzxXclYCQMzpph73BsoWxoCYa4KWW9zboEfTd4=",
+        "lastModified": 1777941049,
+        "narHash": "sha256-QyXmYtr1Sqzezfot7ARd5OL/0sMot/cybcZJh7EmYE0=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "032bfc7f4fee092347cad9a7acb6c6393e29fddf",
+        "rev": "aeb46c4a0af96a116fb0c9dc54cfae2fd6e01a39",
         "type": "github"
       },
       "original": {
@@ -4429,11 +4392,11 @@
     "stackage_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1768176911,
-        "narHash": "sha256-YDkcATzxXclYCQMzpph73BsoWxoCYa4KWW9zboEfTd4=",
+        "lastModified": 1777941049,
+        "narHash": "sha256-QyXmYtr1Sqzezfot7ARd5OL/0sMot/cybcZJh7EmYE0=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "032bfc7f4fee092347cad9a7acb6c6393e29fddf",
+        "rev": "aeb46c4a0af96a116fb0c9dc54cfae2fd6e01a39",
         "type": "github"
       },
       "original": {
@@ -4502,6 +4465,36 @@
         "type": "github"
       }
     },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "utils": {
       "inputs": {
         "systems": "systems"
@@ -4522,7 +4515,25 @@
     },
     "utils_2": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_3": {
+      "inputs": {
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1710146030,

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,8 @@
       [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
   };
   inputs = {
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+    haskellNix.url =
+      "github:input-output-hk/haskell.nix/8b447d7f57d62fab9249f79bb916bc891e29b9d0";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     mkdocs.url = "github:paolino/dev-assets?dir=mkdocs";
@@ -20,12 +21,13 @@
       flake = false;
     };
     cardano-node-clients = {
-      url = "github:lambdasistemi/cardano-node-clients";
+      url =
+        "github:lambdasistemi/cardano-node-clients/e4b01cb9efdf88e99934cf7a09fed0e25bad1019";
     };
     cardano-node.follows = "cardano-node-clients/cardano-node";
     cardano-mpfs-onchain = {
       url =
-        "github:cardano-foundation/cardano-mpfs-onchain/023d352e850f866752927818da44861478ae99e5";
+        "github:cardano-foundation/cardano-mpfs-onchain/457c1cbcbbf622d0e583a3e9c0b413de079f315a";
     };
     ghc-wasm-meta.url =
       "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org";
@@ -46,6 +48,7 @@
                 haskellNix.overlay
                 iohkNix.overlays.haskell-nix-crypto
                 iohkNix.overlays.cardano-lib
+                (_final: prev: { lzma = prev.xz; })
               ];
               inherit system;
             };
@@ -54,9 +57,9 @@
             devnet-genesis =
               cardano-node-clients.packages.${system}.devnet-genesis;
             project = import ./nix/project.nix {
-              indexState = "2025-12-07T00:00:00Z";
-              inherit CHaP pkgs cardano-node-pkgs mpfs-blueprint devnet-genesis
-                version;
+              indexState = "2026-04-17T00:00:00Z";
+              inherit CHaP pkgs system cardano-node-pkgs mpfs-blueprint
+                devnet-genesis version;
               mkdocs = mkdocs.packages.${system};
               asciinema = asciinema.packages.${system};
             };

--- a/nix/haddock.nix
+++ b/nix/haddock.nix
@@ -10,7 +10,7 @@
 
 let
   haddock =
-    pkgs.buildPackages.haskell-nix.compiler.ghc984.passthru.haddock or pkgs.haskellPackages.haddock;
+    pkgs.buildPackages.haskell-nix.compiler.ghc9123.passthru.haddock or pkgs.haskellPackages.haddock;
 
   offchainDoc = project.hsPkgs.cardano-mpfs-offchain.components.library.doc;
 
@@ -19,7 +19,7 @@ let
   offchainHtml = "${offchainDoc}/share/doc/${offchainName}/html";
 
 in pkgs.runCommand "combined-haddock" {
-  nativeBuildInputs = [ pkgs.haskell-nix.compiler.ghc984 ];
+  nativeBuildInputs = [ pkgs.haskell-nix.compiler.ghc9123 ];
 } ''
   mkdir -p $out
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,24 +1,37 @@
-{ CHaP, indexState, pkgs, mkdocs, asciinema, cardano-node-pkgs, mpfs-blueprint
-, devnet-genesis, version ? "dev", ... }:
+{ CHaP, indexState, pkgs, system, mkdocs, asciinema, cardano-node-pkgs
+, mpfs-blueprint, devnet-genesis, version ? "dev", ... }:
 
 let
+  isLinux = system == "x86_64-linux";
   indexTool = { index-state = indexState; };
-  tool = name: pkgs.haskell-nix.tool "ghc984" name indexTool;
-  fix-libs = { lib, pkgs, ... }: {
-    packages.cardano-crypto-praos.components.library.pkgconfig =
-      lib.mkForce [ [ pkgs.libsodium-vrf ] ];
-    packages.cardano-crypto-class.components.library.pkgconfig =
-      lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ]];
-    packages.lzma.components.library.libs = lib.mkForce [ pkgs.xz ];
-  };
+  toolArgs = name:
+    indexTool // pkgs.lib.optionalAttrs (name == "cabal-fmt") {
+      cabalProjectLocal = ''
+        allow-newer: cabal-fmt:base
+      '';
+    };
+  tool = name: pkgs.haskell-nix.tool "ghc9123" name (toolArgs name);
+  fix-libs = { lib, pkgs, ... }:
+    {
+      packages.cardano-crypto-praos.components.library.pkgconfig =
+        lib.mkForce [ [ pkgs.libsodium-vrf ] ];
+      packages.cardano-crypto-class.components.library.pkgconfig =
+        lib.mkForce [[ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ]];
+      packages.cardano-lmdb.components.library.pkgconfig =
+        lib.mkForce [ [ pkgs.lmdb ] ];
+      packages.lzma.components.library.libs = lib.mkForce [ pkgs.xz ];
+    } // lib.optionalAttrs isLinux {
+      packages.blockio-uring.components.library.pkgconfig =
+        lib.mkForce [ [ pkgs.liburing ] ];
+    };
   shell = { pkgs, ... }: {
     tools = {
-      cabal = indexTool;
-      cabal-fmt = indexTool;
-      haskell-language-server = indexTool;
-      hoogle = indexTool;
-      fourmolu = indexTool;
-      hlint = indexTool;
+      cabal = toolArgs "cabal";
+      cabal-fmt = toolArgs "cabal-fmt";
+      haskell-language-server = toolArgs "haskell-language-server";
+      hoogle = toolArgs "hoogle";
+      fourmolu = toolArgs "fourmolu";
+      hlint = toolArgs "hlint";
     };
     withHoogle = true;
     buildInputs = [
@@ -35,7 +48,9 @@ let
       cardano-node-pkgs.cardano-node
       cardano-node-pkgs.cardano-cli
       pkgs.aiken
-    ];
+      pkgs.lmdb
+      pkgs.xz
+    ] ++ pkgs.lib.optionals isLinux [ pkgs.liburing ];
     shellHook = ''
       echo "Entering cardano-mpfs-offchain dev shell"
       export MPFS_BLUEPRINT="${mpfs-blueprint}"
@@ -46,7 +61,7 @@ let
   mkProject = ctx@{ lib, pkgs, ... }: {
     name = "cardano-mpfs-offchain";
     src = ./..;
-    compiler-nix-name = "ghc984";
+    compiler-nix-name = "ghc9123";
     shell = shell { inherit pkgs; };
     modules = [ fix-libs ];
     inputMap = { "https://chap.intersectmbo.org/" = CHaP; };

--- a/nix/wasm/forks.json
+++ b/nix/wasm/forks.json
@@ -74,8 +74,8 @@
     },
     "cardano-tx-tools": {
       "location": "https://github.com/lambdasistemi/cardano-tx-tools",
-      "rev": "69ef635b1bd4815c7d5f718de738dd9ec4a9d61e",
-      "sha256": "06xply3i1s1h6kivyng5dx4j8yk5zzhvmdhcgc3dz90h2c0zr7np",
+      "rev": "db2da7c469df782041aba2531c4abcf4c4483418",
+      "sha256": "1r4y5fgahxs4mrxdijc6xa6xic9fm193blpgxf6mizaj26nghyzk",
       "subdirs": []
     }
   },


### PR DESCRIPTION
## Summary

- Bumps the MPFS offchain stack onto the May 2026 coordinated Cardano pins, including consensus 1.0-era package splits, `cardano-crypto-class` 2.3, ledger 1.19+ APIs, `cardano-node-clients`, `cardano-utxo-csmt`, `cardano-ledger-read`, and `cardano-tx-tools`.
- Keeps the native toolchain on GHC 9.12.3 only and keeps Hoogle enabled in the dev shell.
- Migrates production/server and pure client transaction builders to the `Cardano.Tx.Build` DSL, with post-balance redeemer re-keying for DSL-built client update/reject/retract transactions.
- Updates Conway ledger API drift: `ConwayTx`, compact `CoinPerByte`, fee lenses, `computeScriptIntegrity`, `decodeFullAnnotator`, and consensus block-body access.

Closes #297.

## Verification

- `nix develop --quiet -c sh -lc 'printf "ghc="; ghc --numeric-version; printf "hoogle="; hoogle --version'`
  - `ghc=9.12.3`
  - `hoogle=Hoogle 5.0.19.0`
- `rg -n "ghc[0-9]{3,4}|compiler\\.ghc|compiler-nix-name|withHoogle|hoogle" flake.nix nix cabal.project cabal-wasm.project cardano-mpfs-cli/cardano-mpfs-cli.cabal cardano-mpfs-client/cardano-mpfs-client.cabal cardano-mpfs-offchain/cardano-mpfs-offchain.cabal`
  - only `ghc9123` remains; Hoogle is enabled.
- `rg -n "mkBasicTxBody|mkBasicTx\\b|Cardano\\.Node\\.Client\\.(Balance|TxBuild)" cardano-mpfs-client/lib cardano-mpfs-offchain/lib cardano-mpfs-cli/lib`
  - no production/client builder fallback found.
- `nix run .#format-check`
- `nix run .#hlint`
  - `No hints`
- `git diff --check`
- `nix eval .#haddock.drvPath`
- `nix develop --quiet -c cabal --store-dir=/tmp/epic-287/297/cabal-store-ghc9123 test all`
  - CLI unit: 5 examples, 0 failures
  - workflows unit: 36 examples, 0 failures
  - client unit: 186 examples, 0 failures
  - offchain unit: 406 examples, 0 failures
  - e2e: 33 examples, 0 failures
