### PR TITLE
fix(tx-builder): replace scoped panics with typed failures

### DIFF
--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -74,7 +74,7 @@ import Control.Concurrent.STM
     , modifyTVar'
     , newTVarIO
     )
-import Control.Exception (finally, throwIO)
+import Control.Exception (Exception (..), finally, throwIO)
 import Control.Monad (when)
 import Control.Tracer (Tracer (..), contramap, traceWith)
 import Data.ByteString.Lazy qualified as BSL
@@ -259,6 +259,20 @@ data AppConfig = AppConfig
     , appTracer :: Tracer IO AppTrace
     -- ^ Application event tracer
     }
+
+-- | Typed startup/runtime failure for application
+-- invariants that must stop service startup.
+data ApplicationFailure
+    = UnexpectedFullCSMTOps
+    | MissingColumnFamilies !Int
+    deriving stock (Eq, Show)
+
+instance Exception ApplicationFailure where
+    displayException UnexpectedFullCSMTOps =
+        "openCSMTOps returned ChooseFull, expected ChooseKVOnly"
+    displayException (MissingColumnFamilies actual) =
+        "Expected at least 14 column families, found "
+            <> show actual
 
 -- | Default RocksDB configuration.
 dbConfig :: Config
@@ -453,7 +467,7 @@ withApplication cfg action = do
                         resolveDb (Ready (ChooseKVOnly ops)) =
                             pure ops
                         resolveDb (Ready (ChooseFull _)) =
-                            error "openCSMTOps: unexpected ChooseFull"
+                            throwIO UnexpectedFullCSMTOps
                     kvOnlyOps <- resolveDb dbState
 
                     -- Initialize chain-follower Backend
@@ -701,9 +715,9 @@ withApplication cfg action = do
                             mapM_ cancel mChainThread
                             cancel nodeThread
                 _ ->
-                    error
-                        "Expected at least 14 \
-                        \column families"
+                    throwIO
+                        $ MissingColumnFamilies
+                        $ length (columnFamilies db)
 
 -- | Seed a fresh database with genesis UTxOs from
 -- Shelley (and optionally Byron) genesis files.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
 
 -- |
 -- Module      : Cardano.MPFS.Indexer.Event
@@ -18,15 +19,19 @@
 module Cardano.MPFS.Indexer.Event
     ( -- * Event type
       CageEvent (..)
+    , CageEventFailure (..)
+    , CageEventDetectionFailure (..)
 
       -- * Inverse operations (for rollback)
     , CageInverseOp (..)
 
       -- * Detection
     , detectCageEvents
+    , detectCageEventsDetailed
     , inversesOf
     ) where
 
+import Control.Exception (Exception (..), throw)
 import Data.ByteString (ByteString)
 import Data.ByteString.Short qualified as SBS
 import Data.Foldable (toList)
@@ -160,6 +165,25 @@ data CageInverseOp
       InvTrieDelete !TokenId !ByteString
     deriving stock (Eq, Show)
 
+-- | Typed detection failure for malformed cage data
+-- in a transaction being inspected.
+data CageEventFailure
+    = MissingSpendingInput !TxIn
+    | InvalidPaymentKeyHash !ByteString
+    deriving stock (Eq, Show)
+
+-- | Exception used by the legacy pure detection API
+-- to fail loudly without a bare panic.
+newtype CageEventDetectionFailure
+    = CageEventDetectionFailure [CageEventFailure]
+    deriving stock (Eq, Show)
+
+instance Exception CageEventDetectionFailure where
+    displayException
+        (CageEventDetectionFailure failures) =
+            "Cage event detection failed: "
+                <> show failures
+
 -- | Detect cage events from a transaction.
 --
 -- Inspects mints (boot\/burn), outputs (request),
@@ -172,21 +196,55 @@ detectCageEvents
     -> ConwayTx
     -> [CageEvent]
 detectCageEvents scriptHash resolvedInputs tx =
-    mintEvents ++ requestEvents ++ spendEvents
+    case failures of
+        [] -> events
+        _ ->
+            throw
+                $ CageEventDetectionFailure
+                    failures
+  where
+    (failures, events) =
+        detectCageEventsDetailed
+            scriptHash
+            resolvedInputs
+            tx
+
+-- | Detect cage events and return typed failures
+-- instead of throwing them.
+detectCageEventsDetailed
+    :: ScriptHash
+    -- ^ Cage script hash
+    -> [(TxIn, TxOut ConwayEra)]
+    -- ^ Resolved inputs (UTxOs being spent)
+    -> ConwayTx
+    -> ([CageEventFailure], [CageEvent])
+detectCageEventsDetailed scriptHash resolvedInputs tx =
+    collectDetections
+        $ mintDetections
+            ++ requestDetections
+            ++ spendDetections
   where
     body = tx ^. bodyTxL
     policyId = PolicyID scriptHash
