### PR TITLE
Fix cage eval era history and SPA wasm perf

### DIFF
--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types/Common.hs
@@ -294,9 +294,8 @@ data EvalContext = EvalContext
     , ecSlotLengthMs :: Word64
     -- ^ Fixed Shelley-era slot length in milliseconds.
     , ecEraHistoryCbor :: Hex
-    -- ^ Reserved for future proof-bearing hard-fork
-    -- history. Browser builders use the explicit
-    -- epoch fields above to avoid consensus dependencies.
+    -- ^ CBOR-encoded hard-fork era history used to build
+    -- the ledger 'EpochInfo' for local script evaluation.
     , ecTrusted :: Bool
     -- ^ Whether the service is asserting this context
     -- as trusted.

--- a/cardano-mpfs-cage-tx/cardano-mpfs-cage-tx.cabal
+++ b/cardano-mpfs-cage-tx/cardano-mpfs-cage-tx.cabal
@@ -60,6 +60,7 @@ library
     , cardano-mpfs-verify
     , cardano-slotting
     , cardano-tx-tools:tx-build
+    , cborg                      >=0.2  && <0.3
     , containers                 >=0.6  && <0.8
     , microlens
     , mts:mpf-write

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Eval.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Eval.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -14,15 +15,38 @@ module Cardano.MPFS.Client.Cage.Eval
     , patchEvaluatedRedeemers
     ) where
 
+import Codec.CBOR.Decoding
+    ( Decoder
+    , TokenType (..)
+    , decodeBreakOr
+    , decodeListLen
+    , decodeListLenOrIndef
+    , decodeNull
+    , decodeWord8
+    , peekTokenType
+    )
+import Codec.CBOR.Read
+    ( deserialiseFromBytes
+    )
 import Codec.Serialise
     ( Serialise
     , deserialiseOrFail
+    )
+import Codec.Serialise qualified as Serialise
+import Control.Monad
+    ( replicateM
+    , unless
+    , void
+    , when
     )
 import Data.ByteString.Lazy qualified as BSL
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Word
+    ( Word64
+    )
 import Lens.Micro ((&), (.~), (^.))
 
 import Cardano.Ledger.Address
@@ -44,6 +68,7 @@ import Cardano.Ledger.Api.PParams
 import Cardano.Ledger.Api.Tx
     ( bodyTxL
     , evalTxExUnits
+    , txIdTx
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -92,14 +117,19 @@ import Cardano.MPFS.Client.Cage.BuildError
     )
 import Cardano.Slotting.EpochInfo
     ( EpochInfo
-    , fixedEpochInfo
     )
+import Cardano.Slotting.EpochInfo qualified as EpochInfo
 import Cardano.Slotting.Slot
