### PR TITLE
fix: make proof-bearing reads atomic

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -304,6 +304,7 @@ test-suite unit-tests
   other-modules:
     Cardano.MPFS.BalanceSpec
     Cardano.MPFS.Generators
+    Cardano.MPFS.HTTP.AtomicReadFixture
     Cardano.MPFS.HTTP.BootFactsSpec
     Cardano.MPFS.HTTP.EndFactsSpec
     Cardano.MPFS.HTTP.RejectFactsSpec

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -115,7 +115,6 @@ import Cardano.MPFS.HTTP.Swagger
 import Cardano.MPFS.HTTP.Types
     ( BootFacts (..)
     , BootRequest (..)
-    , ChainPointJSON (..)
     , DeleteRequest (..)
     , EndRequest (..)
     , EvalContext (..)
@@ -174,7 +173,10 @@ import Cardano.MPFS.Indexer.Reads
     , readRequestUtxosAt
     , readSnapshot
     , readStateUtxoAt
+    , readTrieFact
+    , readTrieFacts
     , readUtxoSetAt
+    , readUtxoWitness
     , readWalletInputsAt
     )
 import Cardano.MPFS.Provider (Provider (..))
@@ -414,9 +416,16 @@ tokenHandler ctx tokenId = do
                 { tokenStateRef
                 , tokenState = ts
                 } -> do
-                snapshot <- requireSnapshot ctx
-                witness <-
-                    requireUtxoWitness ctx tokenStateRef
+                (mSnap, mWitness) <-
+                    runProofIndexerTx ctx
+                        $ do
+                            snap <- readSnapshot
+                            witness <-
+                                readUtxoWitness
+                                    tokenStateRef
+                            pure (snap, witness)
+                snapshot <- snapshotFromIndexer mSnap
+                witness <- witnessFromIndexer mWitness
                 pure
                     TokenResponse
                         { trSnapshot = snapshot
@@ -441,36 +450,19 @@ requireToken ctx tid = do
         Nothing -> throwError err404
         Just lts -> pure lts
 
--- | Read the current 'VerificationSnapshot' from
--- context, or 503 if the indexer has not yet
--- produced a UTxO-CSMT root or a checkpoint.
-requireSnapshot
-    :: Context IO -> Handler VerificationSnapshot
-requireSnapshot ctx = do
-    requireProofReadsReady ctx
-    mRoot <- liftIO $ utxoRoot ctx
-    mCp <-
-        liftIO
-            $ St.getCheckpoint
-                (St.checkpoints (state ctx))
-    case (mRoot, mCp) of
-        (Just r, Just (SlotNo s, BlockId b)) ->
-            pure
-                VerificationSnapshot
-                    { vsUtxoRoot = Hex r
-                    , vsChainPoint =
-                        ChainPointJSON
-                            { cpSlot = s
-                            , cpBlockId = Hex b
-                            }
-                    }
-        _ ->
+snapshotFromIndexer
+    :: Maybe BundleSnapshot -> Handler VerificationSnapshot
+snapshotFromIndexer mSnap =
+    case mSnap of
+        Nothing ->
             throwError
                 err503
                     { errBody =
-                        "Verification snapshot \
-                        \not yet available"
+                        "Indexer not ready: \
+                        \snapshot unavailable"
                     }
+        Just snap ->
+            pure (bundleSnapshotToJSON snap)
 
 -- | Resolve a 'TxIn' to a 'WitnessedUtxo', or
 -- @404@ if the UTxO or its CSMT proof is missing.
@@ -489,6 +481,21 @@ requireUtxoWitness ctx txIn = do
                     , wuProof = Hex proof
                     }
         _ -> throwError err404
+
+witnessFromIndexer
+    :: Maybe ResolvedWalletInput -> Handler WitnessedUtxo
+witnessFromIndexer mInput =
+    case mInput of
+        Nothing -> throwError err404
+        Just input -> pure (resolvedInputToWitnessedUtxo input)
+
+resolvedInputToWitnessedUtxo :: ResolvedWalletInput -> WitnessedUtxo
+resolvedInputToWitnessedUtxo (txIn, out, proof) =
+    WitnessedUtxo
+        { wuTxIn = txInToJSON txIn
+        , wuTxOut = Hex out
+        , wuProof = Hex proof
+        }
 
 tokenRootHandler
     :: Context IO
@@ -514,12 +521,15 @@ tokenFactsHandler ctx tokenId = do
         , tokenState = ts
         } <-
         requireToken ctx tid
-    snapshot <- requireSnapshot ctx
-    witness <- requireUtxoWitness ctx tokenStateRef
-    facts <-
-        liftIO
-            $ Trie.withTrie (trieManager ctx) tid
-            $ \trie -> Trie.enumerate trie
+    (mSnap, mWitness, facts) <-
+        runProofIndexerTx ctx
+            $ do
+                snap <- readSnapshot
+                witness <- readUtxoWitness tokenStateRef
+                fs <- readTrieFacts tid
+                pure (snap, witness, fs)
+    snapshot <- snapshotFromIndexer mSnap
+    witness <- witnessFromIndexer mWitness
     pure
         FactsResponse
             { frsSnapshot = snapshot
@@ -550,16 +560,19 @@ tokenFactHandler ctx tokenId (Hex k) = do
         , tokenState = ts
         } <-
         requireToken ctx tid
-    snapshot <- requireSnapshot ctx
-    witness <- requireUtxoWitness ctx tokenStateRef
-    mv <-
-        liftIO
-            $ Trie.withTrie (trieManager ctx) tid
-            $ \trie -> Trie.lookup trie k
-    v <- case mv of
+    (mSnap, mWitness, trieFact) <-
+        runProofIndexerTx ctx
+            $ do
+                snap <- readSnapshot
+                witness <- readUtxoWitness tokenStateRef
+                fact <- readTrieFact tid k
+                pure (snap, witness, fact)
+    snapshot <- snapshotFromIndexer mSnap
+    witness <- witnessFromIndexer mWitness
+    v <- case Tx.factValue trieFact of
         Just v -> pure v
         Nothing -> throwError err404
-    proof <- requireMpfProof ctx tid k
+    let proof = Hex (Tx.factMpfProof trieFact)
     pure
         FactResponse
             { frSnapshot = snapshot
@@ -589,9 +602,16 @@ tokenProofHandler ctx tokenId (Hex k) = do
         , tokenState = ts
         } <-
         requireToken ctx tid
-    snapshot <- requireSnapshot ctx
-    witness <- requireUtxoWitness ctx tokenStateRef
-    proof <- requireMpfProof ctx tid k
+    (mSnap, mWitness, trieFact) <-
+        runProofIndexerTx ctx
+            $ do
+                snap <- readSnapshot
+                witness <- readUtxoWitness tokenStateRef
+                fact <- readTrieFact tid k
+                pure (snap, witness, fact)
+    snapshot <- snapshotFromIndexer mSnap
+    witness <- witnessFromIndexer mWitness
+    let proof = Hex (Tx.factMpfProof trieFact)
     pure
         ProofResponse
             { prSnapshot = snapshot
@@ -606,22 +626,6 @@ tokenProofHandler ctx tokenId (Hex k) = do
                     , fwMpfProof = proof
                     }
             }
