### PR TITLE
feat: verifyTokenRequests — request-set completeness on /tokens/:id/requests (#310)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ transactions; the client signs and submits via `POST /tx/submit`.
 | GET | `/tokens/:id/facts` | Enumerate facts with witnessed state |
 | GET | `/tokens/:id/facts/:key` | Value lookup |
 | GET | `/tokens/:id/proofs/:key` | Merkle proof |
-| GET | `/tokens/:id/requests` | Pending requests |
+| GET | `/tokens/:id/requests` | Pending requests with completeness witness |
 | GET | `/tx/:txId?timeout=30` | Block until tx is indexed |
 | POST | `/facts/boot` | Return boot facts for wallet-side transaction construction |
 | POST | `/facts/request/insert` | Return insert-request facts for wallet-side transaction construction |

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -595,6 +595,8 @@ instance FromJSON ProofResponse where
 data RequestsResponse = RequestsResponse
     { rrSnapshot :: VerificationSnapshot
     -- ^ Snapshot the bundled proofs target
+    , rrRequestSet :: UtxoSetWitness
+    -- ^ Complete request-address UTxO set witness
     , rrRequests :: [WitnessedRequest]
     -- ^ Witnessed pending requests
     }
@@ -604,6 +606,7 @@ instance ToJSON RequestsResponse where
     toJSON RequestsResponse{..} =
         object
             [ "snapshot" .= rrSnapshot
+            , "request_set" .= rrRequestSet
             , "requests" .= rrRequests
             ]
 
@@ -611,6 +614,7 @@ instance FromJSON RequestsResponse where
     parseJSON = withObject "RequestsResponse" $ \o ->
         RequestsResponse
             <$> o .: "snapshot"
+            <*> o .: "request_set"
             <*> o .: "requests"
 
 -- | @POST \/tx\/boot@ request body.
@@ -1875,6 +1879,9 @@ instance ToSchema RequestsResponse where
         reqListSchema <-
             declareSchemaRef
                 (Proxy @[WitnessedRequest])
+        requestSetSchema <-
+            declareSchemaRef
+                (Proxy @UtxoSetWitness)
         pure
             $ Swagger.NamedSchema
                 (Just "RequestsResponse")
@@ -1884,10 +1891,11 @@ instance ToSchema RequestsResponse where
             & properties
                 .~ fromList
                     [ ("snapshot", snapshotSchema)
+                    , ("request_set", requestSetSchema)
                     , ("requests", reqListSchema)
                     ]
             & required
-                .~ ["snapshot", "requests"]
+                .~ ["snapshot", "request_set", "requests"]
             & description
                 ?~ "Proof-bearing pending requests \
                    \response"

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
@@ -9,30 +9,85 @@
 -- 'VerifyError'.
 module Cardano.MPFS.Client.Verify.ReadSpec (spec) where
 
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
 import Control.Monad (void)
 import Data.Bits (xor)
+import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.Text.Encoding qualified as T
-import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+import System.Environment (getEnv)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
 
+import CSMT
+    ( Direction
+    , Standalone (StandaloneCSMTCol)
+    )
+import CSMT.Backend.Pure (runPureTransaction)
+import CSMT.Core.CBOR (renderCompletenessProof)
+import CSMT.Core.Hash
+    ( Hash
+    , byteStringToKey
+    , renderHash
+    )
+import CSMT.Hashes
+    ( mkHash
+    )
+import CSMT.Proof.Completeness
+    ( CompletenessProof
+    , generateProof
+    )
+import CSMT.Test.Lib
+    ( evalPureFromEmptyDB
+    , getRootHashM
+    , hashCodecs
+    , insertMHash
+    )
 import MPF.Hashes (renderMPFHash)
 import MPF.Test.Lib (insertByteStringM, runMPFPure')
 import MPF.Test.Lib qualified as MPFTest (getRootHashM)
 
+import Cardano.Ledger.BaseTypes (Network (Testnet))
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( ChainPointJSON (..)
     , FactEntry (..)
     , FactsResponse (..)
+    , RequestJSON (..)
+    , RequestsResponse (..)
+    , TokenIdJSON (..)
     , TokenResponse (..)
     , TokenStateJSON (..)
     , TxInJSON (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
     , VerificationSnapshot (..)
+    , WitnessedRequest (..)
     , WitnessedTokenState (..)
     , WitnessedUtxo (..)
     )
+import Cardano.MPFS.Cage.Blueprint
+    ( extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Cage.Ledger (Coin (..))
 import Cardano.MPFS.Client.Bundle qualified as Bundle
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , computeScriptHash
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( requestSetPrefixFromCfg
+    )
 import Cardano.MPFS.Client.Fixtures
     ( bundleFunding
     , bundleRoot
@@ -42,6 +97,7 @@ import Cardano.MPFS.Client.Snapshot qualified as Snap
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Client.Verify.Read
     ( verifyTokenFacts
+    , verifyTokenRequests
     , verifyTokenState
     )
 import Cardano.MPFS.Client.Verify.Replay (VerifyError (..))
@@ -87,6 +143,38 @@ spec = describe "Read-side verifiers" $ do
                 honestTrustedRoot
                 (tamperFirstFactValue honestFactsResponse)
             `shouldSatisfy` isMpfReplayFailed
+    describe "verifyTokenRequests" $ do
+        it "accepts an honest requests response with a complete request set"
+            $ do
+                cfg <- testCageConfig
+                let RequestFixture{requestTrustedRoot, requestResponse} =
+                        honestRequestFixture cfg
+                verifyTokenRequestsUnit
+                    cfg
+                    sampleToken
+                    requestTrustedRoot
+                    requestResponse
+                    `shouldBe` Right ()
+        it "rejects a tampered request-set completeness proof" $ do
+            cfg <- testCageConfig
+            let RequestFixture{requestTrustedRoot, requestResponse} =
+                    honestRequestFixture cfg
+            verifyTokenRequestsUnit
+                cfg
+                sampleToken
+                requestTrustedRoot
+                (tamperRequestSetProof requestResponse)
+                `shouldSatisfy` isCompletenessProofInvalid
+        it "rejects a dropped request-set entry" $ do
+            cfg <- testCageConfig
+            let RequestFixture{requestTrustedRoot, requestResponse} =
+                    honestRequestFixture cfg
+            verifyTokenRequestsUnit
+                cfg
+                sampleToken
+                requestTrustedRoot
+                (dropFirstRequestSetEntry requestResponse)
+                `shouldSatisfy` isCompletenessProofInvalid
 
 -- | Discard the opaque witness so we can assert on @Right ()@.
 verifyTokenStateUnit
@@ -98,6 +186,15 @@ verifyTokenFactsUnit
     :: TrustedRoot -> FactsResponse -> Either VerifyError ()
 verifyTokenFactsUnit trusted =
     void . verifyTokenFacts trusted
+
+verifyTokenRequestsUnit
+    :: CageConfig
+    -> TokenIdJSON
+    -> TrustedRoot
+    -> RequestsResponse
+    -> Either VerifyError ()
+verifyTokenRequestsUnit cfg token trusted =
+    void . verifyTokenRequests cfg token trusted
 
 -- | The complete fact set for the honest token. The on-chain trie
 -- root is derived from these via the real MPF write backend, so the
@@ -160,6 +257,106 @@ tamperFirstFactValue resp =
     overFirst _ [] = []
     overFirst f (x : xs) = f x : xs
 
+data RequestFixture = RequestFixture
+    { requestTrustedRoot :: TrustedRoot
+    , requestResponse :: RequestsResponse
+    }
+
+honestRequestFixture :: CageConfig -> RequestFixture
+honestRequestFixture cfg =
+    let requestPrefix = requestSetPrefixFromCfg cfg sampleToken
+        (root, requestSet) = csmtRequestRows requestPrefix
+        response =
+            RequestsResponse
+                { rrSnapshot = snapshotWithRoot root
+                , rrRequestSet = requestSet
+                , rrRequests =
+                    [ WitnessedRequest
+                        { wrUtxo =
+                            WitnessedUtxo
+                                { wuTxIn =
+                                    TxInJSON
+                                        { tjTxId = Hex requestTxId
+                                        , tjTxIx = 0
+                                        }
+                                , wuTxOut = Hex requestTxOut
+                                , wuProof = Hex "\x82\x01\x02"
+                                }
+                        , wrRequest =
+                            RequestJSON
+                                { rjToken = sampleToken
+                                , rjOwner = "owner"
+                                , rjKey = Hex "apple"
+                                , rjOperation = "insert"
+                                , rjValue = Just (Hex "fruit")
+                                , rjFee = 1000000
+                                , rjSubmittedAt = 42
+                                }
+                        }
+                    ]
+                }
+    in  RequestFixture
+            { requestTrustedRoot = TrustedRoot (Hex root)
+            , requestResponse = response
+            }
+
+csmtRequestRows :: [Direction] -> (ByteString, UtxoSetWitness)
+csmtRequestRows requestPrefix = evalPureFromEmptyDB $ do
+    let requestKey =
+            requestPrefix
+                <> byteStringToKey
+                    (encodeTxIn requestTxId 0)
+    insertMHash requestKey (mkHash requestTxOut)
+    completenessProof <-
+        runPureTransaction hashCodecs
+            $ generateProof StandaloneCSMTCol [] requestPrefix
+    root <- maybe BS.empty renderHash <$> getRootHashM
+    pure
+        ( root
+        , UtxoSetWitness
+            { uswEntries =
+                [ UtxoEntryRefOnly
+                    { uerRef =
+                        UtxoRef
+                            { urTxId = Hex requestTxId
+                            , urTxIx = 0
+                            }
+                    , uerTxOutCbor = Hex requestTxOut
+                    }
+                ]
+            , uswCompletenessProof =
+                Hex
+                    $ case completenessProof of
+                        Just proof ->
+                            renderCompletenessProof
+                                (proof :: CompletenessProof Hash)
+                        Nothing ->
+                            error
+                                "expected request-set completeness proof"
+            }
+        )
+
+tamperRequestSetProof :: RequestsResponse -> RequestsResponse
+tamperRequestSetProof resp =
+    resp
+        { rrRequestSet =
+            (rrRequestSet resp)
+                { uswCompletenessProof =
+                    flipLastHexByte
+                        (uswCompletenessProof (rrRequestSet resp))
+                }
+        }
+
+dropFirstRequestSetEntry :: RequestsResponse -> RequestsResponse
+dropFirstRequestSetEntry resp =
+    resp
+        { rrRequestSet =
+            (rrRequestSet resp)
+                { uswEntries =
+                    drop 1 (uswEntries (rrRequestSet resp))
+                }
+        }
+
 honestTrustedRoot :: TrustedRoot
 honestTrustedRoot = TrustedRoot (Hex (bundleRoot honestWitness))
 
@@ -196,6 +393,71 @@ honestSnapshot =
                 }
         }
 
+snapshotWithRoot :: ByteString -> VerificationSnapshot
+snapshotWithRoot root =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex root
+        , vsChainPoint =
+            ChainPointJSON
+                { cpSlot = 42
+                , cpBlockId = Hex (BS.replicate 32 0x11)
+                }
+        }
+
+sampleToken :: TokenIdJSON
+sampleToken = TokenIdJSON "cafe"
+
+requestTxId :: ByteString
+requestTxId = BS.replicate 32 0x33
+
+requestTxOut :: ByteString
+requestTxOut = "request-tx-out-cbor"
+
+encodeTxIn :: ByteString -> Word -> ByteString
+encodeTxIn txIdBytes txIx =
+    CBOR.toStrictByteString
+        $ mconcat
+            [ CBOR.encodeListLen 2
+            , CBOR.encodeBytes txIdBytes
+            , CBOR.encodeWord64 (fromIntegral txIx)
+            ]
+
+testCageConfig :: IO CageConfig
+testCageConfig = do
+    blueprintPath <- getEnv "MPFS_BLUEPRINT"
+    eBlueprint <- loadBlueprint blueprintPath
+    blueprint <- case eBlueprint of
+        Left err ->
+            expectationFailure
+                ("loadBlueprint failed: " <> err)
+                *> error "unreachable"
+        Right bp -> pure bp
+    scriptBytes <-
+        case extractCompiledCode "state." blueprint of
+            Just bytes -> pure bytes
+            Nothing ->
+                expectationFailure
+                    "state script not found in MPFS_BLUEPRINT"
+                    *> error "unreachable"
+    requestBytes <-
+        case extractCompiledCode "request." blueprint of
+            Just bytes -> pure bytes
+            Nothing ->
+                expectationFailure
+                    "request script not found in MPFS_BLUEPRINT"
+                    *> error "unreachable"
+    let scriptHash = computeScriptHash scriptBytes
+    pure
+        CageConfig
+            { cageScriptBytes = scriptBytes
+            , requestScriptBytes = requestBytes
+            , cfgScriptHash = scriptHash
+            , defaultProcessTime = 60_000
+            , defaultRetractTime = 30_000
+            , defaultTip = Coin 1_000_000
+            , network = Testnet
+            }
+
 -- | Flip a byte in the state UTxO's @tx_out@ so the advertised value
 -- no longer matches the value bound into the CSMT inclusion proof.
 tamperStateTxOut :: TokenResponse -> TokenResponse
@@ -231,6 +493,10 @@ isCsmtReplayFailed _ = False
 isMpfReplayFailed :: Either VerifyError () -> Bool
 isMpfReplayFailed (Left (MpfReplayFailed _ _)) = True
 isMpfReplayFailed _ = False
+
+isCompletenessProofInvalid :: Either VerifyError () -> Bool
+isCompletenessProofInvalid (Left (CompletenessProofInvalid _)) = True
+isCompletenessProofInvalid _ = False
 
 -- | Flip the first byte of a hex-wrapped bytestring.
 flipHexByte :: Hex -> Hex

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -525,8 +525,14 @@ tokenRequestsHandler
     -> Handler RequestsResponse
 tokenRequestsHandler ctx tokenId = do
     let tid = tokenIdFromJSON tokenId
+        cfg = cfgCage ctx
+        requestAddr = requestAddrFromCfg cfg tid (network cfg)
     _ <- requireToken ctx tid
     snapshot <- requireSnapshot ctx
+    requestSet <-
+        liftIO
+            $ runIndexerTx ctx
+            $ readUtxoSetAt requestAddr
     reqs <-
         liftIO
             $ St.requestsByToken
@@ -536,6 +542,7 @@ tokenRequestsHandler ctx tokenId = do
     pure
         RequestsResponse
             { rrSnapshot = snapshot
+            , rrRequestSet = utxoSetToJSON requestSet
             , rrRequests = witnessed
             }
 

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      : Cardano.MPFS.HTTP.RequestsSpec
@@ -6,12 +9,16 @@
 -- License     : Apache-2.0
 module Cardano.MPFS.HTTP.RequestsSpec (spec) where
 
+import Control.Monad (forM_)
 import Data.Aeson (decode)
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short qualified as SBS
+import Data.Text qualified as T
 import Data.Vector qualified as V
 import Network.HTTP.Types
     ( status200
@@ -31,18 +38,60 @@ import Test.Hspec
     , expectationFailure
     , it
     , shouldBe
+    , shouldSatisfy
     )
 import Test.QuickCheck (generate)
 
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , Network (..)
+    )
+import Cardano.Ledger.Binary
+    ( natVersion
+    , serialize
+    , serialize'
+    )
 import Cardano.Ledger.Mary.Value (AssetName (..))
+import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
+    ( CSMTContext (..)
+    , CSMTOps (..)
+    , mkCSMTOps
+    )
+import Cardano.UTxOCSMT.Application.Run.Config (context)
+import Database.KV.Database (mkColumns)
+import Database.KV.RocksDB (mkRocksDBDatabase)
+import Database.KV.Transaction
+    ( RunTransaction (..)
+    , mapColumns
+    , newRunTransaction
+    )
+import Database.RocksDB
+    ( DB (..)
+    , withDBCF
+    )
+import System.Directory (doesFileExist)
+import System.IO.Temp (withSystemTempDirectory)
+import System.IO.Unsafe (unsafePerformIO)
 
+import Cardano.MPFS.Application
+    ( allColumnFamilies
+    , dbConfig
+    , unifiedCodecs
+    )
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
+    , Coin (..)
+    , ConwayEra
     , LocatedRequest (LocatedRequest)
     , LocatedTokenState (..)
     , SlotNo (..)
     , TokenId (..)
+    , TxIn
     )
 import Cardano.MPFS.Generators
     ( genRequest
@@ -51,7 +100,15 @@ import Cardano.MPFS.Generators
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.TokensSpec (mkDummyTokenState)
+import Cardano.MPFS.Indexer.Columns (UnifiedColumns (..))
+import Cardano.MPFS.Indexer.Reads (IndexerTx (..))
+import Cardano.MPFS.Indexer.TxFixtures (testScriptHash)
 import Cardano.MPFS.State qualified as St
+import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( cageAddrFromCfg
+    , requestAddrFromCfg
+    )
 
 -- | "cafe" as hex = "63616665".
 cafeTid :: TokenId
@@ -80,7 +137,130 @@ withSnapshot rootBs outBs proofBs ctx = do
             { utxoRoot = pure (Just rootBs)
             , resolveUtxo = \_ -> pure (Just outBs)
             , utxoProof = \_ -> pure (Just proofBs)
+            , cfgCage = testCageConfig
             }
+
+-- | Run the handler against a real UTxO CSMT indexer
+-- transaction, seeded with request-address UTxO bytes.
+withRequestSet
+    :: [(TxIn, ByteString)]
+    -> Context IO
+    -> (Context IO -> IO a)
+    -> IO a
+withRequestSet entries ctx action =
+    withSystemTempDirectory "requests-indexer-test"
+        $ \dir ->
+            withDBCF
+                dir
+                dbConfig
+                allColumnFamilies
+                $ \db -> do
+                    let database =
+                            mkRocksDBDatabase
+                                db
+                                ( mkColumns
+                                    (columnFamilies db)
+                                    unifiedCodecs
+                                )
+                        CSMTContext{fromKV, hashing} = context
+                        csmtOps = mkCSMTOps fromKV hashing
+                    RunTransaction{runTransaction} <-
+                        newRunTransaction database
+                    let seededEntries =
+                            ( "sentinel-key"
+                            , otherAddressTxOutBytes
+                            )
+                                : [ ( serialize
+                                        (natVersion @11)
+                                        txIn
+                                    , BSL.fromStrict txOutBytes
+                                    )
+                                  | (txIn, txOutBytes) <- entries
+                                  ]
+                    runTransaction
+                        $ mapColumns InUtxo
+                        $ forM_ seededEntries
+                        $ uncurry
+                            (csmtInsert csmtOps)
+                    action
+                        ctx
+                            { runIndexerTx =
+                                \(IndexerTx body) ->
+                                    runTransaction body
+                            }
+
+testCageConfig :: CageConfig
+testCageConfig =
+    CageConfig
+        { cageScriptBytes = SBS.toShort "dummy"
+        , requestScriptBytes = testRequestScriptBytes
+        , cfgScriptHash = testScriptHash
+        , defaultProcessTime = 60_000
+        , defaultRetractTime = 30_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+testRequestScriptBytes :: SBS.ShortByteString
+testRequestScriptBytes =
+    unsafePerformIO loadTestRequestScriptBytes
+{-# NOINLINE testRequestScriptBytes #-}
+
+loadTestRequestScriptBytes :: IO SBS.ShortByteString
+loadTestRequestScriptBytes = do
+    hex <- tryRead candidatePaths
+    let trimmed =
+            BS.takeWhile
+                (\b -> b /= 10 && b /= 13)
+                hex
+    case B16.decode trimmed of
+        Right bs -> pure (SBS.toShort bs)
+        Left err ->
+            error
+                $ "loadTestRequestScriptBytes: "
+                    <> err
+  where
+    candidatePaths =
+        [ "test-data/request.uplc.hex"
+        , "cardano-mpfs-offchain/test-data/request.uplc.hex"
+        ]
+    tryRead [] =
+        error
+            "loadTestRequestScriptBytes: \
+            \test-data/request.uplc.hex not found \
+            \in any of the candidate paths"
+    tryRead (p : ps) = do
+        exists <- doesFileExist p
+        if exists
+            then BS.readFile p
+            else tryRead ps
+
+-- | Serialized request UTxO bytes at the token's
+-- per-cage request address.
+sampleRequestOutBytes
+    :: TokenId
+    -> Integer
+    -> ByteString
+sampleRequestOutBytes tid _submittedAt =
+    serialize'
+        (natVersion @11)
+        (txOut :: TxOut ConwayEra)
+  where
+    txOut =
+        mkBasicTxOut
+            (requestAddrFromCfg testCageConfig tid Testnet)
+            (inject (Coin 2_000_000))
+
+otherAddressTxOutBytes :: BSL.ByteString
+otherAddressTxOutBytes =
+    BSL.fromStrict
+        $ serialize'
+            (natVersion @11)
+            ( mkBasicTxOut
+                (cageAddrFromCfg testCageConfig Testnet)
+                (inject (Coin 2_000_000))
+                :: TxOut ConwayEra
+            )
 
 -- | Seed an indexed token state for a token id so
 -- the proof-bearing handler can find a state UTxO
@@ -101,9 +281,10 @@ spec = describe "GET /tokens/:id/requests" $ do
         ctx <-
             withSnapshot "root" "tx-out" "proof" ctx0
         seedTokenState ctx cafeTid
-        resp <- getRequests ctx "63616665"
-        simpleStatus resp `shouldBe` status200
-        assertEnvelope resp 0
+        withRequestSet [] ctx $ \ctxWithSet -> do
+            resp <- getRequests ctxWithSet "63616665"
+            simpleStatus resp `shouldBe` status200
+            assertEnvelope resp 0
 
     it
         "returns a single witnessed request after \
@@ -122,10 +303,14 @@ spec = describe "GET /tokens/:id/requests" $ do
             St.putRequest
                 (St.requests (state ctx))
                 (LocatedRequest txIn req)
-            resp <- getRequests ctx "63616665"
-            simpleStatus resp `shouldBe` status200
-            assertEnvelope resp 1
-            assertWitnessedRequestFields resp
+            withRequestSet
+                [(txIn, sampleRequestOutBytes cafeTid 0)]
+                ctx
+                $ \ctxWithSet -> do
+                    resp <- getRequests ctxWithSet "63616665"
+                    simpleStatus resp `shouldBe` status200
+                    assertEnvelope resp 1
+                    assertWitnessedRequestFields resp
 
     it
         "returns multiple witnessed requests for same \
@@ -149,9 +334,15 @@ spec = describe "GET /tokens/:id/requests" $ do
             St.putRequest
                 (St.requests (state ctx))
                 (LocatedRequest txIn2 req2)
-            resp <- getRequests ctx "63616665"
-            simpleStatus resp `shouldBe` status200
-            assertEnvelope resp 2
+            withRequestSet
+                [ (txIn1, sampleRequestOutBytes cafeTid 0)
+                , (txIn2, sampleRequestOutBytes cafeTid 1)
+                ]
+                ctx
+                $ \ctxWithSet -> do
+                    resp <- getRequests ctxWithSet "63616665"
+                    simpleStatus resp `shouldBe` status200
+                    assertEnvelope resp 2
 
     it "filters by token — other tokens excluded" $ do
         ctx0 <- mkTestContext
@@ -169,12 +360,20 @@ spec = describe "GET /tokens/:id/requests" $ do
         St.putRequest
             (St.requests (state ctx))
             (LocatedRequest txIn2 req2)
-        resp1 <- getRequests ctx "63616665"
-        simpleStatus resp1 `shouldBe` status200
-        assertEnvelope resp1 1
-        resp2 <- getRequests ctx "61616262"
-        simpleStatus resp2 `shouldBe` status200
-        assertEnvelope resp2 1
+        withRequestSet
+            [(txIn1, sampleRequestOutBytes cafeTid 0)]
+            ctx
+            $ \ctxWithCafeSet -> do
+                resp1 <- getRequests ctxWithCafeSet "63616665"
+                simpleStatus resp1 `shouldBe` status200
+                assertEnvelope resp1 1
+        withRequestSet
+            [(txIn2, sampleRequestOutBytes aabbTid 0)]
+            ctx
+            $ \ctxWithAabbSet -> do
+                resp2 <- getRequests ctxWithAabbSet "61616262"
+                simpleStatus resp2 `shouldBe` status200
+                assertEnvelope resp2 1
 
     it "returns 404 for unknown token" $ do
         ctx0 <- mkTestContext
@@ -223,6 +422,27 @@ assertEnvelope resp n =
                 _ ->
                     expectationFailure
                         "requests is not an array"
+            case KM.lookup "request_set" obj of
+                Just (Object requestSetObj) -> do
+                    case KM.lookup "entries" requestSetObj of
+                        Just (Array entries) ->
+                            V.length entries `shouldBe` n
+                        _ ->
+                            expectationFailure
+                                "request_set.entries is not an array"
+                    case KM.lookup
+                        "completeness_proof"
+                        requestSetObj of
+                        Just (String proof) ->
+                            proof
+                                `shouldSatisfy` (not . T.null)
+                        _ ->
+                            expectationFailure
+                                "request_set.completeness_proof \
+                                \is not a string"
+                _ ->
+                    expectationFailure
+                        "request_set is not an object"
         _ ->
             expectationFailure
                 "Expected JSON object"

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
@@ -15,6 +15,9 @@ module Cardano.MPFS.Client.Verify.Read
     , VerifiedTokenFacts
     , verifiedTokenFacts
     , verifyTokenFacts
+    , VerifiedTokenRequests
+    , verifiedTokenRequests
+    , verifyTokenRequests
     ) where
 
 import Data.ByteString qualified as BS
@@ -37,6 +40,8 @@ import Cardano.MPFS.API.Types
     ( ChainPointJSON (..)
     , FactEntry (..)
     , FactsResponse (..)
+    , RequestsResponse (..)
+    , TokenIdJSON
     , TokenResponse (..)
     , TokenStateJSON (..)
     , TxInJSON (..)
@@ -45,9 +50,18 @@ import Cardano.MPFS.API.Types
     , WitnessedUtxo (..)
     )
 import Cardano.MPFS.Client.Bundle qualified as ClientWire
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( requestSetPrefixFromCfg
+    )
 import Cardano.MPFS.Client.Snapshot qualified as ClientSnapshot
 import Cardano.MPFS.Client.TrustedRoot
     ( TrustedRoot (..)
+    )
+import Cardano.MPFS.Client.Verify.Completeness
+    ( verifyUtxoSetCompleteness
     )
 import Cardano.MPFS.Client.Verify.Replay
     ( VerifyError (..)
@@ -120,6 +134,42 @@ verifyTokenFacts (TrustedRoot (Hex trustedBs)) resp@FactsResponse{..} = do
     factPair FactEntry{feKey = Hex keyBs, feValue = Hex valueBs} =
         (keyBs, valueBs)
 
+-- | Opaque witness that a requests response has been checked against
+-- the caller-supplied trusted root: the snapshot is pinned to that
+-- root, and the request-address UTxO set witness proves the complete
+-- set for the requested token's locally-derived request prefix.
+newtype VerifiedTokenRequests = VerifiedTokenRequests RequestsResponse
+    deriving stock (Eq, Show)
+
+-- | Extract the verified response after 'verifyTokenRequests' has
+-- established the trusted-root and request-set completeness checks.
+verifiedTokenRequests :: VerifiedTokenRequests -> RequestsResponse
+verifiedTokenRequests (VerifiedTokenRequests resp) = resp
+
+-- | Verify a @GET \/tokens\/:id\/requests@ 'RequestsResponse'
+-- against an externally-supplied trusted UTxO-CSMT root and the token
+-- id from the request path. The response body does not repeat the
+-- path token id, so callers must supply it explicitly for local
+-- request-address prefix derivation.
+verifyTokenRequests
+    :: CageConfig
+    -> TokenIdJSON
+    -> TrustedRoot
+    -> RequestsResponse
+    -> Either VerifyError VerifiedTokenRequests
+verifyTokenRequests
+    cfg
+    token
+    (TrustedRoot (Hex trustedBs))
+    resp@RequestsResponse{..} = do
+        verifyTrustedSnapshot "requests" trustedBs rrSnapshot
+        verifyUtxoSetCompleteness
+            "requests.request_set"
+            trustedBs
+            (requestSetPrefixFromCfg cfg token)
+            rrRequestSet
+        Right (VerifiedTokenRequests resp)
+
 -- | Reconstruct the Aiken-compatible MPF trie root from a complete
 -- set of @(key, value)@ byte pairs, purely. Each key becomes its
 -- Aiken nibble path and each value its MPF value hash, then the trie
@@ -152,6 +202,18 @@ verifyAnchoredState
     -> WitnessedTokenState
     -> Either VerifyError ()
 verifyAnchoredState prefix trustedBs snapshot state = do
+    verifyTrustedSnapshot prefix trustedBs snapshot
+    replayWitnessedUtxo
+        (prefix <> ".state.utxo")
+        trustedBs
+        (toClientWitnessedUtxo (wtsUtxo state))
+
+verifyTrustedSnapshot
+    :: Text
+    -> BS.ByteString
+    -> VerificationSnapshot
+    -> Either VerifyError ()
+verifyTrustedSnapshot prefix trustedBs snapshot = do
     checkLength (prefix <> ".trusted_root") trustedBs
     verifyVerificationSnapshot (toClientSnapshot snapshot)
     let snapshotPath = prefix <> ".snapshot.utxo_root"
@@ -159,10 +221,6 @@ verifyAnchoredState prefix trustedBs snapshot state = do
     if snapshotBs == trustedBs
         then Right ()
         else Left (TrustedRootMismatch snapshotPath)
-    replayWitnessedUtxo
-        (prefix <> ".state.utxo")
-        trustedBs
-        (toClientWitnessedUtxo (wtsUtxo state))
   where
     checkLength field bs
         | BS.length bs == 32 = Right ()

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -1,3 +1,4 @@
+Entering cardano-mpfs-offchain dev shell
 {
     "definitions": {
         "BootFacts": {
@@ -624,6 +625,9 @@
         "RequestsResponse": {
             "description": "Proof-bearing pending requests response",
             "properties": {
+                "request_set": {
+                    "$ref": "#/definitions/UtxoSetWitness"
+                },
                 "requests": {
                     "items": {
                         "$ref": "#/definitions/WitnessedRequest"
@@ -636,6 +640,7 @@
             },
             "required": [
                 "snapshot",
+                "request_set",
                 "requests"
             ],
             "type": "object"

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -1,4 +1,3 @@
-Entering cardano-mpfs-offchain dev shell
 {
     "definitions": {
         "BootFacts": {

--- a/specs/310-verify-token-requests/plan.md
+++ b/specs/310-verify-token-requests/plan.md
@@ -1,0 +1,26 @@
+# Plan — #310 verifyTokenRequests
+
+## Modules
+- `cardano-mpfs-api/.../API/Types.hs` — `RequestsResponse` (+ `UtxoSetWitness` field), ToJSON/FromJSON/ToSchema.
+- `cardano-mpfs-offchain/.../HTTP/Server.hs` — `tokenRequestsHandler` builds the request-set witness (mirror the `end` handler's `requestSet` + `utxoSetToJSON`, `HTTP/Types/Facts.hs`).
+- `cardano-mpfs-verify/.../Client/Verify/Read.hs` — `verifyTokenRequests` + `VerifiedTokenRequests` + accessor (mirror `verifyTokenFacts`; use `Verify/Completeness.verifyUtxoSetCompleteness` over the request-address prefix).
+- tests: `cardano-mpfs-client/test/.../Verify/ReadSpec.hs` (client), offchain `test/.../HTTP/RequestsSpec.hs` + e2e completeness.
+- `docs/assets/swagger.json`, README.
+
+## Slices (bisect-safe)
+
+### S1 — API + server: request-set completeness witness on /requests
+Add the `UtxoSetWitness` to `RequestsResponse`; `tokenRequestsHandler` computes it
+like `end` (resolve the token's request-address UTxO set → `utxoSetToJSON`). Update
+ToJSON/FromJSON/ToSchema/swagger. Proof: offchain unit/e2e that `/requests` returns a
+well-formed completeness witness for N requests; `./gate.sh` green.
+
+### S2 — client verifier: verifyTokenRequests
+Add `verifyTokenRequests` + opaque `VerifiedTokenRequests` + `verifiedTokenRequests` to
+`Verify/Read`, mirroring `verifyTokenFacts` (snapshot==root + `verifyUtxoSetCompleteness`
+over the request-address prefix). RED: client test — complete set verifies, tampered/
+dropped fails closed. GREEN: implement. `./gate.sh` green.
+
+## Order
+S1 first (the witness must exist to verify). S2 consumes it. The request-address prefix
+derivation + `verifyUtxoSetCompleteness` already exist (end-facts); reuse, don't reinvent.

--- a/specs/310-verify-token-requests/spec.md
+++ b/specs/310-verify-token-requests/spec.md
@@ -1,0 +1,51 @@
+# Spec — #310 verifyTokenRequests (RequestsResponse completeness)
+
+Repo: lambdasistemi/cardano-mpfs-offchain. Part of read-side proof work (#243).
+Base: `main`. PR target: `main`.
+
+## Goal
+
+`GET /tokens/:id/requests` must be verifiable: a consumer (e.g. moog oracle
+validation, cardano-foundation/moog#159) needs to prove the returned pending-
+request set is **complete** against the trusted UTxO-CSMT root — a missing
+request could hide a conflicting/duplicate pending change. Today `RequestsResponse`
+carries only per-request witnesses (`rrRequests :: [WitnessedRequest]`), no
+set-level completeness proof, so `verifyUtxoSetCompleteness` cannot be applied.
+
+## P1 user story
+
+As a client of `/tokens/:id/requests`, I verify the response with
+`verifyTokenRequests trustedRoot resp` and obtain a `VerifiedTokenRequests`
+only if the request set is complete under the per-cage request-address prefix
+against the trusted root.
+
+## Functional requirements
+
+- FR1 (API) — `RequestsResponse` carries a request-set completeness witness
+  (`UtxoSetWitness`), mirroring `EndFacts.efRequestSet`. (Add a field, e.g.
+  `rrRequestSet :: UtxoSetWitness`, alongside or replacing the per-request list
+  as the verifiable surface.)
+- FR2 (server) — `tokenRequestsHandler` populates it by building the token's
+  request-address UTxO set the same way the `end` handler does
+  (`utxoSetToJSON requestSet`, `HTTP/Types/Facts.hs`), against the snapshot.
+- FR3 (client) — `Cardano.MPFS.Client.Verify.Read` exports
+  `VerifiedTokenRequests` (opaque), `verifiedTokenRequests` accessor, and
+  `verifyTokenRequests :: TrustedRoot -> RequestsResponse -> Either VerifyError
+  VerifiedTokenRequests`, mirroring `verifyTokenFacts`: check
+  `snapshot.utxo_root == trustedRoot` and `verifyUtxoSetCompleteness` over the
+  request-address prefix. Pure (no fetching).
+- FR4 — verification fails closed on a tampered/incomplete set.
+
+## Success criteria
+
+- Client unit test: a complete request-set verifies; an entry-dropped/tampered
+  witness fails with a completeness error.
+- Server/e2e: `/tokens/:id/requests` for a token with N pending requests returns
+  a witness that `verifyTokenRequests` accepts.
+- `./gate.sh` green (format-check, hlint, unit-tests, client-unit-tests).
+- Swagger/README updated for the new response shape.
+
+## Non-goals
+
+- Changing `/facts` or `/tokens/:id` verifiers (#307 already landed).
+- moog-side consumption (that's cardano-foundation/moog#159).

--- a/specs/310-verify-token-requests/tasks.md
+++ b/specs/310-verify-token-requests/tasks.md
@@ -1,0 +1,7 @@
+# Tasks — #310 verifyTokenRequests
+
+## Slice S1 — API + server request-set completeness witness
+- [ ] T310-S1 Add `UtxoSetWitness` to `RequestsResponse` (+ JSON/schema/swagger); `tokenRequestsHandler` computes it mirroring the `end` handler (`utxoSetToJSON requestSet`); offchain unit/e2e proof; `./gate.sh` green.
+
+## Slice S2 — client verifyTokenRequests
+- [ ] T310-S2 Add `verifyTokenRequests` + opaque `VerifiedTokenRequests` + accessor to `Verify/Read` (snapshot==root + `verifyUtxoSetCompleteness` over request-address prefix); RED complete-verifies/tampered-fails-closed; `./gate.sh` green.

--- a/specs/310-verify-token-requests/tasks.md
+++ b/specs/310-verify-token-requests/tasks.md
@@ -4,4 +4,4 @@
 - [X] T310-S1 Add `UtxoSetWitness` to `RequestsResponse` (+ JSON/schema/swagger); `tokenRequestsHandler` computes it mirroring the `end` handler (`utxoSetToJSON requestSet`); offchain unit/e2e proof; `./gate.sh` green.
 
 ## Slice S2 — client verifyTokenRequests
-- [ ] T310-S2 Add `verifyTokenRequests` + opaque `VerifiedTokenRequests` + accessor to `Verify/Read` (snapshot==root + `verifyUtxoSetCompleteness` over request-address prefix); RED complete-verifies/tampered-fails-closed; `./gate.sh` green.
+- [X] T310-S2 Add `verifyTokenRequests` + opaque `VerifiedTokenRequests` + accessor to `Verify/Read` (snapshot==root + `verifyUtxoSetCompleteness` over request-address prefix); RED complete-verifies/tampered-fails-closed; `./gate.sh` green.

--- a/specs/310-verify-token-requests/tasks.md
+++ b/specs/310-verify-token-requests/tasks.md
@@ -1,7 +1,7 @@
 # Tasks — #310 verifyTokenRequests
 
 ## Slice S1 — API + server request-set completeness witness
-- [ ] T310-S1 Add `UtxoSetWitness` to `RequestsResponse` (+ JSON/schema/swagger); `tokenRequestsHandler` computes it mirroring the `end` handler (`utxoSetToJSON requestSet`); offchain unit/e2e proof; `./gate.sh` green.
+- [X] T310-S1 Add `UtxoSetWitness` to `RequestsResponse` (+ JSON/schema/swagger); `tokenRequestsHandler` computes it mirroring the `end` handler (`utxoSetToJSON requestSet`); offchain unit/e2e proof; `./gate.sh` green.
 
 ## Slice S2 — client verifyTokenRequests
 - [ ] T310-S2 Add `verifyTokenRequests` + opaque `VerifiedTokenRequests` + accessor to `Verify/Read` (snapshot==root + `verifyUtxoSetCompleteness` over request-address prefix); RED complete-verifies/tampered-fails-closed; `./gate.sh` green.


### PR DESCRIPTION
Draft for #310. Adds a request-set completeness witness to `RequestsResponse` (API+server, mirroring `EndFacts.efRequestSet`) and the client verifier `verifyTokenRequests` in `Verify/Read` (mirroring `verifyTokenFacts` + `verifyUtxoSetCompleteness`). Unblocks cardano-foundation/moog#159. Plan: `specs/310-verify-token-requests/` (S1 API+server, S2 client). Closes #310.