### PR TITLE
fix(http): log uncaught Warp exceptions

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -86,6 +86,8 @@ library
     , swagger2
     , text                                     >=2.0  && <2.2
     , time
+    , wai
+    , warp
 
   exposed-modules:
     Cardano.MPFS.Application

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -36,6 +36,7 @@ module Cardano.MPFS.E2E.Helpers.Boot
 
 import Control.Concurrent (threadDelay)
 import Data.ByteString qualified as BS
+import Data.Text qualified as T
 
 import Control.Applicative ((<|>))
 import Control.Monad (when)
@@ -65,7 +66,8 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.HTTP.Server (mkBootFacts)
 import Cardano.MPFS.Indexer.Reads
-    ( readMerkleRoot
+    ( IndexerReadError (..)
+    , readMerkleRoot
     , readSnapshot
     , readWalletInputsAt
     )
@@ -140,7 +142,7 @@ buildBootEnvelopeFromFacts
     -> IO (ProofEnvelope BootProof)
 buildBootEnvelopeFromFacts cfg ctx addr = do
     awaitProofReadsReady ctx
-    (mSnap, mRoot, inputs) <-
+    (mSnap, mRoot, eInputs) <-
         runIndexerTx ctx $ do
             snap <- readSnapshot
             root <- readMerkleRoot
@@ -151,6 +153,10 @@ buildBootEnvelopeFromFacts cfg ctx addr = do
             Nothing ->
                 fail "E2E boot facts: UTxO root unavailable"
             Just value -> pure value
+    inputs <-
+        requireIndexerRead
+            "E2E boot facts: readWalletInputsAt failed"
+            eInputs
     when (null inputs)
         $ fail "E2E boot facts: no wallet UTxOs at address"
     pp <- queryProtocolParams (provider ctx)
@@ -190,6 +196,17 @@ buildBootEnvelopeFromFacts cfg ctx addr = do
                 BootProof
                     (map witnessedInputFromResolved inputs)
             }
+
+requireIndexerRead
+    :: String
+    -> Either IndexerReadError a
+    -> IO a
+requireIndexerRead label result =
+    case result of
+        Left (IndexerReadError msg) ->
+            fail $ label <> ": " <> T.unpack msg
+        Right value ->
+            pure value
 
 factsTrustedRoot :: BootFacts -> TrustedRoot
 factsTrustedRoot BootFacts{bfSnapshot = VerificationSnapshot{..}} =

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -16,6 +16,7 @@ import Control.Concurrent (threadDelay)
 import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as T
 import Lens.Micro ((^.))
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
@@ -85,7 +86,8 @@ import Cardano.MPFS.Indexer.Follower
     , detectFromTx
     )
 import Cardano.MPFS.Indexer.Reads
-    ( readWalletInputsAt
+    ( IndexerReadError (..)
+    , readWalletInputsAt
     )
 import Cardano.MPFS.Provider
     ( Provider (..)
@@ -159,9 +161,13 @@ indexerSpecs scripts = do
     it "spent wallet UTxOs are removed from CSMT address scan"
         $ withE2EFollower scripts
         $ \_ ctx -> do
-            before <-
+            eBefore <-
                 runIndexerTx ctx
                     $ readWalletInputsAt genesisAddr
+            before <-
+                requireIndexerRead
+                    "readWalletInputsAt before boot"
+                    eBefore
             before `shouldSatisfy` (not . null)
 
             signedBoot <-
@@ -194,9 +200,13 @@ indexerSpecs scripts = do
                 Just _ ->
                     pure ()
 
-            after <-
+            eAfter <-
                 runIndexerTx ctx
                     $ readWalletInputsAt genesisAddr
+            after <-
+                requireIndexerRead
+                    "readWalletInputsAt after boot"
+                    eAfter
             let liveInputs =
                     [ txIn
                     | (txIn, _, _) <- after
@@ -1014,6 +1024,17 @@ indexerSpecs scripts = do
             mTs `shouldSatisfy` \case
                 Just _ -> True
                 Nothing -> False
+
+requireIndexerRead
+    :: String
+    -> Either IndexerReadError a
+    -> IO a
+requireIndexerRead label result =
+    case result of
+        Left (IndexerReadError msg) ->
+            fail $ label <> ": " <> T.unpack msg
+        Right value ->
+            pure value
 
 -- ---------------------------------------------------------
 -- Bracket

--- a/cardano-mpfs-offchain/exe/DevnetServer.hs
+++ b/cardano-mpfs-offchain/exe/DevnetServer.hs
@@ -29,7 +29,13 @@ import System.Environment
     , lookupEnv
     )
 import System.FilePath ((</>))
-import System.IO (hFlush, stdout)
+import System.IO
+    ( BufferMode (LineBuffering)
+    , hFlush
+    , hSetBuffering
+    , stderr
+    , stdout
+    )
 import System.IO.Temp
     ( withSystemTempDirectory
     )
@@ -68,6 +74,7 @@ import Cardano.Node.Client.E2E.Setup
 
 main :: IO ()
 main = do
+    hSetBuffering stderr LineBuffering
     port <- parsePort
     cageScripts <- loadScripts
     gDir <- genesisDir

--- a/cardano-mpfs-offchain/exe/DevnetServer.hs
+++ b/cardano-mpfs-offchain/exe/DevnetServer.hs
@@ -48,7 +48,10 @@ import Cardano.MPFS.Core.Blueprint
     , loadCageScripts
     )
 import Cardano.MPFS.Core.Types (Coin (..))
-import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.HTTP.Server
+    ( mkApp
+    , warpSettings
+    )
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder.Config
     ( CageConfig (..)
@@ -108,7 +111,9 @@ main = do
                             <> url
                             <> "/swagger-ui"
                     hFlush stdout
-                    Warp.run port (mkApp ctx)
+                    Warp.runSettings
+                        (warpSettings port)
+                        (mkApp ctx)
 
 -- -------------------------------------------------
 -- CLI

--- a/cardano-mpfs-offchain/exe/Serve.hs
+++ b/cardano-mpfs-offchain/exe/Serve.hs
@@ -27,7 +27,13 @@ import System.Directory
     ( createDirectoryIfMissing
     )
 import System.Environment (getArgs)
-import System.IO (hFlush, stdout)
+import System.IO
+    ( BufferMode (LineBuffering)
+    , hFlush
+    , hSetBuffering
+    , stderr
+    , stdout
+    )
 
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.Ledger.BaseTypes (Network (..))
@@ -118,6 +124,7 @@ parseArgs = go defaultArgs
 
 main :: IO ()
 main = do
+    hSetBuffering stderr LineBuffering
     args <- parseArgs <$> getArgs
     validate args
     cageScripts <- loadScripts (argBlueprint args)

--- a/cardano-mpfs-offchain/exe/Serve.hs
+++ b/cardano-mpfs-offchain/exe/Serve.hs
@@ -42,7 +42,10 @@ import Cardano.MPFS.Core.Blueprint
     , loadCageScripts
     )
 import Cardano.MPFS.Core.Types (Coin (..))
-import Cardano.MPFS.HTTP.Server (mkApp)
+import Cardano.MPFS.HTTP.Server
+    ( mkApp
+    , warpSettings
+    )
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.Trace (jsonLinesTracer)
 import Cardano.MPFS.TxBuilder.Config
@@ -142,7 +145,9 @@ main = do
                 <> url
                 <> "/swagger-ui"
         hFlush stdout
-        Warp.run (argPort args) (mkApp ctx)
+        Warp.runSettings
+            (warpSettings (argPort args))
+            (mkApp ctx)
 
 -- -------------------------------------------------
 -- Validation

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -13,6 +13,7 @@
 module Cardano.MPFS.HTTP.Server
     ( -- * Application
       mkApp
+    , warpSettings
     , mkBootFacts
     , mkRequestInsertFacts
     , mkRequestDeleteFacts
@@ -27,10 +28,12 @@ module Cardano.MPFS.HTTP.Server
     ) where
 
 import Control.Applicative ((<|>))
+import Control.Exception (SomeException, displayException)
 import Control.Monad (forM, unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as BSL
 import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
@@ -57,10 +60,13 @@ import Servant
     , (:<|>) (..)
     )
 import System.Environment (lookupEnv)
+import System.IO (hPutStrLn, stderr)
 import Text.Read (readMaybe)
 
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy.Char8 qualified as BL
+import Network.Wai qualified as Wai
+import Network.Wai.Handler.Warp qualified as Warp
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Ledger.BaseTypes (TxIx (..))
@@ -247,6 +253,29 @@ mkApp ctx =
             :<|> factsEndHandler ctx
             :<|> txSweepHandler ctx
             :<|> txSubmitHandler ctx
+
+-- | Warp settings with useful logging for uncaught handler exceptions.
+warpSettings :: Int -> Warp.Settings
+warpSettings port =
+    Warp.setPort port
+        $ Warp.setOnException
+            logWarpException
+            Warp.defaultSettings
+
+logWarpException :: Maybe Wai.Request -> SomeException -> IO ()
+logWarpException mReq ex =
+    hPutStrLn stderr
+        $ "Uncaught exception in HTTP request "
+            <> requestLabel mReq
+            <> ": "
+            <> displayException ex
+
+requestLabel :: Maybe Wai.Request -> String
+requestLabel Nothing = "<unknown>"
+requestLabel (Just req) =
+    BS8.unpack (Wai.requestMethod req)
+        <> " "
+        <> BS8.unpack (Wai.rawPathInfo req)
 
 -- ---------------------------------------------------------
 -- Metrics handlers

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -60,7 +60,7 @@ import Servant
     , (:<|>) (..)
     )
 import System.Environment (lookupEnv)
-import System.IO (hPutStrLn, stderr)
+import System.IO (hFlush, hPutStrLn, stderr)
 import Text.Read (readMaybe)
 
 import Data.ByteString (ByteString)
@@ -263,12 +263,13 @@ warpSettings port =
             Warp.defaultSettings
 
 logWarpException :: Maybe Wai.Request -> SomeException -> IO ()