-
--- | Compute an MPF inclusion proof for a key under
--- a token's trie, or @404@ if absent.
-requireMpfProof
-    :: Context IO
-    -> TokenId
-    -> ByteString
-    -> Handler Hex
-requireMpfProof ctx tid k = do
-    mp <-
-        liftIO
-            $ Trie.withTrie (trieManager ctx) tid
-            $ \trie -> Trie.getProof trie k
-    case mp of
-        Nothing -> throwError err404
-        Just p -> pure (Hex (Trie.unProof p))
 
 tokenRequestsHandler
     :: Context IO

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
@@ -33,11 +33,13 @@ module Cardano.MPFS.Indexer.Reads
     , readCheckpoint
     , readMerkleRoot
     , readSnapshot
+    , readUtxoWitness
     , readStateUtxoAt
     , readNamedRequestUtxo
     , readRequestUtxosAt
     , readUtxoSetAt
     , readTrieFact
+    , readTrieFacts
     , readWalletInputsAt
     , ResolvedUtxoSet
 
@@ -65,6 +67,7 @@ import Cardano.Ledger.Binary
     ( DecoderError
     , decodeFull
     , natVersion
+    , serialize
     )
 import Cardano.Ledger.Mary.Value
     ( MaryValue (..)
@@ -320,6 +323,45 @@ readWalletInputsAt addr =
                         , proofBytes
                         )
 
+-- | Resolve a 'TxIn' and its CSMT inclusion proof inside the
+-- indexer transaction. Returns 'Nothing' when the UTxO is absent.
+readUtxoWitness :: TxIn -> IndexerTx (Maybe ResolvedWalletInput)
+readUtxoWitness txIn =
+    IndexerTx
+        $ mapColumns InUtxo
+        $ do
+            let fkv = fromKV context
+                key = serialize (natVersion @11) txIn
+            mTxOut <- query KVCol key
+            case mTxOut of
+                Nothing -> pure Nothing
+                Just txOutBytes -> do
+                    mProof <-
+                        generateInclusionProof
+                            fkv
+                            KVCol
+                            CSMTCol
+                            key
+                    proofBytes <- case mProof of
+                        Just (_, proof) -> pure proof
+                        Nothing ->
+                            error
+                                $ "readUtxoWitness: \
+                                  \indexer corruption — \
+                                  \KV column contains a \
+                                  \TxOut but \
+                                  \generateInclusionProof \
+                                  \returned Nothing \
+                                  \(input: "
+                                    <> show txIn
+                                    <> ")"
+                    pure
+                        $ Just
+                            ( txIn
+                            , BSL.toStrict txOutBytes
+                            , proofBytes
+                            )
+
 -- | Read the current state UTxO for a token at the state
 -- validator address and return it with a CSMT inclusion proof.
 readStateUtxoAt
@@ -457,6 +499,17 @@ readTrieFact tid key =
                     error
                         "readTrieFact: persistent trie \
                         \could not produce an MPF proof"
