### PR TITLE
fix(deps): bump haskell-mts to CSMT completeness inclusion-step-order fix (#319)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -51,8 +51,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: f2e9f584f2ed9dff3990300f1b646090f122585b
-  --sha256: 015gzc7f419qhm4d893v9h3a6pzk66vjcbmjs37dlg6ypxwc3sry
+  tag: ab15f7b2dea73165b785c90333bbd09a36528a07
+  --sha256: 081wz3vq8d15wh1mziqnqhk2ai4i304gv7vxrhw9hqjr2sa9xy1a
 
 source-repository-package
   type: git

--- a/nix/wasm/forks.json
+++ b/nix/wasm/forks.json
@@ -63,8 +63,8 @@
     },
     "haskell-mts": {
       "location": "https://github.com/lambdasistemi/haskell-mts",
-      "rev": "f2e9f584f2ed9dff3990300f1b646090f122585b",
-      "sha256": "015gzc7f419qhm4d893v9h3a6pzk66vjcbmjs37dlg6ypxwc3sry",
+      "rev": "ab15f7b2dea73165b785c90333bbd09a36528a07",
+      "sha256": "081wz3vq8d15wh1mziqnqhk2ai4i304gv7vxrhw9hqjr2sa9xy1a",
       "subdirs": []
     },
     "aiken-codegen": {


### PR DESCRIPTION
Closes #319.

Bumps haskell-mts to `ab15f7b` (merged lambdasistemi/haskell-mts#162), which emits CSMT completeness inclusion steps in **subtree→root** order. This fixes `CompletenessProofInvalid` on `GET /tokens` and `GET /tokens/:id/requests` for any tree with **≥2 address subtrees** (a token + a request) — previously the `generateProof` reversal broke proofs needing ≥2 inclusion steps.

Bumps both `cabal.project` and `nix/wasm/forks.json`.

**Validation:** the moog-v2 full-lifecycle canary (cardano-foundation/moog#152) now clears the boot **and request** boundaries against this pin (previously failed `BoundaryNotObserved "request" CompletenessProofInvalid`). It now advances to a separate, unrelated downstream failure (`POST /facts/update` 500), tracked separately.

No API/schema change (`completeness_proof` is opaque `Hex`); swagger unaffected.