### PR TITLE
feat(cli): ship mpfs-cli release artifacts

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - nixos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           .#client-tests
           .#e2e-tests
           .#cardano-mpfs-offchain
+          .#mpfs-cli
           .#mpfs-spa
           .#docker-image
           .#checks.x86_64-linux.swagger-up-to-date

--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-and-release:
-    name: Build mpfs-serve for aarch64-darwin
+    name: Build mpfs-serve and mpfs-cli for aarch64-darwin
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
@@ -24,30 +24,52 @@ jobs:
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= paolino.cachix.org-1:ecmgO3CXdgSWA2cHlm4srknd/cLFMLmK3i3NrzeDFaE=
 
       - name: Build mpfs-serve
-        run: nix build .#mpfs-serve -L --print-out-paths > /tmp/nix-out
+        run: nix build .#mpfs-serve -L --print-out-paths > /tmp/nix-out-serve
 
-      - name: Bundle
+      - name: Bundle mpfs-serve
         run: |
-          mkdir -p /tmp/bundle/bin /tmp/bundle/lib
-          cp "$(cat /tmp/nix-out)/bin/mpfs-serve" /tmp/bundle/bin/
+          mkdir -p /tmp/bundle-serve/bin /tmp/bundle-serve/lib
+          cp "$(cat /tmp/nix-out-serve)/bin/mpfs-serve" /tmp/bundle-serve/bin/
 
-          otool -L /tmp/bundle/bin/mpfs-serve \
+          otool -L /tmp/bundle-serve/bin/mpfs-serve \
             | grep -v /usr/lib | grep -v /System | grep -v ":" \
-            | awk '{print $1}' | while read lib; do
+            | awk '{print $1}' | while read -r lib; do
               libname=$(basename "$lib")
-              cp "$lib" /tmp/bundle/lib/
-              install_name_tool -change "$lib" "@executable_path/../lib/$libname" /tmp/bundle/bin/mpfs-serve
+              cp "$lib" /tmp/bundle-serve/lib/
+              install_name_tool -change "$lib" "@executable_path/../lib/$libname" /tmp/bundle-serve/bin/mpfs-serve
             done
 
           echo "==> Verify:"
-          otool -L /tmp/bundle/bin/mpfs-serve
-          /tmp/bundle/bin/mpfs-serve --help || true
+          otool -L /tmp/bundle-serve/bin/mpfs-serve
+          /tmp/bundle-serve/bin/mpfs-serve --help || true
+
+      - name: Build mpfs-cli
+        run: nix build .#mpfs-cli -L --print-out-paths > /tmp/nix-out-cli
+
+      - name: Bundle mpfs-cli
+        run: |
+          mkdir -p /tmp/bundle-cli/bin /tmp/bundle-cli/lib
+          cp "$(cat /tmp/nix-out-cli)/bin/mpfs-cli" /tmp/bundle-cli/bin/
+
+          otool -L /tmp/bundle-cli/bin/mpfs-cli \
+            | grep -v /usr/lib | grep -v /System | grep -v ":" \
+            | awk '{print $1}' | while read -r lib; do
+              libname=$(basename "$lib")
+              cp "$lib" /tmp/bundle-cli/lib/
+              install_name_tool -change "$lib" "@executable_path/../lib/$libname" /tmp/bundle-cli/bin/mpfs-cli
+            done
+
+          echo "==> Verify:"
+          otool -L /tmp/bundle-cli/bin/mpfs-cli
+          /tmp/bundle-cli/bin/mpfs-cli --help
 
       - name: Create tarball
         run: |
           VERSION=$(git rev-parse --short HEAD)
-          tar czf /tmp/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz -C /tmp/bundle .
-          shasum -a 256 /tmp/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz
+          tar czf "/tmp/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz" -C /tmp/bundle-serve .
+          tar czf "/tmp/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz" -C /tmp/bundle-cli .
+          shasum -a 256 "/tmp/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz"
+          shasum -a 256 "/tmp/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz"
           echo "$VERSION" > /tmp/version.txt
 
       - name: Create release
@@ -56,12 +78,14 @@ jobs:
         run: |
           VERSION=$(cat /tmp/version.txt)
           TAG="darwin-${VERSION}"
-          TARBALL="/tmp/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz"
+          SERVE_TARBALL="/tmp/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz"
+          CLI_TARBALL="/tmp/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz"
           gh release delete "$TAG" -y 2>/dev/null || true
           gh release create "$TAG" \