+
+-- | Enumerate all raw facts for a token's trie inside the
+-- indexer transaction.
+readTrieFacts
+    :: TokenId -> IndexerTx [(ByteString, ByteString)]
+readTrieFacts tid =
+    IndexerTx
+        $ mapColumns InCage
+        $ Trie.enumerate
+        $ mkUnifiedTrie
+        $ tokenHexPrefix tid
 
 addressScopedLeafKey
     :: FromKV key value hash

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/AtomicReadFixture.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/AtomicReadFixture.hs
@@ -1,0 +1,351 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      : Cardano.MPFS.HTTP.AtomicReadFixture
+-- Description : Shared fixtures for atomic proof-bearing read tests
+-- License     : Apache-2.0
+module Cardano.MPFS.HTTP.AtomicReadFixture
+    ( cafeTid
+    , cafeTokenJSON
+    , insertFacts
+    , sampleRequestOutBytes
+    , sampleStateOutBytes
+    , staleRoot
+    , stateSetPrefix
+    , testCageConfig
+    , toClientCageConfig
+    , withProofIndexer
+    ) where
+
+import Control.Monad (forM, forM_)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as SBS
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+
+import CSMT.Core.Types (Key)
+import CSMT.Hashes (generateInclusionProof)
+import CSMT.Hashes.Types (Hash)
+import CSMT.Interface (FromKV)
+import Cardano.Ledger.Address (serialiseAddr)
+import Cardano.Ledger.Api.Tx.Out (TxOut, mkBasicTxOut)
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , Network (..)
+    )
+import Cardano.Ledger.Binary
+    ( natVersion
+    , serialize
+    , serialize'
+    )
+import Cardano.Ledger.Mary.Value (AssetName (..))
+import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
+    ( Columns (..)
+    )
+import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
+    ( CSMTContext (..)
+    , CSMTOps (..)
+    , mkCSMTOps
+    )
+import Cardano.UTxOCSMT.Application.Run.Config
+    ( context
+    , hashAddressKey
+    )
+import Cardano.UTxOCSMT.Ouroboros.Types (Point)
+import ChainFollower.Rollbacks.Store qualified as Store
+import Database.KV.Database (mkColumns)
+import Database.KV.RocksDB (mkRocksDBDatabase)
+import Database.KV.Transaction
+    ( RunTransaction (..)
+    , Transaction
+    , mapColumns
+    , newRunTransaction
+    )
+import Database.RocksDB
+    ( DB (..)
+    , withDBCF
+    )
+import System.Directory (doesFileExist)
+import System.IO.Temp (withSystemTempDirectory)
+import System.IO.Unsafe (unsafePerformIO)
+
+import Cardano.MPFS.Application
+    ( allColumnFamilies
+    , dbConfig
+    , unifiedCodecs
+    )
+import Cardano.MPFS.Client.Cage.Config qualified as Client
+import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Core.Types
+    ( BlockId (..)
+    , Coin (..)
+    , ConwayEra
+    , Root
+    , SlotNo (..)
+    , TokenId (..)
+    , TxIn
+    )
+import Cardano.MPFS.HTTP.Types (TokenIdJSON (..))
+import Cardano.MPFS.Indexer.Columns (UnifiedColumns (..))
+import Cardano.MPFS.Indexer.Reads
+    ( IndexerTx (..)
+    , readMerkleRoot
+    )
+import Cardano.MPFS.Indexer.TxFixtures (testScriptHash)
+import Cardano.MPFS.State qualified as St
+import Cardano.MPFS.Trie qualified as Trie
+import Cardano.MPFS.Trie.Persistent
+    ( mkPersistentTrieManager
+    )
+import Cardano.MPFS.TxBuilder (ResolvedWalletInput)
+import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( cageAddrFromCfg
+    , requestAddrFromCfg
+    )
+
+-- | "cafe" token — hex "63616665".
+cafeTid :: TokenId
+cafeTid = TokenId (AssetName (SBS.toShort "cafe"))
+
+cafeTokenJSON :: TokenIdJSON
+cafeTokenJSON = TokenIdJSON "cafe"
+
+staleRoot :: ByteString
+staleRoot = BS.replicate 32 0x99
+
+testCageConfig :: CageConfig
+testCageConfig =
+    CageConfig
+        { cageScriptBytes = SBS.toShort "dummy"
+        , requestScriptBytes = testRequestScriptBytes
+        , cfgScriptHash = testScriptHash
+        , defaultProcessTime = 60_000
+        , defaultRetractTime = 30_000
+        , defaultTip = Coin 1_000_000
+        , network = Testnet
+        }
+
+testRequestScriptBytes :: SBS.ShortByteString
+testRequestScriptBytes =
+    unsafePerformIO loadTestRequestScriptBytes
+{-# NOINLINE testRequestScriptBytes #-}
+
+loadTestRequestScriptBytes :: IO SBS.ShortByteString
+loadTestRequestScriptBytes = do
+    hex <- tryRead candidatePaths
+    let trimmed =
+            BS.takeWhile
+                (\b -> b /= 10 && b /= 13)
+                hex
+    case B16.decode trimmed of
+        Right bs -> pure (SBS.toShort bs)
+        Left err ->
+            error
+                $ "loadTestRequestScriptBytes: "
+                    <> err
+  where
+    candidatePaths =
+        [ "test-data/request.uplc.hex"
+        , "cardano-mpfs-offchain/test-data/request.uplc.hex"
+        ]
+    tryRead [] =
+        error
+            "loadTestRequestScriptBytes: \
+            \test-data/request.uplc.hex not found \
+            \in any of the candidate paths"
+    tryRead (p : ps) = do
+        exists <- doesFileExist p
+        if exists
+            then BS.readFile p
+            else tryRead ps
+
+sampleStateOutBytes :: Integer -> ByteString
+sampleStateOutBytes _ =
+    serialize'
+        (natVersion @11)
+        (txOut :: TxOut ConwayEra)
+  where
+    txOut =
+        mkBasicTxOut
+            (cageAddrFromCfg testCageConfig Testnet)
+            (inject (Coin 2_000_000))
+
+sampleRequestOutBytes
+    :: TokenId
+    -> Integer
+    -> ByteString
+sampleRequestOutBytes tid _submittedAt =
+    serialize'
+        (natVersion @11)
+        (txOut :: TxOut ConwayEra)
+  where
+    txOut =
+        mkBasicTxOut
+            (requestAddrFromCfg testCageConfig tid Testnet)
+            (inject (Coin 2_000_000))
+
+stateSetPrefix :: CageConfig -> Key
+stateSetPrefix cfg =
+    hashAddressKey
+        $ serialiseAddr
+        $ cageAddrFromCfg cfg (network cfg)
+
+toClientCageConfig :: CageConfig -> Client.CageConfig
+toClientCageConfig cfg =
+    Client.CageConfig
+        { Client.cageScriptBytes = cageScriptBytes cfg
+        , Client.requestScriptBytes = requestScriptBytes cfg
+        , Client.cfgScriptHash = cfgScriptHash cfg
+        , Client.defaultProcessTime = defaultProcessTime cfg
+        , Client.defaultRetractTime = defaultRetractTime cfg
+        , Client.defaultTip = defaultTip cfg
+        , Client.network = network cfg
+        }
+
+insertFacts
+    :: Context IO
+    -> TokenId
+    -> [(ByteString, ByteString)]
+    -> IO Root
+insertFacts ctx tid facts = do
+    Trie.createTrie (trieManager ctx) tid
+    Trie.withTrie (trieManager ctx) tid $ \trie -> do
+        forM_ facts $ uncurry (Trie.insert trie)
+        Trie.getRoot trie
+
+withProofIndexer
+    :: Maybe ByteString
+    -> [(TxIn, ByteString)]
+    -> Context IO
+    -> (ByteString -> Context IO -> IO a)
+    -> IO a
+withProofIndexer mOutOfTxRoot entries ctx action =
+    withSystemTempDirectory "atomic-read-indexer-test"
+        $ \dir ->
+            withDBCF
+                dir
+                dbConfig
+                allColumnFamilies
+                $ \db@DB{columnFamilies} -> do
+                    let database =
+                            mkRocksDBDatabase
+                                db
+                                (mkColumns columnFamilies unifiedCodecs)
+                        CSMTContext{fromKV, hashing} = context
+                        csmtOps = mkCSMTOps fromKV hashing
+                    RunTransaction{runTransaction} <-
+                        newRunTransaction database
+                    let seededEntries =
+                            [ ( serialize
+                                    (natVersion @11)
+                                    txIn
+                              , BSL.fromStrict txOutBytes
+                              )
+                            | (txIn, txOutBytes) <- entries
+                            ]
+                    runTransaction
+                        $ mapColumns InUtxo
+                        $ forM_ seededEntries
+                        $ uncurry
+                            (csmtInsert csmtOps)
+                    runTransaction
+                        $ Store.armageddonSetup
+                            InRollbacks
+                            (SlotNo 42)
+                            (Just (BlockId "block-id-bytes"))
+                    let IndexerTx readRoot = readMerkleRoot
+                    mRoot <- runTransaction readRoot
+                    txRoot <- case mRoot of
+                        Nothing ->
+                            fail
+                                "proof-indexer helper did not seed \
+                                \a UTxO root"
+                        Just root -> pure root
+                    witnesses <-
+                        Map.fromList
+                            <$> runTransaction
+                                ( mapColumns InUtxo
+                                    $ forM entries
+                                    $ buildWitness fromKV
+                                )
+                    tm <- case drop 9 columnFamilies of
+                        nodesCF : kvCF : metaCF : _ ->
+                            mkPersistentTrieManager
+                                db
+                                nodesCF
+                                kvCF
+                                metaCF
+                        _ ->
+                            fail
+                                "proof-indexer helper did not open \
+                                \trie column families"
+                    St.putCheckpoint
+                        (St.checkpoints (state ctx))
+                        (SlotNo 42)
+                        (BlockId "block-id-bytes")
+                    let ctxWithIndexer =
+                            ctx
+                                { cfgCage = testCageConfig
+                                , trieManager = tm
+                                , runIndexerTx =
+                                    \(IndexerTx body) ->
+                                        runTransaction body
+                                , utxoRoot =
+                                    pure
+                                        $ Just
+                                        $ fromMaybe
+                                            txRoot
+                                            mOutOfTxRoot
+                                , resolveUtxo =
+                                    \txIn ->
+                                        pure
+                                            $ (\(_, out, _) -> out)
+                                                <$> Map.lookup
+                                                    txIn
+                                                    witnesses
+                                , utxoProof =
+                                    \txIn ->
+                                        pure
+                                            $ (\(_, _, proof) -> proof)
+                                                <$> Map.lookup
+                                                    txIn
+                                                    witnesses
+                                }
+                    action txRoot ctxWithIndexer
+
+buildWitness
+    :: FromKV BSL.ByteString BSL.ByteString Hash
+    -> (TxIn, ByteString)
+    -> Transaction
+        IO
+        cf
+        ( Columns
+            Point
+            Hash
+            BSL.ByteString
+            BSL.ByteString
+        )
+        op
+        (TxIn, ResolvedWalletInput)
+buildWitness fromKV (txIn, txOutBytes) = do
+    let key = serialize (natVersion @11) txIn
+    mProof <-
+        generateInclusionProof
+            fromKV
+            KVCol
+            CSMTCol
+            key
+    proof <- case mProof of
+        Just (_, proofBytes) -> pure proofBytes
+        Nothing ->
+            error
+                "proof-indexer helper could not generate \
+                \an inclusion proof for a seeded UTxO"
+    pure (txIn, (txIn, txOutBytes, proof))

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
@@ -102,6 +102,7 @@ import Cardano.MPFS.Generators
     ( genRequest
     , genTxIn
     )
+import Cardano.MPFS.HTTP.AtomicReadFixture (staleRoot)
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
@@ -328,7 +329,7 @@ spec = describe "GET /tokens/:id/requests" $ do
             ctx0 <- mkTestContext
             ctx <-
                 withSnapshot
-                    "stale-root-r1"
+                    staleRoot
                     "tx-out"
                     "proof"
                     ctx0
@@ -339,7 +340,7 @@ spec = describe "GET /tokens/:id/requests" $ do
                 (St.requests (state ctx))
                 (LocatedRequest txIn req)
             withRequestSetRoot
-                (Just "stale-root-r1")
+                (Just staleRoot)
                 [(txIn, sampleRequestOutBytes cafeTid 0)]
                 ctx
                 $ \txRoot ctxWithSet -> do
@@ -347,6 +348,7 @@ spec = describe "GET /tokens/:id/requests" $ do
                     simpleStatus resp `shouldBe` status200
                     root <- responseSnapshotRoot resp
                     root `shouldBe` txRoot
+                    assertVerifiesForCafe resp
 
     it "returns empty list when no requests exist" $ do
         ctx0 <- mkTestContext

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenFactsSpec.hs
@@ -6,11 +6,10 @@
 -- License     : Apache-2.0
 module Cardano.MPFS.HTTP.TokenFactsSpec (spec) where
 
-import Control.Monad (forM_)
 import Data.Aeson (decode)
 import Data.ByteString (ByteString)
-import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
+import Data.Either (isRight)
 import Data.List (sort)
 import Network.HTTP.Types (status200)
 import Network.Wai.Test
@@ -26,20 +25,27 @@ import Test.Hspec
     , expectationFailure
     , it
     , shouldBe
+    , shouldSatisfy
     )
 
 import Cardano.Ledger.Mary.Value (AssetName (..))
 import Test.QuickCheck (generate)
 
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Client.Verify.Read (verifyTokenFacts)
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
-    ( BlockId (..)
-    , LocatedTokenState (..)
-    , SlotNo (..)
+    ( LocatedTokenState (..)
     , TokenId (..)
     , TokenState (..)
     )
 import Cardano.MPFS.Generators (genTxIn)
+import Cardano.MPFS.HTTP.AtomicReadFixture
+    ( insertFacts
+    , sampleStateOutBytes
+    , staleRoot
+    , withProofIndexer
+    )
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
@@ -52,35 +58,10 @@ import Cardano.MPFS.HTTP.Types
     , tokenStateToJSON
     )
 import Cardano.MPFS.State qualified as St