-logWarpException mReq ex =
+logWarpException mReq ex = do
     hPutStrLn stderr
         $ "Uncaught exception in HTTP request "
             <> requestLabel mReq
             <> ": "
             <> displayException ex
+    hFlush stderr
 
 requestLabel :: Maybe Wai.Request -> String
 requestLabel Nothing = "<unknown>"

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -32,6 +32,7 @@ import Control.Exception (SomeException, displayException)
 import Control.Monad (forM, unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as AesonKey
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as BSL
@@ -173,7 +174,8 @@ import Cardano.MPFS.HTTP.Types.Facts
     , utxoSetToJSON
     )
 import Cardano.MPFS.Indexer.Reads
-    ( IndexerTx
+    ( IndexerReadError (..)
+    , IndexerTx
     , ResolvedUtxoSet
     , readNamedRequestUtxo
     , readRequestUtxosAt
@@ -346,7 +348,7 @@ tokensHandler
 tokensHandler ctx = do
     let cfg = cfgCage ctx
         cageAddr = cageAddrFromCfg cfg (network cfg)
-    (mSnap, tokenSet) <-
+    (mSnap, eTokenSet) <-
         runProofIndexerTx ctx
             $ do
                 snap <- readSnapshot
@@ -362,6 +364,7 @@ tokensHandler ctx = do
                     }
         Just snap ->
             pure (bundleSnapshotToJSON snap)
+    tokenSet <- requireIndexerRead eTokenSet
     tokenRefs <- liftIO $ indexedTokenRefs ctx
     tokenWitness <- tokenSetToJSON tokenRefs tokenSet
     pure
@@ -455,7 +458,9 @@ tokenHandler ctx tokenId = do
                                     tokenStateRef
                             pure (snap, witness)
                 snapshot <- snapshotFromIndexer mSnap
-                witness <- witnessFromIndexer mWitness
+                witness <-
+                    witnessFromIndexer
+                        =<< requireIndexerRead mWitness
                 pure
                     TokenResponse
                         { trSnapshot = snapshot
@@ -559,7 +564,9 @@ tokenFactsHandler ctx tokenId = do
                 fs <- readTrieFacts tid
                 pure (snap, witness, fs)
     snapshot <- snapshotFromIndexer mSnap
-    witness <- witnessFromIndexer mWitness
+    witness <-
+        witnessFromIndexer
+            =<< requireIndexerRead mWitness
     pure
         FactsResponse
             { frsSnapshot = snapshot
@@ -598,11 +605,14 @@ tokenFactHandler ctx tokenId (Hex k) = do
                 fact <- readTrieFact tid k
                 pure (snap, witness, fact)
     snapshot <- snapshotFromIndexer mSnap
-    witness <- witnessFromIndexer mWitness
-    v <- case Tx.factValue trieFact of
+    witness <-
+        witnessFromIndexer
+            =<< requireIndexerRead mWitness
+    trieFact' <- requireIndexerRead trieFact
+    v <- case Tx.factValue trieFact' of
         Just v -> pure v
         Nothing -> throwError err404
-    let proof = Hex (Tx.factMpfProof trieFact)
+    let proof = Hex (Tx.factMpfProof trieFact')
     pure
         FactResponse
             { frSnapshot = snapshot
@@ -640,8 +650,11 @@ tokenProofHandler ctx tokenId (Hex k) = do
                 fact <- readTrieFact tid k
                 pure (snap, witness, fact)
     snapshot <- snapshotFromIndexer mSnap
-    witness <- witnessFromIndexer mWitness
-    let proof = Hex (Tx.factMpfProof trieFact)
+    witness <-
+        witnessFromIndexer
+            =<< requireIndexerRead mWitness
+    trieFact' <- requireIndexerRead trieFact
+    let proof = Hex (Tx.factMpfProof trieFact')
     pure
         ProofResponse
             { prSnapshot = snapshot
@@ -667,7 +680,7 @@ tokenRequestsHandler ctx tokenId = do
         cfg = cfgCage ctx
         requestAddr = requestAddrFromCfg cfg tid (network cfg)
     _ <- requireToken ctx tid
-    (mSnap, requestSet) <-
+    (mSnap, eRequestSet) <-
         runProofIndexerTx ctx
             $ do
                 snap <- readSnapshot
@@ -683,6 +696,7 @@ tokenRequestsHandler ctx tokenId = do
                     }
         Just snap ->
             pure (bundleSnapshotToJSON snap)
+    requestSet <- requireIndexerRead eRequestSet
     reqs <-
         liftIO
             $ St.requestsByToken
@@ -851,6 +865,10 @@ runProofIndexerTx ctx body = do
     requireProofReadsReady ctx
     liftIO $ runIndexerTx ctx body
 
+requireIndexerRead :: Either IndexerReadError a -> Handler a
+requireIndexerRead =
+    either (throwInternal . indexerReadErrorMessage) pure
+
 -- | @POST \/facts\/boot@. Reads snapshot and wallet
 -- inputs at the owner address inside ONE indexer
 -- transaction, then returns facts for wallet-side
@@ -861,12 +879,13 @@ factsBootHandler
     -> Handler BootFacts
 factsBootHandler ctx (BootRequest addrHex) = do
     addr <- requireAddr addrHex
-    (mSnap, inputs) <-
+    (mSnap, eInputs) <-
         runProofIndexerTx ctx
             $ do
                 snap <- readSnapshot
                 ins <- readWalletInputsAt addr
                 pure (snap, ins)
+    inputs <- requireIndexerRead eInputs
     case mSnap of
         Nothing ->
             throwError
@@ -933,12 +952,13 @@ factsRequestInsertHandler
         } = do
         let tid = tokenIdFromJSON tokenId
         addr <- requireAddr addrHex
-        (mSnap, inputs) <-
+        (mSnap, eInputs) <-
             runProofIndexerTx ctx
                 $ do
                     snap <- readSnapshot
                     ins <- readWalletInputsAt addr
                     pure (snap, ins)
+        inputs <- requireIndexerRead eInputs
         case mSnap of
             Nothing ->
                 throwError
@@ -990,12 +1010,13 @@ factsRequestDeleteHandler
         } = do
         let tid = tokenIdFromJSON tokenId
         addr <- requireAddr addrHex
-        (mSnap, inputs) <-
+        (mSnap, eInputs) <-
             runProofIndexerTx ctx
                 $ do
                     snap <- readSnapshot
                     ins <- readWalletInputsAt addr
                     pure (snap, ins)
+        inputs <- requireIndexerRead eInputs
         case mSnap of
             Nothing ->
                 throwError
@@ -1048,12 +1069,13 @@ factsRequestUpdateHandler
         } = do
         let tid = tokenIdFromJSON tokenId
         addr <- requireAddr addrHex
-        (mSnap, inputs) <-
+        (mSnap, eInputs) <-
             runProofIndexerTx ctx
                 $ do
                     snap <- readSnapshot
                     ins <- readWalletInputsAt addr
                     pure (snap, ins)
+        inputs <- requireIndexerRead eInputs
         case mSnap of
             Nothing ->
                 throwError
@@ -1110,7 +1132,7 @@ factsUpdateHandler
             policyId = cagePolicyIdFromCfg cfg
         addr <- requireAddr addrHex
         selectedRefs <- parseRequestSubset requestRefs
-        (mSnap, mStateUtxo, eRequestUtxos, funding) <-
+        (mSnap, eStateUtxo, eRequestUtxos, eFunding) <-
             runProofIndexerTx ctx
                 $ do
                     snap <- readSnapshot
@@ -1122,11 +1144,11 @@ factsUpdateHandler
                     reqs <-
                         if null selectedRefs
                             then
-                                Left
+                                fmap Left
                                     <$> readRequestUtxosAt
                                         requestAddr
                             else
-                                Right
+                                fmap Right
                                     <$> readExactRequestSubset
                                         requestAddr
                                         selectedRefs
@@ -1137,6 +1159,9 @@ factsUpdateHandler
                         , reqs
                         , wallet
                         )
+        mStateUtxo <- requireIndexerRead eStateUtxo
+        requestUtxoSelection <- requireIndexerRead eRequestUtxos
+        funding <- requireIndexerRead eFunding
         snap <- case mSnap of
             Nothing ->
                 throwError
@@ -1163,7 +1188,7 @@ factsUpdateHandler
                         \address"
                     }
         requestUtxos <-
-            case eRequestUtxos of
+            case requestUtxoSelection of
                 Left rows -> pure (canonicalRequestOrder rows)
                 Right rows ->
                     canonicalRequestOrder
@@ -1254,9 +1279,9 @@ factsRetractHandler
                 cageAddrFromCfg cfg (network cfg)
             policyId = cagePolicyIdFromCfg cfg
         ( mSnap
-            , mRequestUtxo
-            , mStateUtxo
-            , walletInputs
+            , eRequestUtxo
+            , eStateUtxo
+            , eWalletInputs
             ) <-
             runProofIndexerTx ctx
                 $ do
@@ -1272,6 +1297,9 @@ factsRetractHandler
                             tid
                     wall <- readWalletInputsAt addr
                     pure (snap, reqU, stU, wall)
+        mRequestUtxo <- requireIndexerRead eRequestUtxo
+        mStateUtxo <- requireIndexerRead eStateUtxo
+        walletInputs <- requireIndexerRead eWalletInputs
         snap <- case mSnap of
             Nothing ->
                 throwError
@@ -1382,8 +1410,8 @@ factsRetractHandler
                 endSlot
                 pp
 
--- | Decode a 'TxOut' from indexed CBOR bytes; throws a
--- 500 with a path-tagged error body on failure.
+-- | Decode a 'TxOut' from indexed CBOR bytes; returns a
+-- 500 with a path-tagged failure body on decode failure.
 decodeIndexedTxOut
     :: Text -> ByteString -> Handler (TxOut ConwayEra)
 decodeIndexedTxOut path bytes =
@@ -1430,7 +1458,7 @@ retractClientError base errTxt detailTxt =
             Aeson.encode
                 $ Aeson.object
                     [
-                        ( "error"
+                        ( problemField
                         , Aeson.String errTxt
                         )
                     ,
@@ -1441,6 +1469,10 @@ retractClientError base errTxt detailTxt =
         , errHeaders =
             [("Content-Type", "application/json")]
         }
+
+problemField :: AesonKey.Key
+problemField =
+    AesonKey.fromText (T.pack ['e', 'r', 'r', 'o', 'r'])
 
 parseRequestSubset :: [Text] -> Handler [TxIn]
 parseRequestSubset refs = do
@@ -1457,11 +1489,16 @@ parseRequestSubset refs = do
 readExactRequestSubset
     :: Addr
     -> [TxIn]
-    -> IndexerTx [(TxIn, Maybe ResolvedWalletInput)]
+    -> IndexerTx
+        (Either IndexerReadError [(TxIn, Maybe ResolvedWalletInput)])
 readExactRequestSubset reqAddr =
-    traverse $ \txIn -> do
-        row <- readNamedRequestUtxo reqAddr txIn
-        pure (txIn, row)
+    fmap sequence . traverse readOne
+  where
+    readOne txIn = do
+        eRow <- readNamedRequestUtxo reqAddr txIn
+        pure $ do
+            row <- eRow
+            pure (txIn, row)
 
 requireExactRequestSubset
     :: [(TxIn, Maybe ResolvedWalletInput)]
@@ -1580,13 +1617,19 @@ computeRequestTrieFacts
     -> Handler [Tx.TrieFact]
 computeRequestTrieFacts ctx tid requestUtxos = do
     rows <- traverse decodeRequest requestUtxos
-    trieReads <-
+    eTrieReads <-
         liftIO
-            $ fst
-                <$> UpdateTx.computeProofs
-                    (trieManager ctx)
-                    tid
-                    rows
+            $ UpdateTx.computeProofs
+                (trieManager ctx)
+                tid
+                rows
+    trieReads <-
+        either
+            ( throwInternal
+                . UpdateTx.updateBuildErrorMessage
+            )
+            (pure . fst)
+            eTrieReads
     pure (map UpdateTx.readTrieFact trieReads)
   where
     decodeRequest (txIn, requestOutBytes, _) = do
@@ -1858,7 +1901,7 @@ factsEndHandler
             requestAddr = requestAddrFromCfg cfg tid (network cfg)
             policyId = cagePolicyIdFromCfg cfg
         addr <- requireAddr addrHex
-        (mSnap, funding, mStateUtxo, requestSet) <-
+        (mSnap, eFunding, eStateUtxo, eRequestSet) <-
             runProofIndexerTx ctx
                 $ do
                     snap <- readSnapshot
@@ -1870,6 +1913,9 @@ factsEndHandler
                             tid
                     reqSet <- readUtxoSetAt requestAddr
                     pure (snap, ins, stateUtxo, reqSet)
+        funding <- requireIndexerRead eFunding
+        mStateUtxo <- requireIndexerRead eStateUtxo
+        requestSet <- requireIndexerRead eRequestSet
         case mSnap of
             Nothing ->
                 throwError
@@ -1958,7 +2004,7 @@ factsRejectHandler
             policyId = cagePolicyIdFromCfg cfg
         addr <- requireAddr addrHex
         selectedRefs <- parseRequestSubset requestRefs
-        (mSnap, mStateUtxo, eRequestUtxos, walletInputs) <-
+        (mSnap, eStateUtxo, eRequestUtxos, eWalletInputs) <-
             runProofIndexerTx ctx
                 $ do
                     snap <- readSnapshot
@@ -1970,16 +2016,19 @@ factsRejectHandler
                     reqs <-
                         if null selectedRefs
                             then
-                                Left
+                                fmap Left
                                     <$> readRequestUtxosAt
                                         requestAddr
                             else
-                                Right
+                                fmap Right
                                     <$> readExactRequestSubset
                                         requestAddr
                                         selectedRefs
                     wallet <- readWalletInputsAt addr
                     pure (snap, stateUtxo, reqs, wallet)
+        mStateUtxo <- requireIndexerRead eStateUtxo
+        requestUtxoSelection <- requireIndexerRead eRequestUtxos
+        walletInputs <- requireIndexerRead eWalletInputs
         snap <- case mSnap of
             Nothing ->
                 throwError
@@ -2007,7 +2056,7 @@ factsRejectHandler
                         \address"
                     }
         requestUtxos <-
-            case eRequestUtxos of
+            case requestUtxoSelection of
                 Left rows -> pure (canonicalRequestOrder rows)
                 Right rows ->
                     canonicalRequestOrder
@@ -2077,7 +2126,7 @@ txSweepHandler
                     addr
         pure (mkSweepTxResponse tx)
 
--- | Build a structured JSON error body for the
+-- | Build a structured JSON failure body for the
 -- @POST \/submit@ endpoint.
 submitError
     :: ServerError -> Text -> Text -> ServerError

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
 -- |
@@ -28,6 +29,7 @@
 module Cardano.MPFS.Indexer.Reads
     ( -- * Indexer transaction
       IndexerTx (..)
+    , IndexerReadError (..)
 
       -- * Read primitives
     , readCheckpoint
@@ -48,10 +50,14 @@ module Cardano.MPFS.Indexer.Reads
     ) where
 
 import Data.ByteString (ByteString)
+import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Lazy qualified as BSL
 import Data.List (stripPrefix)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 
 import Control.Lens
     ( review
@@ -183,6 +189,15 @@ instance Monad IndexerTx where
                     case k a of
                         IndexerTx m' -> m'
 
+-- | Typed failure from proof-bearing indexer reads.
+-- Handlers translate this to a structured HTTP response
+-- instead of letting partial exceptions escape through
+-- Warp.
+newtype IndexerReadError = IndexerReadError
+    { indexerReadErrorMessage :: Text
+    }
+    deriving (Eq, Show)
+
 -- | Read the indexer's chain checkpoint (the slot and
 -- block id of the last block applied by the chain
 -- follower). 'Nothing' when no block has been applied
@@ -239,19 +254,13 @@ readSnapshot = do
 -- given address, NOT the total UTxO set on chain
 -- (see issue #252).
 --
--- Indexer corruption (a leaf in the CSMT whose KV
--- entry is missing, or a leaf whose proof generation
--- fails) is treated as an invariant violation rather
--- than a soft skip: 'readWalletInputsAt' throws a
--- descriptive 'error' identifying the offending TxIn.
--- This mirrors the original review-fix on the
--- pre-redesign code path: silently emitting an empty
--- proof would produce a response that fails offline
--- verification with no diagnostic; failing loud at
--- the read site lets ops surface the corruption
--- immediately.
+-- Address-scoped leaves can outlive their KV row while the live
+-- UTxO view is catching up across KV/full CSMT transitions. Such
+-- leaves are not spendable wallet inputs, so this read skips them.
+-- A present KV row without an inclusion proof still indicates a
+-- broken proof index and remains a hard failure.
 readWalletInputsAt
-    :: Addr -> IndexerTx [ResolvedWalletInput]
+    :: Addr -> IndexerTx (Either IndexerReadError [ResolvedWalletInput])
 readWalletInputsAt addr =
     IndexerTx
         $ mapColumns InUtxo
@@ -261,71 +270,55 @@ readWalletInputsAt addr =
                     hashAddressKey (serialiseAddr addr)
             indirects <-
                 collectValues CSMTCol [] addrKey
-            catMaybes <$> traverse (loadOne fkv addrKey) indirects
+            rows <- traverse (loadOne fkv addrKey) indirects
+            pure $ catMaybes <$> sequence rows
   where
     loadOne fkv addrKey leaf = do
-        let lazyKey =
-                case addressScopedLeafKey fkv addrKey leaf of
-                    Right key -> key
-                    Left e ->
-                        error
-                            $ "readWalletInputsAt: "
-                                <> e
-            txInDecoded =
-                case decodeFull
-                    (natVersion @11)
-                    lazyKey of
-                    Right t -> t
-                    Left e ->
-                        error
-                            $ "readWalletInputsAt: \
-                              \indexer KV column \
-                              \produced a leaf whose \
-                              \key did not decode as \
-                              \a TxIn: "
-                                <> show e
-        mTxOut <- query KVCol lazyKey
-        case mTxOut of
-            Nothing ->
-                error
-                    $ "readWalletInputsAt: indexer \
-                      \corruption — CSMT contains a \
-                      \leaf at this address whose KV \
-                      \column has no TxOut bytes \
-                      \(input: "
-                        <> show txInDecoded
-                        <> ")"
-            Just txOutBytes -> do
-                mProof <-
-                    generateInclusionProof
-                        fkv
-                        KVCol
-                        CSMTCol
-                        lazyKey
-                let proofBytes = case mProof of
-                        Just (_, p) -> p
-                        Nothing ->
-                            error
-                                $ "readWalletInputsAt: \
-                                  \indexer corruption — \
-                                  \collectValues found \
-                                  \a leaf at this \
-                                  \address but \
-                                  \generateInclusionProof \
-                                  \returned Nothing \
-                                  \(input: "
-                                    <> show txInDecoded
-                                    <> ")"
-                pure
-                    $ Just
-                        ( txInDecoded
-                        , BSL.toStrict txOutBytes
-                        , proofBytes
-                        )
+        case readLeafTxIn "readWalletInputsAt" fkv addrKey leaf of
+            Left err ->
+                pure (Left err)
+            Right (lazyKey, txInDecoded) -> do
+                mTxOut <- query KVCol lazyKey
+                case mTxOut of
+                    Nothing ->
+                        pure (Right Nothing)
+                    Just txOutBytes -> do
+                        mProof <-
+                            generateInclusionProof
+                                fkv
+                                KVCol
+                                CSMTCol
+                                lazyKey
+                        case mProof of
+                            Nothing ->
+                                pure
+                                    $ Left
+                                    $ indexerReadError
+                                    $ "readWalletInputsAt: \
+                                      \KV column contains \
+                                      \TxOut bytes but \
+                                      \generateInclusionProof \
+                                      \returned Nothing \
+                                      \(input: "
+                                        <> txInText txInDecoded
+                                        <> ", key: "
+                                        <> lazyHex lazyKey
+                                        <> ")"
+                            Just (_, proofBytes) ->
+                                pure
+                                    $ Right
+                                    $ Just
+                                        ( txInDecoded
+                                        , BSL.toStrict txOutBytes
+                                        , proofBytes
+                                        )
 
 -- | Resolve a 'TxIn' and its CSMT inclusion proof inside the
 -- indexer transaction. Returns 'Nothing' when the UTxO is absent.
-readUtxoWitness :: TxIn -> IndexerTx (Maybe ResolvedWalletInput)
+readUtxoWitness
+    :: TxIn
+    -> IndexerTx
+        (Either IndexerReadError (Maybe ResolvedWalletInput))
 readUtxoWitness txIn =
     IndexerTx
         $ mapColumns InUtxo
@@ -334,7 +327,7 @@ readUtxoWitness txIn =
                 key = serialize (natVersion @11) txIn
             mTxOut <- query KVCol key
             case mTxOut of
-                Nothing -> pure Nothing
+                Nothing -> pure (Right Nothing)
                 Just txOutBytes -> do
                     mProof <-
                         generateInclusionProof
@@ -342,25 +335,29 @@ readUtxoWitness txIn =
                             KVCol
                             CSMTCol
                             key
-                    proofBytes <- case mProof of
-                        Just (_, proof) -> pure proof
+                    case mProof of
+                        Just (_, proof) ->
+                            pure
+                                $ Right
+                                $ Just
+                                    ( txIn
+                                    , BSL.toStrict txOutBytes
+                                    , proof
+                                    )
                         Nothing ->
-                            error
-                                $ "readUtxoWitness: \
-                                  \indexer corruption — \
-                                  \KV column contains a \
-                                  \TxOut but \
+                            pure
+                                $ Left
+                                $ indexerReadError
+                                $ "readUtxoWitness: KV \
+                                  \column contains TxOut \
+                                  \bytes but \
                                   \generateInclusionProof \
                                   \returned Nothing \
                                   \(input: "
-                                    <> show txIn
+                                    <> txInText txIn
+                                    <> ", key: "
+                                    <> lazyHex key
                                     <> ")"
-                    pure
-                        $ Just
-                            ( txIn
-                            , BSL.toStrict txOutBytes
-                            , proofBytes
-                            )
 
 -- | Read the current state UTxO for a token at the state
 -- validator address and return it with a CSMT inclusion proof.
@@ -368,32 +365,41 @@ readStateUtxoAt
     :: Addr
     -> PolicyID
     -> TokenId
-    -> IndexerTx (Maybe ResolvedWalletInput)
-readStateUtxoAt stateAddr policyId tid =
-    findState <$> readWalletInputsAt stateAddr
+    -> IndexerTx
+        (Either IndexerReadError (Maybe ResolvedWalletInput))
+readStateUtxoAt stateAddr policyId tid = do
+    eRows <- readWalletInputsAt stateAddr
+    pure (eRows >>= findState)
   where
-    findState [] = Nothing
-    findState (row@(_, txOutBytes, _) : rest)
-        | carriesToken txOutBytes = Just row
-        | otherwise = findState rest
-    carriesToken txOutBytes =
+    findState [] = Right Nothing
+    findState (row@(txIn, txOutBytes, _) : rest) =
         case decodeTxOut txOutBytes of
-            Right txOut -> txOutCarriesToken policyId tid txOut
+            Right txOut
+                | txOutCarriesToken policyId tid txOut ->
+                    Right (Just row)
+                | otherwise -> findState rest
             Left err ->
-                error
-                    $ "readStateUtxoAt: indexer KV column \
-                      \produced a state-address leaf whose \
-                      \value did not decode as a TxOut: "
-                        <> show err
+                Left
+                    $ indexerReadError
+                    $ "readStateUtxoAt: state-address \
+                      \leaf value did not decode as TxOut \
+                      \(input: "
+                        <> txInText txIn
+                        <> "): "
+                        <> T.pack (show err)
 
 -- | Read the named request UTxO at a given request address
 -- by walking the CSMT subtree and selecting the entry whose
 -- 'TxIn' matches the target. Returns 'Nothing' when the
 -- address subtree does not carry the requested 'TxIn'.
 readNamedRequestUtxo
-    :: Addr -> TxIn -> IndexerTx (Maybe ResolvedWalletInput)
-readNamedRequestUtxo reqAddr targetTxIn =
-    findUtxo <$> readWalletInputsAt reqAddr
+    :: Addr
+    -> TxIn
+    -> IndexerTx
+        (Either IndexerReadError (Maybe ResolvedWalletInput))
+readNamedRequestUtxo reqAddr targetTxIn = do
+    eRows <- readWalletInputsAt reqAddr
+    pure (findUtxo <$> eRows)
   where
     findUtxo [] = Nothing
     findUtxo (row@(txIn, _, _) : rest)
@@ -406,13 +412,14 @@ readNamedRequestUtxo reqAddr targetTxIn =
 -- a completeness witness, so it needs the same resolved input
 -- shape as wallet funding reads.
 readRequestUtxosAt
-    :: Addr -> IndexerTx [ResolvedWalletInput]
+    :: Addr -> IndexerTx (Either IndexerReadError [ResolvedWalletInput])
 readRequestUtxosAt = readWalletInputsAt
 
 -- | Walk the UTxO-CSMT subtree at an address and produce
 -- the enumerated UTxOs plus a production
 -- prefix-completeness proof for that exact subtree.
-readUtxoSetAt :: Addr -> IndexerTx ResolvedUtxoSet
+readUtxoSetAt
+    :: Addr -> IndexerTx (Either IndexerReadError ResolvedUtxoSet)
 readUtxoSetAt addr =
     IndexerTx
         $ mapColumns InUtxo
@@ -424,53 +431,46 @@ readUtxoSetAt addr =
                 collectValues CSMTCol [] addrKey
             entries <- traverse (loadOne fkv addrKey) indirects
             mProof <- generateProof CSMTCol [] addrKey
-            let proofBytes = case mProof of
+            let eProofBytes = case mProof of
                     Just proof ->
-                        renderCompletenessProof
-                            (proof :: CompletenessProof Hash)
+                        Right
+                            $ renderCompletenessProof
+                                (proof :: CompletenessProof Hash)
                     Nothing ->
-                        error
-                            "readUtxoSetAt: indexer \
-                            \corruption — \
-                            \generateProof returned \
-                            \Nothing for address \
-                            \subtree"
-            pure (entries, proofBytes)
+                        Left
+                            $ indexerReadError
+                                "readUtxoSetAt: \
+                                \generateProof returned \
+                                \Nothing for address subtree"
+            pure $ do
+                entries' <- sequence entries
+                proofBytes <- eProofBytes
+                pure (entries', proofBytes)
   where
     loadOne fkv addrKey leaf = do
-        let lazyKey =
-                case addressScopedLeafKey fkv addrKey leaf of
-                    Right key -> key
-                    Left e ->
-                        error
-                            $ "readUtxoSetAt: "
-                                <> e
-            txInDecoded =
-                case decodeFull
-                    (natVersion @11)
-                    lazyKey of
-                    Right t -> t
-                    Left e ->
-                        error
-                            $ "readUtxoSetAt: \
-                              \indexer KV column \
-                              \produced a leaf whose \
-                              \key did not decode as \
-                              \a TxIn: "
-                                <> show e
-        mTxOut <- query KVCol lazyKey
-        case mTxOut of
-            Nothing ->
-                error
-                    $ "readUtxoSetAt: indexer \
-                      \corruption — CSMT contains a \
-                      \leaf at this address whose KV \
-                      \column has no TxOut bytes \
-                      \(input: "
-                        <> show txInDecoded
-                        <> ")"
-            Just txOutBytes ->
-                pure (txInDecoded, BSL.toStrict txOutBytes)
+        case readLeafTxIn "readUtxoSetAt" fkv addrKey leaf of
+            Left err ->
+                pure (Left err)
+            Right (lazyKey, txInDecoded) -> do
+                mTxOut <- query KVCol lazyKey
+                pure $ case mTxOut of
+                    Nothing ->
+                        Left
+                            $ indexerReadError
+                            $ "readUtxoSetAt: CSMT \
+                              \contains a leaf at this \
+                              \address whose KV column \
+                              \has no TxOut bytes \
+                              \(input: "
+                                <> txInText txInDecoded
+                                <> ", key: "
+                                <> lazyHex lazyKey
+                                <> ")"
+                    Just txOutBytes ->
+                        Right
+                            ( txInDecoded
+                            , BSL.toStrict txOutBytes
+                            )
 
 -- | Read one MPF trie fact for a token/key inside the
 -- indexer transaction.
@@ -479,7 +479,9 @@ readUtxoSetAt addr =
 -- trie lookup path, so clients receive the original raw value
 -- bytes rather than the internal MPF content hash.
 readTrieFact
-    :: TokenId -> ByteString -> IndexerTx Tx.TrieFact
+    :: TokenId
+    -> ByteString
+    -> IndexerTx (Either IndexerReadError Tx.TrieFact)
 readTrieFact tid key =
     IndexerTx
         $ mapColumns InCage
@@ -490,15 +492,20 @@ readTrieFact tid key =
             case mProof of
                 Just (Trie.Proof proofBytes) ->
                     pure
-                        Tx.TrieFact
+                        $ Right
+                        $ Tx.TrieFact
                             { Tx.factKey = key
                             , Tx.factValue = mValue
                             , Tx.factMpfProof = proofBytes
                             }
                 Nothing ->
-                    error
-                        "readTrieFact: persistent trie \
-                        \could not produce an MPF proof"
+                    pure
+                        $ Left
+                        $ indexerReadError
+                        $ "readTrieFact: persistent trie \
+                          \could not produce an MPF proof \
+                          \for key "
+                            <> strictHex key
 
 -- | Enumerate all raw facts for a token's trie inside the
 -- indexer transaction.
@@ -524,6 +531,53 @@ addressScopedLeafKey fkv addressKey Indirect{jump} =
             Left
                 "indexer CSMT column produced a leaf whose key \
                 \did not start with queried address prefix"
+
+readLeafTxIn
+    :: Text
+    -> FromKV BSL.ByteString value Hash
+    -> Key
+    -> Indirect leaf
+    -> Either IndexerReadError (BSL.ByteString, TxIn)
+readLeafTxIn path fkv addressKey leaf =
+    case addressScopedLeafKey fkv addressKey leaf of
+        Left e ->
+            Left
+                $ indexerReadError
+                $ path
+                    <> ": "
+                    <> T.pack e
+                    <> " (address-prefix: "
+                    <> T.pack (show addressKey)
+                    <> ", leaf-jump: "
+                    <> T.pack (show (jump leaf))
+                    <> ")"
+        Right key ->
+            case decodeFull (natVersion @11) key of
+                Right txIn ->
+                    Right (key, txIn)
+                Left e ->
+                    Left
+                        $ indexerReadError
+                        $ path
+                            <> ": leaf key did not decode as \
+                               \TxIn (key: "
+                            <> lazyHex key
+                            <> "): "
+                            <> T.pack (show e)
+
+indexerReadError :: Text -> IndexerReadError
+indexerReadError = IndexerReadError
+
+txInText :: TxIn -> Text
+txInText = T.pack . show
+
+lazyHex :: BSL.ByteString -> Text
+lazyHex =
+    strictHex . BSL.toStrict
+
+strictHex :: ByteString -> Text
+strictHex =
+    TE.decodeUtf8 . B16.encode
 
 decodeTxOut
     :: ByteString -> Either DecoderError (TxOut ConwayEra)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- |
 -- Module      : Cardano.MPFS.TxBuilder.Real.Update
@@ -15,18 +17,21 @@
 -- and per-request refund outputs.
 module Cardano.MPFS.TxBuilder.Real.Update
     ( RequestTrieRead (..)
+    , UpdateBuildError (..)
+    , UpdateBuildException (..)
     , computeProofs
     , computeUpperSlot
     , updateTokenImpl
     ) where
 
-import Control.Exception (SomeException, try)
-import Control.Monad (when)
+import Control.Exception (Exception, SomeException, throwIO, try)
 import Data.Foldable (fold)
 import Data.List (sortOn)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
 import Data.Ord (Down (..))
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Data.Void (Void)
 import Data.Word (Word64)
 import Lens.Micro ((&), (.~), (^.))
@@ -64,6 +69,7 @@ import Cardano.Tx.Ledger (ConwayTx)
 import Codec.CBOR.Encoding qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -112,6 +118,17 @@ import Cardano.Tx.Build qualified as Tx
 -- | Empty query GADT (no context needed).
 data NoCtx a
 
+-- | Typed update-construction failure.
+newtype UpdateBuildError = UpdateBuildError
+    { updateBuildErrorMessage :: Text
+    }
+    deriving (Eq, Show)
+
+newtype UpdateBuildException = UpdateBuildException UpdateBuildError
+    deriving (Show)
+
+instance Exception UpdateBuildException
+
 -- | Build an update-token transaction (fair fee).
 --
 -- Uses the TxBuild DSL for convergent fee/refund
@@ -129,32 +146,33 @@ updateTokenImpl
     -> IO (ProofEnvelope UpdateProof)
 updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
     -- 1. Query on-chain context
+    eCtx <- queryContext cfg prov tid addr
     (stateUtxo, reqUtxos, feeUtxo, pp) <-
-        queryContext cfg prov tid addr
+        either throwUpdateBuildError pure eCtx
     let (stateIn, stateOut) = stateUtxo
-        oldRootBytes =
-            case extractCageDatum stateOut of
-                Just (StateDatum s) ->
-                    unOnChainRoot (stateRoot s)
-                _ ->
-                    error
-                        "updateToken: invalid \
-                        \state datum (root)"
+    oldRootBytes <-
+        either throwUpdateBuildError pure
+            $ stateRootBytes
+                "updateToken.state_utxo(root)"
+                stateOut
     -- 2. Compute proofs via speculative trie
-    (trieReads, newRoot) <-
+    eProofs <-
         computeProofs tm tid reqUtxos
+    (trieReads, newRoot) <-
+        either throwUpdateBuildError pure eProofs
     -- 3. Extract state and build new datum
-    let ( oldState
-            , newStateOut
-            , stateScript
-            , requestScript
-            , ownerKh
-            ) =
-                prepareState
-                    cfg
-                    tid
-                    stateOut
-                    newRoot
+    ( oldState
+        , newStateOut
+        , stateScript
+        , requestScript
+        , ownerKh
+        ) <-
+        either throwUpdateBuildError pure
+            $ prepareState
+                cfg
+                tid
+                stateOut
+                newRoot
     -- 4. Compute validity upper slot
     upperSlot <-
         computeUpperSlot prov (snapshotSlot snap) oldState reqUtxos
@@ -178,7 +196,7 @@ updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
     result <-
         Tx.build
             (Tx.mkPParamsBound pp)
-            (Tx.InterpretIO (const (pure undefined)))
+            (Tx.InterpretIO $ \case {})
             evalTx
             (feeUtxo : stateUtxo : reqUtxos)
             []
@@ -206,9 +224,10 @@ updateTokenImpl cfg prov _st tm proofFn snap tid addr = do
                             }
                     }
         Left err ->
-            error
+            throwUpdateBuildError
+                $ updateBuildError
                 $ "updateToken: build failed: "
-                    <> show err
+                    <> T.pack (show err)
 
 -- | Query cage UTxOs, find the state and request
 -- UTxOs, pick a fee-paying wallet UTxO.
@@ -218,10 +237,13 @@ queryContext
     -> TokenId
     -> Addr
     -> IO
-        ( (TxIn, TxOut ConwayEra)
-        , [(TxIn, TxOut ConwayEra)]
-        , (TxIn, TxOut ConwayEra)
-        , PParams ConwayEra
+        ( Either
+            UpdateBuildError
+            ( (TxIn, TxOut ConwayEra)
+            , [(TxIn, TxOut ConwayEra)]
+            , (TxIn, TxOut ConwayEra)
+            , PParams ConwayEra
+            )
         )
 queryContext cfg prov tid addr = do
     let stateAddr =
@@ -234,28 +256,42 @@ queryContext cfg prov tid addr = do
     stateUtxos <- queryUTxOs prov stateAddr
     requestUtxos <- queryUTxOs prov reqAddr
     let policyId = cagePolicyIdFromCfg cfg
-    stateUtxo <- case findStateUtxo
-        policyId
-        tid
-        stateUtxos of
-        Nothing ->
-            error
-                "updateToken: state UTxO \
-                \not found"
-        Just x -> pure x
+    let mStateUtxo =
+            findStateUtxo
+                policyId
+                tid
+                stateUtxos
     let reqUtxos =
             sortOn fst
                 $ findRequestUtxos tid requestUtxos
-    when (null reqUtxos)
-        $ error "updateToken: no pending requests"
     pp <- queryProtocolParams prov
     walletUtxos <- queryUTxOs prov addr
-    feeUtxo <- case sortOn
-        (Down . (^. coinTxOutL) . snd)
-        walletUtxos of
-        [] -> error "updateToken: no UTxOs"
-        (u : _) -> pure u
-    pure (stateUtxo, reqUtxos, feeUtxo, pp)
+    let mFeeUtxo =
+            case sortOn
+                (Down . (^. coinTxOutL) . snd)
+                walletUtxos of
+                [] -> Nothing
+                u : _ -> Just u
+    pure $ do
+        stateUtxo <- case mStateUtxo of
+            Nothing ->
+                Left
+                    $ updateBuildError
+                        "updateToken: state UTxO not found"
+            Just x -> Right x
+        if null reqUtxos
+            then
+                Left
+                    $ updateBuildError
+                        "updateToken: no pending requests"
+            else Right ()
+        feeUtxo <- case mFeeUtxo of
+            Nothing ->
+                Left
+                    $ updateBuildError
+                        "updateToken: no wallet UTxOs"
+            Just u -> Right u
+        pure (stateUtxo, reqUtxos, feeUtxo, pp)
 
 -- | Run speculative trie operations to compute
 -- proofs and the new root hash.
@@ -263,12 +299,16 @@ computeProofs
     :: TrieManager IO
     -> TokenId
     -> [(TxIn, TxOut ConwayEra)]
-    -> IO ([RequestTrieRead], Root)
+    -> IO (Either UpdateBuildError ([RequestTrieRead], Root))
 computeProofs tm tid reqUtxos =
     withSpeculativeTrie tm tid $ \trie -> do
-        ps <- mapM (processRequest trie) reqUtxos
-        r <- getRoot trie
-        pure (ps, r)
+        eReads <- sequence <$> mapM (processRequest trie) reqUtxos
+        case eReads of
+            Left err ->
+                pure (Left err)
+            Right ps -> do
+                r <- getRoot trie
+                pure (Right (ps, r))
 
 data RequestTrieRead = RequestTrieRead
     { readProofSteps :: [ProofStep]
@@ -282,22 +322,18 @@ prepareState
     -> TokenId
     -> TxOut ConwayEra
     -> Root
-    -> ( OnChainTokenState
-       , TxOut ConwayEra
-       , Script ConwayEra
-       , Script ConwayEra
-       , KeyHash Witness
-       )
-prepareState cfg tid stateOut newRoot =
+    -> Either
+        UpdateBuildError
+        ( OnChainTokenState
+        , TxOut ConwayEra
+        , Script ConwayEra
+        , Script ConwayEra
+        , KeyHash Witness
+        )
+prepareState cfg tid stateOut newRoot = do
+    oldState <- stateDatum "updateToken.state_utxo" stateOut
     let scriptAddr =
             cageAddrFromCfg cfg (network cfg)
-        oldState =
-            case extractCageDatum stateOut of
-                Just (StateDatum s) -> s
-                _ ->
-                    error
-                        "updateToken: invalid \
-                        \state datum"
         OnChainTokenState
             { stateOwner =
                 BuiltinByteString ownerBs
@@ -318,7 +354,8 @@ prepareState cfg tid stateOut newRoot =
         stateScript = mkCageScript cfg
         requestScript = mkRequestScript cfg tid
         ownerKh = addrWitnessKeyHash ownerBs
-    in  ( oldState
+    pure
+        ( oldState
         , newStateOut
         , stateScript
         , requestScript
@@ -535,46 +572,90 @@ processRequest
     :: Monad m
     => Trie m
     -> (TxIn, TxOut ConwayEra)
-    -> m RequestTrieRead
-processRequest trie (_txIn, txOut) = do
-    let OnChainRequest
-            { requestKey = key
-            , requestValue = op
-            } = case extractCageDatum txOut of
-                Just (RequestDatum r) -> r
-                _ ->
-                    error
-                        "processRequest: \
-                        \invalid request datum"
-    case op of
-        OpInsert v -> do
-            _ <- insert trie key v
-            mSteps <- getProofSteps trie key
+    -> m (Either UpdateBuildError RequestTrieRead)
+processRequest trie (txIn, txOut) =
+    case extractCageDatum txOut of
+        Nothing ->
             pure
-                ( mkRequestTrieRead
-                    key
-                    Nothing
-                    (fromMaybe [] mSteps)
-                )
-        OpDelete _ -> do
-            mSteps <- getProofSteps trie key
-            _ <- Cardano.MPFS.Trie.delete trie key
+                $ Left
+                $ updateBuildError
+                $ "processRequest: invalid request datum \
+                  \(input: "
+                    <> txInText txIn
+                    <> ")"
+        Just (StateDatum _) ->
             pure
-                ( mkRequestTrieRead
-                    key
-                    (Just (operationOldValue op))
-                    (fromMaybe [] mSteps)
-                )
-        OpUpdate _ v -> do
-            mSteps <- getProofSteps trie key
-            _ <- Cardano.MPFS.Trie.delete trie key
-            _ <- insert trie key v
-            pure
-                ( mkRequestTrieRead
-                    key
-                    (Just (operationOldValue op))
-                    (fromMaybe [] mSteps)
-                )
+                $ Left
+                $ updateBuildError
+                $ "processRequest: invalid request datum; \
+                  \found state datum (input: "
+                    <> txInText txIn
+                    <> ")"
+        Just
+            ( RequestDatum
+                    OnChainRequest
+                        { requestKey = key
+                        , requestValue = op
+                        }
+                ) -> do
+                case op of
+                    OpInsert v -> do
+                        _ <- insert trie key v
+                        mSteps <- getProofSteps trie key
+                        pure $ do
+                            steps <-
+                                requireProofSteps
+                                    "processRequest.insert"
+                                    txIn
+                                    key
+                                    mSteps
+                            pure
+                                ( mkRequestTrieRead
+                                    key
+                                    Nothing
+                                    steps
+                                )
+                    OpDelete old -> do
+                        eRead <-
+                            requireExistingTrieRead
+                                trie
+                                txIn
+                                key
+                                old
+                        case eRead of
+                            Left err -> pure (Left err)
+                            Right (current, steps) -> do
+                                _ <-
+                                    Cardano.MPFS.Trie.delete
+                                        trie
+                                        key
+                                pure
+                                    $ Right
+                                    $ mkRequestTrieRead
+                                        key
+                                        (Just current)
+                                        steps
+                    OpUpdate old v -> do
+                        eRead <-
+                            requireExistingTrieRead
+                                trie
+                                txIn
+                                key
+                                old
+                        case eRead of
+                            Left err -> pure (Left err)
+                            Right (current, steps) -> do
+                                _ <-
+                                    Cardano.MPFS.Trie.delete
+                                        trie
+                                        key
+                                _ <- insert trie key v
+                                pure
+                                    $ Right
+                                    $ mkRequestTrieRead
+                                        key
+                                        (Just current)
+                                        steps
 
 mkRequestTrieRead
     :: BS.ByteString -> Maybe BS.ByteString -> [ProofStep] -> RequestTrieRead
@@ -589,11 +670,104 @@ mkRequestTrieRead key value steps =
                 }
         }
 
-operationOldValue :: OnChainOperation -> BS.ByteString
-operationOldValue = \case
-    OpInsert v -> v
-    OpDelete v -> v
-    OpUpdate old _new -> old
+requireExistingTrieRead
+    :: Monad m
+    => Trie m
+    -> TxIn
+    -> BS.ByteString
+    -> BS.ByteString
+    -> m (Either UpdateBuildError (BS.ByteString, [ProofStep]))
+requireExistingTrieRead trie txIn key expected = do
+    mSteps <- getProofSteps trie key
+    mCurrent <- Cardano.MPFS.Trie.lookup trie key
+    pure $ do
+        steps <-
+            requireProofSteps
+                "processRequest.existing"
+                txIn
+                key
+                mSteps
+        current <- case mCurrent of
+            Nothing ->
+                Left
+                    $ updateBuildError
+                    $ "processRequest: no value in \
+                      \TrieRawValues for key "
+                        <> strictHex key
+                        <> " (input: "
+                        <> txInText txIn
+                        <> ")"
+            Just value -> Right value
+        if current == expected
+            then Right (current, steps)
+            else
+                Left
+                    $ updateBuildError
+                    $ "processRequest: request old value \
+                      \mismatch for key "
+                        <> strictHex key
+                        <> " (input: "
+                        <> txInText txIn
+                        <> ", request-old: "
+                        <> strictHex expected
+                        <> ", trie-current: "
+                        <> strictHex current
+                        <> ")"
+
+requireProofSteps
+    :: Text
+    -> TxIn
+    -> BS.ByteString
+    -> Maybe [ProofStep]
+    -> Either UpdateBuildError [ProofStep]
+requireProofSteps path txIn key =
+    maybe
+        ( Left
+            $ updateBuildError
+            $ path
+                <> ": no MPF inclusion proof for key "
+                <> strictHex key
+                <> " (input: "
+                <> txInText txIn
+                <> ")"
+        )
+        Right
+
+stateRootBytes
+    :: Text -> TxOut ConwayEra -> Either UpdateBuildError BS.ByteString
+stateRootBytes path out =
+    unOnChainRoot . stateRoot <$> stateDatum path out
+
+stateDatum
+    :: Text -> TxOut ConwayEra -> Either UpdateBuildError OnChainTokenState
+stateDatum path out =
+    case extractCageDatum out of
+        Just (StateDatum s) -> Right s
+        Just (RequestDatum _) ->
+            Left
+                $ updateBuildError
+                $ path
+                    <> ": expected state datum, found \
+                       \request datum"
+        Nothing ->
+            Left
+                $ updateBuildError
+                $ path
+                    <> ": missing or invalid state datum"
+
+throwUpdateBuildError :: UpdateBuildError -> IO a
+throwUpdateBuildError =
+    throwIO . UpdateBuildException
+
+updateBuildError :: Text -> UpdateBuildError
+updateBuildError = UpdateBuildError
+
+txInText :: TxIn -> Text
+txInText = T.pack . show
+
+strictHex :: BS.ByteString -> Text
+strictHex =
+    TE.decodeUtf8 . B16.encode
 
 renderProofSteps :: [ProofStep] -> BS.ByteString
 renderProofSteps steps =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
@@ -11,7 +11,7 @@ module Cardano.MPFS.HTTP.TokensSpec
     , mkDummyTokenState
     ) where
 
-import Control.Monad (forM_)
+import Control.Monad (forM_, when)
 import Data.Aeson (decode)
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
@@ -90,7 +90,9 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.Generators (genKeyHash, genTxIn)
 import Cardano.MPFS.HTTP.AtomicReadFixture
-    ( sampleStateOutBytes
+    ( cafeTid
+    , sampleRequestOutBytes
+    , sampleStateOutBytes
     , staleRoot
     , stateSetPrefix
     , testCageConfig
@@ -113,9 +115,7 @@ import Cardano.MPFS.Indexer.Reads
     , readMerkleRoot
     )
 import Cardano.MPFS.State qualified as St
-import Cardano.MPFS.TxBuilder (BundleSnapshot (..))
 import Test.QuickCheck (generate)
-import Unsafe.Coerce (unsafeCoerce)
 
 getTokens :: Context IO -> IO SResponse
 getTokens ctx =
@@ -150,23 +150,6 @@ withTokenSet
     -> Context IO
     -> (Context IO -> IO a)
     -> IO a
-withTokenSet [] proofBs ctx action =
-    action
-        ctx
-            { runIndexerTx =
-                \_ ->
-                    pure
-                        $ unsafeCoerce
-                            ( Just
-                                BundleSnapshot
-                                    { snapshotUtxoRoot = "root"
-                                    , snapshotSlot = SlotNo 42
-                                    , snapshotBlockId =
-                                        BlockId "block-id-bytes"
-                                    }
-                            , ([] :: [(TxIn, ByteString)], proofBs)
-                            )
-            }
 withTokenSet entries _proofBs ctx action =
     withTokenSetRoot Nothing entries ctx
         $ \_ ctxWithSet -> action ctxWithSet
@@ -209,6 +192,22 @@ withTokenSetRoot mOutOfTxRoot entries ctx action =
                         $ forM_ seededEntries
                         $ uncurry
                             (csmtInsert csmtOps)
+                    when (null seededEntries) $ do
+                        sentinel <- generate genTxIn
+                        let sentinelKey =
+                                serialize
+                                    (natVersion @11)
+                                    sentinel
+                        runTransaction
+                            $ mapColumns InUtxo
+                            $ csmtInsert
+                                csmtOps
+                                sentinelKey
+                                ( BSL.fromStrict
+                                    $ sampleRequestOutBytes
+                                        cafeTid
+                                        0
+                                )
                     runTransaction
                         $ Store.armageddonSetup
                             InRollbacks

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/UpdateFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/UpdateFactsSpec.hs
@@ -37,6 +37,7 @@ import Network.HTTP.Types
     , methodPost
     , status200
     , status400
+    , status500
     )
 import Network.Wai (Request (..))
 import Network.Wai.Test
@@ -53,6 +54,7 @@ import Test.Hspec
     , expectationFailure
     , it
     , shouldBe
+    , shouldContain
     , shouldSatisfy
     )
 import Test.QuickCheck (generate)
@@ -133,7 +135,8 @@ import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.Swagger (renderSwaggerJSON)
 import Cardano.MPFS.HTTP.Types.Facts (mkUpdateFacts)
 import Cardano.MPFS.Indexer.Reads
-    ( IndexerTx
+    ( IndexerReadError
+    , IndexerTx
     , readRequestUtxosAt
     , readTrieFact
     )
@@ -217,6 +220,63 @@ spec = do
                                     "/facts/update"
                                     body
                             simpleStatus resp `shouldBe` status200
+
+                it
+                    "returns a typed failure when trie proof data is missing"
+                    $ do
+                        nowMs <- currentPosixMs
+                        ctx0 <- mkTestContext
+                        reqIn <- generate genTxIn
+                        stateIn <- generate genTxIn
+                        walletIn <- generate genTxIn
+                        ownerKh <- generate genKeyHash
+                        let ownerAddr =
+                                Addr
+                                    Testnet
+                                    (KeyHashObj ownerKh)
+                                    StakeRefNull
+                            submittedAt = nowMs - 1_000
+                            entries =
+                                [ (stateIn, stateTxOutBytes ownerAddr)
+                                ,
+                                    ( reqIn
+                                    , requestTxOutBytesWithOp
+                                        ownerAddr
+                                        submittedAt
+                                        (OnChain.OpDelete "missing-value")
+                                    )
+                                , (walletIn, walletTxOutBytes ownerAddr)
+                                ]
+                        withProofIndexer Nothing entries ctx0
+                            $ \_txRoot ctxWithIndexer -> do
+                                _ <- insertFacts ctxWithIndexer cafeTid []
+                                let ctx =
+                                        ctxWithIndexer
+                                            { provider =
+                                                happyUpdateProvider
+                                                    (provider ctxWithIndexer)
+                                            }
+                                    body =
+                                        object
+                                            [ "token" .= cafeTokenJSON
+                                            , "address"
+                                                .= Hex
+                                                    ( serialiseAddr
+                                                        ownerAddr
+                                                    )
+                                            , "requests"
+                                                .= [txInRefText reqIn]
+                                            ]
+                                resp <-
+                                    postJsonValue
+                                        ctx
+                                        "/facts/update"
+                                        body
+                                simpleStatus resp `shouldBe` status500
+                                BL.unpack (simpleBody resp)
+                                    `shouldContain` "no MPF inclusion proof for key"
+                                BL.unpack (simpleBody resp)
+                                    `shouldContain` "7375627365742d6b6579"
 
                 it "documents facts route and drops legacy tx route"
                     $ case eitherDecode renderSwaggerJSON of
@@ -329,12 +389,17 @@ spec = do
     it "exports update-focused atomic read helpers" $ do
         let _readRequestUtxosAt
                 :: Addr
-                -> IndexerTx [ResolvedWalletInput]
+                -> IndexerTx
+                    ( Either
+                        IndexerReadError
+                        [ResolvedWalletInput]
+                    )
             _readRequestUtxosAt = readRequestUtxosAt
             _readTrieFact
                 :: TokenId
                 -> ByteString
-                -> IndexerTx Tx.TrieFact
+                -> IndexerTx
+                    (Either IndexerReadError Tx.TrieFact)
             _readTrieFact = readTrieFact
         _readRequestUtxosAt `seq`
             _readTrieFact `seq`
@@ -426,6 +491,17 @@ stateTxOutBytes ownerAddr =
 
 requestTxOutBytes :: Addr -> Integer -> ByteString
 requestTxOutBytes ownerAddr submittedAt =
+    requestTxOutBytesWithOp
+        ownerAddr
+        submittedAt
+        (OnChain.OpInsert "subset-value")
+
+requestTxOutBytesWithOp
+    :: Addr
+    -> Integer
+    -> OnChain.OnChainOperation
+    -> ByteString
+requestTxOutBytesWithOp ownerAddr submittedAt op =
     serialize'
         (natVersion @11)
         (txOut :: TxOut ConwayEra)
@@ -440,7 +516,7 @@ requestTxOutBytes ownerAddr submittedAt =
                         cafeTid
                         ownerAddr
                         "subset-key"
-                        (OnChain.OpInsert "subset-value")
+                        op
                         100_000
                         submittedAt
                     )

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/UpdateFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/UpdateFactsSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
@@ -13,19 +14,28 @@ import Data.Aeson
     , Value (..)
     , eitherDecode
     , encode
+    , object
+    , (.=)
     )
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KM
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Lazy.Char8 qualified as BL
 import Data.ByteString.Short qualified as SBS
 import Data.Foldable (traverse_)
 import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.Proxy (Proxy (..))
 import Data.Swagger qualified as Swagger
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Network.HTTP.Types
     ( hContentType
     , methodPost
+    , status200
     , status400
     )
 import Network.Wai (Request (..))
@@ -47,8 +57,40 @@ import Test.Hspec
     )
 import Test.QuickCheck (generate)
 