-            --title "mpfs-serve $TAG (aarch64-darwin)" \
+            --title "MPFS $TAG (aarch64-darwin)" \
             --notes "aarch64-darwin build from $(git rev-parse HEAD)" \
-            "$TARBALL"
+            "$SERVE_TARBALL" \
+            "$CLI_TARBALL"
 
       - name: Update homebrew tap
         env:
@@ -69,18 +93,23 @@ jobs:
         run: |
           VERSION=$(cat /tmp/version.txt)
           TAG="darwin-${VERSION}"
-          TARBALL="/tmp/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz"
-          SHA=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
-          URL="https://github.com/lambdasistemi/cardano-mpfs-offchain/releases/download/${TAG}/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz"
+          SERVE_TARBALL="/tmp/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz"
+          CLI_TARBALL="/tmp/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz"
+          SERVE_SHA=$(shasum -a 256 "$SERVE_TARBALL" | cut -d' ' -f1)
+          CLI_SHA=$(shasum -a 256 "$CLI_TARBALL" | cut -d' ' -f1)
+          SERVE_URL="https://github.com/lambdasistemi/cardano-mpfs-offchain/releases/download/${TAG}/mpfs-serve-${VERSION}-aarch64-darwin.tar.gz"
+          CLI_URL="https://github.com/lambdasistemi/cardano-mpfs-offchain/releases/download/${TAG}/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz"
 
-          printf 'class MpfsServe < Formula\n  desc "Cardano Merkle Patricia Forestry offchain service"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-serve"\n    (libexec/"lib").install Dir["lib/*"]\n  end\nend\n' "$URL" "$SHA" "$VERSION" > /tmp/mpfs-serve.rb
+          printf 'class MpfsServe < Formula\n  desc "Cardano Merkle Patricia Forestry offchain service"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-serve"\n    (libexec/"lib").install Dir["lib/*"]\n  end\nend\n' "$SERVE_URL" "$SERVE_SHA" "$VERSION" > /tmp/mpfs-serve.rb
+          printf 'class MpfsCli < Formula\n  desc "Command-line front-end for the Cardano MPFS server"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-cli"\n    lib.install Dir["lib/*"]\n  end\nend\n' "$CLI_URL" "$CLI_SHA" "$VERSION" > /tmp/mpfs-cli.rb
 
-          git clone https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git /tmp/tap
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git" /tmp/tap
           mkdir -p /tmp/tap/Formula
           cp /tmp/mpfs-serve.rb /tmp/tap/Formula/mpfs-serve.rb
+          cp /tmp/mpfs-cli.rb /tmp/tap/Formula/mpfs-cli.rb
           cd /tmp/tap
           git config user.name "github-actions"
           git config user.email "actions@github.com"
-          git add Formula/mpfs-serve.rb
-          git diff --cached --quiet || git commit -m "update mpfs-serve to ${TAG}"
+          git add Formula/mpfs-serve.rb Formula/mpfs-cli.rb
+          git diff --cached --quiet || git commit -m "update darwin formulae to ${TAG}"
           git push

--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -101,7 +101,7 @@ jobs:
           CLI_URL="https://github.com/lambdasistemi/cardano-mpfs-offchain/releases/download/${TAG}/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz"
 
           printf 'class MpfsServe < Formula\n  desc "Cardano Merkle Patricia Forestry offchain service"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-serve"\n    (libexec/"lib").install Dir["lib/*"]\n  end\nend\n' "$SERVE_URL" "$SERVE_SHA" "$VERSION" > /tmp/mpfs-serve.rb
-          printf 'class MpfsCli < Formula\n  desc "Command-line front-end for the Cardano MPFS server"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-cli"\n    lib.install Dir["lib/*"]\n  end\nend\n' "$CLI_URL" "$CLI_SHA" "$VERSION" > /tmp/mpfs-cli.rb
+          printf 'class MpfsCli < Formula\n  desc "Command-line front-end for the Cardano MPFS server"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-cli"\n    lib.install Dir["lib/*"]\n  end\n\n  test do\n    system "#{bin}/mpfs-cli", "--help"\n  end\nend\n' "$CLI_URL" "$CLI_SHA" "$VERSION" > /tmp/mpfs-cli.rb
 
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git" /tmp/tap
           mkdir -p /tmp/tap/Formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,169 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  cli-linux-release:
