### PR TITLE
fix: restore verifyTokenRequests (regressed by reconcile 677ec55) (#310)

### DIFF
--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -658,6 +658,8 @@ instance FromJSON ProofResponse where
 data RequestsResponse = RequestsResponse
     { rrSnapshot :: VerificationSnapshot
     -- ^ Snapshot the bundled proofs target
+    , rrRequestSet :: UtxoSetWitness
+    -- ^ Complete request-address UTxO set witness
     , rrRequests :: [WitnessedRequest]
     -- ^ Witnessed pending requests
     }
@@ -667,6 +669,7 @@ instance ToJSON RequestsResponse where
     toJSON RequestsResponse{..} =
         object
             [ "snapshot" .= rrSnapshot
+            , "request_set" .= rrRequestSet
             , "requests" .= rrRequests
             ]
 
@@ -674,6 +677,7 @@ instance FromJSON RequestsResponse where
     parseJSON = withObject "RequestsResponse" $ \o ->
         RequestsResponse
             <$> o .: "snapshot"
+            <*> o .: "request_set"
             <*> o .: "requests"
 
 -- | @POST \/tx\/boot@ request body.
@@ -1982,6 +1986,9 @@ instance ToSchema RequestsResponse where
         reqListSchema <-
             declareSchemaRef
                 (Proxy @[WitnessedRequest])
+        requestSetSchema <-
+            declareSchemaRef
+                (Proxy @UtxoSetWitness)
         pure
             $ Swagger.NamedSchema
                 (Just "RequestsResponse")
@@ -1991,10 +1998,11 @@ instance ToSchema RequestsResponse where
             & properties
                 .~ fromList
                     [ ("snapshot", snapshotSchema)
+                    , ("request_set", requestSetSchema)
                     , ("requests", reqListSchema)
                     ]
             & required
-                .~ ["snapshot", "requests"]
+                .~ ["snapshot", "request_set", "requests"]
             & description
                 ?~ "Proof-bearing pending requests response"
 

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
@@ -11,28 +11,81 @@ module Cardano.MPFS.Client.Verify.ReadSpec (spec) where
 
 import Control.Monad (void)
 import Data.Bits (xor)
+import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.Text.Encoding qualified as T
-import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+import System.Environment (getEnv)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
 
+import CSMT
+    ( Direction
+    , Standalone (StandaloneCSMTCol)
+    )
+import CSMT.Backend.Pure (runPureTransaction)
+import CSMT.Core.CBOR (renderCompletenessProof)
+import CSMT.Core.Hash
+    ( Hash
+    , byteStringToKey
+    , renderHash
+    )
+import CSMT.Hashes (mkHash)
+import CSMT.Proof.Completeness
+    ( CompletenessProof
+    , generateProof
+    )
+import CSMT.Test.Lib
+    ( evalPureFromEmptyDB
+    , getRootHashM
+    , hashCodecs
+    , insertMHash
+    )
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
 import MPF.Hashes (renderMPFHash)
 import MPF.Test.Lib (insertByteStringM, runMPFPure')
 import MPF.Test.Lib qualified as MPFTest (getRootHashM)
 
+import Cardano.Ledger.BaseTypes (Network (Testnet))
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( ChainPointJSON (..)
     , FactEntry (..)
     , FactsResponse (..)
+    , RequestJSON (..)
+    , RequestsResponse (..)
+    , TokenIdJSON (..)
     , TokenResponse (..)
     , TokenStateJSON (..)
     , TxInJSON (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
     , VerificationSnapshot (..)
+    , WitnessedRequest (..)
     , WitnessedTokenState (..)
     , WitnessedUtxo (..)
     )
+import Cardano.MPFS.Cage.Blueprint
+    ( extractCompiledCode
+    , loadBlueprint
+    )
+import Cardano.MPFS.Cage.Ledger (Coin (..))
 import Cardano.MPFS.Client.Bundle qualified as Bundle
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , computeScriptHash
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( requestSetPrefixFromCfg
+    )
 import Cardano.MPFS.Client.Fixtures
     ( bundleFunding
     , bundleRoot
@@ -42,6 +95,7 @@ import Cardano.MPFS.Client.Snapshot qualified as Snap
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Client.Verify.Read
     ( verifyTokenFacts
+    , verifyTokenRequests
     , verifyTokenState
     )
 import Cardano.MPFS.Client.Verify.Replay (VerifyError (..))
@@ -87,6 +141,38 @@ spec = describe "Read-side verifiers" $ do
                 honestTrustedRoot
                 (tamperFirstFactValue honestFactsResponse)
             `shouldSatisfy` isMpfReplayFailed
+    describe "verifyTokenRequests" $ do
+        it "accepts an honest requests response with a complete request set"
+            $ do
+                cfg <- testCageConfig
+                let RequestFixture{requestTrustedRoot, requestResponse} =
+                        honestRequestFixture cfg
+                verifyTokenRequestsUnit
+                    cfg
+                    sampleToken
+                    requestTrustedRoot
+                    requestResponse
+                    `shouldBe` Right ()
+        it "rejects a tampered request-set completeness proof" $ do
+            cfg <- testCageConfig
+            let RequestFixture{requestTrustedRoot, requestResponse} =
+                    honestRequestFixture cfg
+            verifyTokenRequestsUnit
+                cfg
+                sampleToken
+                requestTrustedRoot
+                (tamperRequestSetProof requestResponse)
+                `shouldSatisfy` isCompletenessProofInvalid
+        it "rejects a dropped request-set entry" $ do
+            cfg <- testCageConfig
+            let RequestFixture{requestTrustedRoot, requestResponse} =
+                    honestRequestFixture cfg
+            verifyTokenRequestsUnit
+                cfg
+                sampleToken
+                requestTrustedRoot
+                (dropFirstRequestSetEntry requestResponse)
+                `shouldSatisfy` isCompletenessProofInvalid
 
 -- | Discard the opaque witness so we can assert on @Right ()@.
 verifyTokenStateUnit
@@ -98,6 +184,15 @@ verifyTokenFactsUnit
     :: TrustedRoot -> FactsResponse -> Either VerifyError ()
 verifyTokenFactsUnit trusted =
     void . verifyTokenFacts trusted
+
+verifyTokenRequestsUnit
+    :: CageConfig
+    -> TokenIdJSON
+    -> TrustedRoot
+    -> RequestsResponse
+    -> Either VerifyError ()
+verifyTokenRequestsUnit cfg token trusted =
+    void . verifyTokenRequests cfg token trusted
 
 -- | The complete fact set for the honest token. The on-chain trie
 -- root is derived from these via the real MPF write backend, so the
@@ -160,6 +255,106 @@ tamperFirstFactValue resp =
     overFirst _ [] = []
     overFirst f (x : xs) = f x : xs
 
+data RequestFixture = RequestFixture
+    { requestTrustedRoot :: TrustedRoot
+    , requestResponse :: RequestsResponse
+    }
+
+honestRequestFixture :: CageConfig -> RequestFixture
+honestRequestFixture cfg =
+    let requestPrefix = requestSetPrefixFromCfg cfg sampleToken
+        (rootBytes, requestSet) = csmtRequestRows requestPrefix
+        response =
+            RequestsResponse
+                { rrSnapshot = snapshotWithRoot rootBytes
+                , rrRequestSet = requestSet
+                , rrRequests =
+                    [ WitnessedRequest
+                        { wrUtxo =
+                            WitnessedUtxo
+                                { wuTxIn =
+                                    TxInJSON
+                                        { tjTxId = Hex requestTxId
+                                        , tjTxIx = 0
+                                        }
+                                , wuTxOut = Hex requestTxOut
+                                , wuProof = Hex "\x82\x01\x02"
+                                }
+                        , wrRequest =
+                            RequestJSON
+                                { rjToken = sampleToken
+                                , rjOwner = "owner"
+                                , rjKey = Hex "apple"
+                                , rjOperation = "insert"
+                                , rjValue = Just (Hex "fruit")
+                                , rjFee = 1000000
+                                , rjSubmittedAt = 42
+                                }
+                        }
+                    ]
+                }
+    in  RequestFixture
+            { requestTrustedRoot = TrustedRoot (Hex rootBytes)
+            , requestResponse = response
+            }
+
+csmtRequestRows :: [Direction] -> (ByteString, UtxoSetWitness)
+csmtRequestRows requestPrefix = evalPureFromEmptyDB $ do
+    let requestKey =
+            requestPrefix
+                <> byteStringToKey
+                    (encodeTxIn requestTxId 0)
+    insertMHash requestKey (mkHash requestTxOut)
+    completenessProof <-
+        runPureTransaction hashCodecs
+            $ generateProof StandaloneCSMTCol [] requestPrefix
+    rootBytes <- maybe BS.empty renderHash <$> getRootHashM
+    pure
+        ( rootBytes
+        , UtxoSetWitness
+            { uswEntries =
+                [ UtxoEntryRefOnly
+                    { uerRef =
+                        UtxoRef
+                            { urTxId = Hex requestTxId
+                            , urTxIx = 0
+                            }
+                    , uerTxOutCbor = Hex requestTxOut
+                    }
+                ]
+            , uswCompletenessProof =
+                Hex
+                    $ case completenessProof of
+                        Just proof ->
+                            renderCompletenessProof
+                                (proof :: CompletenessProof Hash)
+                        Nothing ->
+                            error
+                                "expected request-set completeness proof"
+            }
+        )
+
+tamperRequestSetProof :: RequestsResponse -> RequestsResponse
+tamperRequestSetProof resp =
+    resp
+        { rrRequestSet =
+            (rrRequestSet resp)
+                { uswCompletenessProof =
+                    flipLastHexByte
+                        (uswCompletenessProof (rrRequestSet resp))
+                }
+        }
+
+dropFirstRequestSetEntry :: RequestsResponse -> RequestsResponse
+dropFirstRequestSetEntry resp =
+    resp
+        { rrRequestSet =
+            (rrRequestSet resp)
+                { uswEntries =
+                    drop 1 (uswEntries (rrRequestSet resp))
+                }
+        }
+
 honestTrustedRoot :: TrustedRoot
 honestTrustedRoot = TrustedRoot (Hex (bundleRoot honestWitness))
 
@@ -196,6 +391,70 @@ honestSnapshot =
                 }
         }
 
+snapshotWithRoot :: ByteString -> VerificationSnapshot
+snapshotWithRoot rootBytes =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex rootBytes
+        , vsChainPoint =
+            ChainPointJSON
+                { cpSlot = 42
+                , cpBlockId = Hex (BS.replicate 32 0x11)
+                }
+        }
+
+sampleToken :: TokenIdJSON
+sampleToken = TokenIdJSON "cafe"
+
+requestTxId :: ByteString
+requestTxId = BS.replicate 32 0x33
+
+requestTxOut :: ByteString
+requestTxOut = "request-tx-out-cbor"
+
+encodeTxIn :: ByteString -> Word -> ByteString
+encodeTxIn txIdBytes txIx =
+    CBOR.toStrictByteString
+        $ mconcat
+            [ CBOR.encodeListLen 2
+            , CBOR.encodeBytes txIdBytes
+            , CBOR.encodeWord64 (fromIntegral txIx)
+            ]
+
+testCageConfig :: IO CageConfig
+testCageConfig = do
+    blueprintPath <- getEnv "MPFS_BLUEPRINT"
+    eBlueprint <- loadBlueprint blueprintPath
+    blueprint <- case eBlueprint of
+        Left err ->
+            expectationFailure
+                ("loadBlueprint failed: " <> err)
+                *> error "unreachable"
+        Right bp -> pure bp
+    scriptBytes <-
+        case extractCompiledCode "state." blueprint of
+            Just bytes -> pure bytes
+            Nothing ->
+                expectationFailure
+                    "state script not found in MPFS_BLUEPRINT"
+                    *> error "unreachable"
+    requestBytes <-
+        case extractCompiledCode "request." blueprint of
+            Just bytes -> pure bytes
+            Nothing ->
+                expectationFailure
+                    "request script not found in MPFS_BLUEPRINT"
+                    *> error "unreachable"
+    pure
+        CageConfig
+            { cageScriptBytes = scriptBytes
+            , requestScriptBytes = requestBytes
+            , cfgScriptHash = computeScriptHash scriptBytes
+            , defaultProcessTime = 60_000
+            , defaultRetractTime = 30_000
+            , defaultTip = Coin 1_000_000
+            , network = Testnet
+            }
+
 -- | Flip a byte in the state UTxO's @tx_out@ so the advertised value
 -- no longer matches the value bound into the CSMT inclusion proof.
 tamperStateTxOut :: TokenResponse -> TokenResponse
@@ -231,6 +490,10 @@ isCsmtReplayFailed _ = False
 isMpfReplayFailed :: Either VerifyError () -> Bool
 isMpfReplayFailed (Left (MpfReplayFailed _ _)) = True
 isMpfReplayFailed _ = False
+
+isCompletenessProofInvalid :: Either VerifyError () -> Bool
+isCompletenessProofInvalid (Left (CompletenessProofInvalid _)) = True
+isCompletenessProofInvalid _ = False
 
 -- | Flip the first byte of a hex-wrapped bytestring.
 flipHexByte :: Hex -> Hex

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -164,6 +164,7 @@ import Cardano.MPFS.HTTP.Types.Facts
     , mkRequestUpdateFacts
     , mkRetractFacts
     , mkUpdateFacts
+    , utxoSetToJSON
     )
 import Cardano.MPFS.Indexer.Reads
     ( IndexerTx
@@ -617,8 +618,13 @@ tokenRequestsHandler
 tokenRequestsHandler ctx tokenId = do
     requireProofReadsReady ctx
     let tid = tokenIdFromJSON tokenId
+        cfg = cfgCage ctx
+        requestAddr = requestAddrFromCfg cfg tid (network cfg)
     _ <- requireToken ctx tid
     snapshot <- requireSnapshot ctx
+    requestSet <-
+        runProofIndexerTx ctx
+            $ readUtxoSetAt requestAddr
     reqs <-
         liftIO
             $ St.requestsByToken
@@ -628,6 +634,7 @@ tokenRequestsHandler ctx tokenId = do
     pure
         RequestsResponse
             { rrSnapshot = snapshot
+            , rrRequestSet = utxoSetToJSON requestSet
             , rrRequests = witnessed
             }
 

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      : Cardano.MPFS.HTTP.RequestsSpec
@@ -6,12 +9,16 @@
 -- License     : Apache-2.0
 module Cardano.MPFS.HTTP.RequestsSpec (spec) where
 
+import Control.Monad (forM_)
 import Data.Aeson (decode)
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short qualified as SBS
+import Data.Text qualified as T
 import Data.Vector qualified as V
 import Network.HTTP.Types
     ( status200
@@ -31,18 +38,63 @@ import Test.Hspec
     , expectationFailure
     , it
     , shouldBe
+    , shouldSatisfy
     )
 import Test.QuickCheck (generate)
 
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , Network (..)
+    )
+import Cardano.Ledger.Binary
+    ( natVersion
+    , serialize
+    , serialize'
+    )
 import Cardano.Ledger.Mary.Value (AssetName (..))