+
+    collectDetections =
+        foldr collect ([], [])
+      where
+        collect (Left failure) (failures, events) =
+            (failure : failures, events)
+        collect (Right events') (failures, events) =
+            (failures, events' ++ events)
 
     -- --------------------------------------------------
     -- Mint / Burn detection
     -- --------------------------------------------------
 
-    mintEvents =
+    mintDetections =
         let MultiAsset ma = body ^. mintTxBodyL
         in  case Map.lookup policyId ma of
                 Nothing -> []
                 Just assets ->
-                    concatMap
+                    map
                         (uncurry detectMint)
                         (Map.toList assets)
 
@@ -206,12 +264,14 @@ detectCageEvents scriptHash resolvedInputs tx =
                         thisTxId
                         outputs
             in  case mState of
-                    Just (txIn, ts) ->
-                        [CageBoot tid txIn ts]
-                    Nothing -> []
+                    Just (Right (txIn, ts)) ->
+                        Right [CageBoot tid txIn ts]
+                    Just (Left failure) ->
+                        Left failure
+                    Nothing -> Right []
         | qty == -1 =
-            [CageBurn (TokenId assetName)]
-        | otherwise = []
+            Right [CageBurn (TokenId assetName)]
+        | otherwise = Right []
 
     findStateDatum thisTxId =
         foldr
@@ -221,11 +281,11 @@ detectCageEvents scriptHash resolvedInputs tx =
                     case extractDatum txOut of
                         Just (StateDatum ocs) ->
                             Just
-                                ( TxIn
-                                    thisTxId
-                                    (TxIx ix)
-                                , fromOnChainState ocs
-                                )
+                                $ fmap
+                                    (TxIn
+                                        thisTxId
+                                        (TxIx ix),)
+                                    (fromOnChainState ocs)
                         _ -> Nothing
             )
             Nothing
@@ -234,14 +294,15 @@ detectCageEvents scriptHash resolvedInputs tx =
     -- Request detection (new outputs at cage addr)
     -- --------------------------------------------------
 
-    requestEvents =
+    requestDetections =
         let outputs =
                 toList
                     (body ^. outputsTxBodyL)
             thisTxId = txIdTx tx
-        in  concatMap
-                (uncurry (detectRequest thisTxId))
-                (zip [0 ..] outputs)
+        in  zipWith
+                (detectRequest thisTxId)
+                [0 ..]
+                outputs
 
     detectRequest txId (ix :: Word16) txOut =
         -- PR #50: request UTxOs land at the per-cage
@@ -263,23 +324,26 @@ detectCageEvents scriptHash resolvedInputs tx =
                                 TxIn
                                     txId
                                     (TxIx ix)
-                            req =
-                                fromOnChainReq
-                                    addr
-                                    ocReq
-                        in  [CageRequest txIn req]
-                    _ -> []
-            _ -> []
+                        in  case fromOnChainReq
+                                addr
+                                ocReq of
+                                Right req ->
+                                    Right
+                                        [CageRequest txIn req]
+                                Left failure ->
+                                    Left failure
+                    _ -> Right []
+            _ -> Right []
 
     -- --------------------------------------------------
     -- Spend detection (Update / Retract)
     -- --------------------------------------------------
 
-    spendEvents =
+    spendDetections =
         let allInputs = body ^. inputsTxBodyL
             Redeemers rdmrs =
                 tx ^. witsTxL . rdmrsTxWitsL
-        in  concatMap
+        in  map
                 (detectSpend allInputs rdmrs)
                 resolvedInputs
 
@@ -294,20 +358,20 @@ detectCageEvents scriptHash resolvedInputs tx =
         -- already discriminates by redeemer.
         case txOut ^. addrTxOutL of
             Addr _ (ScriptHashObj _) _ ->
-                let ix =
-                        spendingIndex
-                            txIn
-                            allInputs
-                    purpose =
-                        ConwaySpending (AsIx ix)
-                in  case Map.lookup purpose rdmrs of
-                        Just (redeemerData, _) ->
-                            decodeSpend
-                                txIn
-                                txOut
-                                redeemerData
-                        Nothing -> []
-            _ -> []
+                case spendingIndex txIn allInputs of
+                    Left failure ->
+                        Left failure
+                    Right ix ->
+                        let purpose =
+                                ConwaySpending (AsIx ix)
+                        in  case Map.lookup purpose rdmrs of
+                                Just (redeemerData, _) ->
+                                    decodeSpend
+                                        txIn
+                                        txOut
+                                        redeemerData
+                                Nothing -> Right []
+            _ -> Right []
 
     decodeSpend txIn txOut redeemerData =
         let Data plcData = redeemerData
@@ -326,7 +390,7 @@ detectCageEvents scriptHash resolvedInputs tx =
                         detectUpdate txIn txOut
                 Just (Retract _ref) ->
                     detectRetract txIn
-                _ -> []
+                _ -> Right []
 
     detectUpdate _stateTxIn _stateTxOut =
         -- Find the continuing output (new state)
@@ -344,13 +408,14 @@ detectCageEvents scriptHash resolvedInputs tx =
                     let consumed =
                             findConsumedRequests
                                 tid
-                    in  [ CageUpdate
-                            tid
-                            newTxIn
-                            newRoot
-                            consumed
-                        ]
-                Nothing -> []
+                    in  Right
+                            [ CageUpdate
+                                tid
+                                newTxIn
+                                newRoot
+                                consumed
+                            ]
+                Nothing -> Right []
 
     findStateDatumWithToken thisTxId =
         foldr
@@ -427,14 +492,15 @@ detectCageEvents scriptHash resolvedInputs tx =
                     let consumed =
                             findConsumedRequests
                                 tid
-                    in  [ CageReject
-                            tid
-                            newTxIn
-                            consumed
-                        ]
-                Nothing -> []
+                    in  Right
+                            [ CageReject
+                                tid
+                                newTxIn
+                                consumed
+                            ]
+                Nothing -> Right []
 
-    detectRetract txIn = [CageRetract txIn]
+    detectRetract txIn = Right [CageRetract txIn]
 
 -- | Compute inverse operations for a cage event,
 -- given the cage state before the event.
@@ -506,32 +572,40 @@ inversesOf lookupToken lookupReq = \case
 
 -- | Convert on-chain 'OnChainTokenState' to off-chain
 -- 'TokenState'.
-fromOnChainState :: OnChainTokenState -> TokenState
-fromOnChainState OnChainTokenState{..} =
-    TokenState
-        { owner = keyHashFromBBS stateOwner
-        , root = Root (unOnChainRoot stateRoot)
-        , tip = Coin stateMaxFee
-        , processTime = stateProcessTime
-        , retractTime = stateRetractTime
-        }
+fromOnChainState
+    :: OnChainTokenState
+    -> Either CageEventFailure TokenState
+fromOnChainState OnChainTokenState{..} = do
+    owner <- keyHashFromBBS stateOwner
+    pure
+        TokenState
+            { owner = owner
+            , root = Root (unOnChainRoot stateRoot)
+            , tip = Coin stateMaxFee
+            , processTime = stateProcessTime
+            , retractTime = stateRetractTime
+            }
 
 -- | Convert on-chain 'OnChainRequest' to off-chain
 -- 'Request'. The address is accepted for future use
 -- but currently unused.
-fromOnChainReq :: Addr -> OnChainRequest -> Request
-fromOnChainReq _addr OnChainRequest{..} =
-    Request
-        { requestToken =
-            tokenIdFromOnChain requestToken
-        , requestOwner =
-            keyHashFromBBS requestOwner
-        , requestKey = requestKey
-        , requestValue =
-            fromOnChainOp requestValue
-        , requestFee = Coin requestFee
-        , requestSubmittedAt = requestSubmittedAt
-        }
+fromOnChainReq
+    :: Addr
+    -> OnChainRequest
+    -> Either CageEventFailure Request
+fromOnChainReq _addr OnChainRequest{..} = do
+    owner <- keyHashFromBBS requestOwner
+    pure
+        Request
+            { requestToken =
+                tokenIdFromOnChain requestToken
+            , requestOwner = owner
+            , requestKey = requestKey
+            , requestValue =
+                fromOnChainOp requestValue
+            , requestFee = Coin requestFee
+            , requestSubmittedAt = requestSubmittedAt
+            }
 
 -- | Convert on-chain 'OnChainOperation' to off-chain
 -- 'Operation'.
@@ -566,22 +640,23 @@ extractDatum txOut =
 spendingIndex
     :: TxIn
     -> Set.Set TxIn
-    -> Word32
+    -> Either CageEventFailure Word32
 spendingIndex needle inputs =
     go 0 (Set.toAscList inputs)
   where
     go _ [] =
-        error "spendingIndex: TxIn not in input set"
+        Left $ MissingSpendingInput needle
     go n (x : xs)
-        | x == needle = n
+        | x == needle = Right n
         | otherwise = go (n + 1) xs
 
 -- | Convert a 'BuiltinByteString' containing a
 -- payment key hash to a 'KeyHash'.
 keyHashFromBBS
-    :: BuiltinByteString -> KeyHash Payment
+    :: BuiltinByteString
+    -> Either CageEventFailure (KeyHash Payment)
 keyHashFromBBS (BuiltinByteString bs) =
     case hashFromBytes bs of
-        Just h -> KeyHash h
+        Just h -> Right (KeyHash h)
         Nothing ->
-            error "keyHashFromBBS: invalid hash"
+            Left $ InvalidPaymentKeyHash bs

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE EmptyCase #-}
+
 -- |
 -- Module      : Cardano.MPFS.TxBuilder.Real.End
 -- Description : End token (burn) transaction
@@ -53,6 +55,9 @@ import Cardano.Ledger.Api.Tx.Out (coinTxOutL)
 
 data NoCtx a
 
+interpretNoCtx :: NoCtx a -> IO a
+interpretNoCtx q = case q of {}
+
 -- | Build an end-token (burn) transaction.
 --
 -- Consumes the state UTxO with an @End@ spending
@@ -84,19 +89,21 @@ endTokenImpl cfg prov proofFn snap tid addr = do
     stateUtxo <-
         case findStateUtxo policyId tid cageUtxos of
             Nothing ->
-                error
+                throwTxBuilderFailure
                     "endToken: state UTxO not found"
             Just x -> pure x
     let (stateIn, stateOut) = stateUtxo
     -- 3. Extract owner from state datum
+    stateDatum <-
+        case extractCageDatum stateOut of
+            Just (StateDatum s) -> pure s
+            _ ->
+                throwTxBuilderFailure
+                    "endToken: invalid state datum"
     let OnChainTokenState
             { stateOwner =
                 BuiltinByteString ownerBs
-            } = case extractCageDatum stateOut of
-                Just (StateDatum s) -> s
-                _ ->
-                    error
-                        "endToken: invalid state datum"
+            } = stateDatum
         ownerKh = addrWitnessKeyHash ownerBs
     -- 4. Get wallet UTxO for fees
     pp <- queryProtocolParams prov
