### PR TITLE
refactor(api)!: remove verified read projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ path.
 |--------|----------|-------------|
 | GET | `/status` | Chain tip and checkpoint |
 | GET | `/eval-context` | Trusted interim PlutusV3 PParams, cost models, SystemStart, and era-history for wallet-side ex-unit evaluation |
-| GET | `/tokens` | Enumerate token UTxOs with explicit `token_id` values and a completeness witness |
+| GET | `/tokens` | Enumerate token-state UTxOs (token id decoded from each entry's `txout_cbor`) with a completeness witness |
 | GET | `/tokens/:id` | Token state with UTxO witness and verification snapshot |
 | GET | `/tokens/:id/root` | Trie root hash |
 | GET | `/tokens/:id/facts` | Enumerate facts with witnessed state |

--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -21,10 +21,6 @@ module Cardano.MPFS.API.Types
 
       -- * Tokens
     , TokenIdJSON (..)
-    , TokenStateJSON (..)
-
-      -- * Requests
-    , RequestJSON (..)
 
       -- * UTxO witnesses
     , TxInJSON (..)
@@ -181,82 +177,6 @@ instance FromJSON StatusResponse where
             <*> o .: "checkpoint_block_id"
             <*> o .: "utxo_root"
 
--- | JSON representation of on-chain token state.
-data TokenStateJSON = TokenStateJSON
-    { owner :: Text
-    -- ^ Owner payment key hash (hex)
-    , root :: Hex
-    -- ^ Current trie root hash
-    , tip :: Integer
-    -- ^ Maximum fee in lovelace
-    , processTime :: Integer
-    -- ^ Processing window (ms)
-    , retractTime :: Integer
-    -- ^ Retract window (ms)
-    }
-    deriving (Eq, Show)
-
-instance ToJSON TokenStateJSON where
-    toJSON TokenStateJSON{..} =
-        object
-            [ "owner" .= owner
-            , "root" .= root
-            , "tip" .= tip
-            , "process_time" .= processTime
-            , "retract_time" .= retractTime
-            ]
-
-instance FromJSON TokenStateJSON where
-    parseJSON = withObject "TokenStateJSON" $ \o ->
-        TokenStateJSON
-            <$> o .: "owner"
-            <*> o .: "root"
-            <*> o .: "tip"
-            <*> o .: "process_time"
-            <*> o .: "retract_time"
-
--- | JSON representation of a pending request.
-data RequestJSON = RequestJSON
-    { rjToken :: TokenIdJSON
-    -- ^ Token this request targets
-    , rjOwner :: Text
-    -- ^ Requester's payment key hash (hex)
-    , rjKey :: Hex
-    -- ^ Trie key
-    , rjOperation :: Text
-    -- ^ "insert", "delete", or "update"
-    , rjValue :: Maybe Hex
-    -- ^ New value (for insert/update)
-    , rjFee :: Integer
-    -- ^ Fee in lovelace
-    , rjSubmittedAt :: Integer
-    -- ^ POSIXTime (ms)
-    }
-    deriving (Eq, Show)
-
-instance ToJSON RequestJSON where
-    toJSON RequestJSON{..} =
-        object
-            [ "token" .= rjToken
-            , "owner" .= rjOwner
-            , "key" .= rjKey
-            , "operation" .= rjOperation
-            , "value" .= rjValue
-            , "fee" .= rjFee
-            , "submitted_at" .= rjSubmittedAt
-            ]
-
-instance FromJSON RequestJSON where
-    parseJSON = withObject "RequestJSON" $ \o ->
-        RequestJSON
-            <$> o .: "token"
-            <*> o .: "owner"
-            <*> o .: "key"
-            <*> o .: "operation"
-            <*> o .: "value"
-            <*> o .: "fee"
-            <*> o .: "submitted_at"
-
 -- ---------------------------------------------------------
 -- UTxO witnesses
 -- ---------------------------------------------------------
@@ -386,14 +306,16 @@ instance FromJSON UnsignedTxResponse where
 -- Proof-bearing read responses
 -- ---------------------------------------------------------
 
--- | Decoded token state together with the UTxO
--- witness that proves it resides at the indexed
--- snapshot's @utxo_root@.
-data WitnessedTokenState = WitnessedTokenState
+-- | The UTxO witness that proves a token-state output
+-- resides at the indexed snapshot's @utxo_root@.
+--
+-- The on-chain state payload (owner, trie root, timing
+-- parameters) is carried provably as the inline datum
+-- inside @utxo.tx_out@; clients decode it from there
+-- rather than trusting a server-side projection.
+newtype WitnessedTokenState = WitnessedTokenState
     { wtsUtxo :: WitnessedUtxo
     -- ^ UTxO witness for the state output
-    , wtsState :: TokenStateJSON
-    -- ^ Decoded on-chain state payload
     }
     deriving (Eq, Show)
 
@@ -401,7 +323,6 @@ instance ToJSON WitnessedTokenState where
     toJSON WitnessedTokenState{..} =
         object
             [ "utxo" .= wtsUtxo
-            , "state" .= wtsState
             ]
 
 instance FromJSON WitnessedTokenState where
@@ -409,16 +330,18 @@ instance FromJSON WitnessedTokenState where
         withObject "WitnessedTokenState" $ \o ->
             WitnessedTokenState
                 <$> o .: "utxo"
-                <*> o .: "state"
 
--- | A pending request together with the UTxO
--- witness proving it existed in the indexed
--- snapshot.
-data WitnessedRequest = WitnessedRequest
+-- | The UTxO witness proving a pending request existed
+-- in the indexed snapshot.
+--
+-- The request payload (token, owner, key, operation,
+-- value, fee, submitted-at) is carried provably as the
+-- inline datum inside @utxo.tx_out@; clients decode it
+-- from there rather than trusting a server-side
+-- projection.
+newtype WitnessedRequest = WitnessedRequest
     { wrUtxo :: WitnessedUtxo
     -- ^ UTxO witness for the request output
-    , wrRequest :: RequestJSON
-    -- ^ Decoded request payload
     }
     deriving (Eq, Show)
 
@@ -426,7 +349,6 @@ instance ToJSON WitnessedRequest where
     toJSON WitnessedRequest{..} =
         object
             [ "utxo" .= wrUtxo
-            , "request" .= wrRequest
             ]
 
 instance FromJSON WitnessedRequest where
@@ -434,7 +356,6 @@ instance FromJSON WitnessedRequest where
         withObject "WitnessedRequest" $ \o ->
             WitnessedRequest
                 <$> o .: "utxo"
-                <*> o .: "request"
 
 -- | A fact witness: the state witness that carries
 -- the trie root plus an MPF inclusion proof binding a
@@ -460,11 +381,14 @@ instance FromJSON FactWitness where
             <$> o .: "state"
             <*> o .: "mpf_proof"
 
--- | A token-state UTxO entry with the corresponding MPFS token id.
+-- | A token-state UTxO entry: a reference plus its
+-- CBOR-encoded state @TxOut@.
+--
+-- The MPFS token id is not carried explicitly - it is
+-- the asset name of the state token inside the
+-- @txout_cbor@ value, which clients decode locally.
 data TokenUtxoEntry = TokenUtxoEntry
-    { tueTokenId :: TokenIdJSON
-    -- ^ Token id (hex asset name)
-    , tueRef :: UtxoRef
+    { tueRef :: UtxoRef
     -- ^ UTxO reference
     , tueTxOutCbor :: Hex
     -- ^ CBOR-encoded state @TxOut@
@@ -474,8 +398,7 @@ data TokenUtxoEntry = TokenUtxoEntry
 instance ToJSON TokenUtxoEntry where
     toJSON TokenUtxoEntry{..} =
         object
-            [ "token_id" .= tueTokenId
-            , "ref" .= tueRef
+            [ "ref" .= tueRef
             , "txout_cbor" .= tueTxOutCbor
             ]
 
@@ -483,11 +406,12 @@ instance FromJSON TokenUtxoEntry where
     parseJSON =
         withObject "TokenUtxoEntry" $ \o ->
             TokenUtxoEntry
-                <$> o .: "token_id"
-                <*> o .: "ref"
+                <$> o .: "ref"
                 <*> o .: "txout_cbor"
 
--- | Complete token-state UTxO set witness with explicit token ids.
+-- | Complete token-state UTxO set witness. Each entry's
+-- token id is the asset name of the state token inside
+-- its @txout_cbor@; the ids are not carried explicitly.
 data TokenSetWitness = TokenSetWitness
     { tswEntries :: [TokenUtxoEntry]
     -- ^ Enumerated token-state UTxOs
@@ -515,7 +439,8 @@ data TokensResponse = TokensResponse
     { trsSnapshot :: VerificationSnapshot
     -- ^ Snapshot the bundled proof targets
     , trsTokens :: TokenSetWitness
-    -- ^ Complete token-state UTxO set witness with explicit token ids
+    -- ^ Complete token-state UTxO set witness; token ids
+    -- are decoded from each entry's @txout_cbor@
     }
     deriving (Eq, Show)
 
@@ -1332,77 +1257,6 @@ instance ToSchema StatusResponse where
             & description
                 ?~ "Indexer chain tip, checkpoint, and current UTxO-CSMT root"
 
-instance ToSchema TokenStateJSON where
-    declareNamedSchema _ = do
-        textSchema <-
-            declareSchemaRef (Proxy @Text)
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        intSchema <-
-            declareSchemaRef (Proxy @Integer)
-        pure
-            $ Swagger.NamedSchema
-                (Just "TokenStateJSON")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("owner", textSchema)
-                    , ("root", hexSchema)
-                    , ("tip", intSchema)
-                    , ("process_time", intSchema)
-                    , ("retract_time", intSchema)
-                    ]
-            & required
-                .~ [ "owner"
-                   , "root"
-                   , "tip"
-                   , "process_time"
-                   , "retract_time"
-                   ]
-            & description
-                ?~ "On-chain token state"
-
-instance ToSchema RequestJSON where
-    declareNamedSchema _ = do
-        tokenSchema <-
-            declareSchemaRef (Proxy @TokenIdJSON)
-        textSchema <-
-            declareSchemaRef (Proxy @Text)
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
-        maybeHex <-
-            declareSchemaRef (Proxy @(Maybe Hex))
-        intSchema <-
-            declareSchemaRef (Proxy @Integer)
-        pure
-            $ Swagger.NamedSchema
-                (Just "RequestJSON")
-            $ mempty
-            & Swagger.type_
-                ?~ Swagger.SwaggerObject
-            & properties
-                .~ fromList
-                    [ ("token", tokenSchema)
-                    , ("owner", textSchema)
-                    , ("key", hexSchema)
-                    , ("operation", textSchema)
-                    , ("value", maybeHex)
-                    , ("fee", intSchema)
-                    , ("submitted_at", intSchema)
-                    ]
-            & required
-                .~ [ "token"
-                   , "owner"
-                   , "key"
-                   , "operation"
-                   , "fee"
-                   , "submitted_at"
-                   ]
-            & description
-                ?~ "Pending request"
-
 instance ToSchema BootRequest where
     declareNamedSchema _ = do
         hexSchema <-
@@ -1703,8 +1557,6 @@ instance ToSchema WitnessedTokenState where
     declareNamedSchema _ = do
         utxoSchema <-
             declareSchemaRef (Proxy @WitnessedUtxo)
-        stateSchema <-
-            declareSchemaRef (Proxy @TokenStateJSON)
         pure
             $ Swagger.NamedSchema
                 (Just "WitnessedTokenState")
@@ -1714,18 +1566,15 @@ instance ToSchema WitnessedTokenState where
             & properties
                 .~ fromList
                     [ ("utxo", utxoSchema)
-                    , ("state", stateSchema)
                     ]
-            & required .~ ["utxo", "state"]
+            & required .~ ["utxo"]
             & description
-                ?~ "Token state plus UTxO witness"
+                ?~ "UTxO witness for a token-state output; the on-chain state is the inline datum in utxo.tx_out"
 
 instance ToSchema WitnessedRequest where
     declareNamedSchema _ = do
         utxoSchema <-
             declareSchemaRef (Proxy @WitnessedUtxo)
-        requestSchema <-
-            declareSchemaRef (Proxy @RequestJSON)
         pure
             $ Swagger.NamedSchema
                 (Just "WitnessedRequest")
@@ -1735,11 +1584,10 @@ instance ToSchema WitnessedRequest where
             & properties
                 .~ fromList
                     [ ("utxo", utxoSchema)
-                    , ("request", requestSchema)
                     ]
-            & required .~ ["utxo", "request"]
+            & required .~ ["utxo"]
             & description
-                ?~ "Pending request plus UTxO witness"
+                ?~ "UTxO witness for a pending-request output; the request is the inline datum in utxo.tx_out"
 
 instance ToSchema UnsignedTxResponse where
     declareNamedSchema _ = do
@@ -1816,8 +1664,6 @@ instance ToSchema TokenResponse where
 
 instance ToSchema TokenUtxoEntry where
     declareNamedSchema _ = do
-        tokenSchema <-
-            declareSchemaRef (Proxy @TokenIdJSON)
         refSchema <-
             declareSchemaRef (Proxy @UtxoRef)
         hexSchema <-
@@ -1830,13 +1676,12 @@ instance ToSchema TokenUtxoEntry where
                 ?~ Swagger.SwaggerObject
             & properties
                 .~ fromList
-                    [ ("token_id", tokenSchema)
-                    , ("ref", refSchema)
+                    [ ("ref", refSchema)
                     , ("txout_cbor", hexSchema)
                     ]
-            & required .~ ["token_id", "ref", "txout_cbor"]
+            & required .~ ["ref", "txout_cbor"]
             & description
-                ?~ "Token-state UTxO entry with the token_id carried explicitly"
+                ?~ "Token-state UTxO entry; the token id is the state token's asset name inside txout_cbor"
 
 instance ToSchema TokenSetWitness where
     declareNamedSchema _ = do
@@ -1858,7 +1703,7 @@ instance ToSchema TokenSetWitness where
                     ]
             & required .~ ["entries", "completeness_proof"]
             & description
-                ?~ "Enumerated token-state UTxOs with explicit token ids and a CSMT prefix-completeness proof"
+                ?~ "Enumerated token-state UTxOs (token id is the state token's asset name inside each txout_cbor) with a CSMT prefix-completeness proof"
 
 instance ToSchema TokensResponse where
     declareNamedSchema _ = do

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
@@ -17,12 +17,10 @@ import Cardano.MPFS.API.Types
     , FactResponse (..)
     , FactsResponse (..)
     , ProofResponse
-    , RequestJSON (..)
     , RequestsResponse (..)
     , TokenIdJSON (..)
     , TokenResponse (..)
     , TokenSetWitness (..)
-    , TokenStateJSON (..)
     , TokenUtxoEntry (..)
     , TokensResponse (..)
     , TxInJSON (..)
@@ -464,26 +462,16 @@ runRequestsList out mServer tokenText cageConfig trustedRoot =
     withReadRoot mServer trustedRoot $ \_ _ env troot -> do
         cage <- resolveCage cageConfig
         tid <- decodeToken tokenText
-        tokenResp <- getToken env tid >>= orDieClient "requests token state"
-        tokenVerified <-
-            orDieVerify
-                "requests token state"
-                (verifyTokenState troot tokenResp)
         reqResp <- listRequests env tid >>= orDieClient "requests list"
         reqVerified <-
             orDieVerify
                 "requests list"
                 (verifyTokenRequests cage tid troot reqResp)
-        let state = responseTokenState (verifiedTokenState tokenVerified)
-            verifiedResp = verifiedTokenRequests reqVerified
+        let verifiedResp = verifiedTokenRequests reqVerified
         emit
             out
-            ( requestsEnvelope
-                tid
-                state
-                verifiedResp
-            )
-            (formatRequests tid state verifiedResp)
+            (requestsEnvelope tid verifiedResp)
+            (formatRequests tid verifiedResp)
 
 -- | Decode a @TOKEN@ hex argument to a 'TokenIdJSON' or exit.
 decodeToken :: Text -> IO TokenIdJSON
@@ -559,20 +547,28 @@ tokenListResult TokensResponse{trsTokens = TokenSetWitness{..}} =
         [ "tokens" .= map tokenEntryResult tswEntries
         ]
 
+-- | A token entry is rendered as its provable witness fields. The
+-- token id is the state token's asset name inside @txout_cbor@;
+-- consumers that need it decode the witnessed @TxOut@ locally.
 tokenEntryResult :: TokenUtxoEntry -> Value
 tokenEntryResult TokenUtxoEntry{..} =
     object
-        [ "id" .= tokenIdText tueTokenId
-        , "ref" .= utxoRefText tueRef
+        [ "ref" .= utxoRefText tueRef
+        , "txout_cbor" .= hexText tueTxOutCbor
         ]
 
+-- | The token-state response is rendered as its provable state-UTxO
+-- witness. The decoded on-chain state lives in the inline datum of
+-- @tx_out@; consumers decode it locally rather than trusting a
+-- server-side projection.
 tokenStateResult :: TokenIdJSON -> TokenResponse -> Value
 tokenStateResult tid resp =
-    object
-        [ "token" .= tokenIdText tid
-        , "state" .= tokenStateJson (responseTokenState resp)
-        , "stateRef" .= responseStateRef resp
-        ]
+    let wu = responseStateUtxo resp
+    in  object
+            [ "token" .= tokenIdText tid
+            , "stateRef" .= txInText (wuTxIn wu)
+            , "txout_cbor" .= hexText (wuTxOut wu)
+            ]
 
 factListResult :: TokenIdJSON -> FactsResponse -> Value
 factListResult tid FactsResponse{..} =
@@ -614,42 +610,27 @@ factGetAbsentEnvelope tid keyHex =
 
 requestsEnvelope
     :: TokenIdJSON
-    -> TokenStateJSON
     -> RequestsResponse
     -> Value
-requestsEnvelope tid state resp@RequestsResponse{..} =
+requestsEnvelope tid resp@RequestsResponse{..} =
     queryEnvelope
         "requests list"
         ( object
             [ "token" .= tokenIdText tid
-            , "requests" .= map (requestResult state) rrRequests
+            , "requests" .= map requestResult rrRequests
             ]
         )
         resp
 
-requestResult :: TokenStateJSON -> WitnessedRequest -> Value
-requestResult state WitnessedRequest{..} =
-    let RequestJSON{..} = wrRequest
-    in  object
-            [ "id" .= txInText (wuTxIn wrUtxo)
-            , "operation" .= rjOperation
-            , "key" .= hexText rjKey
-            , "value" .= fmap hexText rjValue
-            , "owner" .= rjOwner
-            , "fee" .= rjFee
-            , "submittedAt" .= rjSubmittedAt
-            , "processDeadline" .= deadline processTime state rjSubmittedAt
-            , "retractDeadline" .= deadline retractTime state rjSubmittedAt
-            ]
-
-tokenStateJson :: TokenStateJSON -> Value
-tokenStateJson TokenStateJSON{..} =
+-- | A pending request is rendered as its provable witness fields. The
+-- request payload (operation, key, value, owner, fee, submitted-at)
+-- lives in the inline datum of @tx_out@; consumers decode it locally
+-- rather than trusting a server-side projection.
+requestResult :: WitnessedRequest -> Value
+requestResult WitnessedRequest{..} =
     object
-        [ "owner" .= owner
-        , "root" .= hexText root
-        , "tip" .= tip
-        , "processTime" .= processTime
-        , "retractTime" .= retractTime
+        [ "id" .= txInText (wuTxIn wrUtxo)
+        , "txout_cbor" .= hexText (wuTxOut wrUtxo)
         ]
 
 formatTokenList :: TokensResponse -> String
@@ -663,23 +644,15 @@ formatTokenList TokensResponse{trsTokens = TokenSetWitness{..}} =
 
 formatTokenEntry :: TokenUtxoEntry -> String
 formatTokenEntry TokenUtxoEntry{..} =
-    "- "
-        <> T.unpack (tokenIdText tueTokenId)
-        <> " at "
-        <> T.unpack (utxoRefText tueRef)
+    "- " <> T.unpack (utxoRefText tueRef)
 
 formatTokenState :: TokenIdJSON -> TokenResponse -> String
 formatTokenState tid resp =
-    let TokenStateJSON{..} = responseTokenState resp
+    let wu = responseStateUtxo resp
     in  intercalate
             "\n"
             [ "Verified token " <> T.unpack (tokenIdText tid)
-            , "state_utxo: " <> T.unpack (responseStateRef resp)
-            , "owner: " <> T.unpack owner
-            , "root: " <> T.unpack (hexText root)
-            , "tip: " <> show tip
-            , "process_time_ms: " <> show processTime
-            , "retract_time_ms: " <> show retractTime
+            , "state_utxo: " <> T.unpack (txInText (wuTxIn wu))
             ]
 
 formatFactList :: TokenIdJSON -> FactsResponse -> String
@@ -721,8 +694,8 @@ formatFactAbsent tid keyHex =
         ]
 
 formatRequests
-    :: TokenIdJSON -> TokenStateJSON -> RequestsResponse -> String
-formatRequests tid state RequestsResponse{..} =
+    :: TokenIdJSON -> RequestsResponse -> String
+formatRequests tid RequestsResponse{..} =
     case rrRequests of
         [] ->
             "No verified pending requests for token "
@@ -735,39 +708,19 @@ formatRequests tid state RequestsResponse{..} =
                         <> T.unpack (tokenIdText tid)
                         <> ":"
                   )
-                    : map (formatRequest state) reqs
+                    : map formatRequest reqs
                 )
 
-formatRequest :: TokenStateJSON -> WitnessedRequest -> String
-formatRequest state WitnessedRequest{..} =
-    let RequestJSON{..} = wrRequest
-    in  "- "
-            <> T.unpack (txInText (wuTxIn wrUtxo))
-            <> " "
-            <> T.unpack rjOperation
-            <> " key="
-            <> T.unpack (hexText rjKey)
-            <> " submitted_at="
-            <> show rjSubmittedAt
-            <> " process_deadline="
-            <> show (deadline processTime state rjSubmittedAt)
-            <> " retract_deadline="
-            <> show (deadline retractTime state rjSubmittedAt)
+formatRequest :: WitnessedRequest -> String
+formatRequest WitnessedRequest{..} =
+    "- " <> T.unpack (txInText (wuTxIn wrUtxo))
 
-responseTokenState :: TokenResponse -> TokenStateJSON
-responseTokenState TokenResponse{trState = WitnessedTokenState{..}} =
-    wtsState
-
-responseStateRef :: TokenResponse -> Text
-responseStateRef TokenResponse{trState = WitnessedTokenState{..}} =
-    txInText (wuTxIn wtsUtxo)
+responseStateUtxo :: TokenResponse -> WitnessedUtxo
+responseStateUtxo TokenResponse{trState = WitnessedTokenState{..}} =
+    wtsUtxo
 
 factResponseValue :: FactResponse -> Text
 factResponseValue FactResponse{..} = hexText frValue
-
-deadline
-    :: (TokenStateJSON -> Integer) -> TokenStateJSON -> Integer -> Integer
-deadline field state submittedAt = submittedAt + field state
 
 hexText :: Hex -> Text
 hexText (Hex bytes) = encodeHexText bytes

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
@@ -24,8 +24,11 @@ module Cardano.MPFS.Client.Fixtures
     , honestUpdateResponseEmptyTrie
 
       -- * Underlying primitives
+    , CsmtBundle
     , honestWitness
+    , buildBundleWithStateRoot
     , bundleRoot
+    , bundleState
     , bundleFunding
     , honestTrieInclusion
     , honestTrieExclusion

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/HttpSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/HttpSpec.hs
@@ -430,14 +430,6 @@ honestFactsResponse =
                         , Wire.wuTxOut = Wire.Hex "tx-out"
                         , Wire.wuProof = Wire.Hex "proof"
                         }
-                , Wire.wtsState =
-                    Wire.TokenStateJSON
-                        { Wire.owner = "owner"
-                        , Wire.root = Wire.Hex "root"
-                        , Wire.tip = 1
-                        , Wire.processTime = 2
-                        , Wire.retractTime = 3
-                        }
                 }
         , Wire.frsFacts =
             [ Wire.FactEntry

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReadSpec.hs
@@ -59,12 +59,10 @@ import Cardano.MPFS.API.Types
     ( ChainPointJSON (..)
     , FactEntry (..)
     , FactsResponse (..)
-    , RequestJSON (..)
     , RequestsResponse (..)
     , TokenIdJSON (..)
     , TokenResponse (..)
     , TokenSetWitness (..)
-    , TokenStateJSON (..)
     , TokenUtxoEntry (..)
     , TokensResponse (..)
     , TxInJSON (..)
@@ -91,8 +89,11 @@ import Cardano.MPFS.Client.Cage.Identity
     , requestSetPrefixFromCfg
     )
 import Cardano.MPFS.Client.Fixtures
-    ( bundleFunding
+    ( CsmtBundle
+    , buildBundleWithStateRoot
+    , bundleFunding
     , bundleRoot
+    , bundleState
     , honestWitness
     )
 import Cardano.MPFS.Client.Snapshot qualified as Snap
@@ -151,24 +152,24 @@ spec = describe "Read-side verifiers" $ do
             `shouldSatisfy` isCsmtReplayFailed
     describe "verifyTokenFacts" $ do
         it "accepts an honest facts response with a complete fact set"
-            $ verifyTokenFactsUnit honestTrustedRoot honestFactsResponse
+            $ verifyTokenFactsUnit honestFactsTrustedRoot honestFactsResponse
             `shouldBe` Right ()
         it "rejects a snapshot root that is not the trusted root"
             $ verifyTokenFactsUnit foreignTrustedRoot honestFactsResponse
             `shouldSatisfy` isTrustedRootMismatch
         it "rejects a dropped fact (incomplete set)"
             $ verifyTokenFactsUnit
-                honestTrustedRoot
+                honestFactsTrustedRoot
                 (dropFirstFact honestFactsResponse)
             `shouldSatisfy` isMpfReplayFailed
         it "rejects an added spurious fact"
             $ verifyTokenFactsUnit
-                honestTrustedRoot
+                honestFactsTrustedRoot
                 (addSpuriousFact honestFactsResponse)
             `shouldSatisfy` isMpfReplayFailed
         it "rejects a tampered fact value"
             $ verifyTokenFactsUnit
-                honestTrustedRoot
+                honestFactsTrustedRoot
                 (tamperFirstFactValue honestFactsResponse)
             `shouldSatisfy` isMpfReplayFailed
     describe "verifyTokenRequests" $ do
@@ -249,22 +250,25 @@ honestFactsRoot = fst $ runMPFPure' $ do
     mapM_ (uncurry insertByteStringM) factEntries
     maybe BS.empty renderMPFHash <$> MPFTest.getRootHashM
 
+-- | A CSMT bundle whose state UTxO carries the honest facts root in
+-- its inline datum. The verifier decodes the on-chain trie root from
+-- this witnessed @TxOut@ - there is no server-side projection to
+-- trust - so the witnessed state output must encode 'honestFactsRoot'.
+factsBundle :: CsmtBundle
+factsBundle = buildBundleWithStateRoot honestFactsRoot
+
+-- | Trusted root for the facts fixture: the bundle's UTxO-CSMT root.
+honestFactsTrustedRoot :: TrustedRoot
+honestFactsTrustedRoot = TrustedRoot (Hex (bundleRoot factsBundle))
+
 honestFactsResponse :: FactsResponse
 honestFactsResponse =
     FactsResponse
-        { frsSnapshot = honestSnapshot
+        { frsSnapshot = snapshotWithRoot (bundleRoot factsBundle)
         , frsState =
             WitnessedTokenState
                 { wtsUtxo =
-                    toApiWitnessedUtxo (bundleFunding honestWitness)
-                , wtsState =
-                    TokenStateJSON
-                        { owner = "owner"
-                        , root = Hex honestFactsRoot
-                        , tip = 1000000
-                        , processTime = 60000
-                        , retractTime = 30000
-                        }
+                    toApiWitnessedUtxo (bundleState factsBundle)
                 }
         , frsFacts =
             [FactEntry{feKey = Hex k, feValue = Hex v} | (k, v) <- factEntries]
@@ -317,16 +321,6 @@ honestRequestFixture cfg =
                                         }
                                 , wuTxOut = Hex requestTxOut
                                 , wuProof = Hex "\x82\x01\x02"
-                                }
-                        , wrRequest =
-                            RequestJSON
-                                { rjToken = sampleToken
-                                , rjOwner = "owner"
-                                , rjKey = Hex "apple"
-                                , rjOperation = "insert"
-                                , rjValue = Just (Hex "fruit")
-                                , rjFee = 1000000
-                                , rjSubmittedAt = 42
                                 }
                         }
                     ]
@@ -422,8 +416,7 @@ honestTokenListFixture cfg =
                     TokenSetWitness
                         { tswEntries =
                             [ TokenUtxoEntry
-                                { tueTokenId = sampleToken
-                                , tueRef =
+                                { tueRef =
                                     UtxoRef
                                         { urTxId = Hex requestTxId
                                         , urTxIx = 0
@@ -475,14 +468,6 @@ honestTokenResponse =
             WitnessedTokenState
                 { wtsUtxo =
                     toApiWitnessedUtxo (bundleFunding honestWitness)
-                , wtsState =
-                    TokenStateJSON
-                        { owner = "owner"
-                        , root = Hex (BS.replicate 32 0x00)
-                        , tip = 1000000
-                        , processTime = 60000
-                        , retractTime = 30000
-                        }
                 }
         }
 

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/VerifySpec.hs
@@ -15,7 +15,6 @@ module Cardano.MPFS.Client.VerifySpec (spec) where
 
 import Control.Monad (void)
 import Data.Bits (xor)
-import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.Text.Encoding qualified as T
@@ -69,9 +68,11 @@ import Cardano.MPFS.Client
     , withReason
     )
 import Cardano.MPFS.Client.Fixtures
-    ( TxRedeemerFixture (..)
-    , bundleFunding
+    ( CsmtBundle
+    , TxRedeemerFixture (..)
+    , buildBundleWithStateRoot
     , bundleRoot
+    , bundleState
     , honestBootResponse
     , honestEndResponse
     , honestRejectResponse
@@ -82,7 +83,6 @@ import Cardano.MPFS.Client.Fixtures
     , honestUpdateResponse
     , honestUpdateResponseEmptyTrie
     , honestUpdateResponseMixedTrie
-    , honestWitness
     , sampleStateAsset
     , spendContributeRedeemerTerm
     , spendEndRedeemerTerm
@@ -313,7 +313,7 @@ foreignTxIn =
 
 honestFactTrustedRoot :: TrustedRoot
 honestFactTrustedRoot =
-    TrustedRoot (Api.Hex (bundleRoot honestWitness))
+    TrustedRoot (Api.Hex (bundleRoot factsBundle))
 
 verifyPresentUnit
     :: TrustedRoot -> FactPresentFacts -> Either VerifyError ()
@@ -355,35 +355,32 @@ honestFactAbsentFacts =
                     }
             }
 
+-- | The single-fact verifiers decode the on-chain trie root from the
+-- witnessed state @TxOut@ inline datum, so the witness must encode the
+-- same root the MPF proof targets. The inclusion and exclusion
+-- fixtures are built over the same entries, so they share one root.
+factsTrieRoot :: BS.ByteString
+factsTrieRoot = fst honestTrieInclusion
+
+-- | A CSMT bundle whose state UTxO datum carries 'factsTrieRoot'.
+factsBundle :: CsmtBundle
+factsBundle = buildBundleWithStateRoot factsTrieRoot
+
 factWitness :: TrieFact -> Api.FactWitness
 factWitness trieFact =
     Api.FactWitness
         { Api.fwState =
             Api.WitnessedTokenState
                 { Api.wtsUtxo =
-                    toApiWitnessedUtxo (bundleFunding honestWitness)
-                , Api.wtsState =
-                    Api.TokenStateJSON
-                        { Api.owner = "owner"
-                        , Api.root = toApiHex (trieRootFor trieFact)
-                        , Api.tip = 1000000
-                        , Api.processTime = 60000
-                        , Api.retractTime = 30000
-                        }
+                    toApiWitnessedUtxo (bundleState factsBundle)
                 }
         , Api.fwMpfProof = toApiHex (mpfProof trieFact)
         }
 
-trieRootFor :: TrieFact -> Hex
-trieRootFor TrieFact{value = Just _} =
-    toClientHex (fst honestTrieInclusion)
-trieRootFor TrieFact{value = Nothing} =
-    toClientHex (fst honestTrieExclusion)
-
 factSnapshot :: Api.VerificationSnapshot
 factSnapshot =
     Api.VerificationSnapshot
-        { Api.vsUtxoRoot = Api.Hex (bundleRoot honestWitness)
+        { Api.vsUtxoRoot = Api.Hex (bundleRoot factsBundle)
         , Api.vsChainPoint =
             Api.ChainPointJSON
                 { Api.cpSlot = 42
@@ -445,9 +442,6 @@ toApiHex (Hex txt) =
     case Base16.decode (T.encodeUtf8 txt) of
         Right bs -> Api.Hex bs
         Left err -> error ("VerifySpec.toApiHex: " <> err)
-
-toClientHex :: ByteString -> Hex
-toClientHex = Hex . T.decodeUtf8 . Base16.encode
 
 replaceBootTx :: Hex -> BootTxResponse -> BootTxResponse
 replaceBootTx tx' (BootTxResponse _ s p) =

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -40,6 +40,7 @@ import Data.Aeson
     )
 import Data.Aeson.Key (Key)
 import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (parseEither)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
@@ -505,8 +506,11 @@ assertProofEnvelope v = do
     mpfProof `shouldSatisfy` (not . T.null)
 
 -- | The @/requests@ envelope must contain at least one
--- witnessed request with both its UTxO witness and a
--- decoded request payload.
+-- witnessed request that carries its provable @utxo@
+-- witness (@tx_in@ / @tx_out@ / @utxo_proof@) and ships
+-- NO server-side @request@ projection - a verifying
+-- client reconstructs the request from the inline datum
+-- in @utxo.tx_out@.
 assertRequestsEnvelope :: Value -> IO ()
 assertRequestsEnvelope v = do
     requests <- lookupArr v "requests"
@@ -517,8 +521,7 @@ assertRequestsEnvelope v = do
                 \request"
         (wreq : _) -> do
             assertWitnessedUtxo wreq
-            _ <- lookupObj wreq "request"
-            pure ()
+            assertFieldAbsent wreq "request"
 
 -- | The trusted root for facts-only end verification is
 -- supplied externally by the caller. In this e2e harness,
@@ -710,6 +713,28 @@ lookupHex v k = do
 
 lookupArr :: Value -> Key -> IO [Value]
 lookupArr = parseField
+
+-- | Assert a JSON object does NOT carry the given
+-- field. Used to prove a verified envelope ships no
+-- server-side projection of provable data.
+assertFieldAbsent :: Value -> Key -> IO ()
+assertFieldAbsent v k =
+    case parseEither
+        (withObject "obj" (pure . KM.member k))
+        v of
+        Right False -> pure ()
+        Right True ->
+            expectationFailure
+                $ "field "
+                    <> Key.toString k
+                    <> " must be absent (server-side \
+                       \projection leaked)"
+        Left err ->
+            expectationFailure
+                $ "field "
+                    <> Key.toString k
+                    <> ": "
+                    <> err
 
 parseField :: (FromJSON a) => Value -> Key -> IO a
 parseField v k =

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokenFactsCompletenessSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokenFactsCompletenessSpec.hs
@@ -20,8 +20,6 @@ import Cardano.MPFS.API.Encoding (Hex (..))
 import Cardano.MPFS.API.Types
     ( FactEntry (..)
     , FactsResponse (..)
-    , TokenStateJSON (..)
-    , WitnessedTokenState (..)
     )
 import Cardano.MPFS.Application (AppConfig (..), withApplication)
 import Cardano.MPFS.Context (Context (..))
@@ -147,12 +145,11 @@ completenessSpec scripts =
             let returnedFacts = responseFacts response
             sort returnedFacts `shouldBe` sort expectedFacts
 
-            rebuiltRoot <- reconstructRoot returnedFacts
-            let tokenRoot = tokenRootFromState response
-            rebuiltRoot `shouldBe` tokenRoot
-
+            -- The on-chain trie root is served provably by GET /root;
+            -- the enumerated fact set must reconstruct to exactly it.
             httpRoot <- getTokenRoot app tid
-            httpRoot `shouldBe` tokenRoot
+            rebuiltRoot <- reconstructRoot returnedFacts
+            rebuiltRoot `shouldBe` httpRoot
 
 reconstructRoot :: [(ByteString, ByteString)] -> IO ByteString
 reconstructRoot facts = do
@@ -166,15 +163,6 @@ responseFacts FactsResponse{frsFacts} =
     [ (key, value)
     | FactEntry{feKey = Hex key, feValue = Hex value} <- frsFacts
     ]
-
-tokenRootFromState :: FactsResponse -> ByteString
-tokenRootFromState
-    FactsResponse
-        { frsState =
-            WitnessedTokenState
-                { wtsState = TokenStateJSON{root = Hex tokenRoot}
-                }
-        } = tokenRoot
 
 getTokenFacts :: Application -> TokenId -> IO FactsResponse
 getTokenFacts app tid = do

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -37,7 +37,6 @@ import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as BSL
 import Data.List (sortOn)
-import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes)
 import Data.Proxy (Proxy (..))
 import Data.Set qualified as Set
@@ -156,11 +155,8 @@ import Cardano.MPFS.HTTP.Types
     , bundleSnapshotToJSON
     , mkSweepTxResponse
     , parseAddr
-    , requestToJSON
     , resolvedWalletInputToUtxoEntry
     , tokenIdFromJSON
-    , tokenIdToJSON
-    , tokenStateToJSON
     , txInToJSON
     )
 import Cardano.MPFS.HTTP.Types.Facts
@@ -365,61 +361,29 @@ tokensHandler ctx = do
         Just snap ->
             pure (bundleSnapshotToJSON snap)
     tokenSet <- requireIndexerRead eTokenSet
-    tokenRefs <- liftIO $ indexedTokenRefs ctx
-    tokenWitness <- tokenSetToJSON tokenRefs tokenSet
     pure
         TokensResponse
             { trsSnapshot = snapshot
-            , trsTokens = tokenWitness
+            , trsTokens = tokenSetToJSON tokenSet
             }
 
-indexedTokenRefs :: Context IO -> IO (Map.Map TxIn TokenId)
-indexedTokenRefs ctx = do
-    tids <- St.listTokens (St.tokens (state ctx))
-    entries <-
-        forM tids $ \tid -> do
-            mts <- St.getToken (St.tokens (state ctx)) tid
-            pure $ case mts of
-                Just LocatedTokenState{tokenStateRef} ->
-                    Just (tokenStateRef, tid)
-                Nothing -> Nothing
-    pure (Map.fromList (catMaybes entries))
+tokenSetToJSON :: ResolvedUtxoSet -> TokenSetWitness
+tokenSetToJSON (entries, proof) =
+    TokenSetWitness
+        { tswEntries = map tokenSetEntryToJSON entries
+        , tswCompletenessProof = Hex proof
+        }
 
-tokenSetToJSON
-    :: Map.Map TxIn TokenId
-    -> ResolvedUtxoSet
-    -> Handler TokenSetWitness
-tokenSetToJSON tokenRefs (entries, proof) = do
-    tokenEntries <-
-        traverse
-            (tokenSetEntryToJSON tokenRefs)
-            entries
-    pure
-        TokenSetWitness
-            { tswEntries = tokenEntries
-            , tswCompletenessProof = Hex proof
-            }
-
-tokenSetEntryToJSON
-    :: Map.Map TxIn TokenId
-    -> (TxIn, ByteString)
-    -> Handler TokenUtxoEntry
-tokenSetEntryToJSON tokenRefs (txIn, txOutBytes) =
-    case Map.lookup txIn tokenRefs of
-        Nothing ->
-            throwError
-                err503
-                    { errBody =
-                        "Token index is missing token_id for \
-                        \a state UTxO"
-                    }
-        Just tid ->
-            pure
-                TokenUtxoEntry
-                    { tueTokenId = tokenIdToJSON tid
-                    , tueRef = txInToUtxoRef txIn
-                    , tueTxOutCbor = Hex txOutBytes
-                    }
+-- | A token-state UTxO entry carries only its reference
+-- and CBOR @TxOut@; the token id is the state token's
+-- asset name inside that @TxOut@, which clients decode
+-- locally rather than trusting a server-side projection.
+tokenSetEntryToJSON :: (TxIn, ByteString) -> TokenUtxoEntry
+tokenSetEntryToJSON (txIn, txOutBytes) =
+    TokenUtxoEntry
+        { tueRef = txInToUtxoRef txIn
+        , tueTxOutCbor = Hex txOutBytes
+        }
 
 txInToUtxoRef :: TxIn -> UtxoRef
 txInToUtxoRef (TxIn (TxId sh) (TxIx ix)) =
@@ -447,7 +411,6 @@ tokenHandler ctx tokenId = do
         Just
             LocatedTokenState
                 { tokenStateRef
-                , tokenState = ts
                 } -> do
                 (mSnap, mWitness) <-
                     runProofIndexerTx ctx
@@ -467,8 +430,6 @@ tokenHandler ctx tokenId = do
                         , trState =
                             WitnessedTokenState
                                 { wtsUtxo = witness
-                                , wtsState =
-                                    tokenStateToJSON ts
                                 }
                         }
 
@@ -553,7 +514,6 @@ tokenFactsHandler ctx tokenId = do
     let tid = tokenIdFromJSON tokenId
     LocatedTokenState
         { tokenStateRef
-        , tokenState = ts
         } <-
         requireToken ctx tid
     (mSnap, mWitness, facts) <-
@@ -573,7 +533,6 @@ tokenFactsHandler ctx tokenId = do
             , frsState =
                 WitnessedTokenState
                     { wtsUtxo = witness
-                    , wtsState = tokenStateToJSON ts
                     }
             , frsFacts =
                 [ FactEntry
@@ -594,7 +553,6 @@ tokenFactHandler ctx tokenId (Hex k) = do
     let tid = tokenIdFromJSON tokenId
     LocatedTokenState
         { tokenStateRef
-        , tokenState = ts
         } <-
         requireToken ctx tid
     (mSnap, mWitness, trieFact) <-
@@ -622,8 +580,6 @@ tokenFactHandler ctx tokenId (Hex k) = do
                     { fwState =
                         WitnessedTokenState
                             { wtsUtxo = witness
-                            , wtsState =
-                                tokenStateToJSON ts
                             }
                     , fwMpfProof = proof
                     }
@@ -639,7 +595,6 @@ tokenProofHandler ctx tokenId (Hex k) = do
     let tid = tokenIdFromJSON tokenId
     LocatedTokenState
         { tokenStateRef
-        , tokenState = ts
         } <-
         requireToken ctx tid
     (mSnap, mWitness, trieFact) <-
@@ -663,8 +618,6 @@ tokenProofHandler ctx tokenId (Hex k) = do
                     { fwState =
                         WitnessedTokenState
                             { wtsUtxo = witness
-                            , wtsState =
-                                tokenStateToJSON ts
                             }
                     , fwMpfProof = proof
                     }
@@ -719,12 +672,11 @@ witnessRequest
     -> Handler WitnessedRequest
 witnessRequest
     ctx
-    LocatedRequest{requestRef, request = req} = do
+    LocatedRequest{requestRef} = do
         witness <- requireUtxoWitness ctx requestRef
         pure
             WitnessedRequest
                 { wrUtxo = witness
-                , wrRequest = requestToJSON req
                 }
 
 -- ---------------------------------------------------------

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Swagger.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Swagger.hs
@@ -48,7 +48,23 @@ swaggerDoc =
                \Merkle Patricia Forestry offchain \
                \node. Provides token lifecycle, \
                \trie queries, and transaction \
-               \building endpoints."
+               \building endpoints.\n\n\
+               \Contract: verified read endpoints \
+               \provide only provable on-chain data \
+               \(witnessed UTxOs: TxIn + full TxOut \
+               \+ CSMT proof) plus the proofs that \
+               \bind it to the snapshot's utxo_root, \
+               \and genuinely server-only data the \
+               \client cannot derive (snapshot / \
+               \chain tip / utxo_root). They never \
+               \ship server-side projections - \
+               \parsed convenience JSON of data \
+               \already present in a witnessed \
+               \TxOut. Clients reconstruct \
+               \everything else (token id, token \
+               \state, request payload) by decoding \
+               \the inline datum in the witnessed \
+               \TxOut."
         & info . license ?~ "Apache 2.0"
 
 -- | Type alias for Swagger UI endpoint.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 -- |
 -- Module      : Cardano.MPFS.HTTP.Types
@@ -21,12 +20,6 @@ module Cardano.MPFS.HTTP.Types
     , TokenIdJSON (..)
     , tokenIdToJSON
     , tokenIdFromJSON
-    , TokenStateJSON (..)
-    , tokenStateToJSON
-
-      -- * Requests
-    , RequestJSON (..)
-    , requestToJSON
 
       -- * UTxO witnesses
     , TxInJSON (..)
@@ -100,14 +93,12 @@ module Cardano.MPFS.HTTP.Types
     ) where
 
 import Data.ByteString.Short qualified as SBS
-import Data.Text (Text)
 
 import Cardano.Crypto.Hash.Class qualified as Crypto
 import Cardano.Ledger.Address (decodeAddrEither)
 import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary (natVersion, serialize')
 import Cardano.Ledger.Hashes (extractHash)
-import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Value (AssetName (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Tx.Ledger (ConwayTx)
@@ -132,7 +123,6 @@ import Cardano.MPFS.API.Types
     , RejectProofJSON (..)
     , RejectRequest (..)
     , RejectTxResponse (..)
-    , RequestJSON (..)
     , RequestProofJSON (..)
     , RequestTxResponse (..)
     , RequestsResponse (..)
@@ -148,7 +138,6 @@ import Cardano.MPFS.API.Types
     , TokenIdJSON (..)
     , TokenResponse (..)
     , TokenSetWitness (..)
-    , TokenStateJSON (..)
     , TokenUtxoEntry (..)
     , TokensResponse (..)
     , TrieFactJSON (..)
@@ -171,13 +160,8 @@ import Cardano.MPFS.API.Types
 import Cardano.MPFS.Core.Types
     ( Addr
     , BlockId (..)
-    , Coin (..)
-    , Operation (..)
-    , Request (..)
-    , Root (..)
     , SlotNo (..)
     , TokenId (..)
-    , TokenState (..)
     )
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
 import Cardano.MPFS.TxBuilder
@@ -202,55 +186,6 @@ tokenIdToJSON (TokenId (AssetName sbs)) =
 tokenIdFromJSON :: TokenIdJSON -> TokenId
 tokenIdFromJSON (TokenIdJSON bs) =
     TokenId (AssetName (SBS.toShort bs))
-
--- | Convert internal 'TokenState' to JSON type.
-tokenStateToJSON :: TokenState -> TokenStateJSON
-tokenStateToJSON
-    TokenState
-        { owner = tsOwner
-        , root = tsRoot
-        , tip = tsMaxFee
-        , processTime = tsProcessTime
-        , retractTime = tsRetractTime
-        } =
-        TokenStateJSON
-            { owner = hashToHex tsOwner
-            , root = Hex (unRoot tsRoot)
-            , tip = unCoin tsMaxFee
-            , processTime = tsProcessTime
-            , retractTime = tsRetractTime
-            }
-
--- | Render a 'KeyHash' as hex text.
-hashToHex :: KeyHash Payment -> Text
-hashToHex (KeyHash h) =
-    Crypto.hashToTextAsHex h
-
--- | Convert internal 'Request' to JSON type.
-requestToJSON :: Request -> RequestJSON
-requestToJSON
-    Request
-        { requestToken = tok
-        , requestOwner = own
-        , requestKey = k
-        , requestValue = op
-        , requestFee = fee
-        , requestSubmittedAt = sat
-        } =
-        let (opName, mVal) = case op of
-                Insert v -> ("insert", Just (Hex v))
-                Delete _v -> ("delete", Nothing)
-                Update _old new' ->
-                    ("update", Just (Hex new'))
-        in  RequestJSON
-                { rjToken = tokenIdToJSON tok
-                , rjOwner = hashToHex own
-                , rjKey = Hex k
-                , rjOperation = opName
-                , rjValue = mVal
-                , rjFee = unCoin fee
-                , rjSubmittedAt = sat
-                }
 
 -- | Convert a ledger 'TxIn' to its JSON form.
 txInToJSON :: TxIn -> TxInJSON

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/AtomicReadFixture.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/AtomicReadFixture.hs
@@ -15,6 +15,7 @@ module Cardano.MPFS.HTTP.AtomicReadFixture
     , sampleStateOutBytes
     , staleRoot
     , stateSetPrefix
+    , stateTxOutBytesWithRoot
     , testCageConfig
     , toClientCageConfig
     , withProofIndexer
@@ -34,7 +35,11 @@ import CSMT.Hashes (generateInclusionProof)
 import CSMT.Hashes.Types (Hash)
 import CSMT.Interface (FromKV)
 import Cardano.Ledger.Address (serialiseAddr)
-import Cardano.Ledger.Api.Tx.Out (TxOut, mkBasicTxOut)
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , datumTxOutL
+    , mkBasicTxOut
+    )
 import Cardano.Ledger.BaseTypes
     ( Inject (..)
     , Network (..)
@@ -82,6 +87,11 @@ import Cardano.MPFS.Application
     )
 import Cardano.MPFS.Client.Cage.Config qualified as Client
 import Cardano.MPFS.Context (Context (..))
+import Cardano.MPFS.Core.OnChain
+    ( CageDatum (..)
+    , OnChainRoot (..)
+    , OnChainTokenState (..)
+    )
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
     , Coin (..)
@@ -107,8 +117,12 @@ import Cardano.MPFS.TxBuilder (ResolvedWalletInput)
 import Cardano.MPFS.TxBuilder.Config (CageConfig (..))
 import Cardano.MPFS.TxBuilder.Real.Internal
     ( cageAddrFromCfg
+    , mkInlineDatum
     , requestAddrFromCfg
+    , toPlcData
     )
+import Control.Lens ((&), (.~))
+import PlutusTx.Builtins.Internal (BuiltinByteString (..))
 
 -- | "cafe" token — hex "63616665".
 cafeTid :: TokenId
@@ -176,6 +190,34 @@ sampleStateOutBytes _ =
         mkBasicTxOut
             (cageAddrFromCfg testCageConfig Testnet)
             (inject (Coin 2_000_000))
+
+-- | A state @TxOut@ whose inline datum carries the given trie root.
+-- Unlike 'sampleStateOutBytes', this produces a decodable state datum,
+-- so a witnessed UTxO built from it lets a client decode the on-chain
+-- trie root from provable bytes - exactly what the read verifiers now
+-- require instead of a server-side projection.
+stateTxOutBytesWithRoot :: ByteString -> ByteString
+stateTxOutBytesWithRoot root =
+    serialize'
+        (natVersion @11)
+        (txOut :: TxOut ConwayEra)
+  where
+    datum =
+        StateDatum
+            OnChainTokenState
+                { stateOwner =
+                    BuiltinByteString (BS.replicate 28 0)
+                , stateRoot = OnChainRoot root
+                , stateMaxFee = 1_000_000
+                , stateProcessTime = 60_000
+                , stateRetractTime = 30_000
+                }
+    txOut =
+        mkBasicTxOut
+            (cageAddrFromCfg testCageConfig Testnet)
+            (inject (Coin 2_000_000))
+            & datumTxOutL
+                .~ mkInlineDatum (toPlcData datum)
 
 sampleRequestOutBytes
     :: TokenId

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
@@ -536,8 +536,10 @@ responseSnapshotRoot resp =
         Nothing ->
             failExpectation "Expected RequestsResponse JSON"
 
--- | Assert the first witnessed request has both the
--- @utxo@ witness and the decoded @request@ payload.
+-- | Assert the first witnessed request carries the provable @utxo@
+-- witness (with its @tx_in@ / @tx_out@ / @utxo_proof@ fields) and that
+-- it ships NO server-side @request@ projection - a client reconstructs
+-- the request from the inline datum in @utxo.tx_out@.
 assertWitnessedRequestFields :: SResponse -> IO ()
 assertWitnessedRequestFields resp =
     case decode (simpleBody resp) of
@@ -547,31 +549,23 @@ assertWitnessedRequestFields resp =
                     | not (V.null arr) ->
                         case V.head arr of
                             Object wreq -> do
-                                KM.member "utxo" wreq
-                                    `shouldBe` True
+                                KM.member "request" wreq
+                                    `shouldBe` False
                                 case KM.lookup
-                                    "request"
+                                    "utxo"
                                     wreq of
-                                    Just (Object r) -> do
-                                        KM.member "token" r
+                                    Just (Object u) -> do
+                                        KM.member "tx_in" u
                                             `shouldBe` True
-                                        KM.member "owner" r
-                                            `shouldBe` True
-                                        KM.member "key" r
+                                        KM.member "tx_out" u
                                             `shouldBe` True
                                         KM.member
-                                            "operation"
-                                            r
-                                            `shouldBe` True
-                                        KM.member "fee" r
-                                            `shouldBe` True
-                                        KM.member
-                                            "submitted_at"
-                                            r
+                                            "utxo_proof"
+                                            u
                                             `shouldBe` True
                                     _ ->
                                         expectationFailure
-                                            "request \
+                                            "utxo \
                                             \is not an \
                                             \object"
                             _ ->

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenFactsSpec.hs
@@ -36,14 +36,15 @@ import Cardano.MPFS.Client.Verify.Read (verifyTokenFacts)
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
     ( LocatedTokenState (..)
+    , Root (..)
     , TokenId (..)
     , TokenState (..)
     )
 import Cardano.MPFS.Generators (genTxIn)
 import Cardano.MPFS.HTTP.AtomicReadFixture
     ( insertFacts
-    , sampleStateOutBytes
     , staleRoot
+    , stateTxOutBytesWithRoot
     , withProofIndexer
     )
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
@@ -54,8 +55,6 @@ import Cardano.MPFS.HTTP.Types
     ( FactEntry (..)
     , FactsResponse (..)
     , VerificationSnapshot (..)
-    , WitnessedTokenState (..)
-    , tokenStateToJSON
     )
 import Cardano.MPFS.State qualified as St
 
@@ -72,9 +71,14 @@ spec =
         $ do
             ctx0 <- mkTestContext
             txIn <- generate genTxIn
+            -- Precompute the deterministic trie root so the indexed
+            -- state UTxO can encode it in its inline datum. The read
+            -- verifier decodes the on-chain root from that provable
+            -- @TxOut@ - there is no server-side projection to trust.
+            Root trieRootBytes <- insertFacts ctx0 cafeTid facts
             withProofIndexer
                 (Just staleRoot)
-                [(txIn, sampleStateOutBytes 0)]
+                [(txIn, stateTxOutBytesWithRoot trieRootBytes)]
                 ctx0
                 $ \_txRoot ctx -> do
                     trieRoot <- insertFacts ctx cafeTid facts
@@ -90,8 +94,6 @@ spec =
                     simpleStatus resp `shouldBe` status200
                     case decode (simpleBody resp) of
                         Just body@FactsResponse{..} -> do
-                            wtsState frsState
-                                `shouldBe` tokenStateToJSON ts
                             factPairs frsFacts
                                 `shouldBe` sort facts
                             verifyTokenFacts

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokenSpec.hs
@@ -153,8 +153,9 @@ spec = describe "GET /tokens/:id" $ do
                                 Just (Object stateObj) -> do
                                     KM.member "utxo" stateObj
                                         `shouldBe` True
+                                    -- no server-side state projection
                                     KM.member "state" stateObj
-                                        `shouldBe` True
+                                        `shouldBe` False
                                 _ ->
                                     expectationFailure
                                         "state is not an \

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TokensSpec.hs
@@ -101,8 +101,7 @@ import Cardano.MPFS.HTTP.Encoding (Hex (..))
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.Types
-    ( TokenIdJSON (..)
-    , TokenSetWitness (..)
+    ( TokenSetWitness (..)
     , TokenUtxoEntry (..)
     , TokensResponse (..)
     , UtxoEntryRefOnly (..)
@@ -310,11 +309,7 @@ spec = describe "GET /tokens" $ do
                 resp <- getTokens ctxWithSet
                 simpleStatus resp `shouldBe` status200
                 assertEnvelope resp 2
-                assertTokenEntries
-                    resp
-                    [ ("deadbeef", txOut1)
-                    , ("cafebabe", txOut2)
-                    ]
+                assertTokenEntries resp [txOut1, txOut2]
 
     it "returns 503 when snapshot not yet available" $ do
         ctx0 <- mkTestContext
@@ -364,7 +359,9 @@ responseSnapshotRoot resp =
         Nothing ->
             failExpectation "Expected TokensResponse JSON"
 
-assertTokenEntries :: SResponse -> [(ByteString, ByteString)] -> IO ()
+-- | Token entries no longer carry a server-side @token_id@ projection;
+-- assert on the provable @txout_cbor@ bytes the witness ships.
+assertTokenEntries :: SResponse -> [ByteString] -> IO ()
 assertTokenEntries resp expected =
     case decode (simpleBody resp) of
         Just
@@ -373,10 +370,8 @@ assertTokenEntries resp expected =
                 } ->
                 sort
                     ( map
-                        ( \TokenUtxoEntry
-                            { tueTokenId = TokenIdJSON tokenId
-                            , tueTxOutCbor = Hex txOut
-                            } -> (tokenId, txOut)
+                        ( \TokenUtxoEntry{tueTxOutCbor = Hex txOut} ->
+                            txOut
                         )
                         tswEntries
                     )

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/TrieSpec.hs
@@ -62,6 +62,7 @@ import Cardano.MPFS.HTTP.AtomicReadFixture
     ( insertFacts
     , sampleStateOutBytes
     , staleRoot
+    , stateTxOutBytesWithRoot
     , withProofIndexer
     )
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
@@ -439,9 +440,15 @@ withPersistentFactContextWithTrie
 withPersistentFactContextWithTrie mOutOfTxRoot setupTrie action = do
     ctx0 <- mkTestContext
     stateTxIn <- generate genTxIn
+    -- Precompute the trie root so the indexed state UTxO can encode it
+    -- in its inline datum. The fact verifiers decode the on-chain root
+    -- from that provable TxOut, not from a server-side projection.
+    Root preRootBytes <- do
+        Trie.createTrie (trieManager ctx0) cafeTid
+        Trie.withTrie (trieManager ctx0) cafeTid setupTrie
     withProofIndexer
         mOutOfTxRoot
-        [(stateTxIn, sampleStateOutBytes 0)]
+        [(stateTxIn, stateTxOutBytesWithRoot preRootBytes)]
         ctx0
         $ \_txRoot ctx -> do
             Trie.createTrie (trieManager ctx) cafeTid

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Facts.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Facts.hs
@@ -63,7 +63,6 @@ import Cardano.MPFS.API.Types
     ( FactResponse (..)
     , FactWitness (..)
     , ProofResponse (..)
-    , TokenStateJSON (..)
     , TxInJSON (..)
     , WitnessedTokenState (..)
     , WitnessedUtxo (..)
@@ -117,6 +116,7 @@ import Cardano.MPFS.Client.Verify.Snapshot
 import Cardano.MPFS.Client.Verify.TxView
     ( TxOutView (..)
     , decodeTxOutView
+    , stateRootBytesFromWitness
     , verifyStateRootBinding
     )
 
@@ -1073,9 +1073,11 @@ verifyFactPresentFacts
         } = do
         verifyFactSnapshot "fact_present" trustedBs frSnapshot
         replayFactState "fact_present" trustedBs frFact
+        trieRoot <-
+            factWitnessTrieRoot "fact_present.fact" frFact
         replayTrieFact
             "fact_present.fact"
-            (factWitnessTrieRoot frFact)
+            trieRoot
             ClientWire.TrieFact
                 { ClientWire.key = toClientHex fpfKey
                 , ClientWire.value = Just (toClientHex frValue)
@@ -1098,9 +1100,11 @@ verifyFactAbsentFacts
         } = do
         verifyFactSnapshot "fact_absent" trustedBs prSnapshot
         replayFactState "fact_absent" trustedBs prFact
+        trieRoot <-
+            factWitnessTrieRoot "fact_absent.fact" prFact
         replayTrieFact
             "fact_absent.fact"
-            (factWitnessTrieRoot prFact)
+            trieRoot
             ClientWire.TrieFact
                 { ClientWire.key = toClientHex fafKey
                 , ClientWire.value = Nothing
@@ -1152,10 +1156,16 @@ replayFactState prefix trustedBs FactWitness{fwState} =
         trustedBs
         (toClientWitnessedUtxo (wtsUtxo fwState))
 
-factWitnessTrieRoot :: FactWitness -> BS.ByteString
-factWitnessTrieRoot FactWitness{fwState} =
-    let Hex rootBs = root (wtsState fwState)
-    in  rootBs
+-- | Decode the on-chain trie root from the inline datum of the
+-- witnessed state UTxO carried by a 'FactWitness'. The root is
+-- provable material in @fwState.utxo.tx_out@, not a server-side
+-- projection, so it is decoded locally rather than trusted.
+factWitnessTrieRoot
+    :: T.Text -> FactWitness -> Either VerifyError BS.ByteString
+factWitnessTrieRoot field FactWitness{fwState} =
+    stateRootBytesFromWitness
+        field
+        (toClientWitnessedUtxo (wtsUtxo fwState))
 
 toClientWitnessedUtxo :: WitnessedUtxo -> ClientWire.WitnessedUtxo
 toClientWitnessedUtxo WitnessedUtxo{..} =

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/Read.hs
@@ -47,7 +47,6 @@ import Cardano.MPFS.API.Types
     , TokenIdJSON
     , TokenResponse (..)
     , TokenSetWitness (..)
-    , TokenStateJSON (..)
     , TokenUtxoEntry (..)
     , TokensResponse (..)
     , TxInJSON (..)
@@ -78,6 +77,9 @@ import Cardano.MPFS.Client.Verify.Replay
     )
 import Cardano.MPFS.Client.Verify.Snapshot
     ( verifyVerificationSnapshot
+    )
+import Cardano.MPFS.Client.Verify.TxView
+    ( stateRootBytesFromWitness
     )
 
 -- | Opaque witness that a token listing has been checked against the
@@ -168,17 +170,20 @@ verifiedTokenFacts (VerifiedTokenFacts resp) = resp
 -- 'WitnessedTokenState' to the trusted root (as 'verifyTokenState'
 -- does), then reconstructs the MPF trie root from the complete
 -- enumerated @[FactEntry]@ and asserts it equals the on-chain trie
--- root advertised in the (now-anchored) state. The root binds the
--- whole map, so any omitted, added, or tampered fact makes the
--- reconstructed root diverge — this is the completeness proof.
+-- root decoded from the anchored state UTxO's inline datum. The root
+-- binds the whole map, so any omitted, added, or tampered fact makes
+-- the reconstructed root diverge - this is the completeness proof.
 verifyTokenFacts
     :: TrustedRoot
     -> FactsResponse
     -> Either VerifyError VerifiedTokenFacts
 verifyTokenFacts (TrustedRoot (Hex trustedBs)) resp@FactsResponse{..} = do
     verifyAnchoredState "facts" trustedBs frsSnapshot frsState
-    let Hex onChainRoot = root (wtsState frsState)
-        reconstructed = reconstructMpfRoot (map factPair frsFacts)
+    onChainRoot <-
+        stateRootBytesFromWitness
+            "facts.state.tx_out"
+            (toClientWitnessedUtxo (wtsUtxo frsState))
+    let reconstructed = reconstructMpfRoot (map factPair frsFacts)
     if reconstructed == onChainRoot
         then Right (VerifiedTokenFacts resp)
         else Left (MpfReplayFailed "facts.facts" "root mismatch")

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/TxView.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/TxView.hs
@@ -16,6 +16,7 @@ module Cardano.MPFS.Client.Verify.TxView
     , TxView (..)
     , decodeTxView
     , decodeTxOutView
+    , stateRootBytesFromWitness
     , verifyBootAssetBinding
     , verifyBootRedeemerBinding
     , verifyContinuingStateOutput
@@ -1007,6 +1008,23 @@ stateRootFromWitness endpoint WitnessedUtxo{txOut} = do
             parseStateDatumRoot
                 (endpoint <> ".state.tx_out.datum")
                 datum
+
+-- | Extract the raw 32-byte trie root from the inline state datum of
+-- a witnessed state UTxO. Like 'stateRootFromWitness' but returns the
+-- decoded bytes rather than the hex rendering, for callers that
+-- reconstruct or compare the root in its binary form.
+stateRootBytesFromWitness
+    :: Text -> WitnessedUtxo -> Either VerifyError BS.ByteString
+stateRootBytesFromWitness endpoint witness = do
+    Hex rootHex <- stateRootFromWitness endpoint witness
+    case Base16.decode (T.encodeUtf8 rootHex) of
+        Right bs -> Right bs
+        Left _ ->
+            Left
+                ( TxBindingFailed
+                    (endpoint <> ".state.tx_out.datum.root")
+                    "malformed state root hex"
+                )
 
 parseStateDatumRoot :: Text -> CBOR.Term -> Either VerifyError Hex
 parseStateDatumRoot field datum = do

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -46,6 +46,19 @@ server must not return unsigned transactions for script-bearing cage
 operations. The remaining server-built transaction route is the
 owner-only `/tx/sweep` cleanup path.
 
+Read endpoints ship only **provable on-chain data plus proofs**:
+witnessed UTxOs (`TxIn` + full `TxOut` + CSMT inclusion proof), the
+completeness / MPF-replay proofs binding them to the snapshot's
+`utxo_root`, and genuinely server-only data the client cannot derive
+(the snapshot, chain tip, and `utxo_root`). They must **not** ship
+server-side *projections* - parsed convenience JSON re-rendering data
+already present in a witnessed `TxOut`. Projections are unverified,
+frequently lossy, and tempt verifying clients into trusting
+non-provable data. A client reconstructs everything it needs (token
+id, token state, request payload) by decoding the inline datum of the
+witnessed `TxOut`; the server's job is to provide that provable
+material, not to interpret it.
+
 The 502 era-history failure was fixed by carrying live era history in
 `GET /eval-context` and deriving `EpochInfo` from it in the reactor.
 `ScriptContext` `POSIXTimeRange` costs now use the same era clock as the

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -587,41 +587,6 @@
             ],
             "type": "object"
         },
-        "RequestJSON": {
-            "description": "Pending request",
-            "properties": {
-                "fee": {
-                    "type": "integer"
-                },
-                "key": {
-                    "$ref": "#/definitions/Hex"
-                },
-                "operation": {
-                    "type": "string"
-                },
-                "owner": {
-                    "type": "string"
-                },
-                "submitted_at": {
-                    "type": "integer"
-                },
-                "token": {
-                    "$ref": "#/definitions/TokenIdJSON"
-                },
-                "value": {
-                    "$ref": "#/definitions/Hex"
-                }
-            },
-            "required": [
-                "token",
-                "owner",
-                "key",
-                "operation",
-                "fee",
-                "submitted_at"
-            ],
-            "type": "object"
-        },
         "RequestUpdateFacts": {
             "description": "Facts-only request-update response. Carries request payload, submission timestamp, wallet UTxO witnesses, and unverified protocol parameters, with no unsigned transaction CBOR.",
             "properties": {
@@ -872,7 +837,7 @@
             "type": "object"
         },
         "TokenSetWitness": {
-            "description": "Enumerated token-state UTxOs with explicit token ids and a CSMT prefix-completeness proof",
+            "description": "Enumerated token-state UTxOs (token id is the state token's asset name inside each txout_cbor) with a CSMT prefix-completeness proof",
             "properties": {
                 "completeness_proof": {
                     "$ref": "#/definitions/Hex"
@@ -890,49 +855,17 @@
             ],
             "type": "object"
         },
-        "TokenStateJSON": {
-            "description": "On-chain token state",
-            "properties": {
-                "owner": {
-                    "type": "string"
-                },
-                "process_time": {
-                    "type": "integer"
-                },
-                "retract_time": {
-                    "type": "integer"
-                },
-                "root": {
-                    "$ref": "#/definitions/Hex"
-                },
-                "tip": {
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "owner",
-                "root",
-                "tip",
-                "process_time",
-                "retract_time"
-            ],
-            "type": "object"
-        },
         "TokenUtxoEntry": {
-            "description": "Token-state UTxO entry with the token_id carried explicitly",
+            "description": "Token-state UTxO entry; the token id is the state token's asset name inside txout_cbor",
             "properties": {
                 "ref": {
                     "$ref": "#/definitions/UtxoRef"
-                },
-                "token_id": {
-                    "$ref": "#/definitions/TokenIdJSON"
                 },
                 "txout_cbor": {
                     "$ref": "#/definitions/Hex"
                 }
             },
             "required": [
-                "token_id",
                 "ref",
                 "txout_cbor"
             ],
@@ -1203,34 +1136,26 @@
             "type": "object"
         },
         "WitnessedRequest": {
-            "description": "Pending request plus UTxO witness",
+            "description": "UTxO witness for a pending-request output; the request is the inline datum in utxo.tx_out",
             "properties": {
-                "request": {
-                    "$ref": "#/definitions/RequestJSON"
-                },
                 "utxo": {
                     "$ref": "#/definitions/WitnessedUtxo"
                 }
             },
             "required": [
-                "utxo",
-                "request"
+                "utxo"
             ],
             "type": "object"
         },
         "WitnessedTokenState": {
-            "description": "Token state plus UTxO witness",
+            "description": "UTxO witness for a token-state output; the on-chain state is the inline datum in utxo.tx_out",
             "properties": {
-                "state": {
-                    "$ref": "#/definitions/TokenStateJSON"
-                },
                 "utxo": {
                     "$ref": "#/definitions/WitnessedUtxo"
                 }
             },
             "required": [
-                "utxo",
-                "state"
+                "utxo"
             ],
             "type": "object"
         },
@@ -1256,7 +1181,7 @@
         }
     },
     "info": {
-        "description": "HTTP service for the Cardano Merkle Patricia Forestry offchain node. Provides token lifecycle, trie queries, and transaction building endpoints.",
+        "description": "HTTP service for the Cardano Merkle Patricia Forestry offchain node. Provides token lifecycle, trie queries, and transaction building endpoints.\n\nContract: verified read endpoints provide only provable on-chain data (witnessed UTxOs: TxIn + full TxOut + CSMT proof) plus the proofs that bind it to the snapshot's utxo_root, and genuinely server-only data the client cannot derive (snapshot / chain tip / utxo_root). They never ship server-side projections - parsed convenience JSON of data already present in a witnessed TxOut. Clients reconstruct everything else (token id, token state, request payload) by decoding the inline datum in the witnessed TxOut.",
         "license": {
             "name": "Apache 2.0"
         },

--- a/mpfs-spa/src/MpfsSpa/Http.purs
+++ b/mpfs-spa/src/MpfsSpa/Http.purs
@@ -30,7 +30,7 @@ import Prelude
 import Control.Promise (Promise, toAffE)
 import Data.Argonaut.Core (Json, stringify)
 import Data.Argonaut.Decode (decodeJson)
-import Data.Argonaut.Decode.Combinators ((.:), (.:?))
+import Data.Argonaut.Decode.Combinators ((.:))
 import Data.Argonaut.Decode.Error (JsonDecodeError(..), printJsonDecodeError)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Bifunctor (lmap)
@@ -43,7 +43,7 @@ import Effect.Aff (Aff)
 
 import MpfsSpa.Types
   ( Key(..)
-  , RequestId(..)
+  , RequestId
   , TokenId(..)
   , TrustedRoot(..)
   , Value(..)
@@ -184,17 +184,22 @@ submitTx cfg signedHex = do
 
 -- --- decoders ---------------------------------------------------------------
 
+-- | #342 removed the server-side projections (`state.state`, `token_id`,
+-- | `request`) these decoders used to read. Reconstructing them now means
+-- | decoding the witnessed `tx_out` inline datum, which the SPA does not
+-- | yet do - surface a typed decode failure instead of trusting removed
+-- | projections.
+witnessTxOutDecoderMissing :: forall a. String -> Either JsonDecodeError a
+witnessTxOutDecoderMissing what =
+  Left
+    ( TypeMismatch
+        ( what
+            <> " requires decoding witnessed tx_out; SPA decoder not implemented"
+        )
+    )
+
 decodeTokenState :: Json -> Either JsonDecodeError TokenState
-decodeTokenState j = do
-  top <- decodeJson j
-  wts <- top .: "state"
-  st <- wts .: "state"
-  owner <- st .: "owner"
-  root <- st .: "root"
-  tip <- st .: "tip"
-  processTime <- st .: "process_time"
-  retractTime <- st .: "retract_time"
-  pure { owner, root, tip, processTime, retractTime }
+decodeTokenState _ = witnessTxOutDecoderMissing "token state"
 
 decodeTokensResponse :: Json -> Either JsonDecodeError (Array TokenId)
 decodeTokensResponse j = do
@@ -204,10 +209,7 @@ decodeTokensResponse j = do
   traverse decodeTokenEntry entries
 
 decodeTokenEntry :: Json -> Either JsonDecodeError TokenId
-decodeTokenEntry j = do
-  entry <- decodeJson j
-  tokenId <- entry .: "token_id"
-  pure (TokenId tokenId)
+decodeTokenEntry _ = witnessTxOutDecoderMissing "token id"
 
 decodeFacts :: Json -> Either JsonDecodeError (Array FactEntry)
 decodeFacts j = do
@@ -229,30 +231,7 @@ decodeRequests j = do
   traverse decodeWitnessedRequest reqs
 
 decodeWitnessedRequest :: Json -> Either JsonDecodeError PendingRequest
-decodeWitnessedRequest wj = do
-  o <- decodeJson wj
-  req <- o .: "request"
-  utxo <- o .: "utxo"
-  txin <- utxo .: "tx_in"
-  txId <- txin .: "tx_id"
-  (txIx :: Int) <- txin .: "tx_ix"
-  token <- req .: "token"
-  owner <- req .: "owner"
-  key <- req .: "key"
-  mvalue <- req .:? "value"
-  operation <- req .: "operation"
-  fee <- req .: "fee"
-  submittedAt <- req .: "submitted_at"
-  pure
-    { token: TokenId token
-    , owner
-    , key: Key key
-    , value: Value <$> mvalue
-    , operation
-    , fee
-    , submittedAt
-    , requestId: RequestId (txId <> "#" <> show txIx)
-    }
+decodeWitnessedRequest _ = witnessTxOutDecoderMissing "pending request"
 
 decodeFactValue :: Json -> Either JsonDecodeError Value
 decodeFactValue j = do

--- a/nix/mpfs-spa.nix
+++ b/nix/mpfs-spa.nix
@@ -24,16 +24,15 @@ in pkgs.mkSpagoDerivation {
   inherit src;
   spagoYaml = ../mpfs-spa/spago.yaml;
   spagoLock = ../mpfs-spa/spago.lock;
-  nativeBuildInputs =
-    [
-      pkgs.purs
-      pkgs.spago-unstable
-      pkgs.esbuild
-      pkgs.nodejs_20
-      pkgs.jq
-      pkgs.gzip
-      pkgs.brotli
-    ];
+  nativeBuildInputs = [
+    pkgs.purs
+    pkgs.spago-unstable
+    pkgs.esbuild
+    pkgs.nodejs_20
+    pkgs.jq
+    pkgs.gzip
+    pkgs.brotli
+  ];
   buildPhase = ''
     ln -s ${nodeModules}/node_modules node_modules
 


### PR DESCRIPTION
## Summary
- Removes server-side projection fields from proof-bearing read responses: request payloads, token state payloads, and explicit token IDs in token-set entries.
- Keeps verified read endpoints focused on witnessed UTxOs, proofs, snapshots, and server-only roots/tips; verifier code now derives state roots from witnessed TxOut inline datums.
- Updates CLI output, tests, docs, and generated Swagger for the witness-only contract.
- Defers in-repo SPA consumer migration to #345 (no witnessed tx_out decoder exists yet at the PureScript boundary).

## Verification
- ./gate.sh
- nix develop --quiet -c cabal build cardano-mpfs-offchain:e2e-tests -O0 --enable-tests --ghc-options='-fmax-errors=0'

Refs #342