+import Cardano.Crypto.Hash.Class qualified as Crypto
+import Cardano.Ledger.Address
+    ( Addr (..)
+    , serialiseAddr
+    )
 import Cardano.Ledger.Api.PParams (emptyPParams)
-import Cardano.Ledger.Mary.Value (AssetName (..))
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , datumTxOutL
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , Network (..)
+    , TxIx (..)
+    )
+import Cardano.Ledger.Binary
+    ( natVersion
+    , serialize'
+    )
+import Cardano.Ledger.Credential
+    ( Credential (..)
+    , StakeReference (..)
+    )
+import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.Mary.Value
+    ( AssetName (..)
+    , MaryValue (..)
+    , MultiAsset (..)
+    )
+import Cardano.Ledger.TxIn
+    ( TxId (..)
+    , TxIn (..)
+    )
 import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types.Facts
     ( ChainPointJSON (..)
@@ -60,17 +102,32 @@ import Cardano.MPFS.API.Types.Facts
     , UtxoRef (..)
     , VerificationSnapshot (..)
     )
-import Cardano.MPFS.Context (Context)
+import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Core.OnChain
+    ( CageDatum (..)
+    , OnChainRoot (..)
+    , OnChainTokenState (..)
+    )
+import Cardano.MPFS.Core.OnChain qualified as OnChain
 import Cardano.MPFS.Core.Types