@@ -104,7 +111,9 @@ endTokenImpl cfg prov proofFn snap tid addr = do
     feeUtxo <- case sortOn
         (Down . (^. coinTxOutL) . snd)
         walletUtxos of
-        [] -> error "endToken: no UTxOs"
+        [] ->
+            throwTxBuilderFailure
+                "endToken: no UTxOs"
         (u : _) -> pure u
     let assetName = unTokenId tid
         script = mkCageScript cfg
@@ -133,7 +142,7 @@ endTokenImpl cfg prov proofFn snap tid addr = do
     result <-
         Tx.build
             (Tx.mkPParamsBound pp)
-            (Tx.InterpretIO (const (pure undefined)))
+            (Tx.InterpretIO interpretNoCtx)
             evalTx
             [feeUtxo, stateUtxo]
             []
@@ -143,7 +152,7 @@ endTokenImpl cfg prov proofFn snap tid addr = do
         case result of
             Right tx -> pure tx
             Left err ->
-                error
+                throwTxBuilderFailure
                     $ "endToken: TxBuild failed: "
                         <> show err
     stateWitness <- witness proofFn stateUtxo

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
@@ -13,8 +13,13 @@
 -- UTxO lookup, spending-index computation,
 -- execution-unit defaults, and POSIX-to-slot conversion.
 module Cardano.MPFS.TxBuilder.Real.Internal