+import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
+    ( CSMTContext (..)
+    , CSMTOps (..)
+    , mkCSMTOps
+    )
+import Cardano.UTxOCSMT.Application.Run.Config (context)
+import Database.KV.Database (mkColumns)
+import Database.KV.RocksDB (mkRocksDBDatabase)
+import Database.KV.Transaction
+    ( RunTransaction (..)
+    , mapColumns
+    , newRunTransaction
+    )
+import Database.RocksDB
+    ( DB (..)
+    , withDBCF
+    )
+import System.Directory (doesFileExist)
+import System.IO.Temp (withSystemTempDirectory)
+import System.IO.Unsafe (unsafePerformIO)
 
+import Cardano.MPFS.Application
+    ( allColumnFamilies
+    , dbConfig
+    , unifiedCodecs
+    )
+import Cardano.MPFS.Client.Cage.Config qualified as Client
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Client.Verify.Read (verifyTokenRequests)
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
+    , Coin (..)
+    , ConwayEra
     , LocatedRequest (LocatedRequest)
     , LocatedTokenState (..)
     , SlotNo (..)
     , TokenId (..)
+    , TxIn
     )
 import Cardano.MPFS.Generators
     ( genRequest
@@ -51,7 +103,23 @@ import Cardano.MPFS.Generators
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.TokensSpec (mkDummyTokenState)
+import Cardano.MPFS.HTTP.Types
+    ( RequestsResponse (..)
+    , TokenIdJSON (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.Indexer.Columns (UnifiedColumns (..))
+import Cardano.MPFS.Indexer.Reads
+    ( IndexerTx (..)
+    , readMerkleRoot
+    )
+import Cardano.MPFS.Indexer.TxFixtures (testScriptHash)
 import Cardano.MPFS.State qualified as St
+import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( cageAddrFromCfg
+    , requestAddrFromCfg
+    )
 
 -- | "cafe" as hex = "63616665".
 cafeTid :: TokenId
@@ -80,7 +148,133 @@ withSnapshot rootBs outBs proofBs ctx = do
             { utxoRoot = pure (Just rootBs)
             , resolveUtxo = \_ -> pure (Just outBs)
             , utxoProof = \_ -> pure (Just proofBs)
+            , cfgCage = testCageConfig
             }
+
+-- | Run the handler against a real UTxO CSMT indexer
+-- transaction, seeded with request-address UTxO bytes.
+withRequestSet
+    :: [(TxIn, ByteString)]
+    -> Context IO
+    -> (Context IO -> IO a)
+    -> IO a
+withRequestSet entries ctx action =
+    withSystemTempDirectory "requests-indexer-test"
+        $ \dir ->
+            withDBCF
+                dir
+                dbConfig
+                allColumnFamilies
+                $ \db -> do
+                    let database =
+                            mkRocksDBDatabase
+                                db
+                                ( mkColumns
+                                    (columnFamilies db)
+                                    unifiedCodecs
+                                )
+                        CSMTContext{fromKV, hashing} = context
+                        csmtOps = mkCSMTOps fromKV hashing
+                    RunTransaction{runTransaction} <-
+                        newRunTransaction database
+                    let seededEntries =
+                            ( "sentinel-key"
+                            , otherAddressTxOutBytes
+                            )
+                                : [ ( serialize
+                                        (natVersion @11)
+                                        txIn
+                                    , BSL.fromStrict txOutBytes
+                                    )
+                                  | (txIn, txOutBytes) <- entries
+                                  ]
+                    runTransaction
+                        $ mapColumns InUtxo
+                        $ forM_ seededEntries
+                        $ uncurry
+                            (csmtInsert csmtOps)
+                    let IndexerTx readRoot = readMerkleRoot
+                    mRoot <- runTransaction readRoot
+                    action
+                        ctx
+                            { runIndexerTx =
+                                \(IndexerTx body) ->
+                                    runTransaction body
+                            , utxoRoot = pure mRoot
+                            }
+
+testCageConfig :: CageConfig
+testCageConfig =
+    CageConfig
+        { cageScriptBytes = SBS.toShort "dummy"
+        , requestScriptBytes = testRequestScriptBytes
+        , cfgScriptHash = testScriptHash
+        , defaultProcessTime = 60_000
+        , defaultRetractTime = 30_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+testRequestScriptBytes :: SBS.ShortByteString
+testRequestScriptBytes =
+    unsafePerformIO loadTestRequestScriptBytes
+{-# NOINLINE testRequestScriptBytes #-}
+
+loadTestRequestScriptBytes :: IO SBS.ShortByteString
+loadTestRequestScriptBytes = do
+    hex <- tryRead candidatePaths
+    let trimmed =
+            BS.takeWhile
+                (\b -> b /= 10 && b /= 13)
+                hex
+    case B16.decode trimmed of
+        Right bs -> pure (SBS.toShort bs)
+        Left err ->
+            error
+                $ "loadTestRequestScriptBytes: "
+                    <> err
+  where
+    candidatePaths =
+        [ "test-data/request.uplc.hex"
+        , "cardano-mpfs-offchain/test-data/request.uplc.hex"
+        ]
+    tryRead [] =
+        error
+            "loadTestRequestScriptBytes: \
+            \test-data/request.uplc.hex not found \
+            \in any of the candidate paths"
+    tryRead (p : ps) = do
+        exists <- doesFileExist p
+        if exists
+            then BS.readFile p
+            else tryRead ps
+
+-- | Serialized request UTxO bytes at the token's
+-- per-cage request address.
+sampleRequestOutBytes
+    :: TokenId
+    -> Integer
+    -> ByteString
+sampleRequestOutBytes tid _submittedAt =
+    serialize'
+        (natVersion @11)
+        (txOut :: TxOut ConwayEra)
+  where
+    txOut =
+        mkBasicTxOut
+            (requestAddrFromCfg testCageConfig tid Testnet)
+            (inject (Coin 2_000_000))
+
+otherAddressTxOutBytes :: BSL.ByteString
+otherAddressTxOutBytes =
+    BSL.fromStrict
+        $ serialize'
+            (natVersion @11)
+            ( mkBasicTxOut
+                (cageAddrFromCfg testCageConfig Testnet)
+                (inject (Coin 2_000_000))
+                :: TxOut ConwayEra
+            )
 
 -- | Seed an indexed token state for a token id so
 -- the proof-bearing handler can find a state UTxO
@@ -101,9 +295,10 @@ spec = describe "GET /tokens/:id/requests" $ do
         ctx <-
             withSnapshot "root" "tx-out" "proof" ctx0
         seedTokenState ctx cafeTid
-        resp <- getRequests ctx "63616665"
-        simpleStatus resp `shouldBe` status200
-        assertEnvelope resp 0
+        withRequestSet [] ctx $ \ctxWithSet -> do
+            resp <- getRequests ctxWithSet "63616665"
+            simpleStatus resp `shouldBe` status200
+            assertEnvelope resp 0
 
     it
         "returns a single witnessed request after \
@@ -122,10 +317,15 @@ spec = describe "GET /tokens/:id/requests" $ do
             St.putRequest
                 (St.requests (state ctx))
                 (LocatedRequest txIn req)
-            resp <- getRequests ctx "63616665"
-            simpleStatus resp `shouldBe` status200
-            assertEnvelope resp 1
-            assertWitnessedRequestFields resp
+            withRequestSet
+                [(txIn, sampleRequestOutBytes cafeTid 0)]
+                ctx
+                $ \ctxWithSet -> do
+                    resp <- getRequests ctxWithSet "63616665"
+                    simpleStatus resp `shouldBe` status200
+                    assertEnvelope resp 1
+                    assertWitnessedRequestFields resp
+                    assertVerifiesForCafe resp
 
     it
         "returns multiple witnessed requests for same \
@@ -149,9 +349,15 @@ spec = describe "GET /tokens/:id/requests" $ do
             St.putRequest
                 (St.requests (state ctx))
                 (LocatedRequest txIn2 req2)
-            resp <- getRequests ctx "63616665"
-            simpleStatus resp `shouldBe` status200
-            assertEnvelope resp 2
+            withRequestSet
+                [ (txIn1, sampleRequestOutBytes cafeTid 0)
+                , (txIn2, sampleRequestOutBytes cafeTid 1)
+                ]
+                ctx
+                $ \ctxWithSet -> do
+                    resp <- getRequests ctxWithSet "63616665"
+                    simpleStatus resp `shouldBe` status200
+                    assertEnvelope resp 2
 
     it "filters by token — other tokens excluded" $ do
         ctx0 <- mkTestContext
@@ -169,12 +375,20 @@ spec = describe "GET /tokens/:id/requests" $ do
         St.putRequest
             (St.requests (state ctx))
             (LocatedRequest txIn2 req2)
-        resp1 <- getRequests ctx "63616665"
-        simpleStatus resp1 `shouldBe` status200
-        assertEnvelope resp1 1
-        resp2 <- getRequests ctx "61616262"
-        simpleStatus resp2 `shouldBe` status200
-        assertEnvelope resp2 1
+        withRequestSet
+            [(txIn1, sampleRequestOutBytes cafeTid 0)]
+            ctx
+            $ \ctxWithCafeSet -> do
+                resp1 <- getRequests ctxWithCafeSet "63616665"
+                simpleStatus resp1 `shouldBe` status200
+                assertEnvelope resp1 1
+        withRequestSet
+            [(txIn2, sampleRequestOutBytes aabbTid 0)]
+            ctx
+            $ \ctxWithAabbSet -> do
+                resp2 <- getRequests ctxWithAabbSet "61616262"
+                simpleStatus resp2 `shouldBe` status200
+                assertEnvelope resp2 1
 
     it "returns 404 for unknown token" $ do
         ctx0 <- mkTestContext
@@ -223,6 +437,27 @@ assertEnvelope resp n =
                 _ ->
                     expectationFailure
                         "requests is not an array"
+            case KM.lookup "request_set" obj of
+                Just (Object requestSetObj) -> do
+                    case KM.lookup "entries" requestSetObj of
+                        Just (Array entries) ->
+                            V.length entries `shouldBe` n
+                        _ ->
+                            expectationFailure
+                                "request_set.entries is not an array"
+                    case KM.lookup
+                        "completeness_proof"
+                        requestSetObj of
+                        Just (String proof) ->
+                            proof
+                                `shouldSatisfy` (not . T.null)
+                        _ ->
+                            expectationFailure
+                                "request_set.completeness_proof \
+                                \is not a string"
+                _ ->
+                    expectationFailure
+                        "request_set is not an object"
         _ ->
             expectationFailure
                 "Expected JSON object"
@@ -277,3 +512,37 @@ assertWitnessedRequestFields resp =
         _ ->
             expectationFailure
                 "Expected JSON object"
+
+-- | Assert the response's request-set witness is accepted by the
+-- client verifier using the locally-derived token request prefix.
+assertVerifiesForCafe :: SResponse -> IO ()
+assertVerifiesForCafe resp =
+    case decode (simpleBody resp) of
+        Just body@RequestsResponse{rrSnapshot} ->
+            case verifyTokenRequests
+                (toClientCageConfig testCageConfig)
+                cafeTokenJSON
+                (TrustedRoot (vsUtxoRoot rrSnapshot))
+                body of
+                Right _ -> pure ()
+                Left err ->
+                    expectationFailure
+                        ("verifyTokenRequests failed: " <> show err)
+        Nothing ->
+            expectationFailure
+                "Expected RequestsResponse JSON"
+
+cafeTokenJSON :: TokenIdJSON
+cafeTokenJSON = TokenIdJSON "cafe"
+
+toClientCageConfig :: CageConfig -> Client.CageConfig
+toClientCageConfig cfg =
+    Client.CageConfig
+        { Client.cageScriptBytes = cageScriptBytes cfg
+        , Client.requestScriptBytes = requestScriptBytes cfg
+        , Client.cfgScriptHash = cfgScriptHash cfg
+        , Client.defaultProcessTime = defaultProcessTime cfg
+        , Client.defaultRetractTime = defaultRetractTime cfg
+        , Client.defaultTip = defaultTip cfg
+        , Client.network = network cfg
+        }

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
@@ -15,6 +15,9 @@ module Cardano.MPFS.Client.Verify.Read
     , VerifiedTokenFacts
     , verifiedTokenFacts
     , verifyTokenFacts
+    , VerifiedTokenRequests
+    , verifiedTokenRequests
+    , verifyTokenRequests
     ) where
 
 import Data.ByteString qualified as BS
@@ -37,6 +40,8 @@ import Cardano.MPFS.API.Types
     ( ChainPointJSON (..)
     , FactEntry (..)
     , FactsResponse (..)
+    , RequestsResponse (..)
+    , TokenIdJSON
     , TokenResponse (..)
     , TokenStateJSON (..)
     , TxInJSON (..)
@@ -45,9 +50,18 @@ import Cardano.MPFS.API.Types
     , WitnessedUtxo (..)
     )
 import Cardano.MPFS.Client.Bundle qualified as ClientWire
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( requestSetPrefixFromCfg
+    )
 import Cardano.MPFS.Client.Snapshot qualified as ClientSnapshot
 import Cardano.MPFS.Client.TrustedRoot
     ( TrustedRoot (..)
+    )
+import Cardano.MPFS.Client.Verify.Completeness
+    ( verifyUtxoSetCompleteness
     )
 import Cardano.MPFS.Client.Verify.Replay
     ( VerifyError (..)
@@ -120,6 +134,42 @@ verifyTokenFacts (TrustedRoot (Hex trustedBs)) resp@FactsResponse{..} = do
     factPair FactEntry{feKey = Hex keyBs, feValue = Hex valueBs} =
         (keyBs, valueBs)
 
+-- | Opaque witness that a requests response has been checked against
+-- the caller-supplied trusted root: the snapshot is pinned to that
+-- root, and the request-address UTxO set witness proves the complete
+-- set for the requested token's locally-derived request prefix.
+newtype VerifiedTokenRequests = VerifiedTokenRequests RequestsResponse
+    deriving stock (Eq, Show)
+
+-- | Extract the verified response after 'verifyTokenRequests' has
+-- established the trusted-root and request-set completeness checks.
+verifiedTokenRequests :: VerifiedTokenRequests -> RequestsResponse
+verifiedTokenRequests (VerifiedTokenRequests resp) = resp
+
+-- | Verify a @GET \/tokens\/:id\/requests@ 'RequestsResponse'
+-- against an externally-supplied trusted UTxO-CSMT root and the token
+-- id from the request path. The response body does not repeat the
+-- path token id, so callers must supply it explicitly for local
+-- request-address prefix derivation.
+verifyTokenRequests
+    :: CageConfig
+    -> TokenIdJSON
+    -> TrustedRoot
+    -> RequestsResponse
+    -> Either VerifyError VerifiedTokenRequests
+verifyTokenRequests
+    cfg
+    token
+    (TrustedRoot (Hex trustedBs))
+    resp@RequestsResponse{..} = do
+        verifyTrustedSnapshot "requests" trustedBs rrSnapshot
+        verifyUtxoSetCompleteness
+            "requests.request_set"
+            trustedBs
+            (requestSetPrefixFromCfg cfg token)
+            rrRequestSet
+        Right (VerifiedTokenRequests resp)
+
 -- | Reconstruct the Aiken-compatible MPF trie root from a complete
 -- set of @(key, value)@ byte pairs, purely. Each key becomes its
 -- Aiken nibble path and each value its MPF value hash, then the trie
@@ -152,6 +202,18 @@ verifyAnchoredState
     -> WitnessedTokenState
     -> Either VerifyError ()
 verifyAnchoredState prefix trustedBs snapshot state = do
+    verifyTrustedSnapshot prefix trustedBs snapshot
+    replayWitnessedUtxo
+        (prefix <> ".state.utxo")
+        trustedBs
+        (toClientWitnessedUtxo (wtsUtxo state))
+
+verifyTrustedSnapshot
+    :: Text
+    -> BS.ByteString
+    -> VerificationSnapshot
+    -> Either VerifyError ()
+verifyTrustedSnapshot prefix trustedBs snapshot = do
     checkLength (prefix <> ".trusted_root") trustedBs
     verifyVerificationSnapshot (toClientSnapshot snapshot)
     let snapshotPath = prefix <> ".snapshot.utxo_root"
@@ -159,10 +221,6 @@ verifyAnchoredState prefix trustedBs snapshot state = do
     if snapshotBs == trustedBs
         then Right ()
         else Left (TrustedRootMismatch snapshotPath)
-    replayWitnessedUtxo
-        (prefix <> ".state.utxo")
-        trustedBs
-        (toClientWitnessedUtxo (wtsUtxo state))
   where
     checkLength field bs
         | BS.length bs == 32 = Right ()

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -672,6 +672,9 @@
         "RequestsResponse": {
             "description": "Proof-bearing pending requests response",
             "properties": {
+                "request_set": {
+                    "$ref": "#/definitions/UtxoSetWitness"
+                },
                 "requests": {
                     "items": {
                         "$ref": "#/definitions/WitnessedRequest"
@@ -684,6 +687,7 @@
             },
             "required": [
                 "snapshot",
+                "request_set",
                 "requests"
             ],
             "type": "object"

--- a/specs/310b-restore-verify-token-requests/tasks.md
+++ b/specs/310b-restore-verify-token-requests/tasks.md
@@ -1,0 +1,4 @@
+# Tasks — #310 (restore) verifyTokenRequests regressed by reconcile
+
+## Slice S1 — restore request-set completeness witness + verifier on current main
+- [ ] T310b-S1 Re-apply #310 on the reconciled tree: add `UtxoSetWitness` (`rrRequestSet`) to `RequestsResponse` (+JSON/schema/swagger); `tokenRequestsHandler` computes it (mirror the `end` request-set build on current main); add `verifyTokenRequests` + opaque `VerifiedTokenRequests` + accessor to `Verify/Read` (snapshot==root + `verifyUtxoSetCompleteness`); client + server tests; `./gate.sh` green.

--- a/specs/310b-restore-verify-token-requests/tasks.md
+++ b/specs/310b-restore-verify-token-requests/tasks.md
@@ -1,4 +1,4 @@
 # Tasks — #310 (restore) verifyTokenRequests regressed by reconcile
 
 ## Slice S1 — restore request-set completeness witness + verifier on current main
-- [ ] T310b-S1 Re-apply #310 on the reconciled tree: add `UtxoSetWitness` (`rrRequestSet`) to `RequestsResponse` (+JSON/schema/swagger); `tokenRequestsHandler` computes it (mirror the `end` request-set build on current main); add `verifyTokenRequests` + opaque `VerifiedTokenRequests` + accessor to `Verify/Read` (snapshot==root + `verifyUtxoSetCompleteness`); client + server tests; `./gate.sh` green.
+- [X] T310b-S1 Re-apply #310 on the reconciled tree: add `UtxoSetWitness` (`rrRequestSet`) to `RequestsResponse` (+JSON/schema/swagger); `tokenRequestsHandler` computes it (mirror the `end` request-set build on current main); add `verifyTokenRequests` + opaque `VerifiedTokenRequests` + accessor to `Verify/Read` (snapshot==root + `verifyUtxoSetCompleteness`); client + server tests; `./gate.sh` green.


### PR DESCRIPTION
`677ec55` (reconcile) dropped the merged `verifyTokenRequests` (#312/#310). Re-applies it on the reconciled tree (with the *WithEval refactor): `rrRequestSet :: UtxoSetWitness` on `RequestsResponse` + server handler + client `verifyTokenRequests`. Reference: `1b91a1f` (the original merge). Unblocks moog re-pin (#162) + moog #159. Closes #310.