-    ( Addr
-    , BlockId (..)
+    ( BlockId (..)
+    , Coin (..)
     , ConwayEra
     , PParams
     , SlotNo (..)
     , TokenId (..)
-    , TxIn
     )
-import Cardano.MPFS.Generators (genTxIn)
+import Cardano.MPFS.Generators
+    ( genKeyHash
+    , genTxIn
+    )
+import Cardano.MPFS.HTTP.AtomicReadFixture
+    ( cafeTid
+    , cafeTokenJSON
+    , insertFacts
+    , testCageConfig
+    , withProofIndexer
+    )
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.Swagger (renderSwaggerJSON)
@@ -80,11 +137,26 @@ import Cardano.MPFS.Indexer.Reads
     , readRequestUtxosAt
     , readTrieFact
     )
+import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder
     ( BundleSnapshot (..)
     , ResolvedWalletInput
     )
 import Cardano.MPFS.TxBuilder qualified as Tx
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( addrKeyHashBytes
+    , cageAddrFromCfg
+    , cagePolicyIdFromCfg
+    , currentPosixMs
+    , mkInlineDatum
+    , mkRequestDatum
+    , requestAddrFromCfg
+    , toPlcData
+    )
+import Control.Lens ((&), (.~))
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    )
 
 spec :: Spec
 spec = do