-    ( -- * Script construction
-      mkCageScript
+    ( -- * Failures
+      TxBuilderFailure (..)
+    , raiseTxBuilderFailure
+    , throwTxBuilderFailure
+
+      -- * Script construction
+    , mkCageScript
     , computeScriptHash
 
       -- * Derived identity
@@ -192,7 +197,13 @@ import Cardano.MPFS.Core.Types
     , PParams
     , TokenId (..)
     )
-import Control.Exception (SomeException, try)
+import Control.Exception
+    ( Exception (..)
+    , SomeException
+    , throw
+    , throwIO
+    , try
+    )
 import Data.Time.Clock.POSIX (getPOSIXTime)
 
 import Cardano.MPFS.Provider (Provider (..))
@@ -208,6 +219,24 @@ import Cardano.Tx.Balance
     ( BalanceResult (..)
     , balanceTx
     )
+
+-- | Typed failure for real transaction construction.
+newtype TxBuilderFailure = TxBuilderFailure String
+    deriving stock (Eq, Show)
+
+instance Exception TxBuilderFailure where
+    displayException (TxBuilderFailure msg) = msg
+
+-- | Raise a typed failure from pure helpers whose
+-- public signatures must remain stable.
+raiseTxBuilderFailure :: String -> a
+raiseTxBuilderFailure =
+    throw . TxBuilderFailure
+
+-- | Raise a typed failure in 'IO'.
+throwTxBuilderFailure :: String -> IO a
+throwTxBuilderFailure =
+    throwIO . TxBuilderFailure
 
 -- | Empty MPF root (32 zero bytes).
 emptyRoot :: ByteString
@@ -267,7 +296,7 @@ evaluateAndBalance prov pp inputUtxos changeAddr tx =
         if null failures
             then pure ()
             else
-                error
+                throwTxBuilderFailure
                     $ "evaluateAndBalance: \
                       \script eval failed: "
                         <> show failures
@@ -306,7 +335,7 @@ evaluateAndBalance prov pp inputUtxos changeAddr tx =
             changeAddr
             patched' of
             Left err ->
-                error
+                throwTxBuilderFailure
                     $ "evaluateAndBalance: "
                         <> show err
             Right br -> pure (balancedTx br)
@@ -324,7 +353,7 @@ mkCageScript cfg =
     in  case mkPlutusScript plutus of
             Just ps -> fromPlutusScript ps
             Nothing ->
-                error
+                raiseTxBuilderFailure
                     "mkCageScript: invalid \
                     \PlutusV3 script"
 
@@ -344,7 +373,7 @@ computeScriptHash sbs =
                 hashScript @ConwayEra
                     $ fromPlutusScript ps
             Nothing ->
-                error
+                raiseTxBuilderFailure
                     "computeScriptHash: invalid \
                     \PlutusV3 script"
 
@@ -378,7 +407,7 @@ mkRequestScript cfg tid =
     in  case mkPlutusScript plutus of
             Just ps -> fromPlutusScript ps
             Nothing ->
-                error
+                raiseTxBuilderFailure
                     "mkRequestScript: invalid \
                     \PlutusV3 script"
 
@@ -509,7 +538,7 @@ addrFromKeyHashBytes net bs =
                 (KeyHashObj (KeyHash h))
                 StakeRefNull
         Nothing ->
-            error
+            raiseTxBuilderFailure
                 "addrFromKeyHashBytes: \
                 \invalid hash"
 
@@ -522,7 +551,7 @@ addrWitnessKeyHash bs =
         Just h ->
             coerce (KeyHash h :: KeyHash Payment)
         Nothing ->
-            error
+            raiseTxBuilderFailure
                 "addrWitnessKeyHash: \
                 \invalid hash"
 
@@ -611,7 +640,8 @@ spendingIndex needle inputs =
     in  go 0 sorted
   where
     go _ [] =
-        error "spendingIndex: TxIn not in set"
+        raiseTxBuilderFailure
+            "spendingIndex: TxIn not in set"
     go n (x : xs)
         | x == needle = n
         | otherwise = go (n + 1) xs
@@ -651,7 +681,7 @@ currentPosixMs = do
 trySlots
     :: Provider IO -> [Integer] -> IO SlotNo
 trySlots _ [] =
-    error
+    throwTxBuilderFailure
         "posixMsToSlot: all fallbacks \
         \past horizon"
 trySlots p (ms : rest) = do
@@ -676,7 +706,7 @@ extractOwnerBytes out =
                     } = req
             in  bs
         _ ->