-import Cardano.MPFS.Trie qualified as Trie
 
 -- | "cafe" token — hex "63616665".
 cafeTid :: TokenId
 cafeTid = TokenId (AssetName (SBS.toShort "cafe"))
-
--- | Stub the verification snapshot and the UTxO
--- witness machinery so proof-bearing handlers can
--- assemble their envelopes.
-withSnapshot
-    :: BS.ByteString
-    -- ^ CSMT root bytes
-    -> BS.ByteString
-    -- ^ Resolved TxOut CBOR bytes
-    -> BS.ByteString
-    -- ^ CSMT inclusion proof bytes
-    -> Context IO
-    -> IO (Context IO)
-withSnapshot rootBs outBs proofBs ctx = do
-    St.putCheckpoint
-        (St.checkpoints (state ctx))
-        (SlotNo 42)
-        (BlockId "block-id-bytes")
-    pure
-        ctx
-            { utxoRoot = pure (Just rootBs)
-            , resolveUtxo = \_ -> pure (Just outBs)
-            , utxoProof = \_ -> pure (Just proofBs)
-            }
 
 spec :: Spec
 spec =
@@ -90,38 +71,36 @@ spec =
             \enumerated facts"
         $ do
             ctx0 <- mkTestContext
-            ctx <- withSnapshot "root" "tx-out" "proof" ctx0
-            Trie.createTrie (trieManager ctx) cafeTid
-            trieRoot <-
-                Trie.withTrie
-                    (trieManager ctx)
-                    cafeTid
-                    $ \trie -> do
-                        forM_ facts
-                            $ uncurry (Trie.insert trie)
-                        Trie.getRoot trie
-            ts0 <- mkDummyTokenState
             txIn <- generate genTxIn
-            let ts = ts0{root = trieRoot}
-            St.putToken
-                (St.tokens (state ctx))
-                cafeTid
-                (LocatedTokenState txIn ts)
+            withProofIndexer
+                (Just staleRoot)
+                [(txIn, sampleStateOutBytes 0)]
+                ctx0
+                $ \_txRoot ctx -> do
+                    trieRoot <- insertFacts ctx cafeTid facts
+                    ts0 <- mkDummyTokenState
+                    let ts = ts0{root = trieRoot}
+                    St.putToken
+                        (St.tokens (state ctx))
+                        cafeTid
+                        (LocatedTokenState txIn ts)
 
-            resp <- getFacts ctx "63616665"
+                    resp <- getFacts ctx "63616665"
 
-            simpleStatus resp `shouldBe` status200
-            case decode (simpleBody resp) of
-                Just FactsResponse{..} -> do
-                    vsUtxoRoot frsSnapshot
-                        `shouldBe` Hex "root"
-                    wtsState frsState
-                        `shouldBe` tokenStateToJSON ts
-                    factPairs frsFacts
-                        `shouldBe` sort facts
-                _ ->
-                    expectationFailure
-                        "Expected facts response JSON"
+                    simpleStatus resp `shouldBe` status200
+                    case decode (simpleBody resp) of
+                        Just body@FactsResponse{..} -> do
+                            wtsState frsState
+                                `shouldBe` tokenStateToJSON ts
+                            factPairs frsFacts
+                                `shouldBe` sort facts
+                            verifyTokenFacts
+                                (TrustedRoot (vsUtxoRoot frsSnapshot))
+                                body
+                                `shouldSatisfy` isRight
+                        _ ->
+                            expectationFailure
+                                "Expected facts response JSON"
 
 facts :: [(ByteString, ByteString)]
 facts =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
