### PR TITLE
ci(release): fix linux mpfs-cli bundle (awk not found)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           chmod +x /tmp/bundle/libexec/mpfs-cli
 
           LD_TRACE_LOADED_OBJECTS=1 /tmp/bundle/libexec/mpfs-cli \
-            | awk '/=> \// { print $3 } /^[[:space:]]*\// { print $1 }' \
+            | nix shell --inputs-from . nixpkgs#gawk -c awk '/=> \// { print $3 } /^[[:space:]]*\// { print $1 }' \
             | sort -u \
             | while read -r lib; do
               case "$lib" in


### PR DESCRIPTION
The `cli-linux-release` Bundle step failed on the v0.1.1 release run with `awk: command not found` (exit 127) — the `nixos` runner's minimal per-step PATH has no `gawk`, so the `LD_TRACE_LOADED_OBJECTS` ldd-parse died and the Linux `mpfs-cli` tarball was never uploaded. Fix: run `awk` from nixpkgs via `nix shell --inputs-from . nixpkgs#gawk -c`, matching the upload step's idiom.

The v0.1.1 Linux asset was built+uploaded manually; this makes the next release publish it automatically.