-            error
+            raiseTxBuilderFailure
                 "extractOwnerBytes: \
                 \not a request"
 

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Reject.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 
@@ -98,6 +99,9 @@ import Cardano.Tx.Build qualified as Tx
 -- | Empty query GADT (no context needed).
 data NoCtx a
 
+interpretNoCtx :: NoCtx a -> IO a
+interpretNoCtx q = case q of {}
+
 -- | Build a reject transaction for Phase 3
 -- requests.
 --
@@ -121,13 +125,13 @@ rejectRequestsImpl cfg prov _st proofFn snap tid addr = do
         queryRejectContext cfg prov tid addr
     let (stateIn, stateOut) = stateUtxo
     -- 2. Extract state, build unchanged datum
-    let ( oldState
-            , newStateOut
-            , stateScript
-            , requestScript
-            , ownerKh
-            ) =
-                prepareRejectState cfg tid stateOut
+    ( oldState
+        , newStateOut
+        , stateScript
+        , requestScript
+        , ownerKh
+        ) <-
+        prepareRejectState cfg tid stateOut
     -- 3. Compute validity lower slot
     lowerSlot <-
         computeLowerSlot prov oldState reqUtxos
@@ -149,7 +153,7 @@ rejectRequestsImpl cfg prov _st proofFn snap tid addr = do
     result <-
         Tx.build
             (Tx.mkPParamsBound pp)
-            (Tx.InterpretIO (const (pure undefined)))
+            (Tx.InterpretIO interpretNoCtx)
             evalTx
             (feeUtxo : stateUtxo : reqUtxos)
             []
@@ -175,7 +179,7 @@ rejectRequestsImpl cfg prov _st proofFn snap tid addr = do
                             }
                     }
         Left err ->
-            error
+            throwTxBuilderFailure
                 $ "rejectRequests: build failed: "
                     <> show err
 
@@ -208,22 +212,22 @@ queryRejectContext cfg prov tid addr = do
         tid
         stateUtxos of
         Nothing ->
-            error
+            throwTxBuilderFailure
                 "rejectRequests: state UTxO \
                 \not found"
         Just x -> pure x
     let (_, stateOut) = stateUtxo
     now <- currentPosixMs
+    oldState <-
+        case extractCageDatum stateOut of
+            Just (StateDatum s) -> pure s
+            _ ->
+                throwTxBuilderFailure
+                    "rejectRequests: invalid \
+                    \state datum"
     let allReqs =
             sortOn fst
                 $ findRequestUtxos tid requestUtxos
-        oldState =
-            case extractCageDatum stateOut of
-                Just (StateDatum s) -> s
-                _ ->
-                    error
-                        "rejectRequests: invalid \
-                        \state datum"
         pt = stateProcessTime oldState
         rt = stateRetractTime oldState
         isRejectable (_, rOut) =
@@ -235,7 +239,7 @@ queryRejectContext cfg prov tid addr = do
                 _ -> False
         reqUtxos = filter isRejectable allReqs
     when (null reqUtxos)
