### PR TITLE
ci(release): unblock release-please PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -80,3 +81,37 @@ jobs:
 
       - name: Run E2E tests
         run: nix run --quiet .#e2e-tests
+
+  version-sync:
+    name: Cabal version matches manifest
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - name: Assert Cabal versions equal release manifest
+        run: |
+          set -euo pipefail
+
+          manifest_version=$(sed -n 's/.*"\.":[[:space:]]*"\([^"]*\)".*/\1/p' .release-please-manifest.json)
+          if [ -z "$manifest_version" ]; then
+            echo "::error::.release-please-manifest.json does not contain a root package version"
+            exit 1
+          fi
+
+          pvp_version="$manifest_version"
+          if [[ "$pvp_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            pvp_version="${pvp_version}.0"
+          fi
+
+          check_cabal_version() {
+            cabal_file="$1"
+            cabal_version=$(sed -n 's/^version:[[:space:]]*\([0-9][0-9.]*\).*/\1/p' "$cabal_file" | head -1)
+            echo "manifest=$manifest_version pvp=$pvp_version $cabal_file=$cabal_version"
+
+            if [ "$cabal_version" != "$pvp_version" ]; then
+              echo "::error::$cabal_file version ($cabal_version) does not match release manifest PVP version ($pvp_version)"
+              exit 1
+            fi
+          }
+
+          check_cabal_version cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+          check_cabal_version cardano-mpfs-cli/cardano-mpfs-cli.cabal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/.github/workflows/sync-cabal-version.yaml
+++ b/.github/workflows/sync-cabal-version.yaml
@@ -1,0 +1,66 @@
+name: Sync cabal version
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-version:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync version to release Cabal packages
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          new_version=$(jq -r '."."' .release-please-manifest.json 2>/dev/null || echo "")
+          if [ -z "$new_version" ] || [ "$new_version" = "null" ]; then
+            echo "No version found in manifest, skipping"
+            exit 0
+          fi
+
+          if [[ "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            new_version="${new_version}.0"
+          fi
+
+          changed=0
+          sync_cabal_version() {
+            cabal_file="$1"
+            old_version=$(sed -n 's/^version:[[:space:]]*\([0-9][0-9.]*\).*/\1/p' "$cabal_file" | head -1)
+
+            echo "$cabal_file old version: $old_version"
+            echo "$cabal_file new version: $new_version"
+
+            if [ "$new_version" = "$old_version" ]; then
+              echo "$cabal_file already matches"
+              return
+            fi
+
+            sed -i "s/^version:.*$/version:       $new_version/" "$cabal_file"
+            changed=1
+          }
+
+          sync_cabal_version cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+          sync_cabal_version cardano-mpfs-cli/cardano-mpfs-cli.cabal
+
+          if [ "$changed" -eq 0 ]; then
+            echo "Versions match, nothing to do"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add cardano-mpfs-offchain/cardano-mpfs-offchain.cabal cardano-mpfs-cli/cardano-mpfs-cli.cabal
+          git commit -m "chore: sync cabal version to $new_version"
+          git push origin "HEAD:$HEAD_REF"

--- a/cardano-mpfs-cli/cardano-mpfs-cli.cabal
+++ b/cardano-mpfs-cli/cardano-mpfs-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          cardano-mpfs-cli
-version:       0.0.0
+version:       0.1.0.0
 synopsis:      Command-line front-end for the Cardano MPFS server
 description:
   mpfs-cli drives MPFS token registration and fact management

--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          cardano-mpfs-offchain
-version:       0.0.0
+version:       0.1.0.0
 synopsis:      Offchain service interfaces for Cardano MPFS
 description:
   Record-of-functions interfaces for the Cardano Merkle


### PR DESCRIPTION
## Summary

- Add manual dispatch to CI and Release workflows so the bot release branch can be checked on demand.
- Add a release-please PR workflow that syncs manifest version `.` into `cardano-mpfs-offchain.cabal` and `cardano-mpfs-cli.cabal` as PVP `x.y.z.0`.
- Add CI drift detection for the two published Cabal packages and align the current Cabal versions with manifest `0.1.0`.

## Release PR unblock

After this merges, unblock the existing release-please PR by running:

```bash
gh workflow run CI --ref release-please--branches--main
```

That gives the required `Build Gate`, `build`, and `e2e` checks a run on the bot branch.

The permanent auto-trigger alternative is to add a `RELEASE_PAT` secret for `release-please-action` and wire the action to use that token, so release-please PR updates trigger CI automatically instead of needing manual dispatch. This repo does not currently expose a `RELEASE_PAT`, so this PR leaves the action on `GITHUB_TOKEN`.

## Verification

- `nix --quiet shell nixpkgs#actionlint -c actionlint .github/workflows/*.yml .github/workflows/*.yaml`
- Local manifest/Cabal drift check: manifest `0.1.0` maps to PVP `0.1.0.0` in both Cabal files
- `bash -n` over the embedded CI drift and sync workflow shell blocks

No local Nix project builds were run.