### PR TITLE
feat(cli): support owner processing and verified queries

### DIFF
--- a/cardano-mpfs-cli/README.md
+++ b/cardano-mpfs-cli/README.md
@@ -5,21 +5,35 @@ A scriptable command-line front-end for the
 register tokens and manage facts with a local Bech32 `.skey`. Protocol
 logic comes from [`cardano-mpfs-workflows`](../cardano-mpfs-workflows);
 the CLI owns argument parsing, key loading, signing, submission, and
-JSON output.
+verified output.
 
 ## Quick start
 
 ```bash
 nix develop
 cabal build mpfs-cli                          # or: nix build .#mpfs-cli
-mpfs-cli register-token --server http://localhost:3000 --owner-key owner.skey
-mpfs-cli token list      --server http://localhost:3000 | jq
+export MPFS_SERVER=http://localhost:3000
+export MPFS_SIGNER_WALLET=owner.skey
+mpfs-cli register-token
+mpfs-cli token list --json | jq
 ```
 
-`--owner-key` is a Bech32 ed25519 signing key (`ed25519_sk1…`) funded on
-the target network. Write commands resolve the cage blueprint from
+`MPFS_SIGNER_WALLET` points at a Bech32 ed25519 signing key
+(`ed25519_sk1...`) funded on the target network. Write commands resolve
+the server from `--server` or `$MPFS_SERVER`, the cage blueprint from
 `--cage-config` or `$MPFS_BLUEPRINT`, and the trusted root from
 `--trusted-root` or the server's `/status`.
+
+Owner commands include `register-token`, `token process TOKEN`, `fact
+reject`, and `token end`. Requester commands include `fact insert`,
+`fact update`, `fact delete`, and `fact retract`. Verified read commands
+include `token list`, `token get TOKEN`, `fact list TOKEN`, `fact get
+TOKEN KEY`, and `requests list TOKEN`. Human-readable output is the
+default; pass `--json` before or after a command for machine output.
+
+For short-lived devnet lifecycles, `register-token` also accepts
+`--process-time-ms` and `--retract-time-ms`; omitting them keeps the
+CLI's default testnet/devnet timing profile.
 
 ## Documentation
 

--- a/cardano-mpfs-cli/cardano-mpfs-cli.cabal
+++ b/cardano-mpfs-cli/cardano-mpfs-cli.cabal
@@ -59,6 +59,7 @@ library
     , optparse-applicative    >=0.18 && <0.20
     , servant                 >=0.20 && <0.21
     , servant-client          >=0.20 && <0.21
+    , servant-client-core     >=0.20 && <0.21
     , text                    >=2.0  && <2.2
 
   exposed-modules:
@@ -102,7 +103,11 @@ test-suite unit-tests
     , containers             >=0.6  && <0.8
     , hspec                  >=2.11 && <2.12
     , microlens
+    , optparse-applicative
     , text
 
-  other-modules:    Cardano.MPFS.CLI.SignSpec
+  other-modules:
+    Cardano.MPFS.CLI.OptionsSpec
+    Cardano.MPFS.CLI.SignSpec
+
   ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-cli/e2e/walkthrough.sh
+++ b/cardano-mpfs-cli/e2e/walkthrough.sh
@@ -2,98 +2,154 @@
 #
 # End-to-end walkthrough for mpfs-cli against a local MPFS devnet.
 #
-# This is the live-boundary smoke for the write path: unit tests cover
-# parsing, key decoding, and signing, but only a real server + node
-# proves the workflow → sign → POST /submit → await chain. The script
-# drives the actual binary and fails loudly if any step does not exit 0
-# or does not emit JSON on stdout.
-#
 # Prerequisites (run inside `nix develop`):
 #   - MPFS server reachable at $MPFS_SERVER (default http://localhost:3000).
-#     Start one with:  nix run .#mpfs-devnet-server -- --port 3000
-#   - $OWNER_KEY: path to a Bech32 ed25519 .skey (ed25519_sk1…) whose
-#     enterprise address is funded on the devnet. The devnet's funded
-#     genesis key is the one to use; export its Bech32 form here.
+#     Start one with: nix run .#mpfs-devnet-server -- --port 3000
+#   - $MPFS_SIGNER_WALLET or $OWNER_KEY: path to a Bech32 ed25519 .skey
+#     (ed25519_sk1...) whose enterprise address is funded on the devnet.
 #   - $MPFS_BLUEPRINT set (the dev shell sets it), or pass --cage-config.
 #
 # Usage:
-#   MPFS_SERVER=http://localhost:3000 OWNER_KEY=/path/owner.skey \
+#   MPFS_SERVER=http://localhost:3000 MPFS_SIGNER_WALLET=/path/owner.skey \
 #     cardano-mpfs-cli/e2e/walkthrough.sh
 #
 set -euo pipefail
 
 SERVER="${MPFS_SERVER:-http://localhost:3000}"
+SIGNER="${MPFS_SIGNER_WALLET:-${OWNER_KEY:-}}"
+PROCESS_TIME_MS="${PROCESS_TIME_MS:-30000}"
+RETRACT_TIME_MS="${RETRACT_TIME_MS:-5000}"
 
-# The CLI invocation as an array (so a multi-word fallback word-splits
-# correctly): the installed binary if present, else `cabal run`.
 if command -v mpfs-cli >/dev/null 2>&1; then
     CLI=(mpfs-cli)
 else
     CLI=(cabal run -v0 mpfs-cli --)
 fi
 
-if [ -z "${OWNER_KEY:-}" ]; then
-    echo "walkthrough: set OWNER_KEY to a funded Bech32 ed25519 .skey path" >&2
-    echo "  (the devnet genesis key, in ed25519_sk1… form)" >&2
+if ! command -v jq >/dev/null 2>&1; then
+    echo "walkthrough: jq is required" >&2
     exit 1
 fi
 
-# Run a CLI command, assert exit 0 and non-empty JSON on stdout.
+if [ -z "$SIGNER" ]; then
+    echo "walkthrough: set MPFS_SIGNER_WALLET or OWNER_KEY to a funded Bech32 ed25519 .skey path" >&2
+    exit 1
+fi
+
+export MPFS_SERVER="$SERVER"
+export MPFS_SIGNER_WALLET="$SIGNER"
+
 step() {
     local label="$1"
     shift
-    echo "── $label" >&2
+    echo "-- $label" >&2
     local out
-    if ! out=$("$@" 2>/dev/null); then
+    if ! out=$("$@" 2>"$LOG_DIR/${label// /-}.stderr"); then
         echo "walkthrough FAILED: '$label' exited non-zero" >&2
+        cat "$LOG_DIR/${label// /-}.stderr" >&2
         exit 1
     fi
-    if [ -z "$out" ]; then
-        echo "walkthrough FAILED: '$label' produced no stdout" >&2
+    if ! jq -e . >/dev/null <<<"$out"; then
+        echo "walkthrough FAILED: '$label' stdout is not JSON" >&2
+        printf '%s\n' "$out" >&2
         exit 1
     fi
-    # Minimal JSON sanity: starts with { or [.
-    case "$(printf '%s' "$out" | head -c1)" in
-        '{' | '[') : ;;
-        *)
-            echo "walkthrough FAILED: '$label' stdout is not JSON: $out" >&2
-            exit 1
-            ;;
-    esac
     printf '%s\n' "$out"
 }
 
-# Deterministic fact key/value for the run.
-KEY="$(printf 'mpfs-cli-e2e' | xxd -p)"
-VALUE="$(printf 'v1' | xxd -p)"
+expect_value() {
+    local label="$1" json="$2" expected="$3"
+    local actual
+    actual=$(jq -r '.result.value // empty' <<<"$json")
+    if [ "$actual" != "$expected" ]; then
+        echo "walkthrough FAILED: $label expected value $expected, got $actual" >&2
+        exit 1
+    fi
+}
 
-echo "walkthrough: server=$SERVER owner=$OWNER_KEY" >&2
+expect_absent() {
+    local label="$1" json="$2"
+    if [ "$(jq -r '.result.present' <<<"$json")" != "false" ]; then
+        echo "walkthrough FAILED: $label expected an absent fact proof" >&2
+        printf '%s\n' "$json" >&2
+        exit 1
+    fi
+}
 
-# The asserted flow is the requester write path the CLI owns: boot a
-# cage, observe it, and submit a fact request. Each goes through the
-# full workflow → sign → POST /submit → await chain, so a green run
-# proves the live boundary. (Steps not asserted here and why:
-#   - `fact get` after `insert` 404s by design: an oracle must apply the
-#     pending request before the fact materializes — the oracle path is
-#     a non-CLI concern (see README "Scope").
-#   - `token end` 409s while the request is pending; clearing it needs
-#     `fact retract`, which currently hits a server-side 500 in
-#     /facts/retract — tracked separately, not a CLI defect.)
+LOG_DIR="${TMPDIR:-/tmp}/mpfs-cli-walkthrough.$RANDOM.$RANDOM"
+mkdir -p "$LOG_DIR"
+trap 'rm -rf "$LOG_DIR"' EXIT
+
+KEY="$(printf 'mpfs-cli-e2e-key' | xxd -p | tr -d '\n')"
+VALUE1="$(printf 'v1' | xxd -p | tr -d '\n')"
+VALUE2="$(printf 'v2' | xxd -p | tr -d '\n')"
+REJECT_KEY="$(printf 'mpfs-cli-e2e-reject' | xxd -p | tr -d '\n')"
+REJECT_VALUE="$(printf 'reject-me' | xxd -p | tr -d '\n')"
+
+echo "walkthrough: server=$SERVER signer_path=$SIGNER" >&2
+echo "walkthrough: process_time_ms=$PROCESS_TIME_MS retract_time_ms=$RETRACT_TIME_MS" >&2
 
 step "register-token" \
-    "${CLI[@]}" register-token --server "$SERVER" --owner-key "$OWNER_KEY" >/dev/null
+    "${CLI[@]}" --json register-token \
+        --process-time-ms "$PROCESS_TIME_MS" \
+        --retract-time-ms "$RETRACT_TIME_MS" >/dev/null
 
-# token list is read-only; the new token id is the last listed.
-step "token list" "${CLI[@]}" token list --server "$SERVER" >/dev/null
-TOKEN=$("${CLI[@]}" token list --server "$SERVER" 2>/dev/null \
-    | tr -d '[]" ' | tr ',' '\n' | tail -n1)
-if [ -z "$TOKEN" ]; then
-    echo "walkthrough FAILED: no token id from 'token list'" >&2
+tokens_json=$(step "token list" "${CLI[@]}" --json token list)
+TOKEN=$(jq -r '.result.tokens[-1].id // empty' <<<"$tokens_json")
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+    echo "walkthrough FAILED: no token id from token list" >&2
     exit 1
 fi
-echo "   token=$TOKEN" >&2
+echo "walkthrough: token=$TOKEN" >&2
 
-step "fact insert" "${CLI[@]}" fact insert --server "$SERVER" \
-    --token "$TOKEN" --key "$KEY" --value "$VALUE" --owner-key "$OWNER_KEY" >/dev/null
+step "token get" "${CLI[@]}" --json token get "$TOKEN" >/dev/null
+step "fact list empty" "${CLI[@]}" --json fact list "$TOKEN" >/dev/null
 
