### PR TITLE
fix(update): derive update validTo as an in-horizon slot offset (#324)

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -1131,7 +1131,11 @@ factsUpdateHandler
                 Left msg -> throwInternal msg
                 Right root -> pure root
         validityUpperSlot <-
-            updateValidityUpperSlot ctx stateOutBytes requestUtxos
+            updateValidityUpperSlot
+                ctx
+                snap
+                stateOutBytes
+                requestUtxos
         pp <-
             liftIO
                 $ queryProtocolParams
@@ -1524,10 +1528,11 @@ stateTrieRootBytes bytes = do
 
 updateValidityUpperSlot
     :: Context IO
+    -> BundleSnapshot
     -> ByteString
     -> [ResolvedWalletInput]
     -> Handler Integer
-updateValidityUpperSlot ctx stateOutBytes requestUtxos = do
+updateValidityUpperSlot ctx snap stateOutBytes requestUtxos = do
     stateOut <-
         decodeIndexedTxOut "facts/update.state_utxo" stateOutBytes
     oldState <- case extractCageDatum stateOut of
@@ -1540,6 +1545,7 @@ updateValidityUpperSlot ctx stateOutBytes requestUtxos = do
         liftIO
             $ UpdateTx.computeUpperSlot
                 (provider ctx)
+                (snapshotSlot snap)
                 oldState
                 requestPairs
     pure (toInteger (unSlotNo slot))

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -27,12 +27,11 @@ import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Ord (Down (..))
-import Data.Time.Clock (getCurrentTime)
-import Data.Time.Clock.POSIX
-    ( utcTimeToPOSIXSeconds
-    )
 import Data.Void (Void)
+import Data.Word (Word64)
 import Lens.Micro ((&), (.~), (^.))
+import System.Environment (lookupEnv)
+import Text.Read (readMaybe)
 
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Alonzo.Scripts (AsIx)
@@ -97,7 +96,7 @@ import Cardano.MPFS.Trie
     , TrieManager (..)
     )
 import Cardano.MPFS.TxBuilder
-    ( BundleSnapshot
+    ( BundleSnapshot (..)
     , ProofEnvelope (..)
     , TrieFact (..)
     , UpdateProof (..)
@@ -107,7 +106,7 @@ import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
-import Cardano.Slotting.Slot (SlotNo)
+import Cardano.Slotting.Slot (SlotNo (..))
 import Cardano.Tx.Build qualified as Tx
 
 -- | Empty query GADT (no context needed).
@@ -158,7 +157,7 @@ updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
                     newRoot
     -- 4. Compute validity upper slot
     upperSlot <-
-        computeUpperSlot prov oldState reqUtxos
+        computeUpperSlot prov (snapshotSlot snap) oldState reqUtxos
     -- 5. Build DSL program and execute
     let evalTx = mkEvalTx prov
         prog =
@@ -327,15 +326,18 @@ prepareState cfg tid stateOut newRoot =
         )
 
 -- | Compute the validity upper slot from the
--- earliest request deadline. Falls back to
--- now + 30s/5s/2s if the slot is past the
--- Ouroboros forecast horizon.
+-- earliest request deadline. If that future-time
+-- conversion is past the Ouroboros forecast horizon,
+-- fall back to a fixed slot offset above the indexed
+-- snapshot slot. The fallback avoids a second
+-- POSIX→slot conversion for another future time.
 computeUpperSlot
     :: Provider IO
+    -> SlotNo
     -> OnChainTokenState
     -> [(TxIn, TxOut ConwayEra)]
     -> IO SlotNo
-computeUpperSlot prov oldState reqUtxos = do
+computeUpperSlot prov snapshotSlotNo oldState reqUtxos = do
     let extractSubmittedAt (_, rOut) =
             case extractCageDatum rOut of
                 Just (RequestDatum r) ->
@@ -355,17 +357,32 @@ computeUpperSlot prov oldState reqUtxos = do
             (posixMsToSlot prov earliestDeadline)
     case mUpperSlot of
         Right s -> pure s
-        Left _ -> do
-            nowUtc <- getCurrentTime
-            let posixSec =
-                    utcTimeToPOSIXSeconds nowUtc
-            trySlots prov
-                $ map
-                    ( \d ->
-                        round
-                            ((posixSec + d) * 1000)
-                    )
-                    [30, 5, 2]
+        Left _ ->
+            updateUpperSlotFallback snapshotSlotNo
+
+updateUpperSlotFallback :: SlotNo -> IO SlotNo
+updateUpperSlotFallback (SlotNo lower) = do
+    ttl <- updateTtlSlotsIO
+    pure (SlotNo (lower + ttl))
+
+-- | Slot TTL added to the in-horizon snapshot slot
+-- when update deadline conversion is past the
+-- forecast horizon. Kept small for devnet's short
+-- safe zone and within the client verifier's
+-- update validity buffer.
+updateTtlSlots :: Word64
+updateTtlSlots = 20
+
+-- | Update TTL resolved at request time. The
+-- @MPFS_UPDATE_TTL_SLOTS@ environment variable
+-- overrides 'updateTtlSlots' when set to an integer
+-- in @[1, 600]@.
+updateTtlSlotsIO :: IO Word64
+updateTtlSlotsIO = do
+    mv <- lookupEnv "MPFS_UPDATE_TTL_SLOTS"
+    pure $ case mv >>= readMaybe of
+        Just n | n >= 1 && n <= 600 -> n
+        _ -> updateTtlSlots
 
 -- | Wrap the Provider's evaluateTx for the DSL.
 mkEvalTx

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -5,6 +5,7 @@
 
 module Cardano.MPFS.TxBuilderSpec (spec) where
 
+import Control.Exception (throwIO)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
@@ -174,6 +175,9 @@ import Cardano.MPFS.TxBuilder.Real
 import Cardano.MPFS.TxBuilder.Real.Internal
     ( requestAddrFromCfg
     )
+import Cardano.MPFS.TxBuilder.Real.Update
+    ( computeUpperSlot
+    )
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -329,6 +333,31 @@ mkTestProvider utxos =
         , evaluateTx = \_ -> pure Map.empty
         , posixMsToSlot = \_ -> pure (SlotNo 0)
         , posixMsCeilSlot = \_ -> pure (SlotNo 0)
+        }
+
+failingSlotProvider :: Provider IO
+failingSlotProvider =
+    (mkTestProvider [])
+        { posixMsToSlot = \_ ->
+            throwIO (userError "past horizon")
+        , posixMsCeilSlot = \_ ->
+            throwIO (userError "past horizon")
+        }
+
+fallbackState :: OnChainTokenState
+fallbackState =
+    OnChainTokenState
+        { stateOwner =
+            BuiltinByteString
+                ( hashToBytes
+                    $ let KeyHash h = testKh
+                      in  h
+                )
+        , stateRoot =
+            OnChainRoot (BS.replicate 32 0)
+        , stateMaxFee = 1_000_000
+        , stateProcessTime = 300_000
+        , stateRetractTime = 600_000
         }
 
 -- | Dummy CSMT proof function that always returns