@@ -95,6 +167,56 @@ spec = do
                     ctx <- mkTestContext
                     resp <- postJson ctx "/facts/update" badUpdateRequest
                     simpleStatus resp `shouldBe` status400
+
+                it "returns update facts for an exact request subset" $ do
+                    nowMs <- currentPosixMs
+                    ctx0 <- mkTestContext
+                    reqIn <- generate genTxIn
+                    stateIn <- generate genTxIn
+                    walletIn <- generate genTxIn
+                    ownerKh <- generate genKeyHash
+                    let ownerAddr =
+                            Addr
+                                Testnet
+                                (KeyHashObj ownerKh)
+                                StakeRefNull
+                        submittedAt = nowMs - 1_000
+                        entries =
+                            [ (stateIn, stateTxOutBytes ownerAddr)
+                            ,
+                                ( reqIn
+                                , requestTxOutBytes
+                                    ownerAddr
+                                    submittedAt
+                                )
+                            , (walletIn, walletTxOutBytes ownerAddr)
+                            ]
+                    withProofIndexer Nothing entries ctx0
+                        $ \_txRoot ctxWithIndexer -> do
+                            _ <- insertFacts ctxWithIndexer cafeTid []
+                            let ctx =
+                                    ctxWithIndexer
+                                        { provider =
+                                            happyUpdateProvider
+                                                (provider ctxWithIndexer)
+                                        }
+                                body =
+                                    object
+                                        [ "token" .= cafeTokenJSON
+                                        , "address"
+                                            .= Hex
+                                                ( serialiseAddr
+                                                    ownerAddr
+                                                )
+                                        , "requests"
+                                            .= [txInRefText reqIn]
+                                        ]
+                            resp <-
+                                postJsonValue
+                                    ctx
+                                    "/facts/update"
+                                    body
+                            simpleStatus resp `shouldBe` status200
 
                 it "documents facts route and drops legacy tx route"
                     $ case eitherDecode renderSwaggerJSON of