@@ -9,8 +9,8 @@ module Cardano.MPFS.HTTP.TokenSpec (spec) where
 import Data.Aeson (decode)
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
-import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
+import Data.Either (isRight)
 import Network.HTTP.Types
     ( status200
     , status404
@@ -29,47 +29,34 @@ import Test.Hspec
     , expectationFailure
     , it
     , shouldBe
+    , shouldSatisfy
     )
 
 import Cardano.Ledger.Mary.Value (AssetName (..))
 
 import Test.QuickCheck (generate)
 
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Client.Verify.Read (verifyTokenState)
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
-    ( BlockId (..)
-    , LocatedTokenState (..)
-    , SlotNo (..)
+    ( LocatedTokenState (..)
     , TokenId (..)
     )
 import Cardano.MPFS.Generators (genTxIn)
+import Cardano.MPFS.HTTP.AtomicReadFixture
+    ( sampleStateOutBytes
+    , staleRoot
+    , withProofIndexer
+    )
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.TokensSpec (mkDummyTokenState)
+import Cardano.MPFS.HTTP.Types
+    ( TokenResponse (..)
+    , VerificationSnapshot (..)
+    )
 import Cardano.MPFS.State qualified as St
-
--- | Populate a test context with a synthetic
--- verification snapshot and UTxO witness machinery.
-withSnapshot
-    :: BS.ByteString
-    -- ^ CSMT root bytes
-    -> BS.ByteString
-    -- ^ Resolved TxOut CBOR bytes
-    -> BS.ByteString
-    -- ^ CSMT inclusion proof bytes
-    -> Context IO
-    -> IO (Context IO)
-withSnapshot rootBs outBs proofBs ctx = do
-    St.putCheckpoint
-        (St.checkpoints (state ctx))
-        (SlotNo 42)
-        (BlockId "block-id-bytes")
-    pure
-        ctx
-            { utxoRoot = pure (Just rootBs)
-            , resolveUtxo = \_ -> pure (Just outBs)
-            , utxoProof = \_ -> pure (Just proofBs)
-            }
 
 spec :: Spec
 spec = describe "GET /tokens/:id" $ do
@@ -90,6 +77,8 @@ spec = describe "GET /tokens/:id" $ do
         "returns 503 when snapshot not yet available"
         $ do
             ctx <- mkTestContext
+            let ctxNotReady =
+                    ctx{indexerProofsReady = pure False}
             ts <- mkDummyTokenState
             txIn <- generate genTxIn
             let tid =
@@ -98,7 +87,7 @@ spec = describe "GET /tokens/:id" $ do
                             (SBS.toShort "cafe")
                         )
             St.putToken
-                (St.tokens (state ctx))
+                (St.tokens (state ctxNotReady))
                 tid
                 (LocatedTokenState txIn ts)
             resp <-
@@ -109,7 +98,7 @@ spec = describe "GET /tokens/:id" $ do
                             "/tokens/63616665"
                         )
                     )
-                    (mkApp ctx)
+                    (mkApp ctxNotReady)
             simpleStatus resp `shouldBe` status503
 
     it
@@ -117,55 +106,72 @@ spec = describe "GET /tokens/:id" $ do
         \token"
         $ do
             ctx0 <- mkTestContext
-            ctx <-
-                withSnapshot "root" "tx-out" "proof" ctx0
-            ts <- mkDummyTokenState
             txIn <- generate genTxIn
-            let tid =
-                    TokenId
-                        ( AssetName
-                            (SBS.toShort "cafe")
-                        )
-            St.putToken
-                (St.tokens (state ctx))
-                tid
-                (LocatedTokenState txIn ts)
-            resp <-
-                runSession
-                    ( request
-                        ( setPath
-                            defaultRequest
-                            "/tokens/63616665"
-                        )
-                    )
-                    (mkApp ctx)
-            simpleStatus resp `shouldBe` status200
-            case decode (simpleBody resp) of
-                Just (Object obj) -> do
-                    KM.member "snapshot" obj
-                        `shouldBe` True
-                    KM.member "state" obj
-                        `shouldBe` True
-                    case KM.lookup "snapshot" obj of
-                        Just (Object sObj) -> do
-                            KM.member "utxo_root" sObj
+            let txOut = sampleStateOutBytes 0
+            withProofIndexer
+                (Just staleRoot)
+                [(txIn, txOut)]
+                ctx0
+                $ \_txRoot ctx -> do
+                    ts <- mkDummyTokenState
+                    let tid =
+                            TokenId
+                                ( AssetName
+                                    (SBS.toShort "cafe")
+                                )
+                    St.putToken
+                        (St.tokens (state ctx))
+                        tid
+                        (LocatedTokenState txIn ts)
+                    resp <-
+                        runSession
+                            ( request
+                                ( setPath
+                                    defaultRequest
+                                    "/tokens/63616665"
+                                )
+                            )
+                            (mkApp ctx)
+                    simpleStatus resp `shouldBe` status200
+                    case decode (simpleBody resp) of
+                        Just (Object obj) -> do
+                            KM.member "snapshot" obj
                                 `shouldBe` True
-                            KM.member "chainpoint" sObj
+                            KM.member "state" obj
                                 `shouldBe` True
+                            case KM.lookup "snapshot" obj of
+                                Just (Object sObj) -> do
+                                    KM.member "utxo_root" sObj
+                                        `shouldBe` True
+                                    KM.member "chainpoint" sObj
+                                        `shouldBe` True
+                                _ ->
+                                    expectationFailure
+                                        "snapshot is not an \
+                                        \object"
+                            case KM.lookup "state" obj of
+                                Just (Object stateObj) -> do
+                                    KM.member "utxo" stateObj
+                                        `shouldBe` True
+                                    KM.member "state" stateObj
+                                        `shouldBe` True
+                                _ ->
+                                    expectationFailure
+                                        "state is not an \
+                                        \object"
                         _ ->
                             expectationFailure
-                                "snapshot is not an \
-                                \object"
-                    case KM.lookup "state" obj of
-                        Just (Object stateObj) -> do
-                            KM.member "utxo" stateObj
-                                `shouldBe` True
-                            KM.member "state" stateObj
-                                `shouldBe` True
-                        _ ->
-                            expectationFailure
-                                "state is not an \
-                                \object"
-                _ ->
-                    expectationFailure
-                        "Expected JSON object"
+                                "Expected JSON object"
+                    assertTokenResponseVerifies resp
+
+assertTokenResponseVerifies :: SResponse -> IO ()
+assertTokenResponseVerifies resp =
+    case decode (simpleBody resp) of
+        Just body@TokenResponse{trSnapshot} ->
+            verifyTokenState
+                (TrustedRoot (vsUtxoRoot trSnapshot))
+                body
+                `shouldSatisfy` isRight
+        Nothing ->
+            expectationFailure
+                "Expected TokenResponse JSON"

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
@@ -19,6 +19,7 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short qualified as SBS
+import Data.Either (isRight)
 import Data.List (sort)
 import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
@@ -43,18 +44,9 @@ import Test.Hspec
     , shouldSatisfy
     )
 
-import Cardano.Ledger.Api.Tx.Out
-    ( TxOut
-    , mkBasicTxOut
-    )
-import Cardano.Ledger.BaseTypes
-    ( Inject (..)
-    , Network (..)
-    )
 import Cardano.Ledger.Binary
     ( natVersion
     , serialize
-    , serialize'
     )
 import Cardano.Ledger.Mary.Value (AssetName (..))
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
@@ -82,11 +74,13 @@ import Cardano.MPFS.Application
     , dbConfig
     , unifiedCodecs
     )
+import Cardano.MPFS.Client.Verify.Completeness
+    ( verifyUtxoSetCompleteness
+    )
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
     , Coin (..)
-    , ConwayEra
     , LocatedTokenState (..)
     , Root (..)
     , SlotNo (..)
@@ -95,6 +89,12 @@ import Cardano.MPFS.Core.Types
     , TxIn
     )
 import Cardano.MPFS.Generators (genKeyHash, genTxIn)
+import Cardano.MPFS.HTTP.AtomicReadFixture
+    ( sampleStateOutBytes
+    , staleRoot
+    , stateSetPrefix
+    , testCageConfig
+    )
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
@@ -103,6 +103,8 @@ import Cardano.MPFS.HTTP.Types
     , TokenSetWitness (..)
     , TokenUtxoEntry (..)
     , TokensResponse (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoSetWitness (..)
     , VerificationSnapshot (..)
     )
 import Cardano.MPFS.Indexer.Columns (UnifiedColumns (..))