-        $ error
+        $ throwTxBuilderFailure
             "rejectRequests: no rejectable \
             \requests"
     pp <- queryProtocolParams prov
@@ -243,7 +247,9 @@ queryRejectContext cfg prov tid addr = do
     feeUtxo <- case sortOn
         (Down . (^. coinTxOutL) . snd)
         walletUtxos of
-        [] -> error "rejectRequests: no UTxOs"
+        [] ->
+            throwTxBuilderFailure
+                "rejectRequests: no UTxOs"
         (u : _) -> pure u
     pure (stateUtxo, reqUtxos, feeUtxo, pp)
 
@@ -253,45 +259,46 @@ prepareRejectState
     :: CageConfig
     -> TokenId
     -> TxOut ConwayEra
-    -> ( OnChainTokenState
-       , TxOut ConwayEra
-       , Script ConwayEra
-       , Script ConwayEra
-       , KeyHash Witness
-       )
-prepareRejectState cfg tid stateOut =
-    let scriptAddr =
-            cageAddrFromCfg cfg (network cfg)
-        oldState =
-            case extractCageDatum stateOut of
-                Just (StateDatum s) -> s
-                _ ->
-                    error
-                        "rejectRequests: invalid \
-                        \state datum"
-        OnChainTokenState
-            { stateOwner =
-                BuiltinByteString ownerBs
-            } = oldState
-        -- Root unchanged for reject
-        newStateOut =
-            mkBasicTxOut
-                scriptAddr
-                (stateOut ^. valueTxOutL)
-                & datumTxOutL
-                    .~ mkInlineDatum
-                        ( toPlcData
-                            (StateDatum oldState)
-                        )
-        stateScript = mkCageScript cfg
-        requestScript = mkRequestScript cfg tid
-        ownerKh = addrWitnessKeyHash ownerBs
-    in  ( oldState
-        , newStateOut
-        , stateScript
-        , requestScript
-        , ownerKh
+    -> IO
+        ( OnChainTokenState
+        , TxOut ConwayEra
+        , Script ConwayEra
+        , Script ConwayEra
+        , KeyHash Witness
         )
+prepareRejectState cfg tid stateOut =
+    case extractCageDatum stateOut of
+        Just (StateDatum oldState) ->
+            pure result
+          where
+            scriptAddr =
+                cageAddrFromCfg cfg (network cfg)
+            result =
+                ( oldState
+                , newStateOut
+                , stateScript
+                , requestScript
+                , ownerKh
+                )
+            newStateOut =
+                mkBasicTxOut
+                    scriptAddr
+                    (stateOut ^. valueTxOutL)
+                    & datumTxOutL
+                        .~ mkInlineDatum
+                            ( toPlcData
+                                (StateDatum oldState)
+                            )
+            stateScript = mkCageScript cfg
+            requestScript = mkRequestScript cfg tid
+            ownerKh = addrWitnessKeyHash ownerBs
+            OnChainTokenState
+                { stateOwner =
+                    BuiltinByteString ownerBs
+                } = oldState
+        _ ->
+            throwTxBuilderFailure
+                "rejectRequests: invalid state datum"
 
 -- | Compute the validity lower slot: must be
 -- AFTER the latest Phase 3 deadline among the
@@ -305,18 +312,27 @@ computeLowerSlot
 computeLowerSlot prov oldState reqUtxos = do
     let pt = stateProcessTime oldState
         rt = stateRetractTime oldState
-        latestDeadline =
-            maximum
-                $ map
-                    ( \(_, rOut) ->
-                        case extractCageDatum rOut of
-                            Just (RequestDatum r) ->
-                                requestSubmittedAt r
-                                    + pt
-                                    + rt
-                            _ -> 0
-                    )
-                    reqUtxos
+    deadlines <-
+        traverse
+            ( \(_, rOut) ->
+                case extractCageDatum rOut of
+                    Just (RequestDatum r) ->
+                        pure
+                            $ requestSubmittedAt r
+                                + pt
+                                + rt
+                    _ ->
+                        throwTxBuilderFailure
+                            "rejectRequests: invalid request datum"
+            )
+            reqUtxos
+    latestDeadline <-
+        case deadlines of
+            [] ->
+                throwTxBuilderFailure
+                    "rejectRequests: no requests to bound"
+            firstDeadline : rest ->
+                pure $ maximum (firstDeadline : rest)
     mLowerSlot <-
         try @SomeException
             (posixMsCeilSlot prov latestDeadline)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE EmptyCase #-}
+
 -- |
 -- Module      : Cardano.MPFS.TxBuilder.Real.Request
 -- Description : Request insert/delete/update transactions
@@ -71,6 +73,9 @@ import Cardano.MPFS.TxBuilder.Real.Internal
 import Cardano.Tx.Build qualified as Tx
 
 data NoCtx a
+
+interpretNoCtx :: NoCtx a -> IO a
+interpretNoCtx q = case q of {}
 
 -- | Build a request-insert transaction.
 requestInsertImpl
@@ -188,14 +193,17 @@ requestImpl cfg prov st proofFn snap tid key op addr = do
         } <-
         case mTs of
             Nothing ->