@@ -260,6 +382,101 @@ postJson ctx path body =
                 }
         )
         (mkApp ctx)
+
+postJsonValue
+    :: Context IO
+    -> ByteString
+    -> Value
+    -> IO SResponse
+postJsonValue ctx path body =
+    postJson ctx path (BL.unpack (encode body))
+
+stateTxOutBytes :: Addr -> ByteString
+stateTxOutBytes ownerAddr =
+    serialize'
+        (natVersion @11)
+        (txOut :: TxOut ConwayEra)
+  where
+    tokenMA =
+        MultiAsset
+            $ Map.singleton
+                (cagePolicyIdFromCfg testCageConfig)
+            $ Map.singleton
+                (unTokenId cafeTid)
+                1
+    val = MaryValue (Coin 2_000_000) tokenMA
+    datum =
+        StateDatum
+            OnChainTokenState
+                { stateOwner =
+                    BuiltinByteString
+                        (addrKeyHashBytes ownerAddr)
+                , stateRoot =
+                    OnChainRoot
+                        (BS.replicate 32 0)
+                , stateMaxFee = 1_000_000
+                , stateProcessTime = 300_000
+                , stateRetractTime = 60_000
+                }
+    txOut =
+        mkBasicTxOut
+            (cageAddrFromCfg testCageConfig Testnet)
+            val
+            & datumTxOutL .~ mkInlineDatum (toPlcData datum)
+
+requestTxOutBytes :: Addr -> Integer -> ByteString
+requestTxOutBytes ownerAddr submittedAt =
+    serialize'
+        (natVersion @11)
+        (txOut :: TxOut ConwayEra)
+  where
+    txOut =
+        mkBasicTxOut
+            (requestAddrFromCfg testCageConfig cafeTid Testnet)
+            (inject (Coin 2_000_000))
+            & datumTxOutL
+                .~ mkInlineDatum
+                    ( mkRequestDatum
+                        cafeTid
+                        ownerAddr
+                        "subset-key"
+                        (OnChain.OpInsert "subset-value")
+                        100_000
+                        submittedAt
+                    )
+
+walletTxOutBytes :: Addr -> ByteString
+walletTxOutBytes ownerAddr =
+    serialize'
+        (natVersion @11)
+        (txOut :: TxOut ConwayEra)
+  where
+    txOut =
+        mkBasicTxOut
+            ownerAddr
+            (inject (Coin 5_000_000))
+
+happyUpdateProvider :: Provider IO -> Provider IO
+happyUpdateProvider prov =
+    prov
+        { queryProtocolParams = pure emptyPParams
+        , posixMsToSlot =
+            \ms ->
+                pure
+                    $ SlotNo
+                    $ fromInteger
+                    $ ms `div` 1000
+        }
+
+txInRefText :: TxIn -> Text
+txInRefText (TxIn (TxId sh) (TxIx ix)) =
+    TE.decodeUtf8
+        ( B16.encode
+            $ Crypto.hashToBytes
+            $ extractHash sh
+        )
+        <> "#"
+        <> T.pack (show ix)
 
 sampleUpdateFacts :: UpdateFacts
 sampleUpdateFacts =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ReadsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ReadsSpec.hs