@@ -110,13 +112,8 @@ import Cardano.MPFS.Indexer.Reads
     ( IndexerTx (..)
     , readMerkleRoot
     )
-import Cardano.MPFS.Indexer.TxFixtures (testScriptHash)
 import Cardano.MPFS.State qualified as St
 import Cardano.MPFS.TxBuilder (BundleSnapshot (..))
-import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
-import Cardano.MPFS.TxBuilder.Real.Internal
-    ( cageAddrFromCfg
-    )
 import Test.QuickCheck (generate)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -238,29 +235,6 @@ withTokenSetRoot mOutOfTxRoot entries ctx action =
                                                 mOutOfTxRoot
                                     }
 
-sampleStateOutBytes :: Integer -> ByteString
-sampleStateOutBytes _ =
-    serialize'
-        (natVersion @11)
-        (txOut :: TxOut ConwayEra)
-  where
-    txOut =
-        mkBasicTxOut
-            (cageAddrFromCfg testCageConfig Testnet)
-            (inject (Coin 2_000_000))
-
-testCageConfig :: CageConfig
-testCageConfig =
-    CageConfig
-        { cageScriptBytes = SBS.toShort "dummy"
-        , requestScriptBytes = SBS.toShort "dummy"
-        , cfgScriptHash = testScriptHash
-        , defaultProcessTime = 60_000
-        , defaultRetractTime = 30_000
-        , defaultTip = Coin 1_000_000
-        , network = Testnet
-        }
-
 -- | A dummy token state for testing.
 mkDummyTokenState :: IO TokenState
 mkDummyTokenState = do
@@ -280,7 +254,7 @@ spec = describe "GET /tokens" $ do
         "uses the in-transaction root for the response snapshot"
         $ do
             ctx0 <- mkTestContext
-            ctx <- withSnapshot "stale-root-r1" "tx-out" "proof" ctx0
+            ctx <- withSnapshot staleRoot "tx-out" "proof" ctx0
             ts <- mkDummyTokenState
             txIn <- generate genTxIn
             let tid =
@@ -291,7 +265,7 @@ spec = describe "GET /tokens" $ do
                 tid
                 (LocatedTokenState txIn ts)
             withTokenSetRoot
-                (Just "stale-root-r1")
+                (Just staleRoot)
                 [(txIn, txOut)]
                 ctx
                 $ \txRoot ctxWithSet -> do
@@ -299,6 +273,7 @@ spec = describe "GET /tokens" $ do
                     simpleStatus resp `shouldBe` status200
                     root <- responseSnapshotRoot resp
                     root `shouldBe` txRoot
+                    assertTokenSetVerifies resp
 
     it "returns empty proof-bearing token set on fresh state" $ do
         ctx0 <- mkTestContext
@@ -410,6 +385,34 @@ assertTokenEntries resp expected =
         _ ->
             expectationFailure
                 "Expected TokensResponse"
+
+assertTokenSetVerifies :: SResponse -> IO ()
+assertTokenSetVerifies resp =
+    case decode (simpleBody resp) of
+        Just TokensResponse{trsSnapshot, trsTokens} ->
+            let Hex root = vsUtxoRoot trsSnapshot
+            in  verifyUtxoSetCompleteness
+                    "tokens.tokens"
+                    root
+                    (stateSetPrefix testCageConfig)
+                    (tokenSetAsUtxoSet trsTokens)
+                    `shouldSatisfy` isRight
+        _ ->
+            expectationFailure
+                "Expected TokensResponse"
+
+tokenSetAsUtxoSet :: TokenSetWitness -> UtxoSetWitness
+tokenSetAsUtxoSet TokenSetWitness{..} =
+    UtxoSetWitness
+        { uswEntries =
+            [ UtxoEntryRefOnly
+                { uerRef = tueRef
+                , uerTxOutCbor = tueTxOutCbor
+                }
+            | TokenUtxoEntry{..} <- tswEntries
+            ]
+        , uswCompletenessProof = tswCompletenessProof
+        }
 
 failExpectation :: String -> IO a
 failExpectation msg = do

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs
@@ -10,13 +10,10 @@
 -- @\/tokens\/:id\/proofs\/:key@.
 module Cardano.MPFS.HTTP.TrieSpec (spec) where
 
-import Codec.CBOR.Encoding qualified as CBOR
-import Codec.CBOR.Write qualified as CBOR
 import Data.Aeson (decode)
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
 import Data.ByteString (ByteString)
-import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Short qualified as SBS
 import Data.Either (isRight)
@@ -45,24 +42,6 @@ import Test.Hspec
 import Cardano.Ledger.Mary.Value (AssetName (..))
 import Test.QuickCheck (generate)
 