-                error "requestImpl: unknown token"
+                throwTxBuilderFailure
+                    "requestImpl: unknown token"
             Just x -> pure x
     pp <- queryProtocolParams prov
     utxos <- queryUTxOs prov addr
     feeUtxo <- case sortOn
         (Down . (^. coinTxOutL) . snd)
         utxos of
-        [] -> error "requestImpl: no UTxOs"
+        [] ->
+            throwTxBuilderFailure
+                "requestImpl: no UTxOs"
         (u : _) -> pure u
     now <- currentPosixMs
     let datum =
@@ -232,7 +240,7 @@ requestImpl cfg prov st proofFn snap tid key op addr = do
     result <-
         Tx.build
             (Tx.mkPParamsBound pp)
-            (Tx.InterpretIO (const (pure undefined)))
+            (Tx.InterpretIO interpretNoCtx)
             (const $ pure Map.empty)
             [feeUtxo]
             []
@@ -240,7 +248,7 @@ requestImpl cfg prov st proofFn snap tid key op addr = do
             (prog :: Tx.TxBuild NoCtx Void ())
     case result of
         Left err ->
-            error
+            throwTxBuilderFailure
                 $ "requestImpl: TxBuild failed: "
                     <> show err
         Right tx -> do

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE EmptyCase #-}
+
 -- |
 -- Module      : Cardano.MPFS.TxBuilder.Real.Retract
 -- Description : Retract request transaction
@@ -60,6 +62,9 @@ import PlutusTx.Builtins.Internal
 
 data NoCtx a
 
+interpretNoCtx :: NoCtx a -> IO a
+interpretNoCtx q = case q of {}
+
 -- | Build a retract-request transaction.
 --
 -- The requester spends their request UTxO
@@ -86,7 +91,8 @@ retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
     mReq <- getRequest (requests st) reqTxIn
     req <- case mReq of
         Nothing ->
-            error "retractRequest: unknown request"
+            throwTxBuilderFailure
+                "retractRequest: unknown request"
         Just LocatedRequest{request = r} -> pure r
     -- 2. Query the per-cage request address for the
     --    request UTxO and the global state address
@@ -105,7 +111,7 @@ retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
             findUtxoByTxIn reqTxIn requestUtxos
     reqUtxoPair <- case reqUtxo of
         Nothing ->
-            error
+            throwTxBuilderFailure
                 "retractRequest: request UTxO \
                 \not found on chain"
         Just x -> pure x
@@ -118,7 +124,7 @@ retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
             tid
             stateUtxos of
             Nothing ->
-                error
+                throwTxBuilderFailure
                     "retractRequest: state UTxO \
                     \not found"
             Just x -> pure x
@@ -129,16 +135,20 @@ retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
     feeUtxo <- case sortOn
         (Down . (^. coinTxOutL) . snd)
         walletUtxos of
-        [] -> error "retractRequest: no UTxOs"
+        [] ->
+            throwTxBuilderFailure
+                "retractRequest: no UTxOs"
         (u : _) -> pure u
     -- 5. Extract request owner for required signer
     -- 5. Extract request datum fields
-    let reqDatum = case extractCageDatum reqOut of
-            Just (RequestDatum r) -> r
+    reqDatum <-
+        case extractCageDatum reqOut of
+            Just (RequestDatum r) -> pure r
             _ ->
-                error
+                throwTxBuilderFailure
                     "retractRequest: invalid \
                     \request datum"