-    ( EpochSize (..)
+    ( EpochNo (..)
+    , EpochSize (..)
+    , SlotNo (..)
     )
 import Cardano.Slotting.Time
-    ( SystemStart
-    , slotLengthFromMillisec
+    ( RelativeTime (..)
+    , SlotLength
+    , SystemStart
+    , addRelativeTime
+    , getSlotLength
     )
 import Cardano.Tx.Balance
     ( BalanceResult (..)
@@ -118,6 +148,19 @@ data DecodedEvalContext = DecodedEvalContext
     , evalEpochInfo :: !(EpochInfo (Either Text))
     }
 
+data EraSummaryLite = EraSummaryLite
+    { esStart :: !EraBoundLite
+    , esEnd :: !(Maybe EraBoundLite)
+    , esEpochSize :: !EpochSize
+    , esSlotLength :: !SlotLength
+    }
+
+data EraBoundLite = EraBoundLite
+    { ebRelativeTime :: !RelativeTime
+    , ebSlot :: !SlotNo
+    , ebEpoch :: !EpochNo
+    }
+
 decodeEvalContext
     :: Wire.EvalContext
     -> Either BuildError DecodedEvalContext
@@ -127,16 +170,12 @@ decodeEvalContext Wire.EvalContext{..} = do
         decodeSerialise
             "eval_context.system_start_cbor"
             ecSystemStartCbor
+    epochInfo <- decodeEraHistoryEpochInfo ecEraHistoryCbor
     pure
         DecodedEvalContext
             { evalProtocolParameters = pp
             , evalSystemStart = systemStart
-            , evalEpochInfo =
-                fixedEpochInfo
-                    (EpochSize ecEpochSize)
-                    ( slotLengthFromMillisec
-                        (fromIntegral ecSlotLengthMs)
-                    )
+            , evalEpochInfo = epochInfo
             }
 
 decodePParams
@@ -163,6 +202,240 @@ decodeSerialise label (Hex bytes) =
                 $ EvaluationFailed
                 $ label <> ": " <> T.pack (show err)
         Right value -> Right value
+
+decodeEraHistoryEpochInfo
+    :: Hex
+    -> Either BuildError (EpochInfo (Either Text))
+decodeEraHistoryEpochInfo (Hex bytes) = do
+    summaries <-
+        case deserialiseFromBytes
+            decodeEraSummaries
+            (BSL.fromStrict bytes) of
+            Left err ->
+                Left
+                    $ EvaluationFailed
+                    $ "eval_context.era_history_cbor: "
+                        <> T.pack (show err)
+            Right (trailing, value)
+                | BSL.null trailing -> Right value
+                | otherwise ->
+                    Left
+                        $ EvaluationFailed
+                            "eval_context.era_history_cbor: trailing bytes"
+    case summaries of
+        [] ->
+            Left
+                $ EvaluationFailed
+                    "eval_context.era_history_cbor: empty era history"
+        _ -> Right $ eraSummariesEpochInfo summaries
+
+decodeEraSummaries :: Decoder s [EraSummaryLite]
+decodeEraSummaries =
+    decodeListLenOrIndef >>= \case
+        Just n -> replicateM n decodeEraSummaryLite
+        Nothing -> go []
+  where
+    go acc = do
+        done <- decodeBreakOr
+        if done
+            then pure $ reverse acc
+            else do
+                summary <- decodeEraSummaryLite
+                go (summary : acc)
+
+decodeEraSummaryLite :: Decoder s EraSummaryLite
+decodeEraSummaryLite = do
+    enforceListLen "EraSummary" 3
+    esStart <- decodeEraBoundLite
+    esEnd <- decodeEraEndLite
+    (esEpochSize, esSlotLength) <- decodeEraParamsLite
+    pure EraSummaryLite{..}
+
+decodeEraBoundLite :: Decoder s EraBoundLite
+decodeEraBoundLite = do
+    len <- decodeListLen
+    unless (len == 3 || len == 4)
+        $ fail "Bound: expected list length 3 or 4"
+    ebRelativeTime <- Serialise.decode
+    ebSlot <- Serialise.decode
+    ebEpoch <- Serialise.decode
+    when (len == 4)
+        $ void (Serialise.decode @Word64)
+    pure EraBoundLite{..}
+
+decodeEraEndLite :: Decoder s (Maybe EraBoundLite)
+decodeEraEndLite =
+    peekTokenType >>= \case
+        TypeNull -> do
+            decodeNull
+            pure Nothing
+        _ -> Just <$> decodeEraBoundLite
+
+decodeEraParamsLite :: Decoder s (EpochSize, SlotLength)
+decodeEraParamsLite = do
+    len <- decodeListLen
+    unless (len == 4 || len == 5)
+        $ fail "EraParams: expected list length 4 or 5"
+    epochSize <- EpochSize <$> Serialise.decode @Word64
+    slotLength <- Serialise.decode
+    decodeSafeZoneLite
+    void (Serialise.decode @Word64)
+    when (len == 5)
+        $ void (Serialise.decode @Word64)
+    pure (epochSize, slotLength)
+
+decodeSafeZoneLite :: Decoder s ()
+decodeSafeZoneLite = do
+    size <- decodeListLen
+    tag <- decodeWord8
+    case (size, tag) of
+        (3, 0) -> do
+            void (Serialise.decode @Word64)
+            decodeSafeBeforeEpochLite
+        (1, 1) ->
+            pure ()
+        _ ->
+            fail
+                $ "SafeZone: invalid size and tag "
+                    <> show (size, tag)
+
+decodeSafeBeforeEpochLite :: Decoder s ()
+decodeSafeBeforeEpochLite = do
+    size <- decodeListLen
+    tag <- decodeWord8
+    case (size, tag) of
+        (1, 0) ->
+            pure ()
+        (2, 1) ->
+            void (Serialise.decode @EpochNo)
+        _ ->
+            fail
+                $ "SafeBeforeEpoch: invalid size and tag "
+                    <> show (size, tag)
+
+enforceListLen :: String -> Int -> Decoder s ()
+enforceListLen label expected = do
+    actual <- decodeListLen
+    unless (actual == expected)
+        $ fail
+        $ label
+            <> ": expected list length "
+            <> show expected
+            <> ", got "
+            <> show actual
+
+eraSummariesEpochInfo
+    :: [EraSummaryLite]
+    -> EpochInfo (Either Text)
+eraSummariesEpochInfo summaries =
+    EpochInfo.EpochInfo
+        { EpochInfo.epochInfoSize_ =
+            fmap esEpochSize . findEraByEpoch
+        , EpochInfo.epochInfoFirst_ = epochToSlot
+        , EpochInfo.epochInfoEpoch_ = slotToEpoch
+        , EpochInfo.epochInfoSlotToRelativeTime_ =
+            slotToRelativeTime
+        , EpochInfo.epochInfoSlotLength_ =
+            fmap esSlotLength . findEraBySlot
+        }
+  where
+    findEraBySlot slot =
+        maybe
+            ( Left
+                $ "slot "
+                    <> T.pack (show slot)
+                    <> " outside eval-context era history"
+            )
+            Right
+            $ findFirst (eraContainsSlot slot) summaries
+
+    findEraByEpoch epoch =
+        maybe
+            ( Left
+                $ "epoch "
+                    <> T.pack (show epoch)
+                    <> " outside eval-context era history"
+            )
+            Right
+            $ findFirst (eraContainsEpoch epoch) summaries
+
+    slotToRelativeTime slot = do
+        EraSummaryLite{esStart, esSlotLength} <- findEraBySlot slot
+        slotDelta <- countSlotDelta slot (ebSlot esStart)
+        let timeDelta =
+                fromIntegral slotDelta * getSlotLength esSlotLength
+        Right
+            $ addRelativeTime
+                timeDelta
+                (ebRelativeTime esStart)
+
+    slotToEpoch slot = do
+        EraSummaryLite{esStart, esEpochSize = EpochSize epochSize} <-
+            findEraBySlot slot
+        slotDelta <- countSlotDelta slot (ebSlot esStart)
+        Right
+            $ addEpochs
+                (slotDelta `div` epochSize)
+                (ebEpoch esStart)
+
+    epochToSlot epoch = do
+        EraSummaryLite{esStart, esEpochSize = EpochSize epochSize} <-
+            findEraByEpoch epoch
+        epochDelta <- countEpochDelta epoch (ebEpoch esStart)
+        Right
+            $ addSlots
+                (epochDelta * epochSize)
+                (ebSlot esStart)
+
+eraContainsSlot :: SlotNo -> EraSummaryLite -> Bool
+eraContainsSlot slot EraSummaryLite{esStart, esEnd} =
+    ebSlot esStart <= slot
+        && maybe True ((slot <) . ebSlot) esEnd
+
+eraContainsEpoch :: EpochNo -> EraSummaryLite -> Bool
+eraContainsEpoch epoch EraSummaryLite{esStart, esEnd} =
+    ebEpoch esStart <= epoch
+        && maybe True ((epoch <) . ebEpoch) esEnd
+
+countSlotDelta
+    :: SlotNo
+    -> SlotNo
+    -> Either Text Word64
+countSlotDelta (SlotNo hi) (SlotNo lo)
+    | hi >= lo = Right $ hi - lo
+    | otherwise =
+        Left
+            $ "slot "
+                <> T.pack (show hi)
+                <> " precedes era start slot "
+                <> T.pack (show lo)
+
+countEpochDelta
+    :: EpochNo
+    -> EpochNo
+    -> Either Text Word64
+countEpochDelta (EpochNo hi) (EpochNo lo)
+    | hi >= lo = Right $ hi - lo
+    | otherwise =
+        Left
+            $ "epoch "
+                <> T.pack (show hi)
+                <> " precedes era start epoch "
+                <> T.pack (show lo)
+
+addSlots :: Word64 -> SlotNo -> SlotNo
+addSlots delta (SlotNo slot) =
+    SlotNo $ slot + delta
+
+addEpochs :: Word64 -> EpochNo -> EpochNo
+addEpochs delta (EpochNo epoch) =
+    EpochNo $ epoch + delta
+
+findFirst :: (a -> Bool) -> [a] -> Maybe a
+findFirst _ [] = Nothing
+findFirst p (x : xs)
+    | p x = Just x
+    | otherwise = findFirst p xs
 
 evaluateAndBalancePure
     :: DecodedEvalContext
@@ -206,22 +479,19 @@ evaluateAndBalancePure ctx inputUtxos refUtxos changeAddr tx =
                     txForEval
                     preBalanceReport
             preBalanced <- balance preBalancePatched
-            balancedReport <-
-                evaluateRedeemers ctx inputUtxos refUtxos preBalanced
             finalPatched <-
-                patchEvaluatedRedeemers
+                stabilizeSubmittedRedeemers
                     ctx
+                    inputUtxos
                     refUtxos
-                    txForEval
-                    balancedReport
-            balanced <- balance finalPatched
+                    preBalanced
             let finalFee =
-                    balanced ^. bodyTxL . feeTxBodyL
+                    finalPatched ^. bodyTxL . feeTxBodyL
                 finalExUnits =
-                    redeemerExUnits balanced
+                    redeemerExUnits finalPatched
             if finalFee == previousFee
                 && maybe True (== finalExUnits) previousExUnits
-                then Right balanced
+                then Right finalPatched
                 else go (n + 1) finalFee (Just finalExUnits)
 
     balance candidate =
@@ -269,15 +539,13 @@ evaluateAndBalancePureAtFee ctx expectedFee inputUtxos refUtxos changeAddr tx = 
     if balancedFee /= expectedFee
         then Right preBalanced
         else do
-            balancedReport <-
-                evaluateRedeemers ctx inputUtxos refUtxos preBalanced
             finalPatched <-
-                patchEvaluatedRedeemers
+                stabilizeSubmittedRedeemers
                     ctx
+                    inputUtxos
                     refUtxos
-                    txForEval
-                    balancedReport
-            balance finalPatched
+                    preBalanced
+            Right finalPatched
   where
     pp = evalProtocolParameters ctx
     existingInputs =
@@ -310,10 +578,31 @@ evaluateRedeemers
     -> ConwayTx
     -> Either BuildError (RedeemerReport ConwayEra)
 evaluateRedeemers ctx inputUtxos refUtxos tx = do
+    evaluateRedeemersWith
+        ctx
+        inputUtxos
+        refUtxos
+        (placeholderRedeemers ctx refUtxos tx)
+
+evaluateSubmittedRedeemers
+    :: DecodedEvalContext
+    -> [(TxIn, TxOut ConwayEra)]
+    -> [(TxIn, TxOut ConwayEra)]
+    -> ConwayTx
+    -> Either BuildError (RedeemerReport ConwayEra)
+evaluateSubmittedRedeemers = evaluateRedeemersWith
+
+evaluateRedeemersWith
+    :: DecodedEvalContext
+    -> [(TxIn, TxOut ConwayEra)]
+    -> [(TxIn, TxOut ConwayEra)]
+    -> ConwayTx
+    -> Either BuildError (RedeemerReport ConwayEra)
+evaluateRedeemersWith ctx inputUtxos refUtxos tx = do
     let report =
             evalTxExUnits
                 (evalProtocolParameters ctx)
-                (placeholderRedeemers ctx refUtxos tx)
+                tx
                 (UTxO $ Map.fromList $ inputUtxos <> refUtxos)
                 (evalEpochInfo ctx)
                 (evalSystemStart ctx)
@@ -328,6 +617,38 @@ evaluateRedeemers ctx inputUtxos refUtxos tx = do
                 $ EvaluationFailed
                 $ "script evaluation failed: "
                     <> T.pack (show failures)
+
+stabilizeSubmittedRedeemers
+    :: DecodedEvalContext
+    -> [(TxIn, TxOut ConwayEra)]
+    -> [(TxIn, TxOut ConwayEra)]
+    -> ConwayTx
+    -> Either BuildError ConwayTx
+stabilizeSubmittedRedeemers ctx inputUtxos refUtxos =
+    go (0 :: Int)
+  where
+    go n tx
+        | n > 10 =
+            Left
+                $ EvaluationFailed
+                    "submitted ex-unit convergence failed"
+        | otherwise = do
+            report <-
+                evaluateSubmittedRedeemers
+                    ctx
+                    inputUtxos
+                    refUtxos
+                    tx
+            patched <-
+                patchEvaluatedRedeemers
+                    ctx
+                    refUtxos
+                    tx
+                    report
+            if txIdTx patched == txIdTx tx
+                then Right patched
+                else go (n + 1) patched
+
 type RedeemerReport era =
     Map.Map
         (PlutusPurpose AsIx era)

--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -118,6 +118,7 @@ test-suite unit-tests
     , cardano-ledger-mary
     , cardano-mpfs-api
     , cardano-mpfs-cage
+    , cardano-mpfs-cage-tx
     , cardano-mpfs-client
     , cardano-slotting
     , cardano-tx-tools
@@ -135,6 +136,7 @@ test-suite unit-tests
     , mts:mpf-test-lib
     , mts:mpf-write
     , plutus-tx
+    , serialise
     , text
     , time
     , wai                     >=3.2  && <3.3
@@ -146,6 +148,7 @@ test-suite unit-tests
     Cardano.MPFS.Client.BundleSpec
     Cardano.MPFS.Client.Cage.BootSpec
     Cardano.MPFS.Client.Cage.EndSpec
+    Cardano.MPFS.Client.Cage.EvalSpec
     Cardano.MPFS.Client.Cage.RejectSpec
     Cardano.MPFS.Client.Cage.RequestSpec
     Cardano.MPFS.Client.Cage.RetractSpec

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EvalSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EvalSpec.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.Client.Cage.EvalSpec
+-- Description : Unit tests for pure cage ex-unit evaluation context.
+module Cardano.MPFS.Client.Cage.EvalSpec
+    ( spec
+    ) where
+
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
+import Codec.Serialise qualified as Serialise
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BSL
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    )
+
+import Cardano.Ledger.Api.PParams (emptyPParams)
+import Cardano.Ledger.Binary (natVersion, serialize')
+import Cardano.MPFS.API.Encoding (Hex (..))
+import Cardano.MPFS.API.Types.Common
+    ( EvalContext (..)
+    , UnverifiedPParams (..)
+    )
+import Cardano.MPFS.Client.Cage.Eval
+    ( DecodedEvalContext (..)
+    , decodeEvalContext
+    )
+import Cardano.MPFS.Client.Cage.TestEvalContext
+    ( testEvalPParams
+    )
+import Cardano.Slotting.EpochInfo qualified as EpochInfo
+import Cardano.Slotting.Slot
+    ( EpochNo (..)
+    , SlotNo (..)
+    )
+import Cardano.Slotting.Time
+    ( RelativeTime (..)
+    , SystemStart (..)
+    , slotLengthFromMillisec
+    )
+
+spec :: Spec
+spec = describe "decodeEvalContext" $ do
+    it "uses the live era history for slot-to-time conversion" $ do
+        ctx <-
+            case decodeEvalContext evalContextWithEraOffset of
+                Left err ->
+                    expectationFailure
+                        ("decodeEvalContext failed: " <> show err)
+                        *> error "unreachable"
+                Right decoded -> pure decoded
+
+        EpochInfo.epochInfoSlotToRelativeTime
+            (evalEpochInfo ctx)
+            (SlotNo 12)
+            `shouldBe` Right (RelativeTime 104)
+        EpochInfo.epochInfoEpoch
+            (evalEpochInfo ctx)
+            (SlotNo 12)
+            `shouldBe` Right (EpochNo 1)
+        EpochInfo.epochInfoFirst
+            (evalEpochInfo ctx)
+            (EpochNo 1)
+            `shouldBe` Right (SlotNo 10)
+
+evalContextWithEraOffset :: EvalContext
+evalContextWithEraOffset =
+    EvalContext
+        { ecProtocolParameters =
+            UnverifiedPParams
+                { uppVerified = False
+                , uppCbor =
+                    Hex
+                        $ serialize'
+                            (natVersion @11)
+                            (testEvalPParams emptyPParams)
+                }
+        , ecSystemStartCbor =
+            Hex
+                $ BSL.toStrict
+                $ Serialise.serialise
+                $ SystemStart (posixSecondsToUTCTime 0)
+        , ecEpochSize = 432_000
+        , ecSlotLengthMs = 1_000
+        , ecEraHistoryCbor = Hex eraHistoryWithOffsetCbor
+        , ecTrusted = True
+        , ecTrustAssumption = "test"
+        }
+
+eraHistoryWithOffsetCbor :: ByteString
+eraHistoryWithOffsetCbor =
+    CBOR.toStrictByteString
+        $ CBOR.encodeListLen 2
+            <> eraSummary
+                (RelativeTime 0)
+                (SlotNo 0)
+                (EpochNo 0)
+                (Just (RelativeTime 10, SlotNo 10, EpochNo 1))
+                10
+                1_000
+            <> eraSummary
+                (RelativeTime 100)
+                (SlotNo 10)
+                (EpochNo 1)
+                Nothing
+                10
+                2_000
+
+eraSummary
+    :: RelativeTime
+    -> SlotNo
+    -> EpochNo
+    -> Maybe (RelativeTime, SlotNo, EpochNo)
+    -> Word
+    -> Integer
+    -> CBOR.Encoding
+eraSummary startTime startSlot startEpoch end epochSize slotLengthMs =
+    CBOR.encodeListLen 3
+        <> eraBound startTime startSlot startEpoch
+        <> maybe
+            CBOR.encodeNull
+            ( \(endTime, endSlot, endEpoch) ->
+                eraBound endTime endSlot endEpoch
+            )
+            end
+        <> eraParams epochSize slotLengthMs
+
+eraBound
+    :: RelativeTime
+    -> SlotNo
+    -> EpochNo
+    -> CBOR.Encoding
+eraBound relativeTime slot epoch =
+    CBOR.encodeListLen 3
+        <> Serialise.encode relativeTime
+        <> Serialise.encode slot
+        <> Serialise.encode epoch
+
+eraParams :: Word -> Integer -> CBOR.Encoding
+eraParams epochSize slotLengthMs =
+    CBOR.encodeListLen 4
+        <> CBOR.encodeWord64 (fromIntegral epochSize)
+        <> Serialise.encode (slotLengthFromMillisec slotLengthMs)
+        <> (CBOR.encodeListLen 1 <> CBOR.encodeWord8 1)
+        <> CBOR.encodeWord64 0

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RejectSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RejectSpec.hs
@@ -14,7 +14,7 @@ import Codec.CBOR.Write qualified as CBOR
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.Coerce (coerce)
-import Data.Foldable (toList)
+import Data.Foldable (forM_, toList)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
 import Data.Ratio ((%))
@@ -78,6 +78,8 @@ import Cardano.Ledger.Api.Scripts.Data
     )
 import Cardano.Ledger.Api.Tx
     ( bodyTxL
+    , evalTxExUnits
+    , txIdTx
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
@@ -143,6 +145,9 @@ import Cardano.Ledger.Plutus.ExUnits
 import Cardano.Ledger.Plutus.Language
     ( Language (..)
     )
+import Cardano.Ledger.State
+    ( UTxO (..)
+    )
 import Cardano.Ledger.TxIn
     ( TxId (..)
     , TxIn (..)
@@ -185,6 +190,10 @@ import Cardano.MPFS.Client.Cage.Config
     ( CageConfig (..)
     , cagePolicyIdFromCfg
     , computeScriptHash
+    )
+import Cardano.MPFS.Client.Cage.Eval
+    ( DecodedEvalContext (..)
+    , patchEvaluatedRedeemers
     )
 import Cardano.MPFS.Client.Cage.Identity
     ( onChainTokenId
@@ -398,6 +407,16 @@ spec = describe "rejectCageTx" $ do
         feeBound `shouldSatisfy` (>= rejectFee)
         feeBound `shouldSatisfy` (<= grossFeeBufferUpperBound)
 
+    it
+        "returns the same reject body evaluated for final budgets"
+        $ do
+            cfg <- testCageConfig
+            let fixture@RejectFixture{trustedRoot, facts} =
+                    honestRejectFixture cfg
+            verified <- expectVerified trustedRoot facts
+            tx <- expectBuilt cfg verified
+            assertFinalRejectBudgetsAreStable cfg fixture tx
+
 -- ---------------------------------------------------------------
 -- Redeemer decoding helpers (test-only)
 -- ---------------------------------------------------------------
@@ -552,6 +571,78 @@ expectBuilt cfg verified =
                 ("rejectCageTx failed: " <> show err)
                 *> error "unreachable"
         Right tx -> pure tx
+
+assertFinalRejectBudgetsAreStable
+    :: CageConfig
+    -> RejectFixture
+    -> ConwayTx
+    -> IO ()
+assertFinalRejectBudgetsAreStable cfg fixture tx = do
+    let ctx = testEvalContext realisticPParams
+        inputUtxos = rejectInputUtxos cfg fixture
+        report =
+            evalTxExUnits
+                (evalProtocolParameters ctx)
+                tx
+                (UTxO $ Map.fromList inputUtxos)
+                (evalEpochInfo ctx)
+                (evalSystemStart ctx)
+        Redeemers budgets =
+            tx ^. witsTxL . rdmrsTxWitsL
+    actuals <-
+        case sequenceA report of
+            Left err ->
+                expectationFailure
+                    ("final reject evaluation failed: " <> show err)
+                    *> error "unreachable"
+            Right xs -> pure xs
+    Map.keysSet actuals `shouldBe` Map.keysSet budgets
+    forM_ (Map.toList actuals) $ \(purpose, actual) ->
+        case Map.lookup purpose budgets of
+            Nothing ->
+                expectationFailure
+                    ("missing final budget for " <> show purpose)
+            Just (_, budget) ->
+                budget `shouldCoverExUnits` actual
+    case patchEvaluatedRedeemers ctx [] tx report of
+        Left err ->
+            expectationFailure
+                ("patching final reject budgets failed: " <> show err)
+        Right patched ->
+            txIdTx patched `shouldBe` txIdTx tx
+
+rejectInputUtxos
+    :: CageConfig
+    -> RejectFixture
+    -> [(TxIn, TxOut ConwayEra)]
+rejectInputUtxos cfg RejectFixture{stateInput, requestInput, walletInput} =
+    let token = tokenIdFromJSON sampleToken
+        requestAddr =
+            requestAddrFromCfg cfg token Testnet
+        stateAddr =
+            Addr
+                Testnet
+                (ScriptHashObj $ cfgScriptHash cfg)
+                StakeRefNull
+    in  [
+            ( stateInput
+            , stateTxOut stateAddr cfg (unTokenId token)
+            )
+        , (requestInput, requestTxOut requestAddr token)
+        , (walletInput, walletTxOut)
+        ]
+
+shouldCoverExUnits :: ExUnits -> ExUnits -> IO ()
+shouldCoverExUnits budget@(ExUnits budgetMem budgetSteps) actual@(ExUnits actualMem actualSteps) =
+    if budgetMem >= actualMem && budgetSteps >= actualSteps
+        then pure ()
+        else
+            expectationFailure
+                ( "final budget "
+                    <> show budget
+                    <> " is below actual "
+                    <> show actual
+                )
 
 requestTxOut :: Addr -> TokenId -> TxOut ConwayEra
 requestTxOut requestAddr token =

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -5,6 +5,7 @@ import Cardano.MPFS.Client.BootFactsSpec qualified as BootFactsSpec
 import Cardano.MPFS.Client.BundleSpec qualified as BundleSpec
 import Cardano.MPFS.Client.Cage.BootSpec qualified as BootSpec
 import Cardano.MPFS.Client.Cage.EndSpec qualified as EndSpec
+import Cardano.MPFS.Client.Cage.EvalSpec qualified as EvalSpec
 import Cardano.MPFS.Client.Cage.RejectSpec qualified as CageRejectSpec
 import Cardano.MPFS.Client.Cage.RequestSpec qualified as RequestSpec
 import Cardano.MPFS.Client.Cage.RetractSpec qualified as CageRetractSpec
@@ -39,6 +40,7 @@ main = hspec $ do
     EndFactsSpec.spec
     UpdateFactsSpec.spec
     BootSpec.spec
+    EvalSpec.spec
     SerializeSpec.spec
     RequestSpec.spec
     CageRetractSpec.spec

--- a/deploy/spa/.dockerignore
+++ b/deploy/spa/.dockerignore
@@ -1,0 +1,5 @@
+*
+!Dockerfile
+!nginx.conf
+!spa/
+!spa/**

--- a/deploy/spa/Dockerfile
+++ b/deploy/spa/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY spa/ /usr/share/nginx/html/spa/

--- a/deploy/spa/nginx.conf
+++ b/deploy/spa/nginx.conf
@@ -1,0 +1,49 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+  etag on;
+  absolute_redirect off;
+
+  gzip on;
+  gzip_static on;
+  gzip_vary on;
+  gzip_min_length 256;
+  gzip_types
+    application/javascript
+    application/json
+    application/wasm
+    image/svg+xml
+    text/css
+    text/plain;
+
+  location = /spa {
+    return 308 /spa/;
+  }
+
+  location = /spa/index.html {
+    add_header Cache-Control "public, max-age=0, must-revalidate" always;
+    try_files $uri =404;
+  }
+
+  location = /spa/index.js {
+    add_header Cache-Control "public, max-age=0, must-revalidate" always;
+    try_files $uri =404;
+  }
+
+  location ~* "^/spa/.*\.[A-Za-z0-9_-]{8,}\.(?:wasm|js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$" {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    try_files $uri =404;
+  }
+
+  location /spa/ {
+    add_header Cache-Control "public, max-age=0, must-revalidate" always;
+    try_files $uri $uri/ /spa/index.html;
+  }
+
+  location / {
+    return 404;
+  }
+}

--- a/mpfs-spa/src/bootstrap.js
+++ b/mpfs-spa/src/bootstrap.js
@@ -1,13 +1,17 @@
-// Bootstrap the MPFS cage reactor for the browser bundle.
-//
-// esbuild embeds the WASM bytes via --loader:.wasm=binary. Each reactor call
-// gets a fresh WASI instance while the compiled WebAssembly.Module is shared.
+// Bootstrap the MPFS cage reactor for the browser bundle. The wasm file is
+// emitted as a separate hashed asset by esbuild, so browsers can stream and
+// cache it independently from the JavaScript bundle.
 
 import { WASI, File, OpenFile, ConsoleStdout }
   from "@bjorn3/browser_wasi_shim";
-import wasmBytes from "./assets/mpfs-cage-reactor.wasm";
+import reactorWasmAssetUrl from "./assets/mpfs-cage-reactor.wasm";
 
-const compiledModulePromise = WebAssembly.compile(wasmBytes);
+const reactorWasmUrl = new URL(
+  reactorWasmAssetUrl,
+  globalThis.document?.baseURI ?? globalThis.location?.href ?? "http://localhost/"
+).toString();
+
+let compiledModulePromise = null;
 
 globalThis.runCageReactor = async (stdinText) => {
   const stdin = new OpenFile(
@@ -19,8 +23,7 @@ globalThis.runCageReactor = async (stdinText) => {
   const stderr = new ConsoleStdout((chunk) => stderrChunks.push(chunk));
 
   const wasi = new WASI([], [], [stdin, stdout, stderr]);
-  const mod = await compiledModulePromise;
-  const inst = await WebAssembly.instantiate(mod, {
+  const inst = await instantiateReactor({
     wasi_snapshot_preview1: wasi.wasiImport,
   });
 
@@ -38,6 +41,55 @@ globalThis.runCageReactor = async (stdinText) => {
     exitOk,
   };
 };
+
+async function instantiateReactor(imports) {
+  if (compiledModulePromise !== null) {
+    const mod = await compiledModulePromise;
+    return WebAssembly.instantiate(mod, imports);
+  }
+
+  if (WebAssembly.instantiateStreaming) {
+    try {
+      const result = await WebAssembly.instantiateStreaming(
+        fetchReactorWasm(),
+        imports
+      );
+      compiledModulePromise = Promise.resolve(result.module);
+      return result.instance;
+    } catch (_err) {
+      compiledModulePromise = compileReactorWasm();
+      const mod = await compiledModulePromise;
+      return WebAssembly.instantiate(mod, imports);
+    }
+  }
+
+  compiledModulePromise = compileReactorWasm();
+  const mod = await compiledModulePromise;
+  return WebAssembly.instantiate(mod, imports);
+}
+
+async function compileReactorWasm() {
+  if (WebAssembly.compileStreaming) {
+    try {
+      return await WebAssembly.compileStreaming(fetchReactorWasm());
+    } catch (_err) {
+      // Fall back for servers that miss application/wasm on the response.
+    }
+  }
+
+  const response = await fetchReactorWasm();
+  return WebAssembly.compile(await response.arrayBuffer());
+}
+
+async function fetchReactorWasm() {
+  const response = await fetch(reactorWasmUrl);
+  if (!response.ok) {
+    throw new Error(
+      `failed to fetch reactor wasm: HTTP ${response.status}`
+    );
+  }
+  return response;
+}
 
 function decodeChunks(chunks) {
   const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);

--- a/nix/mpfs-spa.nix
+++ b/nix/mpfs-spa.nix
@@ -25,7 +25,15 @@ in pkgs.mkSpagoDerivation {
   spagoYaml = ../mpfs-spa/spago.yaml;
   spagoLock = ../mpfs-spa/spago.lock;
   nativeBuildInputs =
-    [ pkgs.purs pkgs.spago-unstable pkgs.esbuild pkgs.nodejs_20 pkgs.jq ];
+    [
+      pkgs.purs
+      pkgs.spago-unstable
+      pkgs.esbuild
+      pkgs.nodejs_20
+      pkgs.jq
+      pkgs.gzip
+      pkgs.brotli
+    ];
   buildPhase = ''
     ln -s ${nodeModules}/node_modules node_modules
 
@@ -67,7 +75,9 @@ in pkgs.mkSpagoDerivation {
       --outfile=dist/deps.js \
       --format=iife \
       --platform=browser \
-      --loader:.wasm=binary \
+      --loader:.wasm=file \
+      --asset-names='[name].[hash]' \
+      --public-path=. \
       --minify
 
     spago bundle --offline --module Main --outfile dist/index.js
@@ -80,6 +90,11 @@ in pkgs.mkSpagoDerivation {
     mkdir -p $out
     cp dist/index.html $out/
     cp dist/index.js $out/
-    cp src/assets/mpfs-cage-reactor.wasm $out/
+    cp dist/*.wasm $out/
+
+    for asset in $out/index.html $out/index.js $out/*.wasm; do
+      gzip -9 -n -k "$asset"
+      brotli --best --keep "$asset"
+    done
   '';
 }


### PR DESCRIPTION
## Summary
- derive cage eval EpochInfo from live era history instead of a fixed clock
- add client coverage for era-history slot/time conversion and final reject budget stability
- compress SPA deploy assets and serve the reactor wasm as a separate cached asset under /spa

## Local verification
- nix develop --quiet -c just build
- just ci
- nix build .#wasm-mpfs-verify --out-link result-wasm-mpfs-verify
- nix build .#mpfs-spa --out-link result-mpfs-spa
- MPFS_CAGE_REACTOR_WASM=result-wasm-mpfs-verify/mpfs-cage-reactor.wasm cabal test cardano-mpfs-cage-tx:byte-identity -O0 --test-show-details=direct
- just e2e "CageFlow E2E"
- just unit-client "rejectCageTx"

## Notes
- Keeps main Plutus patch flow; no plutus fork pin included.
- nix/mpfs-spa.nix nativeBuildInputs resolved to purs, spago-unstable, esbuild, nodejs_20, jq, gzip, brotli.
- Branch intentionally not rebased after owner main updates; orchestrator will rebase before merge.