-import CSMT.Core.CBOR (renderProof)
-import CSMT.Core.Hash
-    ( byteStringToKey
-    , renderHash
-    )
-import CSMT.Hashes
-    ( hashHashing
-    , mkHash
-    )
-import CSMT.Test.Lib
-    ( evalPureFromEmptyDB
-    , getRootHashM
-    , hashCodecs
-    , identityFromKV
-    , insertMHash
-    , proofM
-    )
-import Cardano.MPFS.Application (dbConfig)
 import Cardano.MPFS.Client.Facts
     ( FactAbsentFacts (..)
     , FactPresentFacts (..)
@@ -72,15 +51,19 @@ import Cardano.MPFS.Client.Facts
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
-    ( BlockId (..)
-    , LocatedTokenState (..)
+    ( LocatedTokenState (..)
     , Root (..)
-    , SlotNo (..)
     , TokenId (..)
     , TokenState (..)
     , TxIn
     )
 import Cardano.MPFS.Generators (genTxIn)
+import Cardano.MPFS.HTTP.AtomicReadFixture
+    ( insertFacts
+    , sampleStateOutBytes
+    , staleRoot
+    , withProofIndexer
+    )
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
@@ -89,23 +72,13 @@ import Cardano.MPFS.HTTP.Types
     ( FactResponse (..)
     , FactWitness (..)
     , ProofResponse (..)
-    , TxInJSON (..)
     , VerificationSnapshot (..)
-    , txInToJSON
     )
 import Cardano.MPFS.State qualified as St
 import Cardano.MPFS.Trie qualified as Trie
-import Cardano.MPFS.Trie.Persistent
-    ( mkPersistentTrieManager
-    )
-import Database.RocksDB
-    ( DB (..)
-    , withDBCF
-    )
 import MPF.Verify
     ( verifyAikenExclusionProof
     )
-import System.IO.Temp (withSystemTempDirectory)
 
 -- | "cafe" token — hex "63616665".
 cafeTid :: TokenId
@@ -114,31 +87,6 @@ cafeTid = TokenId (AssetName (SBS.toShort "cafe"))
 -- | Hex-encode raw bytes for URL paths.
 hex :: ByteString -> ByteString
 hex = B16.encode
-
--- | Stub the verification snapshot and the UTxO
--- witness machinery (root, resolveUtxo, utxoProof)
--- and seed a checkpoint so the proof-bearing
--- endpoints can assemble their envelopes.
-withSnapshot
-    :: BS.ByteString
-    -- ^ CSMT root bytes
-    -> BS.ByteString
-    -- ^ Resolved TxOut CBOR bytes
-    -> BS.ByteString
-    -- ^ CSMT inclusion proof bytes
-    -> Context IO
-    -> IO (Context IO)
-withSnapshot rootBs outBs proofBs ctx = do
-    St.putCheckpoint
-        (St.checkpoints (state ctx))
-        (SlotNo 42)
-        (BlockId "block-id-bytes")
-    pure
-        ctx
-            { utxoRoot = pure (Just rootBs)
-            , resolveUtxo = \_ -> pure (Just outBs)
-            , utxoProof = \_ -> pure (Just proofBs)
-            }
 
 -- | Seed an indexed token state for 'cafeTid' so
 -- the proof-bearing handlers can find a state UTxO
@@ -188,47 +136,45 @@ spec = do
             \existing key"
             $ do
                 ctx0 <- mkTestContext
-                ctx <-
-                    withSnapshot
-                        "root"
-                        "tx-out"
-                        "proof"
-                        ctx0
-                seedTokenState ctx
-                Trie.createTrie (trieManager ctx) cafeTid
-                _ <-
-                    Trie.withTrie
-                        (trieManager ctx)
-                        cafeTid
-                        $ \trie ->
-                            Trie.insert trie "mykey" "myval"
-                resp <-
-                    getFact
-                        ctx
-                        "63616665"
-                        (hex "mykey")
-                simpleStatus resp `shouldBe` status200
-                case decode (simpleBody resp) of
-                    Just (Object obj) -> do
-                        KM.member "snapshot" obj
-                            `shouldBe` True
-                        KM.member "value" obj
-                            `shouldBe` True
-                        KM.member "fact" obj
-                            `shouldBe` True
-                        case KM.lookup "fact" obj of
-                            Just (Object fObj) -> do
-                                KM.member "state" fObj
+                txIn <- generate genTxIn
+                withProofIndexer
+                    Nothing
+                    [(txIn, sampleStateOutBytes 0)]
+                    ctx0
+                    $ \_txRoot ctx -> do
+                        trieRoot <-
+                            insertFacts
+                                ctx
+                                cafeTid
+                                [("mykey", "myval")]
+                        seedTokenStateWithRoot ctx txIn trieRoot
+                        resp <-
+                            getFact
+                                ctx
+                                "63616665"
+                                (hex "mykey")
+                        simpleStatus resp `shouldBe` status200
+                        case decode (simpleBody resp) of
+                            Just (Object obj) -> do
+                                KM.member "snapshot" obj
                                     `shouldBe` True
-                                KM.member "mpf_proof" fObj
+                                KM.member "value" obj
                                     `shouldBe` True
+                                KM.member "fact" obj
+                                    `shouldBe` True
+                                case KM.lookup "fact" obj of
+                                    Just (Object fObj) -> do
+                                        KM.member "state" fObj
+                                            `shouldBe` True
+                                        KM.member "mpf_proof" fObj
+                                            `shouldBe` True
+                                    _ ->
+                                        expectationFailure
+                                            "fact is not an \
+                                            \object"
                             _ ->
                                 expectationFailure
-                                    "fact is not an \
-                                    \object"
-                    _ ->
-                        expectationFailure
-                            "Expected JSON object"
+                                    "Expected JSON object"
 
         it
             "returns a persistent fact value that replays \
@@ -256,21 +202,23 @@ spec = do
 
         it "returns 404 for missing key" $ do
             ctx0 <- mkTestContext
-            ctx <-
-                withSnapshot "root" "tx-out" "proof" ctx0
-            seedTokenState ctx
-            Trie.createTrie (trieManager ctx) cafeTid
-            resp <-
-                getFact
-                    ctx
-                    "63616665"
-                    (hex "nokey")
-            simpleStatus resp `shouldBe` status404
+            txIn <- generate genTxIn
+            withProofIndexer
+                Nothing
+                [(txIn, sampleStateOutBytes 0)]
+                ctx0
+                $ \_txRoot ctx -> do
+                    trieRoot <- insertFacts ctx cafeTid []
+                    seedTokenStateWithRoot ctx txIn trieRoot
+                    resp <-
+                        getFact
+                            ctx
+                            "63616665"
+                            (hex "nokey")
+                    simpleStatus resp `shouldBe` status404
 
         it "returns 404 for unknown token" $ do
-            ctx0 <- mkTestContext
-            ctx <-
-                withSnapshot "root" "tx-out" "proof" ctx0
+            ctx <- mkTestContext
             resp <-
                 getFact ctx "63616665" (hex "k")
             simpleStatus resp `shouldBe` status404
@@ -279,7 +227,8 @@ spec = do
             "returns 503 when snapshot not yet \
             \available"
             $ do
-                ctx <- mkTestContext
+                ctx0 <- mkTestContext
+                let ctx = ctx0{indexerProofsReady = pure False}
                 seedTokenState ctx
                 Trie.createTrie (trieManager ctx) cafeTid
                 _ <-
@@ -298,79 +247,76 @@ spec = do
             \existing key"
             $ do
                 ctx0 <- mkTestContext
-                ctx <-
-                    withSnapshot
-                        "root"
-                        "tx-out"
-                        "proof"
-                        ctx0
-                seedTokenState ctx
-                Trie.createTrie (trieManager ctx) cafeTid
-                _ <-
-                    Trie.withTrie
-                        (trieManager ctx)
-                        cafeTid
-                        $ \trie ->
-                            Trie.insert trie "pk" "pv"
-                resp <-
-                    getProof
-                        ctx
-                        "63616665"
-                        (hex "pk")
-                simpleStatus resp `shouldBe` status200
-                case decode (simpleBody resp) of
-                    Just (Object obj) -> do
-                        KM.member "snapshot" obj
-                            `shouldBe` True
-                        KM.member "fact" obj
-                            `shouldBe` True
-                        case KM.lookup "fact" obj of
-                            Just (Object fObj) -> do
-                                KM.member "state" fObj
+                txIn <- generate genTxIn
+                withProofIndexer
+                    Nothing
+                    [(txIn, sampleStateOutBytes 0)]
+                    ctx0
+                    $ \_txRoot ctx -> do
+                        trieRoot <-
+                            insertFacts
+                                ctx
+                                cafeTid
+                                [("pk", "pv")]
+                        seedTokenStateWithRoot ctx txIn trieRoot
+                        resp <-
+                            getProof
+                                ctx
+                                "63616665"
+                                (hex "pk")
+                        simpleStatus resp `shouldBe` status200
+                        case decode (simpleBody resp) of
+                            Just (Object obj) -> do
+                                KM.member "snapshot" obj
                                     `shouldBe` True
-                                KM.member "mpf_proof" fObj
+                                KM.member "fact" obj
                                     `shouldBe` True
+                                case KM.lookup "fact" obj of
+                                    Just (Object fObj) -> do
+                                        KM.member "state" fObj
+                                            `shouldBe` True
+                                        KM.member "mpf_proof" fObj
+                                            `shouldBe` True
+                                    _ ->
+                                        expectationFailure
+                                            "fact is not an \
+                                            \object"
                             _ ->
                                 expectationFailure
-                                    "fact is not an \
-                                    \object"
-                    _ ->
-                        expectationFailure
-                            "Expected JSON object"
+                                    "Expected JSON object"
 
         it "returns verifiable exclusion proof for missing key" $ do
             ctx0 <- mkTestContext
-            ctx <-
-                withSnapshot "root" "tx-out" "proof" ctx0
-            Trie.createTrie (trieManager ctx) cafeTid
-            trieRoot <-
-                Trie.withTrie
-                    (trieManager ctx)
-                    cafeTid
-                    Trie.getRoot
             txIn <- generate genTxIn
-            seedTokenStateWithRoot ctx txIn trieRoot
-            resp <-
-                getProof
-                    ctx
-                    "63616665"
-                    (hex "absent")
-            simpleStatus resp `shouldBe` status200
-            case decode (simpleBody resp) of
-                Just ProofResponse{prFact} ->
-                    verifyAikenExclusionProof
-                        (unRoot trieRoot)
-                        "absent"
-                        (unHex (fwMpfProof prFact))
-                        `shouldBe` True
-                _ ->
-                    expectationFailure
-                        "Expected proof response JSON"
+            withProofIndexer
+                Nothing
+                [(txIn, sampleStateOutBytes 0)]
+                ctx0
+                $ \_txRoot ctx -> do
+                    trieRoot <- insertFacts ctx cafeTid []
+                    seedTokenStateWithRoot ctx txIn trieRoot
+                    resp <-
+                        getProof
+                            ctx
+                            "63616665"
+                            (hex "absent")
+                    simpleStatus resp `shouldBe` status200
+                    case decode (simpleBody resp) of
+                        Just ProofResponse{prFact} ->
+                            verifyAikenExclusionProof
+                                (unRoot trieRoot)
+                                "absent"
+                                (unHex (fwMpfProof prFact))
+                                `shouldBe` True
+                        _ ->
+                            expectationFailure
+                                "Expected proof response JSON"
 
         it
             "returns a persistent absence proof that \
             \verifies after delete"
             $ withPersistentFactContextWithTrie
+                (Just staleRoot)
                 ( \trie -> do
                     _ <- Trie.insert trie "deleted" "gone"
                     Trie.delete trie "deleted"
@@ -396,9 +342,7 @@ spec = do
                             "Expected proof response JSON"
 
         it "returns 404 for unknown token" $ do
-            ctx0 <- mkTestContext
-            ctx <-
-                withSnapshot "root" "tx-out" "proof" ctx0
+            ctx <- mkTestContext
             resp <-
                 getProof ctx "63616665" (hex "k")
             simpleStatus resp `shouldBe` status404
@@ -407,7 +351,8 @@ spec = do
             "returns 503 when snapshot not yet \
             \available"
             $ do
-                ctx <- mkTestContext
+                ctx0 <- mkTestContext
+                let ctx = ctx0{indexerProofsReady = pure False}
                 seedTokenState ctx
                 Trie.createTrie (trieManager ctx) cafeTid
                 _ <-
@@ -480,99 +425,33 @@ getProof ctx tokenHex keyHex =
 withPersistentFactContext :: (Context IO -> IO a) -> IO a
 withPersistentFactContext =
     withPersistentFactContextWithTrie
+        (Just staleRoot)
         ( \trie -> do
             _ <- Trie.insert trie "hello" "world"
             Trie.getRoot trie
         )
 
 withPersistentFactContextWithTrie
-    :: (Trie.Trie IO -> IO Root)
+    :: Maybe ByteString
+    -> (Trie.Trie IO -> IO Root)
     -> (Context IO -> IO a)
     -> IO a
-withPersistentFactContextWithTrie setupTrie action =
-    withSystemTempDirectory "persistent-fact-http" $ \dir ->
-        withDBCF
-            dir
-            dbConfig
-            [ ("nodes", dbConfig)
-            , ("kv", dbConfig)
-            , ("meta", dbConfig)
-            , ("raw", dbConfig)
-            ]
-            $ \db@DB{columnFamilies} ->
-                case columnFamilies of
-                    [nodesCF, kvCF, metaCF, _rawCF] -> do
-                        tm <-
-                            mkPersistentTrieManager
-                                db
-                                nodesCF
-                                kvCF
-                                metaCF
-                        ctx0 <- mkTestContext
-                        stateTxIn <- generate genTxIn
-                        let stateTxOut = "state-tx-out"
-                            CsmtWitness
-                                { cwRoot
-                                , cwTxOut
-                                , cwProof
-                                } =
-                                    singleUtxoWitness
-                                        stateTxIn
-                                        stateTxOut
-                        ctx <-
-                            withSnapshot
-                                cwRoot
-                                cwTxOut
-                                cwProof
-                                ctx0{trieManager = tm}
-                        Trie.createTrie (trieManager ctx) cafeTid
-                        trieRoot <-
-                            Trie.withTrie
-                                (trieManager ctx)
-                                cafeTid
-                                setupTrie
-                        seedTokenStateWithRoot
-                            ctx
-                            stateTxIn
-                            trieRoot
-                        action ctx
-                    _ ->
-                        expectationFailure
-                            "expected four test column families"
-                            >> error "unreachable"
-
-data CsmtWitness = CsmtWitness
-    { cwRoot :: ByteString
-    , cwTxOut :: ByteString
-    , cwProof :: ByteString
-    }
-
-singleUtxoWitness :: TxIn -> ByteString -> CsmtWitness
-singleUtxoWitness txIn txOutBs =
-    evalPureFromEmptyDB $ do
-        let key = byteStringToKey (encodeTxInForCsmt txIn)
-        insertMHash key (mkHash txOutBs)
-        mProof <- proofM hashCodecs identityFromKV hashHashing key
-        mRoot <- getRootHashM
-        pure
-            CsmtWitness
-                { cwRoot = maybe BS.empty renderHash mRoot
-                , cwTxOut = txOutBs
-                , cwProof =
-                    case mProof of
-                        Just (_, proof) -> renderProof proof
-                        Nothing -> BS.empty
-                }
-
-encodeTxInForCsmt :: TxIn -> ByteString
-encodeTxInForCsmt txIn =
-    let TxInJSON
-            { tjTxId = Hex txIdBs
-            , tjTxIx
-            } = txInToJSON txIn
-    in  CBOR.toStrictByteString
-            $ mconcat
-                [ CBOR.encodeListLen 2
-                , CBOR.encodeBytes txIdBs
-                , CBOR.encodeWord64 tjTxIx
-                ]
+withPersistentFactContextWithTrie mOutOfTxRoot setupTrie action = do
+    ctx0 <- mkTestContext
+    stateTxIn <- generate genTxIn
+    withProofIndexer
+        mOutOfTxRoot
+        [(stateTxIn, sampleStateOutBytes 0)]
+        ctx0
+        $ \_txRoot ctx -> do
+            Trie.createTrie (trieManager ctx) cafeTid
+            trieRoot <-
+                Trie.withTrie
+                    (trieManager ctx)
+                    cafeTid
+                    setupTrie
+            seedTokenStateWithRoot
+                ctx
+                stateTxIn
+                trieRoot
+            action ctx


### PR DESCRIPTION
## Summary
- Add in-transaction UTxO witness and trie fact enumeration reads.
- Make token state, facts, fact, and proof handlers read snapshot plus proof data in one `runProofIndexerTx`.
- Extend stale-root guard coverage across all six proof-bearing read endpoints.

## Verification
- `./gate.sh`

Refs #327.