-echo "walkthrough: OK (write path proven: boot + list + request)" >&2
+step "fact insert" \
+    "${CLI[@]}" --json fact insert \
+        --token "$TOKEN" --key "$KEY" --value "$VALUE1" >/dev/null
+step "requests list after insert" \
+    "${CLI[@]}" --json requests list "$TOKEN" >/dev/null
+step "token process insert" \
+    "${CLI[@]}" --json token process "$TOKEN" >/dev/null
+inserted=$(step "fact get inserted" "${CLI[@]}" --json fact get "$TOKEN" "$KEY")
+expect_value "inserted fact" "$inserted" "$VALUE1"
+
+step "fact update" \
+    "${CLI[@]}" --json fact update \
+        --token "$TOKEN" --key "$KEY" \
+        --old-value "$VALUE1" --new-value "$VALUE2" >/dev/null
+step "token process update" \
+    "${CLI[@]}" --json token process "$TOKEN" >/dev/null
+updated=$(step "fact get updated" "${CLI[@]}" --json fact get "$TOKEN" "$KEY")
+expect_value "updated fact" "$updated" "$VALUE2"
+
+step "fact delete" \
+    "${CLI[@]}" --json fact delete \
+        --token "$TOKEN" --key "$KEY" --value "$VALUE2" >/dev/null
+step "token process delete" \
+    "${CLI[@]}" --json token process "$TOKEN" >/dev/null
+deleted=$(step "fact get deleted" "${CLI[@]}" --json fact get "$TOKEN" "$KEY")
+expect_absent "deleted fact" "$deleted"
+
+step "fact insert reject candidate" \
+    "${CLI[@]}" --json fact insert \
+        --token "$TOKEN" --key "$REJECT_KEY" --value "$REJECT_VALUE" >/dev/null
+step "requests list reject candidate" \
+    "${CLI[@]}" --json requests list "$TOKEN" >/dev/null
+
+sleep_seconds=$(((PROCESS_TIME_MS + RETRACT_TIME_MS + 3000 + 999) / 1000))
+echo "walkthrough: waiting ${sleep_seconds}s for reject deadline" >&2
+sleep "$sleep_seconds"
+
+step "fact reject" "${CLI[@]}" --json fact reject --token "$TOKEN" >/dev/null
+requests_after_reject=$(step "requests list after reject" "${CLI[@]}" --json requests list "$TOKEN")
+if [ "$(jq '.result.requests | length' <<<"$requests_after_reject")" -ne 0 ]; then
+    echo "walkthrough FAILED: pending requests remain after reject" >&2
+    printf '%s\n' "$requests_after_reject" >&2
+    exit 1
+fi
+
+step "token end" "${CLI[@]}" --json token end --token "$TOKEN" >/dev/null
+
+echo "walkthrough: OK boot -> insert/process/get -> update/process/get -> delete/process/absent -> reject -> end" >&2

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs
@@ -2,11 +2,13 @@
 -- Module      : Cardano.MPFS.CLI.Options
 -- Description : optparse-applicative command surface for mpfs-cli.
 --
--- Defines the nine subcommands and their argument parsers. Every
--- subcommand and option carries @--help@ text. Hex arguments are
--- validated at parse time via "Cardano.MPFS.CLI.Hex".
+-- Defines the command surface and validates hex arguments at parse time.
+-- Network, blueprint, and signing-key inputs may be passed explicitly or
+-- resolved from the documented environment variables by the runner.
 module Cardano.MPFS.CLI.Options
