### PR TITLE
feat: read-side verifiers (verifyTokenState + verifyTokenFacts)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -51,8 +51,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: 13264a52b47e3a1f43a6ebeebd424a10f9e4466a
-  --sha256: 1bqgpxdy79ncsz8hyg2qyd7jnm8hqj4q8rq8mhr3iirix66c77fb
+  tag: 73a094ae3602e272bff11f07899dd951616fb0e7
+  --sha256: 1xzqkchzavs50shham0s0m7kr5k5qldc2dv04glkvrr7vgj6wsng
 
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -51,8 +51,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: 73a094ae3602e272bff11f07899dd951616fb0e7
-  --sha256: 1xzqkchzavs50shham0s0m7kr5k5qldc2dv04glkvrr7vgj6wsng
+  tag: 2893775286801e91afe10e14775507a36e97e169
+  --sha256: 1ipwx1xgbyp0fwyq90zp7j6habvl0164d08s4mfbixg40w15sd8w
 
 source-repository-package
   type: git

--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -161,6 +161,7 @@ test-suite unit-tests
     Cardano.MPFS.Client.SnapshotSpec
     Cardano.MPFS.Client.UpdateFactsSpec
     Cardano.MPFS.Client.Verify.ReactorSpec
+    Cardano.MPFS.Client.Verify.ReadSpec
     Cardano.MPFS.Client.Verify.WriteSpec
     Cardano.MPFS.Client.VerifySpec
 

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
@@ -16,9 +16,15 @@ import Data.ByteString.Base16 qualified as Base16
 import Data.Text.Encoding qualified as T
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
+import MPF.Hashes (renderMPFHash)
+import MPF.Test.Lib (insertByteStringM, runMPFPure')
+import MPF.Test.Lib qualified as MPFTest (getRootHashM)
+
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( ChainPointJSON (..)
+    , FactEntry (..)
+    , FactsResponse (..)
     , TokenResponse (..)
     , TokenStateJSON (..)
     , TxInJSON (..)
@@ -35,7 +41,8 @@ import Cardano.MPFS.Client.Fixtures
 import Cardano.MPFS.Client.Snapshot qualified as Snap
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Client.Verify.Read
-    ( verifyTokenState
+    ( verifyTokenFacts
+    , verifyTokenState
     )
 import Cardano.MPFS.Client.Verify.Replay (VerifyError (..))
 
@@ -58,12 +65,100 @@ spec = describe "Read-side verifiers" $ do
                 honestTrustedRoot
                 (tamperStateProof honestTokenResponse)
             `shouldSatisfy` isCsmtReplayFailed
+    describe "verifyTokenFacts" $ do
+        it "accepts an honest facts response with a complete fact set"
+            $ verifyTokenFactsUnit honestTrustedRoot honestFactsResponse
+            `shouldBe` Right ()
+        it "rejects a snapshot root that is not the trusted root"
+            $ verifyTokenFactsUnit foreignTrustedRoot honestFactsResponse
+            `shouldSatisfy` isTrustedRootMismatch
+        it "rejects a dropped fact (incomplete set)"
+            $ verifyTokenFactsUnit
+                honestTrustedRoot
+                (dropFirstFact honestFactsResponse)
+            `shouldSatisfy` isMpfReplayFailed
+        it "rejects an added spurious fact"
+            $ verifyTokenFactsUnit
+                honestTrustedRoot
+                (addSpuriousFact honestFactsResponse)
+            `shouldSatisfy` isMpfReplayFailed
+        it "rejects a tampered fact value"
+            $ verifyTokenFactsUnit
+                honestTrustedRoot
+                (tamperFirstFactValue honestFactsResponse)
+            `shouldSatisfy` isMpfReplayFailed
 
 -- | Discard the opaque witness so we can assert on @Right ()@.
 verifyTokenStateUnit
     :: TrustedRoot -> TokenResponse -> Either VerifyError ()
 verifyTokenStateUnit trusted =
     void . verifyTokenState trusted
+
+verifyTokenFactsUnit
+    :: TrustedRoot -> FactsResponse -> Either VerifyError ()
+verifyTokenFactsUnit trusted =
+    void . verifyTokenFacts trusted
+
+-- | The complete fact set for the honest token. The on-chain trie
+-- root is derived from these via the real MPF write backend, so the
+-- verifier's independent reconstruction must reproduce it.
+factEntries :: [(BS.ByteString, BS.ByteString)]
+factEntries =
+    [ ("apple", "fruit")
+    , ("banana", "yellow")
+    , ("cherry", "red")
+    ]
+
+-- | The MPF trie root of 'factEntries', computed by the genuine write
+-- backend (not the verifier's reconstruction path).
+honestFactsRoot :: BS.ByteString
+honestFactsRoot = fst $ runMPFPure' $ do
+    mapM_ (uncurry insertByteStringM) factEntries
+    maybe BS.empty renderMPFHash <$> MPFTest.getRootHashM
+
+honestFactsResponse :: FactsResponse
+honestFactsResponse =
+    FactsResponse
+        { frsSnapshot = honestSnapshot
+        , frsState =
+            WitnessedTokenState
+                { wtsUtxo =
+                    toApiWitnessedUtxo (bundleFunding honestWitness)
+                , wtsState =
+                    TokenStateJSON
+                        { owner = "owner"
+                        , root = Hex honestFactsRoot
+                        , tip = 1000000
+                        , processTime = 60000
+                        , retractTime = 30000
+                        }
+                }
+        , frsFacts =
+            [FactEntry{feKey = Hex k, feValue = Hex v} | (k, v) <- factEntries]
+        }
+
+-- | Drop a fact so the enumerated set is incomplete.
+dropFirstFact :: FactsResponse -> FactsResponse
+dropFirstFact resp = resp{frsFacts = drop 1 (frsFacts resp)}
+
+-- | Add a fact that is not in the on-chain trie.
+addSpuriousFact :: FactsResponse -> FactsResponse
+addSpuriousFact resp =
+    resp
+        { frsFacts =
+            FactEntry{feKey = Hex "durian", feValue = Hex "spiky"}
+                : frsFacts resp
+        }
+
+-- | Tamper the value of the first fact, so its trie leaf — and thus
+-- the reconstructed root — diverges.
+tamperFirstFactValue :: FactsResponse -> FactsResponse
+tamperFirstFactValue resp =
+    resp{frsFacts = overFirst bumpValue (frsFacts resp)}
+  where
+    bumpValue entry = entry{feValue = flipHexByte (feValue entry)}
+    overFirst _ [] = []
+    overFirst f (x : xs) = f x : xs
 
 honestTrustedRoot :: TrustedRoot
 honestTrustedRoot = TrustedRoot (Hex (bundleRoot honestWitness))
@@ -132,6 +227,10 @@ isTrustedRootMismatch _ = False
 isCsmtReplayFailed :: Either VerifyError () -> Bool
 isCsmtReplayFailed (Left (CsmtReplayFailed _ _)) = True
 isCsmtReplayFailed _ = False
+
+isMpfReplayFailed :: Either VerifyError () -> Bool
+isMpfReplayFailed (Left (MpfReplayFailed _ _)) = True
+isMpfReplayFailed _ = False
 
 -- | Flip the first byte of a hex-wrapped bytestring.
 flipHexByte :: Hex -> Hex

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
@@ -1,0 +1,174 @@
+-- |
+-- Module      : Cardano.MPFS.Client.Verify.ReadSpec
+-- Description : Honest + forged corpus for the read-side verifiers.
+--
+-- Exercises 'verifyTokenState' (GET \/tokens\/:id) and
+-- 'verifyTokenFacts' (GET \/tokens\/:id\/facts) on honest fixtures
+-- built from the pure CSMT \/ MPF backends — each must accept — and
+-- on hand-forged variants that must reject with a matching
+-- 'VerifyError'.
+module Cardano.MPFS.Client.Verify.ReadSpec (spec) where
+
+import Control.Monad (void)
+import Data.Bits (xor)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Text.Encoding qualified as T
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( ChainPointJSON (..)
+    , TokenResponse (..)
+    , TokenStateJSON (..)
+    , TxInJSON (..)
+    , VerificationSnapshot (..)
+    , WitnessedTokenState (..)
+    , WitnessedUtxo (..)
+    )
+import Cardano.MPFS.Client.Bundle qualified as Bundle
+import Cardano.MPFS.Client.Fixtures
+    ( bundleFunding
+    , bundleRoot
+    , honestWitness
+    )
+import Cardano.MPFS.Client.Snapshot qualified as Snap
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Client.Verify.Read
+    ( verifyTokenState
+    )
+import Cardano.MPFS.Client.Verify.Replay (VerifyError (..))
+
+spec :: Spec
+spec = describe "Read-side verifiers" $ do
+    describe "verifyTokenState" $ do
+        it "accepts an honest token response"
+            $ verifyTokenStateUnit honestTrustedRoot honestTokenResponse
+            `shouldBe` Right ()
+        it "rejects a snapshot root that is not the trusted root"
+            $ verifyTokenStateUnit foreignTrustedRoot honestTokenResponse
+            `shouldSatisfy` isTrustedRootMismatch
+        it "rejects a tampered state tx_out (broken UTxO proof)"
+            $ verifyTokenStateUnit
+                honestTrustedRoot
+                (tamperStateTxOut honestTokenResponse)
+            `shouldSatisfy` isCsmtReplayFailed
+        it "rejects a tampered state inclusion proof"
+            $ verifyTokenStateUnit
+                honestTrustedRoot
+                (tamperStateProof honestTokenResponse)
+            `shouldSatisfy` isCsmtReplayFailed
+
+-- | Discard the opaque witness so we can assert on @Right ()@.
+verifyTokenStateUnit
+    :: TrustedRoot -> TokenResponse -> Either VerifyError ()
+verifyTokenStateUnit trusted =
+    void . verifyTokenState trusted
+
+honestTrustedRoot :: TrustedRoot
+honestTrustedRoot = TrustedRoot (Hex (bundleRoot honestWitness))
+
+foreignTrustedRoot :: TrustedRoot
+foreignTrustedRoot = TrustedRoot (Hex (BS.replicate 32 0x2a))
+
+honestTokenResponse :: TokenResponse
+honestTokenResponse =
+    TokenResponse
+        { trSnapshot = honestSnapshot
+        , trState =
+            WitnessedTokenState
+                { wtsUtxo =
+                    toApiWitnessedUtxo (bundleFunding honestWitness)
+                , wtsState =
+                    TokenStateJSON
+                        { owner = "owner"
+                        , root = Hex (BS.replicate 32 0x00)
+                        , tip = 1000000
+                        , processTime = 60000
+                        , retractTime = 30000
+                        }
+                }
+        }
+
+honestSnapshot :: VerificationSnapshot
+honestSnapshot =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex (bundleRoot honestWitness)
+        , vsChainPoint =
+            ChainPointJSON
+                { cpSlot = 42
+                , cpBlockId = Hex (BS.replicate 32 0x11)
+                }
+        }
+
+-- | Flip a byte in the state UTxO's @tx_out@ so the advertised value
+-- no longer matches the value bound into the CSMT inclusion proof.
+tamperStateTxOut :: TokenResponse -> TokenResponse
+tamperStateTxOut = overStateUtxo $ \u ->
+    u{wuTxOut = flipHexByte (wuTxOut u)}
+
+-- | Flip the last byte of the state UTxO's inclusion proof. The
+-- trailing bytes carry sibling-hash material, so the recomputed root
+-- no longer matches the trusted root (flipping the leading CBOR header
+-- byte would not).
+tamperStateProof :: TokenResponse -> TokenResponse
+tamperStateProof = overStateUtxo $ \u ->
+    u{wuProof = flipLastHexByte (wuProof u)}
+
+overStateUtxo
+    :: (WitnessedUtxo -> WitnessedUtxo) -> TokenResponse -> TokenResponse
+overStateUtxo f resp =
+    resp
+        { trState =
+            (trState resp)
+                { wtsUtxo = f (wtsUtxo (trState resp))
+                }
+        }
+
+isTrustedRootMismatch :: Either VerifyError () -> Bool
+isTrustedRootMismatch (Left (TrustedRootMismatch _)) = True
+isTrustedRootMismatch _ = False
+
+isCsmtReplayFailed :: Either VerifyError () -> Bool
+isCsmtReplayFailed (Left (CsmtReplayFailed _ _)) = True
+isCsmtReplayFailed _ = False
+
+-- | Flip the first byte of a hex-wrapped bytestring.
+flipHexByte :: Hex -> Hex
+flipHexByte (Hex bs) =
+    case BS.uncons bs of
+        Just (b, rest) -> Hex (BS.cons (b `xor` 0x01) rest)
+        Nothing -> Hex bs
+
+-- | Flip the last byte of a hex-wrapped bytestring.
+flipLastHexByte :: Hex -> Hex
+flipLastHexByte (Hex bs) =
+    case BS.unsnoc bs of
+        Just (initBs, b) -> Hex (BS.snoc initBs (b `xor` 0x01))
+        Nothing -> Hex bs
+
+toApiWitnessedUtxo :: Bundle.WitnessedUtxo -> WitnessedUtxo
+toApiWitnessedUtxo
+    Bundle.WitnessedUtxo
+        { Bundle.txIn =
+            Bundle.TxIn{Bundle.txId = txId', Bundle.txIx = txIx'}
+        , Bundle.txOut = txOut'
+        , Bundle.utxoProof = utxoProof'
+        } =
+        WitnessedUtxo
+            { wuTxIn =
+                TxInJSON
+                    { tjTxId = clientToApiHex txId'
+                    , tjTxIx = txIx'
+                    }
+            , wuTxOut = clientToApiHex txOut'
+            , wuProof = clientToApiHex utxoProof'
+            }
+
+-- | The client 'Bundle' types carry hex as 'Text'; the API wire types
+-- carry it as raw bytes. Decode across the boundary.
+clientToApiHex :: Snap.Hex -> Hex
+clientToApiHex (Snap.Hex txt) =
+    case Base16.decode (T.encodeUtf8 txt) of
+        Right bs -> Hex bs
+        Left err -> error ("ReadSpec.clientToApiHex: " <> err)

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -20,6 +20,7 @@ import Cardano.MPFS.Client.RetractFactsSpec qualified as RetractFactsSpec
 import Cardano.MPFS.Client.SnapshotSpec qualified as SnapshotSpec
 import Cardano.MPFS.Client.UpdateFactsSpec qualified as UpdateFactsSpec
 import Cardano.MPFS.Client.Verify.ReactorSpec qualified as ReactorSpec
+import Cardano.MPFS.Client.Verify.ReadSpec qualified as ReadVerifySpec
 import Cardano.MPFS.Client.Verify.WriteSpec qualified as WriteSpec
 import Cardano.MPFS.Client.VerifySpec qualified as VerifySpec
 import Test.Hspec (hspec)
@@ -45,6 +46,7 @@ main = hspec $ do
     EndSpec.spec
     CageUpdateSpec.spec
     VerifySpec.spec
+    ReadVerifySpec.spec
     WriteSpec.spec
     ReactorSpec.spec
     HttpSpec.spec

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
@@ -12,6 +12,9 @@ module Cardano.MPFS.Client.Verify.Read
     ( VerifiedTokenState
     , verifiedTokenState
     , verifyTokenState
+    , VerifiedTokenFacts
+    , verifiedTokenFacts
+    , verifyTokenFacts
     ) where
 
 import Data.ByteString qualified as BS
@@ -19,10 +22,23 @@ import Data.ByteString.Base16 qualified as Base16
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T
 
+import MPF.Hashes
+    ( aikenKeyPath
+    , mkMPFHash
+    , mpfHashing
+    , nullHash
+    , renderMPFHash
+    )
+import MPF.Insertion (buildComposeFromList, scanMPFCompose)
+import MPF.Interface (hexValue)
+
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( ChainPointJSON (..)
+    , FactEntry (..)
+    , FactsResponse (..)
     , TokenResponse (..)
+    , TokenStateJSON (..)
     , TxInJSON (..)
     , VerificationSnapshot (..)
     , WitnessedTokenState (..)
@@ -66,6 +82,63 @@ verifyTokenState
 verifyTokenState (TrustedRoot (Hex trustedBs)) resp@TokenResponse{..} = do
     verifyAnchoredState "token" trustedBs trSnapshot trState
     Right (VerifiedTokenState resp)
+
+-- | Opaque witness that a facts response has been checked against the
+-- caller-supplied trusted root: the 'WitnessedTokenState' is anchored
+-- to that root, and the MPF root reconstructed from the enumerated
+-- fact set equals the on-chain trie root in that state. The
+-- constructor is not exported, so public callers cannot bypass
+-- 'verifyTokenFacts'.
+newtype VerifiedTokenFacts = VerifiedTokenFacts FactsResponse
+    deriving stock (Eq, Show)
+
+-- | Extract the verified response after 'verifyTokenFacts' has
+-- established the anchoring and completeness checks.
+verifiedTokenFacts :: VerifiedTokenFacts -> FactsResponse
+verifiedTokenFacts (VerifiedTokenFacts resp) = resp
+
+-- | Verify a @GET \/tokens\/:id\/facts@ 'FactsResponse' against an
+-- externally-supplied trusted UTxO-CSMT root. First anchors the
+-- 'WitnessedTokenState' to the trusted root (as 'verifyTokenState'
+-- does), then reconstructs the MPF trie root from the complete
+-- enumerated @[FactEntry]@ and asserts it equals the on-chain trie
+-- root advertised in the (now-anchored) state. The root binds the
+-- whole map, so any omitted, added, or tampered fact makes the
+-- reconstructed root diverge — this is the completeness proof.
+verifyTokenFacts
+    :: TrustedRoot
+    -> FactsResponse
+    -> Either VerifyError VerifiedTokenFacts
+verifyTokenFacts (TrustedRoot (Hex trustedBs)) resp@FactsResponse{..} = do
+    verifyAnchoredState "facts" trustedBs frsSnapshot frsState
+    let Hex onChainRoot = root (wtsState frsState)
+        reconstructed = reconstructMpfRoot (map factPair frsFacts)
+    if reconstructed == onChainRoot
+        then Right (VerifiedTokenFacts resp)
+        else Left (MpfReplayFailed "facts.facts" "root mismatch")
+  where
+    factPair FactEntry{feKey = Hex keyBs, feValue = Hex valueBs} =
+        (keyBs, valueBs)
+
+-- | Reconstruct the Aiken-compatible MPF trie root from a complete
+-- set of @(key, value)@ byte pairs, purely. Each key becomes its
+-- Aiken nibble path and each value its MPF value hash, then the trie
+-- is folded to a root via the same primitives the write path uses
+-- (@buildComposeFromList@ / @scanMPFCompose@). @scanMPFCompose@
+-- returns the root indirect with the node hash already in its
+-- @hexValue@ — the same value @MPF.MTS@'s @mtsRootHash@ reports for
+-- the stored root node — so the trie root is exactly that. An empty
+-- fact set yields the null (empty-trie) root.
+reconstructMpfRoot
+    :: [(BS.ByteString, BS.ByteString)] -> BS.ByteString
+reconstructMpfRoot kvs =
+    case buildComposeFromList items of
+        Nothing -> renderMPFHash nullHash
+        Just compose ->
+            let (rootInd, _) = scanMPFCompose [] mpfHashing compose
+            in  renderMPFHash (hexValue rootInd)
+  where
+    items = [(aikenKeyPath k, mkMPFHash v) | (k, v) <- kvs]
 
 -- | Shared anchoring check for read-side responses that carry a
 -- snapshot plus a 'WitnessedTokenState': the trusted root has the

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
@@ -2,8 +2,127 @@
 -- Module      : Cardano.MPFS.Client.Verify.Read
 -- Description : Verifiers for the read-side responses.
 --
--- Populated incrementally by tasks T031, T032, T072, T087 — see
--- @specs\/243-proof-redesign\/tasks.md@.
+-- Client-side verifiers for the read endpoints, mirroring the
+-- opaque-witness pattern of "Cardano.MPFS.Client.Facts": each
+-- verifier threads in an externally-supplied trusted UTxO-CSMT root,
+-- performs only pure checks (no fetching), and returns an opaque
+-- @Verified*@ value whose constructor is not exported, so public
+-- callers cannot bypass verification.
 module Cardano.MPFS.Client.Verify.Read
-    (
+    ( VerifiedTokenState
+    , verifiedTokenState
+    , verifyTokenState
     ) where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Text (Text)
+import Data.Text.Encoding qualified as T
+
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types
+    ( ChainPointJSON (..)
+    , TokenResponse (..)
+    , TxInJSON (..)
+    , VerificationSnapshot (..)
+    , WitnessedTokenState (..)
+    , WitnessedUtxo (..)
+    )
+import Cardano.MPFS.Client.Bundle qualified as ClientWire
+import Cardano.MPFS.Client.Snapshot qualified as ClientSnapshot
+import Cardano.MPFS.Client.TrustedRoot
+    ( TrustedRoot (..)
+    )
+import Cardano.MPFS.Client.Verify.Replay
+    ( VerifyError (..)
+    , replayWitnessedUtxo
+    )
+import Cardano.MPFS.Client.Verify.Snapshot
+    ( verifyVerificationSnapshot
+    )
+
+-- | Opaque witness that a token response has been checked against the
+-- caller-supplied trusted root: the embedded 'WitnessedTokenState' is
+-- anchored to that root via the state UTxO inclusion proof. The
+-- constructor is intentionally not exported, so public callers cannot
+-- bypass 'verifyTokenState'.
+newtype VerifiedTokenState = VerifiedTokenState TokenResponse
+    deriving stock (Eq, Show)
+
+-- | Extract the verified response after 'verifyTokenState' has
+-- established the trusted-root and state-UTxO anchoring checks.
+verifiedTokenState :: VerifiedTokenState -> TokenResponse
+verifiedTokenState (VerifiedTokenState resp) = resp
+
+-- | Verify a @GET \/tokens\/:id@ 'TokenResponse' against an
+-- externally-supplied trusted UTxO-CSMT root. Confirms the snapshot is
+-- structurally valid, its @utxo_root@ equals the trusted root, and the
+-- state UTxO's inclusion proof replays against that root — i.e. the
+-- 'WitnessedTokenState' is anchored to the trusted root.
+verifyTokenState
+    :: TrustedRoot
+    -> TokenResponse
+    -> Either VerifyError VerifiedTokenState
+verifyTokenState (TrustedRoot (Hex trustedBs)) resp@TokenResponse{..} = do
+    verifyAnchoredState "token" trustedBs trSnapshot trState
+    Right (VerifiedTokenState resp)
+
+-- | Shared anchoring check for read-side responses that carry a
+-- snapshot plus a 'WitnessedTokenState': the trusted root has the
+-- right length, the snapshot is structurally valid and pins the
+-- trusted @utxo_root@, and the state UTxO inclusion proof replays
+-- against that root.
+verifyAnchoredState
+    :: Text
+    -> BS.ByteString
+    -> VerificationSnapshot
+    -> WitnessedTokenState
+    -> Either VerifyError ()
+verifyAnchoredState prefix trustedBs snapshot state = do
+    checkLength (prefix <> ".trusted_root") trustedBs
+    verifyVerificationSnapshot (toClientSnapshot snapshot)
+    let snapshotPath = prefix <> ".snapshot.utxo_root"
+        Hex snapshotBs = vsUtxoRoot snapshot
+    if snapshotBs == trustedBs
+        then Right ()
+        else Left (TrustedRootMismatch snapshotPath)
+    replayWitnessedUtxo
+        (prefix <> ".state.utxo")
+        trustedBs
+        (toClientWitnessedUtxo (wtsUtxo state))
+  where
+    checkLength field bs
+        | BS.length bs == 32 = Right ()
+        | otherwise = Left (WrongHexLength field 32 (BS.length bs))
+
+toClientSnapshot
+    :: VerificationSnapshot -> ClientSnapshot.VerificationSnapshot
+toClientSnapshot VerificationSnapshot{..} =
+    ClientSnapshot.VerificationSnapshot
+        { ClientSnapshot.utxoRoot = toClientHex vsUtxoRoot
+        , ClientSnapshot.chainpoint =
+            let ChainPointJSON{..} = vsChainPoint
+            in  ClientSnapshot.ChainPoint
+                    { ClientSnapshot.slot = cpSlot
+                    , ClientSnapshot.blockId = toClientHex cpBlockId
+                    }
+        }
+
+toClientWitnessedUtxo :: WitnessedUtxo -> ClientWire.WitnessedUtxo
+toClientWitnessedUtxo WitnessedUtxo{..} =
+    ClientWire.WitnessedUtxo
+        { ClientWire.txIn = toClientTxIn wuTxIn
+        , ClientWire.txOut = toClientHex wuTxOut
+        , ClientWire.utxoProof = toClientHex wuProof
+        }
+
+toClientTxIn :: TxInJSON -> ClientWire.TxIn
+toClientTxIn TxInJSON{..} =
+    ClientWire.TxIn
+        { ClientWire.txId = toClientHex tjTxId
+        , ClientWire.txIx = tjTxIx
+        }
+
+toClientHex :: Hex -> ClientSnapshot.Hex
+toClientHex (Hex bs) =
+    ClientSnapshot.Hex (T.decodeUtf8 (Base16.encode bs))

--- a/nix/wasm/forks.json
+++ b/nix/wasm/forks.json
@@ -62,8 +62,8 @@
     },
     "haskell-mts": {
       "location": "https://github.com/lambdasistemi/haskell-mts",
-      "rev": "73a094ae3602e272bff11f07899dd951616fb0e7",
-      "sha256": "1xzqkchzavs50shham0s0m7kr5k5qldc2dv04glkvrr7vgj6wsng",
+      "rev": "2893775286801e91afe10e14775507a36e97e169",
+      "sha256": "1ipwx1xgbyp0fwyq90zp7j6habvl0164d08s4mfbixg40w15sd8w",
       "subdirs": []
     },
     "aiken-codegen": {

--- a/nix/wasm/forks.json
+++ b/nix/wasm/forks.json
@@ -62,8 +62,8 @@
     },
     "haskell-mts": {
       "location": "https://github.com/lambdasistemi/haskell-mts",
-      "rev": "13264a52b47e3a1f43a6ebeebd424a10f9e4466a",
-      "sha256": "1bqgpxdy79ncsz8hyg2qyd7jnm8hqj4q8rq8mhr3iirix66c77fb",
+      "rev": "73a094ae3602e272bff11f07899dd951616fb0e7",
+      "sha256": "1xzqkchzavs50shham0s0m7kr5k5qldc2dv04glkvrr7vgj6wsng",
       "subdirs": []
     },
     "aiken-codegen": {

--- a/specs/307-verify-read/plan.md
+++ b/specs/307-verify-read/plan.md
@@ -1,0 +1,72 @@
+# Plan — #307 read-side verifiers (`Client/Verify/Read`)
+
+## Goal
+
+Populate the empty stub
+`cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs` with two
+pure, IO-free verifiers that mirror the `Client/Facts` `verify*Facts`
+pattern (opaque `Verified*` newtype, hidden constructor, `verified*`
+extractor, `TrustedRoot` threaded in, structured `VerifyError`):
+
+- `verifyTokenState`  — verifies a `TokenResponse` (`GET /tokens/:id`).
+- `verifyTokenFacts`  — verifies a `FactsResponse`
+  (`GET /tokens/:id/facts`) by reconstructing the MPF root from the
+  full enumerated `[FactEntry]` and asserting it equals the on-chain
+  trie root in the (verified) `WitnessedTokenState`. This is the
+  completeness proof.
+
+Consumer: `cardano-foundation/moog` #155.
+
+## Relationship to specs/243-proof-redesign
+
+The 243 spec models a *per-key* facts endpoint
+(`verifyTokenResponse` / `verifyFactPresentResponse`) anchored on
+CSMT completeness proofs (tasks T013/T014, blocked upstream on
+`lambdasistemi/haskell-mts#153`). Issue #307 supersedes that for the
+read path: it verifies the *bulk* `[FactEntry]` endpoint (#305/#306)
+by root reconstruction, which needs no upstream change. We follow the
+issue, keep the issue's names, and leave the 243 read-side tasks as
+they are.
+
+## Tech notes
+
+- `verifyTokenState`: check trusted-root length (32), assert
+  `vsUtxoRoot trSnapshot == trustedRoot`, verify the snapshot
+  (`verifyVerificationSnapshot`), and replay the state UTxO inclusion
+  proof (`wtsUtxo trState`) against the trusted root via
+  `replayWitnessedUtxo`. Mirrors `verifyBootFacts` + `replayFactState`.
+- `verifyTokenFacts`: verify the embedded state anchoring (reuse
+  `verifyTokenState`'s core over `frsSnapshot`/`frsState`), extract the
+  on-chain trie root `root (wtsState frsState)`, reconstruct the MPF
+  root from `frsFacts`, assert equality.
+- Pure MPF reconstruction (no monadic MTS backend — package is
+  IO-free per constitution VIII): map each `FactEntry` to
+  `(aikenKeyPath feKey, mkMPFHash feValue)`, then
+  `buildComposeFromList` → `scanMPFCompose [] mpfHashing` →
+  `mpfRootFromNode mpfHashing` → `renderMPFHash`. Empty fact set →
+  `nullHash`. All from `mts:mpf-write` (already a dependency).
+- New `VerifyError` use: reconstruction/equality mismatch reported via
+  an MPF-completeness error (reuse `MpfReplayFailed` or add a dedicated
+  completeness constructor — decided in slice 2).
+
+## Slices (one bisect-safe commit each)
+
+- **Slice 1 (T001)** — `verifyTokenState` + `VerifiedTokenState` +
+  `verifiedTokenState`, exports, honest fixture (accept) + forgeries
+  (wrong trusted root, tampered state `tx_out`, tampered proof).
+- **Slice 2 (T002)** — `verifyTokenFacts` + `VerifiedTokenFacts` +
+  `verifiedTokenFacts`, reuse slice 1's anchoring; honest fixture
+  (accept) + completeness forgeries (drop a fact, add a spurious fact,
+  tamper a fact value → reconstructed-root mismatch rejects).
+
+## Proof
+
+TDD against `Cardano.MPFS.Client.Fixtures` honest fixtures (built from
+the *real* MPF backend via `MPF.Test.Lib`, so reconstruction is an
+independent check — not circular) plus the `TrieForge` forgery DSL.
+No Lean for this PR (operator decision); the reconstruction-completeness
+invariant is left as a Lean follow-up.
+
+## Gate
+
+`./gate.sh` — `just unit-client` + `just format-check` + `just hlint`.

--- a/specs/307-verify-read/tasks.md
+++ b/specs/307-verify-read/tasks.md
@@ -1,0 +1,23 @@
+# Tasks — #307 read-side verifiers
+
+## Slice 1 — `verifyTokenState`
+
+- [ ] T001 Implement `verifyTokenState :: TrustedRoot -> TokenResponse
+  -> Either VerifyError VerifiedTokenState` in
+  `cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs` (opaque
+  `VerifiedTokenState` + `verifiedTokenState` extractor, exports),
+  reachable from the client test umbrella. Honest fixture accepts;
+  forgeries (wrong trusted root, tampered state `tx_out`, tampered
+  inclusion proof) reject with the matching `VerifyError`. Tests in
+  `cardano-mpfs-client/test/...`.
+
+## Slice 2 — `verifyTokenFacts`
+
+- [ ] T002 Implement `verifyTokenFacts :: TrustedRoot -> FactsResponse
+  -> Either VerifyError VerifiedTokenFacts` in the same module (opaque
+  `VerifiedTokenFacts` + `verifiedTokenFacts` extractor, exports):
+  verify the embedded state anchoring (reuse slice 1), reconstruct the
+  MPF root from `frsFacts` via `buildComposeFromList`/`scanMPFCompose`/
+  `mpfRootFromNode`, assert it equals `root (wtsState frsState)`.
+  Honest fixture accepts; completeness forgeries (drop a fact, add a
+  spurious fact, tamper a fact value) reject.

--- a/specs/307-verify-read/tasks.md
+++ b/specs/307-verify-read/tasks.md
@@ -13,7 +13,7 @@
 
 ## Slice 2 — `verifyTokenFacts`
 
-- [ ] T002 Implement `verifyTokenFacts :: TrustedRoot -> FactsResponse
+- [X] T002 Implement `verifyTokenFacts :: TrustedRoot -> FactsResponse
   -> Either VerifyError VerifiedTokenFacts` in the same module (opaque
   `VerifiedTokenFacts` + `verifiedTokenFacts` extractor, exports):
   verify the embedded state anchoring (reuse slice 1), reconstruct the

--- a/specs/307-verify-read/tasks.md
+++ b/specs/307-verify-read/tasks.md
@@ -2,7 +2,7 @@
 
 ## Slice 1 — `verifyTokenState`
 
-- [ ] T001 Implement `verifyTokenState :: TrustedRoot -> TokenResponse
+- [X] T001 Implement `verifyTokenState :: TrustedRoot -> TokenResponse
   -> Either VerifyError VerifiedTokenState` in
   `cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs` (opaque
   `VerifiedTokenState` + `verifiedTokenState` extractor, exports),


### PR DESCRIPTION
Closes lambdasistemi/cardano-mpfs-offchain#307.

Populates the empty stub `cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs` with two pure, IO-free read-side verifiers mirroring the `Client/Facts` `verify*Facts` pattern (opaque `Verified*` newtype with a hidden constructor, a `verified*` extractor, `TrustedRoot` threaded in, structured `VerifyError`).

## What ships

- **`verifyTokenState`** — verifies a `TokenResponse` (`GET /tokens/:id`): the `WitnessedTokenState` is anchored to the trusted UTxO-CSMT root (`utxo_root`). Checks trusted-root length, `snapshot.utxo_root == trustedRoot`, verifies the snapshot, and replays the state UTxO inclusion proof against the trusted root. Same shape as `verifyBootFacts` + `replayFactState`.
- **`verifyTokenFacts`** — verifies a `FactsResponse` (`GET /tokens/:id/facts`): reuses the state anchoring above, then **reconstructs** the MPF root from the full enumerated `[FactEntry]` and asserts it equals the on-chain trie root in the verified `WitnessedTokenState`. The completeness proof — the root binds the whole map, so any omission/addition/tamper fails.

Reconstruction is pure (no monadic MTS backend, per the package's IO-free constitution): `(aikenKeyPath feKey, mkMPFHash feValue)` → `buildComposeFromList` → `scanMPFCompose [] mpfHashing` → root indirect, whose `hexValue` is the canonical root (the same value `MPF.MTS.mtsRootHash` reports for the stored root node). Empty fact set → `nullHash`.

## Dependency (merged)

Needed `buildComposeFromList` exported from `MPF.Insertion`, done in **lambdasistemi/haskell-mts#161** (now merged). This PR pins haskell-mts to that merged `main` commit (`dea6134`) in `cabal.project` and `nix/wasm/forks.json`.

## Note on specs/243-proof-redesign

The 243 spec models a *per-key* facts endpoint (`verifyTokenResponse`/`verifyFactPresentResponse`) backed by CSMT completeness proofs (tasks T013/T014, blocked upstream on `lambdasistemi/haskell-mts#153`). #307 supersedes that for the read path: it verifies the *bulk* `[FactEntry]` endpoint (#305/#306) by root reconstruction, which needs no new upstream functionality. This PR follows the issue's names and approach; the 243 read-side tasks are left untouched.

## Verification

TDD against `Cardano.MPFS.Client.Fixtures` honest fixtures plus a hand-forged corpus. The `verifyTokenFacts` honest fixture's on-chain root is computed from the *real* MPF write backend (`MPF.Test.Lib`), so the verifier's independent reconstruction reproducing it is a genuine (non-circular) check. Forgeries: wrong trusted root, tampered state tx_out/proof; dropped/added/tampered facts. No Lean in this PR (operator decision); the reconstruction-completeness invariant is noted as a Lean follow-up.

Consumer: `cardano-foundation/moog`#155.