@@ -508,6 +537,7 @@ spec = describe "Cardano.MPFS.TxBuilder.Real" $ do
     requestDeleteSpec
     retractRequestSpec
     updateTokenSpec
+    computeUpperSlotSpec
     endTokenSpec
     rejectRequestsSpec
     requestLockedAdaProps
@@ -752,6 +782,21 @@ updateTokenSpec =
                     tx ^. witsTxL . rdmrsTxWitsL
             -- one Modify + one Contribute
             Map.size rdmrs `shouldBe` 2
+
+computeUpperSlotSpec :: Spec
+computeUpperSlotSpec =
+    describe "computeUpperSlot" $ do
+        it
+            "falls back to an in-horizon slot offset when POSIX conversion fails"
+            $ do
+                txIn <- generate genTxIn
+                slot <-
+                    computeUpperSlot
+                        failingSlotProvider
+                        (SlotNo 42)
+                        fallbackState
+                        [(txIn, mkRequestTxOut)]
+                slot `shouldBe` SlotNo 62
 
 -- ---------------------------------------------------------
 -- endToken


### PR DESCRIPTION
Closes #324.

`POST /facts/update` returned a 500 ("Something went wrong" — an uncaught `ErrorCall`) on short-forecast-horizon devnets. `computeUpperSlot` derived the update tx's `validTo` by POSIX→slot-converting a **future** deadline (`submittedAt + processTime`); when that and the `now+30/5/2s` fallbacks were all past the Ouroboros forecast horizon, `trySlots []` raised `error "posixMsToSlot: all fallbacks past horizon"`.

The **reject** path already solved this (`rejectValiditySlots`/`rejectTtlSlots`): never convert a future time — use a fixed slot offset above an in-horizon slot. This applies the same to update: the happy path is unchanged (in-horizon deadline conversion), but the fallback now derives `validTo = snapshotSlot + updateTtlSlots` (default 20, env `MPFS_UPDATE_TTL_SLOTS`), threading the indexed snapshot slot through the facts handler and the server-side update builder.

Unit regression: a Provider stub whose slot conversion always trips PastHorizon — old code throws `ErrorCall`, fixed code returns `snapshotSlot + ttl`. Gate: unit 418/0, Facts API e2e matrix (update + reject) 0 failures, swagger unchanged.

**Validation:** to be confirmed by the moog-v2 canary (cardano-foundation/moog#152), which now clears boot+request (completeness fix, #319/#323) and should clear the update boundary with this.