+    let
         OnChainRequest
             { requestOwner =
                 BuiltinByteString ownerBs
@@ -147,12 +157,14 @@ retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
         ownerKh = addrWitnessKeyHash ownerBs
     -- 5b. Read process_time and retract_time
     -- from the state datum
-    let stateDatum = case extractCageDatum stateOut of
-            Just (StateDatum s) -> s
+    stateDatum <-
+        case extractCageDatum stateOut of
+            Just (StateDatum s) -> pure s
             _ ->
-                error
+                throwTxBuilderFailure
                     "retractRequest: invalid \
                     \state datum"
+    let
         OnChainTokenState
             { stateProcessTime = procTime
             , stateRetractTime = retrTime
@@ -193,7 +205,7 @@ retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
     result <-
         Tx.build
             (Tx.mkPParamsBound pp)
-            (Tx.InterpretIO (const (pure undefined)))
+            (Tx.InterpretIO interpretNoCtx)
             evalTx
             [feeUtxo, reqUtxoPair]
             [stateUtxo]
@@ -203,7 +215,7 @@ retractRequestImpl cfg prov st proofFn snap reqTxIn addr = do
         case result of
             Right tx -> pure tx
             Left err ->
-                error
+                throwTxBuilderFailure
                     $ "retractRequest: TxBuild failed: "
                         <> show err
     reqWitness <- witness proofFn reqUtxoPair

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Sweep.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Sweep.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE EmptyCase #-}
+
 -- |
 -- Module      : Cardano.MPFS.TxBuilder.Real.Sweep
 -- Description : Owner-sweep transaction
@@ -51,6 +53,9 @@ import Cardano.Tx.Build qualified as Tx
 
 data NoCtx a
 
+interpretNoCtx :: NoCtx a -> IO a
+interpretNoCtx q = case q of {}
+
 -- | Build a standalone sweep transaction.
 --
 -- Spends one non-legitimate UTxO at the cage's
@@ -85,7 +90,7 @@ sweepUtxoImpl cfg prov tid garbTxIn addr = do
             garbTxIn
             requestUtxos of
             Nothing ->
-                error
+                throwTxBuilderFailure
                     "sweepUtxo: garbage UTxO not \
                     \found at the request address"
             Just x -> pure x
@@ -97,7 +102,7 @@ sweepUtxoImpl cfg prov tid garbTxIn addr = do
             tid
             stateUtxos of
             Nothing ->
-                error
+                throwTxBuilderFailure
                     "sweepUtxo: state UTxO not \
                     \found at the state address"
             Just x -> pure x
@@ -107,15 +112,18 @@ sweepUtxoImpl cfg prov tid garbTxIn addr = do
     feeUtxo <- case sortOn
         (Down . (^. coinTxOutL) . snd)
         walletUtxos of
-        [] -> error "sweepUtxo: no UTxOs in wallet"
+        [] ->
+            throwTxBuilderFailure
+                "sweepUtxo: no UTxOs in wallet"
         (u : _) -> pure u
-    let stateDatum =
-            case extractCageDatum stateOut of
-                Just (StateDatum s) -> s
-                _ ->
-                    error
-                        "sweepUtxo: invalid state \
-                        \datum at state UTxO"
+    stateDatum <-
+        case extractCageDatum stateOut of
+            Just (StateDatum s) -> pure s
+            _ ->
+                throwTxBuilderFailure
+                    "sweepUtxo: invalid state \
+                    \datum at state UTxO"
+    let
         OnChainTokenState
             { stateOwner =
                 BuiltinByteString ownerBs
@@ -138,7 +146,7 @@ sweepUtxoImpl cfg prov tid garbTxIn addr = do
     result <-
         Tx.build
             (Tx.mkPParamsBound pp)
-            (Tx.InterpretIO (const (pure undefined)))
+            (Tx.InterpretIO interpretNoCtx)
             evalTx
             [feeUtxo, garbUtxoPair]
             [stateUtxo]
@@ -147,6 +155,6 @@ sweepUtxoImpl cfg prov tid garbTxIn addr = do
     case result of
         Right tx -> pure tx
         Left err ->
-            error
+            throwTxBuilderFailure
                 $ "sweepUtxo: TxBuild failed: "
                     <> show err

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/EventSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/EventSpec.hs
@@ -17,10 +17,14 @@ import Test.QuickCheck
     ( Gen
     , forAll
     , listOf1
+    , suchThat
     )
 
+import Cardano.Ledger.Api.Tx.Out (mkBasicTxOut)
+import Cardano.Ledger.BaseTypes (Inject (..))
 import Cardano.MPFS.Core.Types
-    ( Request (..)
+    ( Coin (..)
+    , Request (..)
     , Root (..)
     , TokenId (..)
     , TokenState (..)
@@ -35,12 +39,45 @@ import Cardano.MPFS.Generators
     )
 import Cardano.MPFS.Indexer.Event
     ( CageEvent (..)
+    , CageEventFailure (..)
     , CageInverseOp (..)
+    , detectCageEventsDetailed
     , inversesOf
+    )
+import Cardano.MPFS.Indexer.TxFixtures
+    ( mkPlainTx
+    , testCageAddr
+    , testScriptHash
     )
 
 spec :: Spec
 spec = describe "CageEvent" $ do
+    describe "detectCageEventsDetailed" $ do
+        it
+            "reports a typed failure for a resolved input outside the tx input set"
+            $ forAll genTxIn
+            $ \txInput ->
+                forAll
+                    (genTxIn `suchThat` (/= txInput))
+                    $ \resolvedInput ->
+                        let tx = mkPlainTx txInput
+                            txOut =
+                                mkBasicTxOut
+                                    testCageAddr
+                                    (inject (Coin 2_000_000))
+                            result =
+                                detectCageEventsDetailed
+                                    testScriptHash
+                                    [(resolvedInput, txOut)]
+                                    tx
+                        in  result
+                                `shouldBe` (
+                                               [ MissingSpendingInput
+                                                    resolvedInput
+                                               ]
+                                           , []
+                                           )
+
     describe "inversesOf" $ do
         it "boot produces InvRemoveToken"
             $ forAll genBoot


### PR DESCRIPTION
## Summary
- replace scoped real tx-builder panics and empty query partials with typed `TxBuilderFailure` paths
- add typed cage event detection failures and application startup failures
- cover detailed event detection failure reporting in `EventSpec`

## Verification
- `./gate.sh`

Refs #333
Refs #335