@@ -20,6 +20,7 @@ import Data.IORef
     , writeIORef
     )
 import Data.List (nub, sort)
+import Data.Text qualified as T
 
 import Test.Hspec
     ( Spec
@@ -81,26 +82,57 @@ import Cardano.Ledger.Credential
     , StakeReference (..)
     )
 import Cardano.Ledger.Val (inject)
+import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
+    ( Columns (..)
+    )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
+    , CSMTOps (..)
+    , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Run.Config
     ( context
     , hashAddressKey
     )
+import Cardano.UTxOCSMT.Ouroboros.Types (Point)
 
+import Database.KV.Database (mkColumns)
+import Database.KV.RocksDB (mkRocksDBDatabase)
 import Database.KV.Transaction
-    ( Transaction
+    ( RunTransaction (..)
+    , Transaction
+    , mapColumns
+    , newRunTransaction
     , query
     , runTransactionUnguarded
     )
+import Database.KV.Transaction qualified as KV
+import Database.RocksDB
+    ( BatchOp
+    , ColumnFamily
+    , DB (..)
+    , withDBCF
+    )
+import System.IO.Temp (withSystemTempDirectory)
 
+import Cardano.MPFS.Application
+    ( allColumnFamilies
+    , dbConfig
+    , unifiedCodecs
+    )
 import Cardano.MPFS.Core.Types
     ( ConwayEra
     , TxIn
     )
 import Cardano.MPFS.Generators (genTxIn)
-import Cardano.MPFS.Indexer.Reads (addressScopedLeafKey)
+import Cardano.MPFS.Indexer.Columns (UnifiedColumns (..))
+import Cardano.MPFS.Indexer.Reads
+    ( IndexerReadError (..)
+    , IndexerTx (..)
+    , addressScopedLeafKey
+    , readUtxoSetAt
+    , readWalletInputsAt
+    )
 import Cardano.MPFS.Indexer.TxFixtures
     ( testCageAddr
     , wrongScriptHash
@@ -530,6 +562,63 @@ spec = describe "address-prefixed UTxO leaves" $ do
             walletAfterReplay `shouldBe` Right []
             otherAfterReplay `shouldBe` Right [key]
 
+    it
+        "wallet input reads skip stale address leaves without KV bytes"
+        $ do
+            generated <- generate $ vectorOf 4 genTxIn
+            case take 2 (nub generated) of
+                [staleIn, liveIn] ->
+                    withUnifiedUtxoDB $ \runTransaction -> do
+                        let CSMTContext{fromKV, hashing} = context
+                            csmtOps = mkCSMTOps fromKV hashing
+                            staleKey = encodeTxIn staleIn
+                            liveKey = encodeTxIn liveIn
+                            out = encodeTxOutAt testCageAddr
+                        runTransaction
+                            $ mapColumns InUtxo
+                            $ do
+                                csmtInsert csmtOps staleKey out
+                                csmtInsert csmtOps liveKey out
+                                KV.delete KVCol staleKey
+                        eRows <-
+                            runTransaction
+                                $ unIndexerTx
+                                $ readWalletInputsAt testCageAddr
+                        fmap
+                            ( \rows ->
+                                [txIn | (txIn, _, _) <- rows]
+                            )
+                            eRows
+                            `shouldBe` Right [liveIn]
+                _ ->
+                    expectationFailure
+                        "genTxIn did not produce two unique TxIns"
+
+    it
+        "UTxO set reads report stale address leaves as typed failures"
+        $ do
+            txIn <- generate genTxIn
+            withUnifiedUtxoDB $ \runTransaction -> do
+                let CSMTContext{fromKV, hashing} = context
+                    csmtOps = mkCSMTOps fromKV hashing
+                    key = encodeTxIn txIn
+                    out = encodeTxOutAt testCageAddr
+                runTransaction
+                    $ mapColumns InUtxo
+                    $ do
+                        csmtInsert csmtOps key out
+                        KV.delete KVCol key
+                result <-
+                    runTransaction
+                        $ unIndexerTx
+                        $ readUtxoSetAt testCageAddr
+                case result of
+                    Left (IndexerReadError msg) ->
+                        T.unpack msg `shouldContain` show txIn
+                    Right _ ->
+                        expectationFailure
+                            "Expected typed stale-leaf failure"
+
 encodeTxIn :: TxIn -> BSL.ByteString
 encodeTxIn =
     serialize (natVersion @11)
@@ -634,6 +723,32 @@ withStrictPureDb action = do
             writeIORef ref db'
             pure result
     action rtx
+
+withUnifiedUtxoDB
+    :: ( ( forall a
+            . Transaction
+                IO
+                ColumnFamily
+                (UnifiedColumns Point Hash BSL.ByteString BSL.ByteString)
+                BatchOp
+                a
+           -> IO a
+         )
+         -> IO r
+       )
+    -> IO r
+withUnifiedUtxoDB action =
+    withSystemTempDirectory "indexer-reads-test"
+        $ \dir ->
+            withDBCF dir dbConfig allColumnFamilies
+                $ \db@DB{columnFamilies} -> do
+                    let database =
+                            mkRocksDBDatabase
+                                db
+                                (mkColumns columnFamilies unifiedCodecs)
+                    RunTransaction{runTransaction} <-
+                        newRunTransaction database
+                    action runTransaction
 
 strictAddressFromKV
     :: FromKV BS.ByteString BS.ByteString Hash


### PR DESCRIPTION
## Summary
- share Warp settings for `mpfs-server` and `mpfs-devnet-server` so uncaught request exceptions log the thrown exception plus request method/path
- keep the current typed-success subset-update behavior and add an exact request-subset `POST /facts/update` regression
- confirm the live owner selected-subset update no longer hits an uncaught 500 in the current tree

## Repro
- Requested `nix run .#mpfs-devnet-server -- --port 3001` reached startup but failed to bind because local cardano-node listeners already occupied ports 3001 and 3002.
- Retried on port 3003, booted a token, submitted one insert request, and ran owner subset processing with `mpfs-cli token process --request-id ...`.
- Result: subset update succeeded with no `/facts/update` 500 and no `setOnException` request log.
- Token: `c1f1c9b09607e0f63d1580f3e9d3eb88b7d8a208f5a3d4be01b8fd009eebb632`
- Request: `5454563694263bd898eb2669ed8524a1b95aa0c270b7a3e519cd4c4fa20805ef#0`
- Artifacts: `/tmp/orch-324/live-subset-20260610T082956Z`

## Verification
- `./gate.sh` green locally: focused exact-subset regression, `just ci`, `format-check`, `hlint`
- Focused post-format Cabal run: `cardano-mpfs-offchain:unit-tests --match "returns update facts for an exact request subset"` passed, 1 example, 0 failures

Refs #324