+    name: Build mpfs-cli for x86_64-linux
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build mpfs-cli
+        run: nix build .#mpfs-cli -L --print-out-paths > /tmp/nix-out
+
+      - name: Bundle
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/bundle/bin /tmp/bundle/lib /tmp/bundle/libexec
+          cp "$(cat /tmp/nix-out)/bin/mpfs-cli" /tmp/bundle/libexec/
+          chmod +x /tmp/bundle/libexec/mpfs-cli
+
+          LD_TRACE_LOADED_OBJECTS=1 /tmp/bundle/libexec/mpfs-cli \
+            | awk '/=> \// { print $3 } /^[[:space:]]*\// { print $1 }' \
+            | sort -u \
+            | while read -r lib; do
+              case "$lib" in
+                /lib/*|/lib64/*|/usr/lib/*|/usr/lib64/*) ;;
+                *) cp -L "$lib" "/tmp/bundle/lib/$(basename "$lib")" ;;
+              esac
+            done
+
+          cat > /tmp/bundle/bin/mpfs-cli <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+          LOADER="$DIR/../lib/ld-linux-x86-64.so.2"
+          if [[ -x "$LOADER" ]]; then
+            exec "$LOADER" --library-path "$DIR/../lib" "$DIR/../libexec/mpfs-cli" "$@"
+          fi
+          exec "$DIR/../libexec/mpfs-cli" "$@"
+          EOF
+          sed -i 's/^          //' /tmp/bundle/bin/mpfs-cli
+          chmod +x /tmp/bundle/bin/mpfs-cli
+
+          echo "==> Verify:"
+          /tmp/bundle/bin/mpfs-cli --help
+
+      - name: Create tarball
+        id: package
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${TAG#v}"
+          TARBALL="/tmp/mpfs-cli-${VERSION}-x86_64-linux.tar.gz"
+          tar czf "$TARBALL" -C /tmp/bundle .
+          sha256sum "$TARBALL"
+          {
+            echo "tag=$TAG"
+            echo "tarball=$TARBALL"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload release artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          nix shell --inputs-from . nixpkgs#gh -c gh release upload \
+            "${{ steps.package.outputs.tag }}" \
+            "${{ steps.package.outputs.tarball }}" \
+            --clobber
+
+  cli-darwin-release:
+    name: Build mpfs-cli for aarch64-darwin
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            extra-substituters = https://cache.iog.io https://paolino.cachix.org
+            extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= paolino.cachix.org-1:ecmgO3CXdgSWA2cHlm4srknd/cLFMLmK3i3NrzeDFaE=
+
+      - name: Build mpfs-cli
+        run: nix build .#mpfs-cli -L --print-out-paths > /tmp/nix-out
+
+      - name: Bundle
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/bundle/bin /tmp/bundle/lib
+          cp "$(cat /tmp/nix-out)/bin/mpfs-cli" /tmp/bundle/bin/
+
+          otool -L /tmp/bundle/bin/mpfs-cli \
+            | grep -v /usr/lib | grep -v /System | grep -v ":" \
+            | awk '{print $1}' | while read -r lib; do
+              libname=$(basename "$lib")
+              cp "$lib" /tmp/bundle/lib/
+              install_name_tool -change "$lib" "@executable_path/../lib/$libname" /tmp/bundle/bin/mpfs-cli
+            done
+
+          echo "==> Verify:"
+          otool -L /tmp/bundle/bin/mpfs-cli
+          /tmp/bundle/bin/mpfs-cli --help
+
+      - name: Create tarball
+        id: package
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${TAG#v}"
+          TARBALL="/tmp/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz"
+          tar czf "$TARBALL" -C /tmp/bundle .
+          shasum -a 256 "$TARBALL"
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "tarball=$TARBALL"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload release artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload \
+            "${{ steps.package.outputs.tag }}" \
+            "${{ steps.package.outputs.tarball }}" \
+            --clobber
+
+      - name: Update homebrew tap
+        env:
+          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.package.outputs.version }}"
+          TAG="${{ steps.package.outputs.tag }}"
+          TARBALL="${{ steps.package.outputs.tarball }}"
+          SHA=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
+          URL="https://github.com/lambdasistemi/cardano-mpfs-offchain/releases/download/${TAG}/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz"
+
+          printf 'class MpfsCli < Formula\n  desc "Command-line front-end for the Cardano MPFS server"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-cli"\n    lib.install Dir["lib/*"]\n  end\nend\n' "$URL" "$SHA" "$VERSION" > /tmp/mpfs-cli.rb
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git" /tmp/tap
+          mkdir -p /tmp/tap/Formula
+          cp /tmp/mpfs-cli.rb /tmp/tap/Formula/mpfs-cli.rb
+          cd /tmp/tap
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add Formula/mpfs-cli.rb
+          git diff --cached --quiet || git commit -m "update mpfs-cli to ${TAG}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           SHA=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
           URL="https://github.com/lambdasistemi/cardano-mpfs-offchain/releases/download/${TAG}/mpfs-cli-${VERSION}-aarch64-darwin.tar.gz"
 
-          printf 'class MpfsCli < Formula\n  desc "Command-line front-end for the Cardano MPFS server"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-cli"\n    lib.install Dir["lib/*"]\n  end\nend\n' "$URL" "$SHA" "$VERSION" > /tmp/mpfs-cli.rb
+          printf 'class MpfsCli < Formula\n  desc "Command-line front-end for the Cardano MPFS server"\n  homepage "https://github.com/lambdasistemi/cardano-mpfs-offchain"\n  url "%s"\n  sha256 "%s"\n  version "%s"\n\n  def install\n    bin.install "bin/mpfs-cli"\n    lib.install Dir["lib/*"]\n  end\n\n  test do\n    system "#{bin}/mpfs-cli", "--help"\n  end\nend\n' "$URL" "$SHA" "$VERSION" > /tmp/mpfs-cli.rb
 
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/lambdasistemi/homebrew-tap.git" /tmp/tap
           mkdir -p /tmp/tap/Formula

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -11,6 +11,24 @@ owns argument parsing, key loading, local signing, submission, and
 output formatting. See the [walkthrough](walkthrough.md) for a recorded
 session and [troubleshooting](troubleshooting.md) for known issues.
 
+## Install
+
+Release builds are attached to
+[GitHub Releases](https://github.com/lambdasistemi/cardano-mpfs-offchain/releases):
+
+- `mpfs-cli-<version>-x86_64-linux.tar.gz`
+- `mpfs-cli-<version>-aarch64-darwin.tar.gz`
+
+Unpack the tarball for your platform and put `bin/mpfs-cli` on your
+`PATH`.
+
+On macOS with Homebrew:
+
+```bash
+brew tap lambdasistemi/tap
+brew install mpfs-cli
+```
+
 ## Quick start
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
             packages = {
               inherit (project.packages)
                 offchain-tests client-tests workflows-tests e2e-tests
-                cardano-mpfs-offchain mpfs-serve mpfs-devnet-server
+                cardano-mpfs-offchain mpfs-serve mpfs-cli mpfs-devnet-server
                 mpfs-bootstrap-genesis docker-image haddock;
               inherit (wasmTargets) wasm-mpfs-verify;
               inherit mpfs-spa;


### PR DESCRIPTION
## Summary

- Export `.#mpfs-cli` from the top-level flake and include it in the CI build gate.
- Extend `release.yml` so release-please-created releases attach `mpfs-cli` Linux and macOS tarballs.
- Extend the manual Darwin release to include `mpfs-cli` and publish a Homebrew `mpfs-cli` formula with a `brew test` `--help` smoke.
- Document release tarball and Homebrew install paths for the CLI.

## Release-flow choice

This extends `release.yml` instead of adding a separate tag/release workflow. Release-please creates the release in this workflow, so the `release_created` and `tag_name` outputs let the artifact jobs upload to the same release without depending on a follow-on event from `GITHUB_TOKEN`.

The manual `darwin-release.yml` remains as the SHA-scoped Darwin release path and now mirrors the existing `mpfs-serve` `otool`/`install_name_tool` bundling for `mpfs-cli`.

Fixes #313.

## Verification

- `nix build .#mpfs-cli -L`
- `./result/bin/mpfs-cli --help`
- local Linux tarball smoke: bundle libs, package, extract, run `bin/mpfs-cli --help`
- `git diff --check`
- `nix --quiet shell nixpkgs#actionlint -c actionlint .github/workflows/*.yml`
- `nix --quiet shell nixpkgs#ruby -c ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/*.yml`
- generated `mpfs-cli.rb` formula syntax: `nix --quiet shell nixpkgs#ruby -c ruby -c <formula>`
- `nix develop --quiet -c just ci` (`417`, `197`, `36`, and `5` examples; `0` failures; `hlint`: `No hints`)