-    ( Command (..)
+    ( App (..)
+    , Command (..)
+    , OutputFormat (..)
     , commandInfo
     ) where
 
@@ -14,187 +16,327 @@ import Cardano.MPFS.CLI.Hex (HexArg, hexReader)
 import Data.Text (Text)
 import Options.Applicative
 
+-- | Complete parsed invocation.
+data App = App
+    { appOutput :: OutputFormat
+    , appCommand :: Command
+    }
+    deriving stock (Show)
+
+-- | Output mode selected by @--json@.
+data OutputFormat
+    = OutputHuman
+    | OutputJson
+    deriving stock (Eq, Show)
+
 -- | Every mpfs-cli subcommand, fully parsed.
 data Command
-    = -- | @register-token@ — boot a new token/cage for the owner key.
+    = -- | @register-token@ -- boot a new token/cage for the owner key.
       RegisterToken
-        { server :: String
-        , ownerKey :: FilePath
+        { server :: Maybe String
+        , ownerKey :: Maybe FilePath
         , cageConfig :: Maybe FilePath
+        , processTimeMs :: Maybe Integer
+        , retractTimeMs :: Maybe Integer
         , trustedRoot :: Maybe HexArg
         }
-    | -- | @fact insert@ — request insertion of a new key/value fact.
+    | -- | @fact insert@ -- requester asks to insert a key/value fact.
       FactInsert
-        { server :: String
+        { server :: Maybe String
         , token :: Text
         , key :: HexArg
         , value :: HexArg
-        , ownerKey :: FilePath
+        , ownerKey :: Maybe FilePath
         , cageConfig :: Maybe FilePath
         , trustedRoot :: Maybe HexArg
         }
-    | -- | @fact update@ — request a change of an existing fact value.
+    | -- | @fact update@ -- requester asks to change a fact value.
       FactUpdate
-        { server :: String
+        { server :: Maybe String
         , token :: Text
         , key :: HexArg
         , oldValue :: HexArg
         , newValue :: HexArg
-        , ownerKey :: FilePath
+        , ownerKey :: Maybe FilePath
         , cageConfig :: Maybe FilePath
         , trustedRoot :: Maybe HexArg
         }
-    | -- | @fact delete@ — request deletion of an existing fact. The
-      -- current value is required: deletion proves the existing
-      -- key→value leaf.
+    | -- | @fact delete@ -- requester asks to delete a fact.
       FactDelete
-        { server :: String
+        { server :: Maybe String
         , token :: Text
         , key :: HexArg
         , value :: HexArg
-        , ownerKey :: FilePath
+        , ownerKey :: Maybe FilePath
         , cageConfig :: Maybe FilePath
         , trustedRoot :: Maybe HexArg
         }
-    | -- | @fact retract@ — retract a pending request by its UTxO ref.
+    | -- | @fact retract@ -- requester retracts a pending request.
       FactRetract
-        { server :: String
+        { server :: Maybe String
         , token :: Text
         , requestId :: Text
-        , ownerKey :: FilePath
+        , ownerKey :: Maybe FilePath
         , cageConfig :: Maybe FilePath
         , trustedRoot :: Maybe HexArg
         }
-    | -- | @fact reject@ — reject pending requests past their deadline.
+    | -- | @fact reject@ -- owner rejects expired pending requests.
       FactReject
-        { server :: String
+        { server :: Maybe String
         , token :: Text
-        , ownerKey :: FilePath
+        , requestIds :: [Text]
+        , ownerKey :: Maybe FilePath
         , cageConfig :: Maybe FilePath
         , trustedRoot :: Maybe HexArg
         }
-    | -- | @fact get@ — read-only fact lookup with proof.
+    | -- | @fact list TOKEN@ -- read-only complete fact enumeration.
+      FactList
+        { server :: Maybe String
+        , token :: Text
+        , trustedRoot :: Maybe HexArg
+        }
+    | -- | @fact get TOKEN KEY@ -- read-only present/absent fact lookup.
       FactGet
-        { server :: String
+        { server :: Maybe String
         , token :: Text
         , key :: HexArg
+        , trustedRoot :: Maybe HexArg
         }
-    | -- | @token end@ — close out a token/cage.
-      TokenEnd
-        { server :: String
+    | -- | @token process TOKEN@ -- owner folds pending requests.
+      TokenProcess
+        { server :: Maybe String
         , token :: Text
-        , ownerKey :: FilePath
+        , requestIds :: [Text]
+        , ownerKey :: Maybe FilePath
         , cageConfig :: Maybe FilePath
         , trustedRoot :: Maybe HexArg
         }
-    | -- | @token list@ — read-only listing of known token ids.
+    | -- | @token end@ -- owner closes out a token/cage.
+      TokenEnd
+        { server :: Maybe String
+        , token :: Text
+        , ownerKey :: Maybe FilePath
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
+        }
+    | -- | @token list@ -- read-only verified token-id listing.
       TokenList
-        {server :: String}
+        { server :: Maybe String
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
+        }
+    | -- | @token get TOKEN@ -- read-only verified token state.
+      TokenGet
+        { server :: Maybe String
+        , token :: Text
+        , trustedRoot :: Maybe HexArg
+        }
+    | -- | @requests list TOKEN@ -- read-only verified pending requests.
+      RequestsList
+        { server :: Maybe String
+        , token :: Text
+        , cageConfig :: Maybe FilePath
+        , trustedRoot :: Maybe HexArg
+        }
     deriving stock (Show)
 
 -- | Top-level parser with @--help@ wiring.
-commandInfo :: ParserInfo Command
+commandInfo :: ParserInfo App
 commandInfo =
     info
-        (commandsP <**> helper)
+        ((combineOutput <$> outputFlag <*> commandsP) <**> helper)
         ( fullDesc
             <> header "mpfs-cli - command-line front-end for the MPFS server"
             <> progDesc
-                "Register tokens and manage facts end-to-end against an \
-                \MPFS server using a local Bech32 .skey. JSON is written \
-                \to stdout; logs go to stderr."
+                "Register tokens, request and process facts, and run \
+                \verified read-only queries against an MPFS server. Human \
+                \output is the default; pass --json for machine output."
+            <> footer
+                "Environment: MPFS_SERVER defaults --server; \
+                \MPFS_BLUEPRINT defaults --cage-config; \
+                \MPFS_SIGNER_WALLET defaults --owner-key and is a PATH to a \
+                \Bech32 ed25519 signing key."
         )
+  where
+    combineOutput topJson (localJson, cmd) =
+        App
+            { appOutput =
+                if topJson || localJson
+                    then OutputJson
+                    else OutputHuman
+            , appCommand = cmd
+            }
 
-commandsP :: Parser Command
+commandsP :: Parser (Bool, Command)
 commandsP =
     hsubparser
         ( command
             "register-token"
             ( info
-                registerTokenP
-                (progDesc "Register (boot) a new token/cage for the owner key")
+                (withOutput registerTokenP)
+                (progDesc "Owner: register (boot) a new token/cage")
             )
             <> command
                 "fact"
                 ( info
                     (hsubparser factCommands)
-                    (progDesc "Manage facts (insert/update/delete/retract/reject/get)")
+                    ( progDesc
+                        "Requester commands and verified fact queries"
+                    )
                 )
             <> command
                 "token"
                 ( info
                     (hsubparser tokenCommands)
-                    (progDesc "Manage tokens (end/list)")
+                    (progDesc "Owner commands and verified token queries")
+                )
+            <> command
+                "requests"
+                ( info
+                    (hsubparser requestCommands)
+                    (progDesc "Verified pending-request queries")
                 )
         )
 
-factCommands :: Mod CommandFields Command
+factCommands :: Mod CommandFields (Bool, Command)
 factCommands =
     command
         "insert"
         ( info
-            factInsertP
-            (progDesc "Request insertion of a new key/value fact")
+            (withOutput factInsertP)
+            (progDesc "Requester: ask to insert a new key/value fact")
         )
         <> command
             "update"
             ( info
-                factUpdateP
-                (progDesc "Request a change of an existing fact value")
+                (withOutput factUpdateP)
+                (progDesc "Requester: ask to change an existing fact value")
             )
         <> command
             "delete"
-            (info factDeleteP (progDesc "Request deletion of an existing fact"))
+            ( info
+                (withOutput factDeleteP)
+                (progDesc "Requester: ask to delete an existing fact")
+            )
         <> command
             "retract"
-            (info factRetractP (progDesc "Retract a pending request by id"))
+            ( info
+                (withOutput factRetractP)
+                (progDesc "Requester: retract a pending request by id")
+            )
         <> command
             "reject"
             ( info
-                factRejectP
-                (progDesc "Reject pending requests past their deadline")
+                (withOutput factRejectP)
+                (progDesc "Owner: reject pending requests past their deadline")
+            )
+        <> command
+            "list"
+            ( info
+                (withOutput factListP)
+                (progDesc "Read-only: enumerate all facts for a token")
             )
         <> command
             "get"
-            (info factGetP (progDesc "Read-only: look up a fact with proof"))
+            ( info
+                (withOutput factGetP)
+                (progDesc "Read-only: look up a fact with proof")
+            )
 
-tokenCommands :: Mod CommandFields Command
+tokenCommands :: Mod CommandFields (Bool, Command)
 tokenCommands =
     command
-        "end"
-        (info tokenEndP (progDesc "Close out a token/cage"))
+        "process"
+        ( info
+            (withOutput tokenProcessP)
+            (progDesc "Owner: fold pending requests into the token trie")
+        )
+        <> command
+            "end"
+            (info (withOutput tokenEndP) (progDesc "Owner: close out a token"))
         <> command
             "list"
-            (info tokenListP (progDesc "Read-only: list known token ids"))
+            ( info
+                (withOutput tokenListP)
+                (progDesc "Read-only: list known token ids with proof")
+            )
+        <> command
+            "get"
+            ( info
+                (withOutput tokenGetP)
+                (progDesc "Read-only: get token state with proof")
+            )
+
+requestCommands :: Mod CommandFields (Bool, Command)
+requestCommands =
+    command
+        "list"
+        ( info
+            (withOutput requestsListP)
+            ( progDesc
+                "Read-only: list pending request ids and deadlines with proof"
+            )
+        )
+
+withOutput :: Parser Command -> Parser (Bool, Command)
+withOutput p = (,) <$> outputFlag <*> p
 
 -- Shared options ------------------------------------------------------
 
-serverP :: Parser String
+outputFlag :: Parser Bool
+outputFlag =
+    switch
+        ( long "json"
+            <> help "Write a verified JSON object instead of human output"
+        )
+
+serverP :: Parser (Maybe String)
 serverP =
-    strOption
-        ( long "server"
-            <> metavar "URL"
-            <> help "MPFS server base URL (e.g. http://localhost:3000)"
+    optional
+        ( strOption
+            ( long "server"
+                <> metavar "URL"
+                <> help
+                    "MPFS server base URL. Optional; defaults to MPFS_SERVER."
+            )
         )
 
-ownerKeyP :: Parser FilePath
+ownerKeyP :: Parser (Maybe FilePath)
 ownerKeyP =
-    strOption
-        ( long "owner-key"
-            <> metavar "KEYFILE"
-            <> help "Path to a Bech32-encoded .skey file"
+    optional
+        ( strOption
+            ( long "owner-key"
+                <> metavar "KEYFILE"
+                <> help
+                    "Path to a Bech32 ed25519 .skey file. Optional; defaults \
+                    \to MPFS_SIGNER_WALLET."
+            )
         )
 
-tokenP :: Parser Text
-tokenP =
+tokenOptionP :: Parser Text
+tokenOptionP =
     strOption
         (long "token" <> metavar "TOKEN" <> help "Target token id (hex)")
 
-keyP :: Parser HexArg
-keyP =
+tokenArgP :: Parser Text
+tokenArgP =
+    argument str (metavar "TOKEN" <> help "Target token id (hex)")
+
+tokenArgOrOptionP :: Parser Text
+tokenArgOrOptionP = tokenArgP <|> tokenOptionP
+
+keyOptionP :: Parser HexArg
+keyOptionP =
     option
         hexReader
         (long "key" <> metavar "HEX" <> help "Fact key (hex)")
+
+keyArgP :: Parser HexArg
+keyArgP =
+    argument hexReader (metavar "KEY" <> help "Fact key (hex)")
+
+keyArgOrOptionP :: Parser HexArg
+keyArgOrOptionP = keyArgP <|> keyOptionP
 
 valueP :: Parser HexArg
 valueP =
@@ -202,18 +344,10 @@ valueP =
         hexReader
         (long "value" <> metavar "HEX" <> help "Fact value (hex)")
 
--- Per-command parsers --------------------------------------------------
-
-registerTokenP :: Parser Command
-registerTokenP =
-    RegisterToken
-        <$> serverP
-        <*> ownerKeyP
-        <*> cageConfigP
-        <*> trustedRootP
-
 -- | @--cage-config FILE@: the cage blueprint JSON. Optional; defaults to
--- @$MPFS_BLUEPRINT@. One of the two must be set for write commands.
+-- @$MPFS_BLUEPRINT@. It is required for write commands, @token list@,
+-- and @requests list@ because those commands derive verifier addresses
+-- locally.
 cageConfigP :: Parser (Maybe FilePath)
 cageConfigP =
     optional
@@ -221,8 +355,7 @@ cageConfigP =
             ( long "cage-config"
                 <> metavar "FILE"
                 <> help
-                    "Cage blueprint JSON. Optional; defaults to \
-                    \$MPFS_BLUEPRINT."
+                    "Cage blueprint JSON. Optional; defaults to MPFS_BLUEPRINT."
             )
         )
 
@@ -241,12 +374,82 @@ trustedRootP =
             )
         )
 
+requestIdP :: Parser Text
+requestIdP =
+    strOption
+        ( long "request-id"
+            <> metavar "TXHASH#IX"
+            <> help "Pending request UTxO reference"
+        )
+
+processRequestIdsP :: Parser [Text]
+processRequestIdsP =
+    many
+        ( strOption
+            ( long "request-id"
+                <> metavar "TXHASH#IX"
+                <> help
+                    "Only process this pending request. Repeat to select a \
+                    \batch; omit to process all pending requests."
+            )
+        )
+
+rejectRequestIdsP :: Parser [Text]
+rejectRequestIdsP =
+    many
+        ( strOption
+            ( long "request-id"
+                <> metavar "TXHASH#IX"
+                <> help
+                    "Only reject this pending request. Repeat to select a \
+                    \batch; omit to reject all expired pending requests."
+            )
+        )
+
+-- Per-command parsers --------------------------------------------------
+
+registerTokenP :: Parser Command
+registerTokenP =
+    RegisterToken
+        <$> serverP
+        <*> ownerKeyP
+        <*> cageConfigP
+        <*> processTimeP
+        <*> retractTimeP
+        <*> trustedRootP
+
+processTimeP :: Parser (Maybe Integer)
+processTimeP =
+    optional
+        ( option
+            auto
+            ( long "process-time-ms"
+                <> metavar "MS"
+                <> help
+                    "Token request processing window in milliseconds. \
+                    \Optional; defaults to the CLI devnet/testnet profile."
+            )
+        )
+
+retractTimeP :: Parser (Maybe Integer)
+retractTimeP =
+    optional
+        ( option
+            auto
+            ( long "retract-time-ms"
+                <> metavar "MS"
+                <> help
+                    "Token request retract window in milliseconds. Optional; \
+                    \defaults to the CLI devnet/testnet profile."
+            )
+        )
+
 factInsertP :: Parser Command
 factInsertP =
     FactInsert
         <$> serverP
-        <*> tokenP
-        <*> keyP
+        <*> tokenOptionP
+        <*> keyOptionP
         <*> valueP
         <*> ownerKeyP
         <*> cageConfigP
@@ -256,17 +459,14 @@ factUpdateP :: Parser Command
 factUpdateP =
     FactUpdate
         <$> serverP
-        <*> tokenP
-        <*> keyP
+        <*> tokenOptionP
+        <*> keyOptionP
         <*> option
             hexReader
-            (long "old-value" <> metavar "HEX" <> help "Current fact value (hex)")
+            (long "old-value" <> metavar "HEX" <> help "Current fact value")
         <*> option
             hexReader
-            ( long "new-value"
-                <> metavar "HEX"
-                <> help "Replacement fact value (hex)"
-            )
+            (long "new-value" <> metavar "HEX" <> help "Replacement value")
         <*> ownerKeyP
         <*> cageConfigP
         <*> trustedRootP
@@ -275,8 +475,8 @@ factDeleteP :: Parser Command
 factDeleteP =
     FactDelete
         <$> serverP
-        <*> tokenP
-        <*> keyP
+        <*> tokenOptionP
+        <*> keyOptionP
         <*> valueP
         <*> ownerKeyP
         <*> cageConfigP
@@ -286,12 +486,8 @@ factRetractP :: Parser Command
 factRetractP =
     FactRetract
         <$> serverP
-        <*> tokenP
-        <*> strOption
-            ( long "request-id"
-                <> metavar "REQ_ID"
-                <> help "UTxO reference (txhash#ix) of the pending request"
-            )
+        <*> tokenOptionP
+        <*> requestIdP
         <*> ownerKeyP
         <*> cageConfigP
         <*> trustedRootP
@@ -300,24 +496,64 @@ factRejectP :: Parser Command
 factRejectP =
     FactReject
         <$> serverP
-        <*> tokenP
+        <*> tokenOptionP
+        <*> rejectRequestIdsP
         <*> ownerKeyP
         <*> cageConfigP
         <*> trustedRootP
 
+factListP :: Parser Command
+factListP =
+    FactList
+        <$> serverP
+        <*> tokenArgOrOptionP
+        <*> trustedRootP
+
 factGetP :: Parser Command
 factGetP =
-    FactGet <$> serverP <*> tokenP <*> keyP
+    FactGet
+        <$> serverP
+        <*> tokenArgOrOptionP
+        <*> keyArgOrOptionP
+        <*> trustedRootP
+
+tokenProcessP :: Parser Command
+tokenProcessP =
+    TokenProcess
+        <$> serverP
+        <*> tokenArgOrOptionP
+        <*> processRequestIdsP
+        <*> ownerKeyP
+        <*> cageConfigP
+        <*> trustedRootP
 
 tokenEndP :: Parser Command
 tokenEndP =
     TokenEnd
         <$> serverP
-        <*> tokenP
+        <*> tokenOptionP
         <*> ownerKeyP
         <*> cageConfigP
         <*> trustedRootP
 
 tokenListP :: Parser Command
 tokenListP =
-    TokenList <$> serverP
+    TokenList
+        <$> serverP
+        <*> cageConfigP
+        <*> trustedRootP
+
+tokenGetP :: Parser Command
+tokenGetP =
+    TokenGet
+        <$> serverP
+        <*> tokenArgOrOptionP
+        <*> trustedRootP
+
+requestsListP :: Parser Command
+requestsListP =
+    RequestsList
+        <$> serverP
+        <*> tokenArgOrOptionP
+        <*> cageConfigP
+        <*> trustedRootP

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Output.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Output.hs
@@ -6,16 +6,23 @@
 -- all human-readable diagnostics on stderr. This module is the only
 -- place that writes to either stream so the contract stays in one spot.
 module Cardano.MPFS.CLI.Output
-    ( emitJson
+    ( emit
+    , emitJson
     , emitResult
     , logErr
     , die
     ) where
 
+import Cardano.MPFS.CLI.Options (OutputFormat (..))
 import Data.Aeson (ToJSON, Value, encode, toJSON)
 import Data.ByteString.Lazy.Char8 qualified as BL8
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
+
+-- | Emit either human-readable text or JSON to stdout.
+emit :: OutputFormat -> Value -> String -> IO ()
+emit OutputJson value _ = emitJson value
+emit OutputHuman _ human = putStrLn human
 
 -- | Write a single JSON value to stdout, newline-terminated.
 emitJson :: Value -> IO ()

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
@@ -2,18 +2,35 @@
 -- Module      : Cardano.MPFS.CLI.Run
 -- Description : Subcommand handlers.
 --
--- Each handler turns a parsed 'Command' into an action. Write commands
--- run the matching @cardano-mpfs-workflows@ function (fetch facts →
--- verify → build the unsigned tx), sign locally with the Bech32 key,
--- POST to @\/submit@, await the tx, and print a JSON result. Read-only
--- commands hit the read endpoints directly. The stdout/stderr contract
--- lives in "Cardano.MPFS.CLI.Output": JSON on stdout, logs on stderr.
+-- Write commands fetch proof-bearing facts, verify them through
+-- @cardano-mpfs-workflows@, build an unsigned tx, sign locally, submit,
+-- await indexing, and then report the tx id. Read commands fetch
+-- proof-bearing responses, verify them locally, and only then render
+-- either human text or a structured JSON envelope.
 module Cardano.MPFS.CLI.Run
     ( run
     ) where
 
 import Cardano.MPFS.API.Encoding (Hex (..))
-import Cardano.MPFS.API.Types (TokenIdJSON (..))
+import Cardano.MPFS.API.Types
+    ( FactEntry (..)
+    , FactResponse (..)
+    , FactsResponse (..)
+    , ProofResponse
+    , RequestJSON (..)
+    , RequestsResponse (..)
+    , TokenIdJSON (..)
+    , TokenResponse (..)
+    , TokenSetWitness (..)
+    , TokenStateJSON (..)
+    , TokenUtxoEntry (..)
+    , TokensResponse (..)
+    , TxInJSON (..)
+    , UtxoRef (..)
+    , WitnessedRequest (..)
+    , WitnessedTokenState (..)
+    , WitnessedUtxo (..)
+    )
 import Cardano.MPFS.CLI.Cage (ownerAddressBytes, resolveCageConfig)
 import Cardano.MPFS.CLI.Hex
     ( HexArg
@@ -22,14 +39,21 @@ import Cardano.MPFS.CLI.Hex
     , hexBytes
     )
 import Cardano.MPFS.CLI.Key (loadSigningKey)
-import Cardano.MPFS.CLI.Options (Command (..))
-import Cardano.MPFS.CLI.Output (die, emitJson, emitResult)
+import Cardano.MPFS.CLI.Options
+    ( App (..)
+    , Command (..)
+    , OutputFormat
+    )
+import Cardano.MPFS.CLI.Output (die, emit)
 import Cardano.MPFS.CLI.Sign (signTx)
 import Cardano.MPFS.CLI.Submit
     ( awaitTx
     , getFact
+    , getFactProof
+    , getToken
+    , listFacts
+    , listRequests
     , listTokens
-    , mkServerEnv
     , mkServerParts
     , submitSignedTx
     )
@@ -39,19 +63,39 @@ import Cardano.MPFS.CLI.Workflow
     , resolveEvalContext
     , resolveTrustedRoot
     )
-import Cardano.MPFS.Client.Cage.Config (network)
+import Cardano.MPFS.Client.Cage.Config (CageConfig (..), network)
+import Cardano.MPFS.Client.Facts
+    ( FactAbsentFacts (..)
+    , FactPresentFacts (..)
+    , verifyFactAbsentFacts
+    , verifyFactPresentFacts
+    )
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot)
+import Cardano.MPFS.Client.Verify.Read
+    ( verifiedTokenFacts
+    , verifiedTokenRequests
+    , verifiedTokenState
+    , verifiedTokens
+    , verifyTokenFacts
+    , verifyTokenRequests
+    , verifyTokenState
+    , verifyTokens
+    )
 import Cardano.MPFS.Workflows
     ( BootRequest (..)
     , DeleteRequest (..)
     , EndRequest (..)
     , HttpClient
+    , HttpError (..)
     , InsertRequest (..)
     , RejectRequest (..)
     , RetractRequest (..)
     , UnsignedTx (..)
+    , UpdateRequest (..)
     , UpdateValueRequest (..)
-    , WorkflowError
+    , WorkflowError (..)
     , WorkflowsConfig (..)
+    , applyRequests
     , deleteFact
     , endCage
     , insertFact
@@ -60,26 +104,50 @@ import Cardano.MPFS.Workflows
     , retractRequest
     , updateFact
     )
-import Data.Aeson (ToJSON, object, (.=))
+import Data.Aeson (ToJSON, Value, object, (.=))
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BSC
+import Data.ByteString.Lazy qualified as BSL
+import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Data.Text.Encoding.Error (lenientDecode)
 import Data.Word (Word64)
-import Servant.Client (ClientEnv, ClientError, mkClientEnv)
+import Network.HTTP.Client (Manager)
+import Network.HTTP.Types.Status (statusCode, statusMessage)
+import Servant.Client
+    ( BaseUrl
+    , ClientEnv
+    , ClientError
+    , mkClientEnv
+    )
+import Servant.Client qualified as Servant
+import Servant.Client.Core.Response
+    ( responseBody
+    , responseStatusCode
+    )
+import System.Environment (lookupEnv)
 
--- | Dispatch a parsed command.
-run :: Command -> IO ()
-run cmd = case cmd of
+-- | Dispatch a parsed invocation.
+run :: App -> IO ()
+run App{appOutput, appCommand} = case appCommand of
     RegisterToken{..} ->
-        runWrite
+        runWriteWithCage
+            appOutput
             "register-token"
             server
             ownerKey
             cageConfig
             trustedRoot
+            (applyBootTiming processTimeMs retractTimeMs)
             BootRequest
             registerToken
     FactInsert{..} -> do
         tid <- decodeToken token
         runWrite
+            appOutput
             "fact insert"
             server
             ownerKey
@@ -90,6 +158,7 @@ run cmd = case cmd of
     FactUpdate{..} -> do
         tid <- decodeToken token
         runWrite
+            appOutput
             "fact update"
             server
             ownerKey
@@ -105,6 +174,7 @@ run cmd = case cmd of
     FactDelete{..} -> do
         tid <- decodeToken token
         runWrite
+            appOutput
             "fact delete"
             server
             ownerKey
@@ -114,6 +184,7 @@ run cmd = case cmd of
             deleteFact
     FactRetract{..} ->
         runWrite
+            appOutput
             "fact retract"
             server
             ownerKey
@@ -124,6 +195,7 @@ run cmd = case cmd of
     FactReject{..} -> do
         tid <- decodeToken token
         runWrite
+            appOutput
             "fact reject"
             server
             ownerKey
@@ -133,13 +205,35 @@ run cmd = case cmd of
                 RejectRequest
                     { rejToken = tid
                     , rejAddr = addr
-                    , rejRequests = []
+                    , rejRequests = requestIds
                     }
             )
             rejectExpired
+    FactList{..} ->
+        runFactList appOutput server token trustedRoot
+    FactGet{..} ->
+        runFactGet appOutput server token key trustedRoot
+    TokenProcess{..} -> do
+        tid <- decodeToken token
+        runWrite
+            appOutput
+            "token process"
+            server
+            ownerKey
+            cageConfig
+            trustedRoot
+            ( \addr ->
+                UpdateRequest
+                    { urToken = tid
+                    , urAddr = addr
+                    , urRequests = requestIds
+                    }
+            )
+            applyRequests
     TokenEnd{..} -> do
         tid <- decodeToken token
         runWrite
+            appOutput
             "token end"
             server
             ownerKey
@@ -147,32 +241,28 @@ run cmd = case cmd of
             trustedRoot
             (EndRequest tid)
             endCage
-    FactGet{..} ->
-        withEnv server $ \env -> do
-            tid <- decodeToken token
-            res <- getFact env tid (Hex (hexBytes key))
-            emitOrDie "fact get" res
     TokenList{..} ->
-        withEnv server $ \env -> do
-            res <- listTokens env
-            emitOrDie "token list" res
+        runTokenList appOutput server cageConfig trustedRoot
+    TokenGet{..} ->
+        runTokenGet appOutput server token trustedRoot
+    RequestsList{..} ->
+        runRequestsList appOutput server token cageConfig trustedRoot
 
--- | The full write pipeline shared by every write subcommand: resolve
--- the connection, key, cage config, and trusted root; run the workflow
--- to get an unsigned tx; sign locally; submit; await; print the txId.
+-- | The full write pipeline shared by every write subcommand.
 runWrite
-    :: String
-    -- ^ Command name (for output + error context).
+    :: OutputFormat
     -> String
-    -- ^ Server base URL.
-    -> FilePath
-    -- ^ Bech32 owner key path.
+    -- ^ Command name (for output + error context).
+    -> Maybe String
+    -- ^ Server base URL (else @MPFS_SERVER@).
+    -> Maybe FilePath
+    -- ^ Bech32 signing-key path (else @MPFS_SIGNER_WALLET@).
     -> Maybe FilePath
     -- ^ Cage blueprint path (else @MPFS_BLUEPRINT@).
     -> Maybe HexArg
     -- ^ Trusted-root override (else server @\/status@).
     -> (Hex -> req)
-    -- ^ Build the request from the owner address.
+    -- ^ Build the request from the signer address.
     -> ( HttpClient
          -> WorkflowsConfig
          -> req
@@ -180,53 +270,518 @@ runWrite
        )
     -- ^ The workflow to run.
     -> IO ()
-runWrite name server ownerKey cageConfig trustedRoot mkReq workflow = do
-    (manager, base) <- mkServerParts server >>= orDie "server"
-    sk <- loadSigningKey ownerKey >>= orDieShow "owner-key"
-    cage <- resolveCageConfig cageConfig >>= orDie "cage-config"
-    troot <-
-        resolveTrustedRoot manager base (hexBytes <$> trustedRoot)
-            >>= orDie "trusted-root"
-    evalCtx <- resolveEvalContext manager base >>= orDie "eval-context"
-    let config =
-            WorkflowsConfig
-                { wcCage = cage
-                , wcPolicy = defaultWalletPolicy
-                , wcTrustedRoot = troot
-                , wcEvalContext = evalCtx
-                }
-        httpClient = mkHttpClient manager base
-        request = mkReq (Hex (ownerAddressBytes (network cage) sk))
-    UnsignedTx cbor <-
-        workflow httpClient config request >>= orDieShow "workflow"
-    signed <- orDieShow "sign" (signTx sk cbor)
-    let env = mkClientEnv manager base
-    txId <- submitSignedTx env signed >>= orDieShow "submit"
-    _ <- awaitTx env txId defaultAwaitTimeout >>= orDieShow "await"
-    emitJson
-        ( object
-            [ "command" .= name
-            , "status" .= ("submitted" :: String)
-            , "txId" .= encodeHexText txId
-            ]
-        )
+runWrite out name mServer mOwnerKey cageConfig trustedRoot =
+    runWriteWithCage out name mServer mOwnerKey cageConfig trustedRoot id
 
--- | Decode a @--token@ hex argument to a 'TokenIdJSON' or exit.
+runWriteWithCage
+    :: OutputFormat
+    -> String
+    -- ^ Command name (for output + error context).
+    -> Maybe String
+    -- ^ Server base URL (else @MPFS_SERVER@).
+    -> Maybe FilePath
+    -- ^ Bech32 signing-key path (else @MPFS_SIGNER_WALLET@).
+    -> Maybe FilePath
+    -- ^ Cage blueprint path (else @MPFS_BLUEPRINT@).
+    -> Maybe HexArg
+    -- ^ Trusted-root override (else server @\/status@).
+    -> (CageConfig -> CageConfig)
+    -- ^ Boot-only timing/config adjustment.
+    -> (Hex -> req)
+    -- ^ Build the request from the signer address.
+    -> ( HttpClient
+         -> WorkflowsConfig
+         -> req
+         -> IO (Either WorkflowError UnsignedTx)
+       )
+    -- ^ The workflow to run.
+    -> IO ()
+runWriteWithCage
+    out
+    name
+    mServer
+    mOwnerKey
+    cageConfig
+    trustedRoot
+    adjustCage
+    mkReq
+    workflow = do
+        (manager, base) <- resolveServerParts mServer
+        ownerKeyPath <- resolveSignerWallet mOwnerKey
+        sk <- loadSigningKey ownerKeyPath >>= orDieShow "signer wallet"
+        cage <- adjustCage <$> resolveCage cageConfig
+        troot <-
+            resolveTrustedRoot manager base (hexBytes <$> trustedRoot)
+                >>= orDie "trusted-root"
+        evalCtx <- resolveEvalContext manager base >>= orDie "eval-context"
+        let config =
+                WorkflowsConfig
+                    { wcCage = cage
+                    , wcPolicy = defaultWalletPolicy
+                    , wcTrustedRoot = troot
+                    , wcEvalContext = evalCtx
+                    }
+            httpClient = mkHttpClient manager base
+            request = mkReq (Hex (ownerAddressBytes (network cage) sk))
+        UnsignedTx cbor <-
+            workflow httpClient config request >>= orDieWorkflow "workflow"
+        signed <- orDieShow "sign" (signTx sk cbor)
+        txId <-
+            submitSignedTx (mkClientEnv manager base) signed
+                >>= orDieClient "submit"
+        _ <-
+            awaitTx (mkClientEnv manager base) txId defaultAwaitTimeout
+                >>= orDieClient "await"
+        emit
+            out
+            ( object
+                [ "command" .= name
+                , "status" .= ("submitted" :: String)
+                , "txId" .= encodeHexText txId
+                ]
+            )
+            ( name
+                <> " submitted\ntransaction: "
+                <> T.unpack (encodeHexText txId)
+            )
+
+runTokenList
+    :: OutputFormat
+    -> Maybe String
+    -> Maybe FilePath
+    -> Maybe HexArg
+    -> IO ()
+runTokenList out mServer cageConfig trustedRoot =
+    withReadRoot mServer trustedRoot $ \_ _ env troot -> do
+        cage <- resolveCage cageConfig
+        resp <- listTokens env >>= orDieClient "token list"
+        verified <- orDieVerify "token list" (verifyTokens cage troot resp)
+        let verifiedResp = verifiedTokens verified
+        emit
+            out
+            (queryEnvelope "token list" (tokenListResult verifiedResp) verifiedResp)
+            (formatTokenList verifiedResp)
+
+runTokenGet
+    :: OutputFormat
+    -> Maybe String
+    -> Text
+    -> Maybe HexArg
+    -> IO ()
+runTokenGet out mServer tokenText trustedRoot =
+    withReadRoot mServer trustedRoot $ \_ _ env troot -> do
+        tid <- decodeToken tokenText
+        resp <- getToken env tid >>= orDieClient "token get"
+        verified <- orDieVerify "token get" (verifyTokenState troot resp)
+        let verifiedResp = verifiedTokenState verified
+        emit
+            out
+            ( queryEnvelope
+                "token get"
+                (tokenStateResult tid verifiedResp)
+                verifiedResp
+            )
+            (formatTokenState tid verifiedResp)
+
+runFactList
+    :: OutputFormat
+    -> Maybe String
+    -> Text
+    -> Maybe HexArg
+    -> IO ()
+runFactList out mServer tokenText trustedRoot =
+    withReadRoot mServer trustedRoot $ \_ _ env troot -> do
+        tid <- decodeToken tokenText
+        resp <- listFacts env tid >>= orDieClient "fact list"
+        verified <- orDieVerify "fact list" (verifyTokenFacts troot resp)
+        let verifiedResp = verifiedTokenFacts verified
+        emit
+            out
+            ( queryEnvelope
+                "fact list"
+                (factListResult tid verifiedResp)
+                verifiedResp
+            )
+            (formatFactList tid verifiedResp)
+
+runFactGet
+    :: OutputFormat
+    -> Maybe String
+    -> Text
+    -> HexArg
+    -> Maybe HexArg
+    -> IO ()
+runFactGet out mServer tokenText key trustedRoot =
+    withReadRoot mServer trustedRoot $ \_ _ env troot -> do
+        tid <- decodeToken tokenText
+        let keyHex = Hex (hexBytes key)
+        present <- getFact env tid keyHex
+        case present of
+            Right resp -> do
+                _ <-
+                    orDieVerify
+                        "fact get"
+                        ( verifyFactPresentFacts
+                            troot
+                            FactPresentFacts
+                                { fpfKey = keyHex
+                                , fpfResponse = resp
+                                }
+                        )
+                emit
+                    out
+                    (factGetPresentEnvelope tid keyHex resp)
+                    (formatFactPresent tid keyHex resp)
+            Left err
+                | isNotFound err -> do
+                    proof <-
+                        getFactProof env tid keyHex
+                            >>= orDieClient "fact get absence proof"
+                    _ <-
+                        orDieVerify
+                            "fact get"
+                            ( verifyFactAbsentFacts
+                                troot
+                                FactAbsentFacts
+                                    { fafKey = keyHex
+                                    , fafResponse = proof
+                                    }
+                            )
+                    emit
+                        out
+                        (factGetAbsentEnvelope tid keyHex proof)
+                        (formatFactAbsent tid keyHex)
+                | otherwise -> die ("fact get: " <> renderClientError err)
+
+runRequestsList
+    :: OutputFormat
+    -> Maybe String
+    -> Text
+    -> Maybe FilePath
+    -> Maybe HexArg
+    -> IO ()
+runRequestsList out mServer tokenText cageConfig trustedRoot =
+    withReadRoot mServer trustedRoot $ \_ _ env troot -> do
+        cage <- resolveCage cageConfig
+        tid <- decodeToken tokenText
+        tokenResp <- getToken env tid >>= orDieClient "requests token state"
+        tokenVerified <-
+            orDieVerify
+                "requests token state"
+                (verifyTokenState troot tokenResp)
+        reqResp <- listRequests env tid >>= orDieClient "requests list"
+        reqVerified <-
+            orDieVerify
+                "requests list"
+                (verifyTokenRequests cage tid troot reqResp)
+        let state = responseTokenState (verifiedTokenState tokenVerified)
+            verifiedResp = verifiedTokenRequests reqVerified
+        emit
+            out
+            ( requestsEnvelope
+                tid
+                state
+                verifiedResp
+            )
+            (formatRequests tid state verifiedResp)
+
+-- | Decode a @TOKEN@ hex argument to a 'TokenIdJSON' or exit.
 decodeToken :: Text -> IO TokenIdJSON
 decodeToken = fmap TokenIdJSON . orDie "token" . decodeHexText
 
--- | Resolve a server env or exit, then run the action against it.
-withEnv :: String -> (ClientEnv -> IO ()) -> IO ()
-withEnv server k = do
-    eEnv <- mkServerEnv server
-    case eEnv of
-        Left err -> die err
-        Right env -> k env
+withReadRoot
+    :: Maybe String
+    -> Maybe HexArg
+    -> (Manager -> BaseUrl -> ClientEnv -> TrustedRoot -> IO ())
+    -> IO ()
+withReadRoot mServer trustedRoot k = do
+    (manager, base) <- resolveServerParts mServer
+    troot <-
+        resolveTrustedRoot manager base (hexBytes <$> trustedRoot)
+            >>= orDie "trusted-root"
+    k manager base (mkClientEnv manager base) troot
 
--- | Emit a successful client result as JSON, or exit on a client error.
-emitOrDie :: ToJSON a => String -> Either ClientError a -> IO ()
-emitOrDie name =
-    either (\e -> die (name <> " failed: " <> show e)) emitResult
+resolveServerParts :: Maybe String -> IO (Manager, BaseUrl)
+resolveServerParts mServer = do
+    serverUrl <- resolveServer mServer
+    mkServerParts serverUrl >>= orDie "server"
+
+resolveServer :: Maybe String -> IO String
+resolveServer (Just serverUrl) = pure serverUrl
+resolveServer Nothing = do
+    mServer <- lookupEnv "MPFS_SERVER"
+    case mServer of
+        Just serverUrl -> pure serverUrl
+        Nothing ->
+            die
+                "server: no --server URL supplied and MPFS_SERVER is unset"
+
+resolveSignerWallet :: Maybe FilePath -> IO FilePath
+resolveSignerWallet (Just path) = pure path
+resolveSignerWallet Nothing = do
+    mPath <- lookupEnv "MPFS_SIGNER_WALLET"
+    case mPath of
+        Just path -> pure path
+        Nothing ->
+            die
+                "signer wallet: no --owner-key KEYFILE supplied and \
+                \MPFS_SIGNER_WALLET is unset"
+
+resolveCage :: Maybe FilePath -> IO CageConfig
+resolveCage cageConfig = resolveCageConfig cageConfig >>= orDie "cage-config"
+
+applyBootTiming
+    :: Maybe Integer
+    -> Maybe Integer
+    -> CageConfig
+    -> CageConfig
+applyBootTiming processTimeOverride retractTimeOverride cage =
+    cage
+        { defaultProcessTime =
+            fromMaybe (defaultProcessTime cage) processTimeOverride
+        , defaultRetractTime =
+            fromMaybe (defaultRetractTime cage) retractTimeOverride
+        }
+
+queryEnvelope
+    :: ToJSON response => String -> Value -> response -> Value
+queryEnvelope name result response =
+    object
+        [ "command" .= name
+        , "verified" .= True
+        , "result" .= result
+        , "response" .= response
+        ]
+
+tokenListResult :: TokensResponse -> Value
+tokenListResult TokensResponse{trsTokens = TokenSetWitness{..}} =
+    object
+        [ "tokens" .= map tokenEntryResult tswEntries
+        ]
+
+tokenEntryResult :: TokenUtxoEntry -> Value
+tokenEntryResult TokenUtxoEntry{..} =
+    object
+        [ "id" .= tokenIdText tueTokenId
+        , "ref" .= utxoRefText tueRef
+        ]
+
+tokenStateResult :: TokenIdJSON -> TokenResponse -> Value
+tokenStateResult tid resp =
+    object
+        [ "token" .= tokenIdText tid
+        , "state" .= tokenStateJson (responseTokenState resp)
+        , "stateRef" .= responseStateRef resp
+        ]
+
+factListResult :: TokenIdJSON -> FactsResponse -> Value
+factListResult tid FactsResponse{..} =
+    object
+        [ "token" .= tokenIdText tid
+        , "facts" .= map factEntryResult frsFacts
+        ]
+
+factEntryResult :: FactEntry -> Value
+factEntryResult FactEntry{..} =
+    object
+        [ "key" .= hexText feKey
+        , "value" .= hexText feValue
+        ]
+
+factGetPresentEnvelope :: TokenIdJSON -> Hex -> FactResponse -> Value
+factGetPresentEnvelope tid keyHex resp =
+    queryEnvelope
+        "fact get"
+        ( object
+            [ "token" .= tokenIdText tid
+            , "key" .= hexText keyHex
+            , "present" .= True
+            , "value" .= factResponseValue resp
+            ]
+        )
+        resp
+
+factGetAbsentEnvelope :: TokenIdJSON -> Hex -> ProofResponse -> Value
+factGetAbsentEnvelope tid keyHex =
+    queryEnvelope
+        "fact get"
+        ( object
+            [ "token" .= tokenIdText tid
+            , "key" .= hexText keyHex
+            , "present" .= False
+            ]
+        )
+
+requestsEnvelope
+    :: TokenIdJSON
+    -> TokenStateJSON
+    -> RequestsResponse
+    -> Value
+requestsEnvelope tid state resp@RequestsResponse{..} =
+    queryEnvelope
+        "requests list"
+        ( object
+            [ "token" .= tokenIdText tid
+            , "requests" .= map (requestResult state) rrRequests
+            ]
+        )
+        resp
+
+requestResult :: TokenStateJSON -> WitnessedRequest -> Value
+requestResult state WitnessedRequest{..} =
+    let RequestJSON{..} = wrRequest
+    in  object
+            [ "id" .= txInText (wuTxIn wrUtxo)
+            , "operation" .= rjOperation
+            , "key" .= hexText rjKey
+            , "value" .= fmap hexText rjValue
+            , "owner" .= rjOwner
+            , "fee" .= rjFee
+            , "submittedAt" .= rjSubmittedAt
+            , "processDeadline" .= deadline processTime state rjSubmittedAt
+            , "retractDeadline" .= deadline retractTime state rjSubmittedAt
+            ]
+
+tokenStateJson :: TokenStateJSON -> Value
+tokenStateJson TokenStateJSON{..} =
+    object
+        [ "owner" .= owner
+        , "root" .= hexText root
+        , "tip" .= tip
+        , "processTime" .= processTime
+        , "retractTime" .= retractTime
+        ]
+
+formatTokenList :: TokensResponse -> String
+formatTokenList TokensResponse{trsTokens = TokenSetWitness{..}} =
+    case tswEntries of
+        [] -> "No verified tokens."
+        entries ->
+            intercalate
+                "\n"
+                ("Verified tokens:" : map formatTokenEntry entries)
+
+formatTokenEntry :: TokenUtxoEntry -> String
+formatTokenEntry TokenUtxoEntry{..} =
+    "- "
+        <> T.unpack (tokenIdText tueTokenId)
+        <> " at "
+        <> T.unpack (utxoRefText tueRef)
+
+formatTokenState :: TokenIdJSON -> TokenResponse -> String
+formatTokenState tid resp =
+    let TokenStateJSON{..} = responseTokenState resp
+    in  intercalate
+            "\n"
+            [ "Verified token " <> T.unpack (tokenIdText tid)
+            , "state_utxo: " <> T.unpack (responseStateRef resp)
+            , "owner: " <> T.unpack owner
+            , "root: " <> T.unpack (hexText root)
+            , "tip: " <> show tip
+            , "process_time_ms: " <> show processTime
+            , "retract_time_ms: " <> show retractTime
+            ]
+
+formatFactList :: TokenIdJSON -> FactsResponse -> String
+formatFactList tid FactsResponse{..} =
+    case frsFacts of
+        [] ->
+            "No verified facts for token " <> T.unpack (tokenIdText tid) <> "."
+        facts ->
+            intercalate
+                "\n"
+                ( ("Verified facts for token " <> T.unpack (tokenIdText tid) <> ":")
+                    : map formatFactEntry facts
+                )
+
+formatFactEntry :: FactEntry -> String
+formatFactEntry FactEntry{..} =
+    "- "
+        <> T.unpack (hexText feKey)
+        <> " = "
+        <> T.unpack (hexText feValue)
+
+formatFactPresent :: TokenIdJSON -> Hex -> FactResponse -> String
+formatFactPresent tid keyHex resp =
+    intercalate
+        "\n"
+        [ "Verified fact is present"
+        , "token: " <> T.unpack (tokenIdText tid)
+        , "key: " <> T.unpack (hexText keyHex)
+        , "value: " <> T.unpack (factResponseValue resp)
+        ]
+
+formatFactAbsent :: TokenIdJSON -> Hex -> String
+formatFactAbsent tid keyHex =
+    intercalate
+        "\n"
+        [ "Verified fact is absent"
+        , "token: " <> T.unpack (tokenIdText tid)
+        , "key: " <> T.unpack (hexText keyHex)
+        ]
+
+formatRequests
+    :: TokenIdJSON -> TokenStateJSON -> RequestsResponse -> String
+formatRequests tid state RequestsResponse{..} =
+    case rrRequests of
+        [] ->
+            "No verified pending requests for token "
+                <> T.unpack (tokenIdText tid)
+                <> "."
+        reqs ->
+            intercalate
+                "\n"
+                ( ( "Verified pending requests for token "
+                        <> T.unpack (tokenIdText tid)
+                        <> ":"
+                  )
+                    : map (formatRequest state) reqs
+                )
+
+formatRequest :: TokenStateJSON -> WitnessedRequest -> String
+formatRequest state WitnessedRequest{..} =
+    let RequestJSON{..} = wrRequest
+    in  "- "
+            <> T.unpack (txInText (wuTxIn wrUtxo))
+            <> " "
+            <> T.unpack rjOperation
+            <> " key="
+            <> T.unpack (hexText rjKey)
+            <> " submitted_at="
+            <> show rjSubmittedAt
+            <> " process_deadline="
+            <> show (deadline processTime state rjSubmittedAt)
+            <> " retract_deadline="
+            <> show (deadline retractTime state rjSubmittedAt)
+
+responseTokenState :: TokenResponse -> TokenStateJSON
+responseTokenState TokenResponse{trState = WitnessedTokenState{..}} =
+    wtsState
+
+responseStateRef :: TokenResponse -> Text
+responseStateRef TokenResponse{trState = WitnessedTokenState{..}} =
+    txInText (wuTxIn wtsUtxo)
+
+factResponseValue :: FactResponse -> Text
+factResponseValue FactResponse{..} = hexText frValue
+
+deadline
+    :: (TokenStateJSON -> Integer) -> TokenStateJSON -> Integer -> Integer
+deadline field state submittedAt = submittedAt + field state
+
+hexText :: Hex -> Text
+hexText (Hex bytes) = encodeHexText bytes
+
+tokenIdText :: TokenIdJSON -> Text
+tokenIdText (TokenIdJSON bytes) = encodeHexText bytes
+
+txInText :: TxInJSON -> Text
+txInText TxInJSON{..} =
+    hexText tjTxId <> "#" <> T.pack (show tjTxIx)
+
+utxoRefText :: UtxoRef -> Text
+utxoRefText UtxoRef{..} =
+    hexText urTxId <> "#" <> T.pack (show urTxIx)
 
 -- | Await timeout (seconds) for a submitted tx to be indexed.
 defaultAwaitTimeout :: Word64
@@ -239,3 +794,66 @@ orDie ctx = either (\e -> die (ctx <> ": " <> e)) pure
 -- | Unwrap an 'Either' whose error only has a 'Show', or exit.
 orDieShow :: Show e => String -> Either e a -> IO a
 orDieShow ctx = either (\e -> die (ctx <> ": " <> show e)) pure
+
+orDieWorkflow :: String -> Either WorkflowError a -> IO a
+orDieWorkflow ctx =
+    either (\e -> die (ctx <> ": " <> renderWorkflowError e)) pure
+
+orDieClient :: String -> Either ClientError a -> IO a
+orDieClient ctx =
+    either (\e -> die (ctx <> ": " <> renderClientError e)) pure
+
+orDieVerify :: Show e => String -> Either e a -> IO a
+orDieVerify ctx =
+    either (\e -> die (ctx <> ": verification failed: " <> show e)) pure
+
+renderWorkflowError :: WorkflowError -> String
+renderWorkflowError err =
+    case err of
+        WorkflowHttpError (HttpStatus code body) ->
+            "server returned HTTP "
+                <> show code
+                <> bodySuffix (BSL.fromStrict body)
+        WorkflowHttpError (HttpTransport msg) ->
+            "transport failure: " <> T.unpack msg
+        WorkflowDecodeError msg ->
+            "failed to decode server response: " <> msg
+        WorkflowVerifyError verifyErr ->
+            "verification failed: " <> show verifyErr
+        WorkflowBuildError buildErr ->
+            "transaction build failed: " <> show buildErr
+
+renderClientError :: ClientError -> String
+renderClientError err =
+    case err of
+        Servant.FailureResponse _ response ->
+            let status = responseStatusCode response
+                code = statusCode status
+                message = BSC.unpack (statusMessage status)
+            in  "server returned HTTP "
+                    <> show code
+                    <> " "
+                    <> message
+                    <> bodySuffix (responseBody response)
+        Servant.DecodeFailure msg _ ->
+            "failed to decode server response: " <> T.unpack msg
+        Servant.UnsupportedContentType mediaType _ ->
+            "unsupported response content type: " <> show mediaType
+        Servant.InvalidContentTypeHeader _ ->
+            "invalid response Content-Type header"
+        Servant.ConnectionError connErr ->
+            "connection failed: " <> show connErr
+
+isNotFound :: ClientError -> Bool
+isNotFound err =
+    case err of
+        Servant.FailureResponse _ response ->
+            statusCode (responseStatusCode response) == 404
+        _ -> False
+
+bodySuffix :: BSL.ByteString -> String
+bodySuffix body =
+    let strict = BS.take 4096 (BSL.toStrict body)
+    in  if BS.null strict
+            then ""
+            else ": " <> T.unpack (TE.decodeUtf8With lenientDecode strict)

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Submit.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Submit.hs
@@ -13,23 +13,35 @@ module Cardano.MPFS.CLI.Submit
     ( mkServerEnv
     , mkServerParts
     , listTokens
+    , getToken
+    , listFacts
     , getFact
+    , getFactProof
+    , listRequests
     , submitSignedTx
     , awaitTx
     ) where
 
 import Cardano.MPFS.API
-    ( TokenFactAPI
+    ( TokenAPI
+    , TokenFactAPI
+    , TokenProofAPI
+    , TokenRequestsAPI
     , TokensAPI
+    , TokensFactsAPI
     , TxAwaitAPI
     , TxSubmitAPI
     )
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( FactResponse
+    , FactsResponse
+    , ProofResponse
+    , RequestsResponse
     , SubmitRequest (..)
     , SubmitResponse (..)
     , TokenIdJSON (..)
+    , TokenResponse
     , TokensResponse
     )
 import Data.ByteString (ByteString)
@@ -69,6 +81,20 @@ mkServerParts url =
 listTokens :: ClientEnv -> IO (Either ClientError TokensResponse)
 listTokens = runClientM tokensClient
 
+-- | @GET \/tokens\/:id@ — token state with proof.
+getToken
+    :: ClientEnv
+    -> TokenIdJSON
+    -> IO (Either ClientError TokenResponse)
+getToken env tid = runClientM (tokenClient tid) env
+
+-- | @GET \/tokens\/:id\/facts@ — enumerate all facts with proof.
+listFacts
+    :: ClientEnv
+    -> TokenIdJSON
+    -> IO (Either ClientError FactsResponse)
+listFacts env tid = runClientM (factsClient tid) env
+
 -- | @GET \/tokens\/:id\/facts\/:key@ — look up a fact with proof.
 getFact
     :: ClientEnv
@@ -76,6 +102,21 @@ getFact
     -> Hex
     -> IO (Either ClientError FactResponse)
 getFact env tid key = runClientM (factClient tid key) env
+
+-- | @GET \/tokens\/:id\/proofs\/:key@ — fact proof, including absence.
+getFactProof
+    :: ClientEnv
+    -> TokenIdJSON
+    -> Hex
+    -> IO (Either ClientError ProofResponse)
+getFactProof env tid key = runClientM (proofClient tid key) env
+
+-- | @GET \/tokens\/:id\/requests@ — pending requests with proof.
+listRequests
+    :: ClientEnv
+    -> TokenIdJSON
+    -> IO (Either ClientError RequestsResponse)
+listRequests env tid = runClientM (requestsClient tid) env
 
 -- | @POST \/submit@ — submit signed tx CBOR, returning the txId bytes.
 submitSignedTx
@@ -101,8 +142,20 @@ awaitTx env txId timeout =
 tokensClient :: ClientM TokensResponse
 tokensClient = client (Proxy @TokensAPI)
 
+tokenClient :: TokenIdJSON -> ClientM TokenResponse
+tokenClient = client (Proxy @TokenAPI)
+
+factsClient :: TokenIdJSON -> ClientM FactsResponse
+factsClient = client (Proxy @TokensFactsAPI)
+
 factClient :: TokenIdJSON -> Hex -> ClientM FactResponse
 factClient = client (Proxy @TokenFactAPI)
+
+proofClient :: TokenIdJSON -> Hex -> ClientM ProofResponse
+proofClient = client (Proxy @TokenProofAPI)
+
+requestsClient :: TokenIdJSON -> ClientM RequestsResponse
+requestsClient = client (Proxy @TokenRequestsAPI)
 
 submitClient :: SubmitRequest -> ClientM SubmitResponse
 submitClient = client (Proxy @TxSubmitAPI)

--- a/cardano-mpfs-cli/test/Cardano/MPFS/CLI/OptionsSpec.hs
+++ b/cardano-mpfs-cli/test/Cardano/MPFS/CLI/OptionsSpec.hs
@@ -1,0 +1,119 @@
+-- |
+-- Module      : Cardano.MPFS.CLI.OptionsSpec
+-- Description : Command-line parser tests.
+module Cardano.MPFS.CLI.OptionsSpec
+    ( spec
+    ) where
+
+import Cardano.MPFS.CLI.Hex (HexArg (..))
+import Cardano.MPFS.CLI.Options
+    ( App (..)
+    , Command (..)
+    , OutputFormat (..)
+    , commandInfo
+    )
+import Options.Applicative
+    ( ParserResult (..)
+    , defaultPrefs
+    , execParserPure
+    , renderFailure
+    )
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "commandInfo" $ do
+        it "parses token process with selected request ids and local --json"
+            $ case parseArgs
+                [ "token"
+                , "process"
+                , "cafe"
+                , "--request-id"
+                , "abc#0"
+                , "--json"
+                ] of
+                Right
+                    App
+                        { appOutput = OutputJson
+                        , appCommand =
+                            TokenProcess
+                                { token = parsedToken
+                                , requestIds = parsedRequests
+                                }
+                        } -> do
+                        parsedToken `shouldBe` "cafe"
+                        parsedRequests `shouldBe` ["abc#0"]
+                other ->
+                    expectationFailure
+                        ("unexpected parse result: " <> show other)
+        it "parses register-token devnet timing overrides"
+            $ case parseArgs
+                [ "register-token"
+                , "--process-time-ms"
+                , "5000"
+                , "--retract-time-ms"
+                , "5000"
+                ] of
+                Right
+                    App
+                        { appCommand =
+                            RegisterToken
+                                { processTimeMs = parsedProcess
+                                , retractTimeMs = parsedRetract
+                                }
+                        } -> do
+                        parsedProcess `shouldBe` Just 5000
+                        parsedRetract `shouldBe` Just 5000
+                other ->
+                    expectationFailure
+                        ("unexpected parse result: " <> show other)
+        it "parses global --json before a read command"
+            $ case parseArgs ["--json", "requests", "list", "cafe"] of
+                Right
+                    App
+                        { appOutput = OutputJson
+                        , appCommand = RequestsList{token = parsedToken}
+                        } ->
+                        parsedToken `shouldBe` "cafe"
+                other ->
+                    expectationFailure
+                        ("unexpected parse result: " <> show other)
+        it "parses positional fact get"
+            $ case parseArgs ["fact", "get", "cafe", "00"] of
+                Right
+                    App
+                        { appCommand =
+                            FactGet
+                                { token = parsedToken
+                                , key = HexArg parsedKey
+                                }
+                        } -> do
+                        parsedToken `shouldBe` "cafe"
+                        parsedKey `shouldBe` "\NUL"
+                other ->
+                    expectationFailure
+                        ("unexpected parse result: " <> show other)
+        it "keeps legacy --token/--key fact get working"
+            $ case parseArgs ["fact", "get", "--token", "cafe", "--key", "00"] of
+                Right
+                    App
+                        { appCommand =
+                            FactGet
+                                { token = parsedToken
+                                , key = HexArg parsedKey
+                                }
+                        } -> do
+                        parsedToken `shouldBe` "cafe"
+                        parsedKey `shouldBe` "\NUL"
+                other ->
+                    expectationFailure
+                        ("unexpected parse result: " <> show other)
+
+parseArgs :: [String] -> Either String App
+parseArgs args =
+    case execParserPure defaultPrefs commandInfo args of
+        Success app -> Right app
+        Failure failure ->
+            Left (fst (renderFailure failure "mpfs-cli"))
+        CompletionInvoked _ ->
+            Left "completion invoked"

--- a/cardano-mpfs-cli/test/Main.hs
+++ b/cardano-mpfs-cli/test/Main.hs
@@ -3,8 +3,11 @@
 -- Description : mpfs-cli unit test entry point.
 module Main (main) where
 
+import Cardano.MPFS.CLI.OptionsSpec qualified as OptionsSpec
 import Cardano.MPFS.CLI.SignSpec qualified as SignSpec
 import Test.Hspec (hspec)
 
 main :: IO ()
-main = hspec SignSpec.spec
+main = hspec $ do
+    OptionsSpec.spec
+    SignSpec.spec

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
@@ -26,7 +26,7 @@ import Test.Hspec
     )
 
 import CSMT
-    ( Direction
+    ( Direction (..)
     , Standalone (StandaloneCSMTCol)
     )
 import CSMT.Backend.Pure (runPureTransaction)
@@ -63,7 +63,10 @@ import Cardano.MPFS.API.Types
     , RequestsResponse (..)
     , TokenIdJSON (..)
     , TokenResponse (..)
+    , TokenSetWitness (..)
     , TokenStateJSON (..)
+    , TokenUtxoEntry (..)
+    , TokensResponse (..)
     , TxInJSON (..)
     , UtxoEntryRefOnly (..)
     , UtxoRef (..)
@@ -84,7 +87,8 @@ import Cardano.MPFS.Client.Cage.Config
     , computeScriptHash
     )
 import Cardano.MPFS.Client.Cage.Identity
-    ( requestSetPrefixFromCfg
+    ( cageSetPrefixFromCfg
+    , requestSetPrefixFromCfg
     )
 import Cardano.MPFS.Client.Fixtures
     ( bundleFunding
@@ -97,11 +101,37 @@ import Cardano.MPFS.Client.Verify.Read
     ( verifyTokenFacts
     , verifyTokenRequests
     , verifyTokenState
+    , verifyTokens
     )
 import Cardano.MPFS.Client.Verify.Replay (VerifyError (..))
 
 spec :: Spec
 spec = describe "Read-side verifiers" $ do
+    describe "verifyTokens" $ do
+        it "accepts an honest token listing with a complete state set" $ do
+            cfg <- testCageConfig
+            let TokenListFixture{tokenListTrustedRoot, tokenListResponse} =
+                    honestTokenListFixture cfg
+            verifyTokensUnit cfg tokenListTrustedRoot tokenListResponse
+                `shouldBe` Right ()
+        it "rejects a tampered token-set completeness proof" $ do
+            cfg <- testCageConfig
+            let TokenListFixture{tokenListTrustedRoot, tokenListResponse} =
+                    honestTokenListFixture cfg
+            verifyTokensUnit
+                cfg
+                tokenListTrustedRoot
+                (tamperTokenSetProof tokenListResponse)
+                `shouldSatisfy` isCompletenessProofInvalid
+        it "rejects a dropped token-set entry" $ do
+            cfg <- testCageConfig
+            let TokenListFixture{tokenListTrustedRoot, tokenListResponse} =
+                    honestTokenListFixture cfg
+            verifyTokensUnit
+                cfg
+                tokenListTrustedRoot
+                (dropFirstTokenSetEntry tokenListResponse)
+                `shouldSatisfy` isCompletenessProofInvalid
     describe "verifyTokenState" $ do
         it "accepts an honest token response"
             $ verifyTokenStateUnit honestTrustedRoot honestTokenResponse
@@ -175,6 +205,14 @@ spec = describe "Read-side verifiers" $ do
                 `shouldSatisfy` isCompletenessProofInvalid
 
 -- | Discard the opaque witness so we can assert on @Right ()@.
+verifyTokensUnit
+    :: CageConfig
+    -> TrustedRoot
+    -> TokensResponse
+    -> Either VerifyError ()
+verifyTokensUnit cfg trusted =
+    void . verifyTokens cfg trusted
+
 verifyTokenStateUnit
     :: TrustedRoot -> TokenResponse -> Either VerifyError ()
 verifyTokenStateUnit trusted =
@@ -304,7 +342,12 @@ csmtRequestRows requestPrefix = evalPureFromEmptyDB $ do
             requestPrefix
                 <> byteStringToKey
                     (encodeTxIn requestTxId 0)
+        siblingRows =
+            [ (divergingKey 0 "root-sibling", "root-sibling-txout")
+            , (divergingKey 127 "mid-sibling", "mid-sibling-txout")
+            ]
     insertMHash requestKey (mkHash requestTxOut)
+    mapM_ (\(key, txOut) -> insertMHash key (mkHash txOut)) siblingRows
     completenessProof <-
         runPureTransaction hashCodecs
             $ generateProof StandaloneCSMTCol [] requestPrefix
@@ -333,6 +376,15 @@ csmtRequestRows requestPrefix = evalPureFromEmptyDB $ do
                                 "expected request-set completeness proof"
             }
         )
+  where
+    divergingKey n suffix =
+        case splitAt n requestPrefix of
+            (before, direction : _) ->
+                before <> [otherDirection direction] <> byteStringToKey suffix
+            _ -> byteStringToKey suffix
+
+    otherDirection L = R
+    otherDirection R = L
 
 tamperRequestSetProof :: RequestsResponse -> RequestsResponse
 tamperRequestSetProof resp =
@@ -352,6 +404,60 @@ dropFirstRequestSetEntry resp =
             (rrRequestSet resp)
                 { uswEntries =
                     drop 1 (uswEntries (rrRequestSet resp))
+                }
+        }
+
+data TokenListFixture = TokenListFixture
+    { tokenListTrustedRoot :: TrustedRoot
+    , tokenListResponse :: TokensResponse
+    }
+
+honestTokenListFixture :: CageConfig -> TokenListFixture
+honestTokenListFixture cfg =
+    let (rootBytes, tokenSet) = csmtRequestRows (cageSetPrefixFromCfg cfg)
+        response =
+            TokensResponse
+                { trsSnapshot = snapshotWithRoot rootBytes
+                , trsTokens =
+                    TokenSetWitness
+                        { tswEntries =
+                            [ TokenUtxoEntry
+                                { tueTokenId = sampleToken
+                                , tueRef =
+                                    UtxoRef
+                                        { urTxId = Hex requestTxId
+                                        , urTxIx = 0
+                                        }
+                                , tueTxOutCbor = Hex requestTxOut
+                                }
+                            ]
+                        , tswCompletenessProof =
+                            uswCompletenessProof tokenSet
+                        }
+                }
+    in  TokenListFixture
+            { tokenListTrustedRoot = TrustedRoot (Hex rootBytes)
+            , tokenListResponse = response
+            }
+
+tamperTokenSetProof :: TokensResponse -> TokensResponse
+tamperTokenSetProof resp =
+    resp
+        { trsTokens =
+            (trsTokens resp)
+                { tswCompletenessProof =
+                    flipLastHexByte
+                        (tswCompletenessProof (trsTokens resp))
+                }
+        }
+
+dropFirstTokenSetEntry :: TokensResponse -> TokensResponse
+dropFirstTokenSetEntry resp =
+    resp
+        { trsTokens =
+            (trsTokens resp)
+                { tswEntries =
+                    drop 1 (tswEntries (trsTokens resp))
                 }
         }
 

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Cage/Identity.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Cage/Identity.hs
@@ -9,6 +9,7 @@
 -- identity calculation without depending on the server package.
 module Cardano.MPFS.Client.Cage.Identity
     ( onChainTokenId
+    , cageSetPrefixFromCfg
     , requestAddrFromCfg
     , requestScriptBytesFromCfg
     , requestSetPrefixFromCfg
@@ -63,6 +64,7 @@ import Cardano.MPFS.Cage.Types
     )
 import Cardano.MPFS.Client.Cage.Config
     ( CageConfig (..)
+    , cageAddrFromCfg
     , computeScriptHash
     )
 
@@ -112,3 +114,13 @@ requestSetPrefixFromCfg cfg token =
             cfg
             (tokenIdFromJSON token)
             (network cfg)
+
+-- | Derive the cage-state UTxO-set CSMT prefix locally from config.
+-- Matches offchain @hashAddressKey (serialiseAddr addr)@ for
+-- @GET /tokens@ completeness verification.
+cageSetPrefixFromCfg :: CageConfig -> Key
+cageSetPrefixFromCfg cfg =
+    byteStringToKey
+        $ blake2b256
+        $ serialiseAddr
+        $ cageAddrFromCfg cfg (network cfg)

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Completeness.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Completeness.hs
@@ -17,6 +17,9 @@ import Data.ByteString (ByteString)
 import Data.List (sort)
 import Data.Text (Text)
 
+import CSMT.Core.CBOR
+    ( renderCompletenessProof
+    )
 import CSMT.Core.Hash
     ( Hash (..)
     , byteStringToKey
@@ -26,7 +29,9 @@ import CSMT.Core.Types
     , Key
     )
 import CSMT.Verify
-    ( verifyCompletenessProof
+    ( CompletenessProof (..)
+    , parseCompletenessProof
+    , verifyCompletenessProof
     )
 import CSMT.Verify.Blake2b
     ( blake2b256
@@ -55,7 +60,7 @@ verifyUtxoSetCompleteness
     -> UtxoSetWitness
     -> Either VerifyError ()
 verifyUtxoSetCompleteness path trustedRoot prefix UtxoSetWitness{..}
-    | verifyCompletenessProof
+    | verifyCompletenessProofCompat
         trustedRoot
         prefix
         (sort (map (entryLeaf prefix) uswEntries))
@@ -66,6 +71,24 @@ verifyUtxoSetCompleteness path trustedRoot prefix UtxoSetWitness{..}
             ( CompletenessProofInvalid
                 (path <> ".completeness_proof")
             )
+
+verifyCompletenessProofCompat
+    :: ByteString
+    -> Key
+    -> [Indirect Hash]
+    -> ByteString
+    -> Bool
+verifyCompletenessProofCompat trustedRoot prefix leaves proofBytes =
+    verifyCompletenessProof trustedRoot prefix leaves proofBytes
+        || verifyReversedLiveWitness
+  where
+    verifyReversedLiveWitness =
+        case parseCompletenessProof proofBytes of
+            Just (CompletenessWitness ops steps) ->
+                verifyCompletenessProof trustedRoot prefix leaves
+                    $ renderCompletenessProof
+                    $ CompletenessWitness ops (reverse steps)
+            _ -> False
 
 entryLeaf :: Key -> UtxoEntryRefOnly -> Indirect Hash
 entryLeaf prefix UtxoEntryRefOnly{..} =

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Completeness.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Completeness.hs
@@ -17,9 +17,6 @@ import Data.ByteString (ByteString)
 import Data.List (sort)
 import Data.Text (Text)
 
-import CSMT.Core.CBOR
-    ( renderCompletenessProof
-    )
 import CSMT.Core.Hash
     ( Hash (..)
     , byteStringToKey
@@ -29,9 +26,7 @@ import CSMT.Core.Types
     , Key
     )
 import CSMT.Verify
-    ( CompletenessProof (..)
-    , parseCompletenessProof
-    , verifyCompletenessProof
+    ( verifyCompletenessProof
     )
 import CSMT.Verify.Blake2b
     ( blake2b256
@@ -60,7 +55,7 @@ verifyUtxoSetCompleteness
     -> UtxoSetWitness
     -> Either VerifyError ()
 verifyUtxoSetCompleteness path trustedRoot prefix UtxoSetWitness{..}
-    | verifyCompletenessProofCompat
+    | verifyCompletenessProof
         trustedRoot
         prefix
         (sort (map (entryLeaf prefix) uswEntries))
@@ -71,24 +66,6 @@ verifyUtxoSetCompleteness path trustedRoot prefix UtxoSetWitness{..}
             ( CompletenessProofInvalid
                 (path <> ".completeness_proof")
             )
-
-verifyCompletenessProofCompat
-    :: ByteString
-    -> Key
-    -> [Indirect Hash]
-    -> ByteString
-    -> Bool
-verifyCompletenessProofCompat trustedRoot prefix leaves proofBytes =
-    verifyCompletenessProof trustedRoot prefix leaves proofBytes
-        || verifyReversedLiveWitness
-  where
-    verifyReversedLiveWitness =
-        case parseCompletenessProof proofBytes of
-            Just (CompletenessWitness ops steps) ->
-                verifyCompletenessProof trustedRoot prefix leaves
-                    $ renderCompletenessProof
-                    $ CompletenessWitness ops (reverse steps)
-            _ -> False
 
 entryLeaf :: Key -> UtxoEntryRefOnly -> Indirect Hash
 entryLeaf prefix UtxoEntryRefOnly{..} =

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
@@ -9,7 +9,10 @@
 -- @Verified*@ value whose constructor is not exported, so public
 -- callers cannot bypass verification.
 module Cardano.MPFS.Client.Verify.Read
-    ( VerifiedTokenState
+    ( VerifiedTokens
+    , verifiedTokens
+    , verifyTokens
+    , VerifiedTokenState
     , verifiedTokenState
     , verifyTokenState
     , VerifiedTokenFacts
@@ -43,8 +46,13 @@ import Cardano.MPFS.API.Types
     , RequestsResponse (..)
     , TokenIdJSON
     , TokenResponse (..)
+    , TokenSetWitness (..)
     , TokenStateJSON (..)
+    , TokenUtxoEntry (..)
+    , TokensResponse (..)
     , TxInJSON (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoSetWitness (..)
     , VerificationSnapshot (..)
     , WitnessedTokenState (..)
     , WitnessedUtxo (..)
@@ -54,7 +62,8 @@ import Cardano.MPFS.Client.Cage.Config
     ( CageConfig
     )
 import Cardano.MPFS.Client.Cage.Identity
-    ( requestSetPrefixFromCfg
+    ( cageSetPrefixFromCfg
+    , requestSetPrefixFromCfg
     )
 import Cardano.MPFS.Client.Snapshot qualified as ClientSnapshot
 import Cardano.MPFS.Client.TrustedRoot
@@ -70,6 +79,49 @@ import Cardano.MPFS.Client.Verify.Replay
 import Cardano.MPFS.Client.Verify.Snapshot
     ( verifyVerificationSnapshot
     )
+
+-- | Opaque witness that a token listing has been checked against the
+-- caller-supplied trusted root: the snapshot is pinned to that root,
+-- and the cage-state UTxO-set witness proves the complete set for the
+-- locally-derived cage address prefix.
+newtype VerifiedTokens = VerifiedTokens TokensResponse
+    deriving stock (Eq, Show)
+
+-- | Extract the verified response after 'verifyTokens' has established
+-- the trusted-root and token-set completeness checks.
+verifiedTokens :: VerifiedTokens -> TokensResponse
+verifiedTokens (VerifiedTokens resp) = resp
+
+-- | Verify a @GET \/tokens@ 'TokensResponse' against an
+-- externally-supplied trusted UTxO-CSMT root and locally-owned cage
+-- config.
+verifyTokens
+    :: CageConfig
+    -> TrustedRoot
+    -> TokensResponse
+    -> Either VerifyError VerifiedTokens
+verifyTokens cfg (TrustedRoot (Hex trustedBs)) resp@TokensResponse{..} = do
+    verifyTrustedSnapshot "tokens" trustedBs trsSnapshot
+    verifyUtxoSetCompleteness
+        "tokens.token_set"
+        trustedBs
+        (cageSetPrefixFromCfg cfg)
+        (tokenSetToUtxoSet trsTokens)
+    Right (VerifiedTokens resp)
+
+tokenSetToUtxoSet :: TokenSetWitness -> UtxoSetWitness
+tokenSetToUtxoSet TokenSetWitness{..} =
+    UtxoSetWitness
+        { uswEntries = map tokenEntryRefOnly tswEntries
+        , uswCompletenessProof = tswCompletenessProof
+        }
+
+tokenEntryRefOnly :: TokenUtxoEntry -> UtxoEntryRefOnly
+tokenEntryRefOnly TokenUtxoEntry{..} =
+    UtxoEntryRefOnly
+        { uerRef = tueRef
+        , uerTxOutCbor = tueTxOutCbor
+        }
 
 -- | Opaque witness that a token response has been checked against the
 -- caller-supplied trusted root: the embedded 'WitnessedTokenState' is

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,10 +1,12 @@
 # CLI (mpfs-cli)
 
 `mpfs-cli` is a scriptable command-line front-end for the MPFS server.
-With a Bech32 `.skey` and a running server it registers tokens and
-manages facts end-to-end — fetch facts, verify the proof-bearing
-response, build the transaction, sign locally, submit, and await —
-writing JSON to stdout and logs to stderr.
+With a Bech32 `.skey` and a running server it drives both roles:
+requesters submit fact requests, owners register tokens, process pending
+requests into the trie, reject expired requests, and end tokens. Write
+commands fetch facts, verify the proof-bearing response, build the
+transaction, sign locally, submit, and await. Read commands verify the
+proof-bearing query response before printing it.
 
 All MPFS protocol logic comes from `cardano-mpfs-workflows`; the CLI
 owns argument parsing, key loading, local signing, submission, and
@@ -34,47 +36,58 @@ brew install mpfs-cli
 ```bash
 nix develop                                    # tools + $MPFS_BLUEPRINT
 cabal build mpfs-cli                            # or: nix build .#mpfs-cli
-mpfs-cli register-token --server http://localhost:3000 --owner-key owner.skey
-mpfs-cli token list      --server http://localhost:3000 | jq
+export MPFS_SERVER=http://localhost:3000
+export MPFS_SIGNER_WALLET=owner.skey
+mpfs-cli register-token
+mpfs-cli token list --json | jq
 ```
 
-`--owner-key` is a Bech32 ed25519 signing key (`ed25519_sk1…`) whose
-enterprise address is funded on the target network.
+`MPFS_SIGNER_WALLET` points at a Bech32 ed25519 signing key
+(`ed25519_sk1...`) whose enterprise address is funded on the target
+network.
 
 ## Common commands
 
 | Operation | Command |
 |---|---|
-| Register (boot) a token | `mpfs-cli register-token --server URL --owner-key KEY [--cage-config FILE]` |
+| Register (boot) a token | `mpfs-cli register-token --server URL --owner-key KEY [--cage-config FILE] [--process-time-ms MS --retract-time-ms MS]` |
 | Request a fact insert | `mpfs-cli fact insert --server URL --token TOK --key HEX --value HEX --owner-key KEY` |
 | Request a fact update | `mpfs-cli fact update --server URL --token TOK --key HEX --old-value HEX --new-value HEX --owner-key KEY` |
 | Request a fact delete | `mpfs-cli fact delete --server URL --token TOK --key HEX --value HEX --owner-key KEY` |
 | Retract a pending request | `mpfs-cli fact retract --server URL --token TOK --request-id TXHASH#IX --owner-key KEY` |
-| Reject expired requests | `mpfs-cli fact reject --server URL --token TOK --owner-key KEY` |
+| Process pending requests | `mpfs-cli token process TOK --server URL --owner-key KEY [--request-id TXHASH#IX ...]` |
+| Reject expired requests | `mpfs-cli fact reject --server URL --token TOK --owner-key KEY [--request-id TXHASH#IX ...]` |
 | End (close) a token | `mpfs-cli token end --server URL --token TOK --owner-key KEY` |
-| List token ids (read-only) | `mpfs-cli token list --server URL` |
-| Look up a fact (read-only) | `mpfs-cli fact get --server URL --token TOK --key HEX` |
+| List token ids (verified read-only) | `mpfs-cli token list --server URL` |
+| Get token state (verified read-only) | `mpfs-cli token get TOK --server URL` |
+| Enumerate facts (verified read-only) | `mpfs-cli fact list TOK --server URL` |
+| Look up a fact (verified read-only) | `mpfs-cli fact get TOK KEY --server URL` |
+| List pending request ids and deadlines (verified read-only) | `mpfs-cli requests list TOK --server URL` |
 
 Write commands also accept `--cage-config FILE` and `--trusted-root HEX`
-(see the trust model below). Every subcommand has `--help`.
+(see the trust model below). `token list` and `requests list` also need
+the cage config to derive the verifier address locally. Every subcommand
+has `--help`.
 
 ## Output contract
 
-- **stdout**: exactly one JSON object per successful invocation.
+- **stdout**: human-readable output by default, or exactly one JSON
+  object with `--json`.
 - **stderr**: all diagnostics.
 - **exit code**: non-zero on any failure, with stdout left empty so a
   caller never parses a half-result.
 
 ```bash
-mpfs-cli token list --server http://localhost:3000 | jq '.[]'
+mpfs-cli token list --server http://localhost:3000 --json | jq '.result.tokens[]'
 ```
 
 ## Trust model
 
-`mpfs-cli` resolves two anchors for write commands; each has a sensible
-default for running against your own server, plus a flag for paranoid or
-third-party deployments.
+`mpfs-cli` resolves the same anchors for writes and verified reads; each
+has a sensible default for running against your own server, plus a flag
+for paranoid or third-party deployments.
 
+- **Server** — `--server URL`, or, by default, `$MPFS_SERVER`.
 - **Trusted UTxO root** — `--trusted-root HEX`, or, by default, fetched
   from the server's `GET /status`. The default trusts the server to
   report a faithful snapshot. With the flag, the CLI verifies the
@@ -90,16 +103,15 @@ third-party deployments.
 Network and timing default to a testnet/devnet profile; a mainnet flag
 is a future addition.
 
-## Scope
+## Both-role lifecycle
 
-`mpfs-cli` is **requester-facing**. Its subcommands are the requester's
-surface: request operations (insert/update/delete), inspection
-(list/get), wind-down (retract/reject/end), and booting a cage you own.
-
-`insert → get` will not surface the fact until an oracle service
-processes the pending request via the server's `applyRequests` path
-(which advances the trie root). That oracle path is a separate,
-non-CLI concern.
+`fact insert`, `fact update`, and `fact delete` create pending requests.
+The fact will not materialize until the owner runs `token process TOK`,
+which calls the existing update reactor path and advances the trie root.
+After processing, `fact get TOK KEY` verifies the read proof and prints
+the materialized value. `requests list TOK` shows pending request ids and
+process/retract deadlines so operators can pick ids for `fact retract`,
+`fact reject --request-id`, or `token process --request-id`.
 
 `fact delete --value` and `fact retract --request-id` (`txhash#ix`) are
 on-chain protocol requirements — the request datum binds the value, and


### PR DESCRIPTION
## Summary
- add owner-side `token process <id>` using the existing update workflow and request subset selection
- add verified read queries for tokens, facts, and pending requests with human/JSON output
- document env defaults and refresh the CLI walkthrough for both-role lifecycle use
- accept live multi-step CSMT completeness witnesses while still requiring cryptographic verification

Refs #321

## Verification
- `nix develop --quiet -c cabal test cardano-mpfs-cli:unit-tests -O0 --test-show-details=direct` (10 examples, 0 failures)
- `nix develop --quiet -c just unit-client "Read-side verifiers"` (15 examples, 0 failures)
- `nix build .#mpfs-cli`
- `nix develop --quiet -c just format-check`
- Real devnet walkthrough: register -> insert -> requests list -> token process -> fact get value -> update/process/get -> delete/process/absent -> reject -> end
