### PR TITLE
feat(submit): reject non-MPFS transactions

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -99,6 +99,7 @@ library
     Cardano.MPFS.HTTP.API
     Cardano.MPFS.HTTP.Encoding
     Cardano.MPFS.HTTP.Server
+    Cardano.MPFS.HTTP.SubmitScope
     Cardano.MPFS.HTTP.Swagger
     Cardano.MPFS.HTTP.Types
     Cardano.MPFS.HTTP.Types.Facts
@@ -316,6 +317,7 @@ test-suite unit-tests
     Cardano.MPFS.HTTP.RequestUpdateFactsSpec
     Cardano.MPFS.HTTP.RetractFactsSpec
     Cardano.MPFS.HTTP.StatusSpec
+    Cardano.MPFS.HTTP.SubmitScopeSpec
     Cardano.MPFS.HTTP.SubmitSpec
     Cardano.MPFS.HTTP.TokenFactsSpec
     Cardano.MPFS.HTTP.TokenSpec

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
@@ -5,29 +5,28 @@
 
 -- |
 -- Module      : Cardano.MPFS.E2E.SubmitEndpointSpec
--- Description : HTTP-level E2E for POST /submit
+-- Description : HTTP-level E2E for POST /submit scope gate
 -- License     : Apache-2.0
 --
--- Boots a devnet + full application, builds and
--- signs a genesis ADA-transfer tx, POSTs its CBOR to
--- @POST \/submit@ over HTTP, and awaits the returned
--- txId against the node. This is the live-boundary
--- proof that the locked wire contract works against a
--- real N2C submitter and a real chain.
+-- Boots a devnet + full application, builds and signs a
+-- genesis ADA-transfer tx, POSTs its CBOR to @POST
+-- \/submit@ over HTTP, and asserts the #343 scope gate
+-- rejects it with @400@ \"this service only submits MPFS
+-- operations\" — the live-boundary proof that a non-MPFS
+-- tx is refused before it ever reaches the N2C
+-- submitter. Undecodable CBOR is likewise a @400@.
 module Cardano.MPFS.E2E.SubmitEndpointSpec
     ( spec
     ) where
 
 import Data.Aeson (decode, encode)
-import Data.ByteString (ByteString)
-import Data.ByteString qualified as BS
-import Data.ByteString.Base16 qualified as B16
+import Data.Aeson.KeyMap qualified as KM
+import Data.Aeson.Types (Value (..))
 import Data.ByteString.Lazy qualified as BSL
 import Lens.Micro ((&), (.~))
 import Network.HTTP.Types
     ( hContentType
     , methodPost
-    , status200
     , status400
     )
 import Network.Wai
@@ -39,7 +38,6 @@ import Network.Wai.Test
     ( SRequest (..)
     , SResponse (..)
     , defaultRequest
-    , request
     , runSession
     , setPath
     , srequest
@@ -98,7 +96,6 @@ import Cardano.MPFS.HTTP.Encoding (Hex (..))
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.Types
     ( SubmitRequest (..)
-    , SubmitResponse (..)
     )
 import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder.Config
@@ -139,14 +136,9 @@ spec = describe "POST /submit (e2e)" $ do
                 Right scripts ->
                     submitEndpointSpec scripts
 
--- | Await timeout in seconds. Devnet slots are
--- 100ms so 60s is plenty.
-awaitTimeout :: Int
-awaitTimeout = 60
-
 submitEndpointSpec :: CageScripts -> Spec
 submitEndpointSpec scripts =
-    it "signs, submits, and awaits a real tx"
+    it "rejects a non-MPFS tx with a typed 400 scope error"
         $ withE2E scripts
         $ \_cfg ctx -> do
             let app = mkApp ctx
@@ -191,25 +183,20 @@ submitEndpointSpec scripts =
                                         ( SubmitRequest
                                             (Hex rawCbor)
                                         )
+                            -- #343 scope gate: a plain
+                            -- ADA transfer touches no MPFS
+                            -- contract surface, so the
+                            -- server rejects it before the
+                            -- node ever sees it.
                             resp <- post app reqBody
                             simpleStatus resp
-                                `shouldBe` status200
-                            case decode (simpleBody resp) of
-                                Nothing ->
-                                    expectationFailure
-                                        "expected a \
-                                        \SubmitResponse \
-                                        \JSON body"
-                                Just (SubmitResponse (Hex txIdBytes)) -> do
-                                    BS.length txIdBytes
-                                        `shouldBe` 32
-                                    awaitTx
-                                        awaitTimeout
-                                        app
-                                        (B16.encode txIdBytes)
-                            -- Bonus: undecodable CBOR is a
-                            -- 400 (reuses the same booted
-                            -- app; never reaches the node).
+                                `shouldBe` status400
+                            scopeDetail resp
+                                `shouldBe` Just
+                                    "this service only \
+                                    \submits MPFS operations"
+                            -- Undecodable CBOR is also a
+                            -- 400 (never reaches the node).
                             garbage <-
                                 post
                                     app
@@ -220,6 +207,14 @@ submitEndpointSpec scripts =
                                     )
                             simpleStatus garbage
                                 `shouldBe` status400
+
+-- | Extract the @detail@ field of a @POST \/submit@
+-- JSON error body, if present.
+scopeDetail :: SResponse -> Maybe Value
+scopeDetail resp =
+    case decode (simpleBody resp) of
+        Just (Object o) -> KM.lookup "detail" o
+        _ -> Nothing
 
 -- | @POST \/submit@ with a JSON body.
 post :: Application -> BSL.ByteString -> IO SResponse
@@ -232,27 +227,6 @@ post app body =
             , requestHeaders =
                 [(hContentType, "application/json")]
             }
-
--- | @GET \/tx\/:txId?timeout=N@ — block until the
--- indexer has seen this transaction.
-awaitTx
-    :: Int -> Application -> ByteString -> IO ()
-awaitTx timeout app txIdHex = do
-    resp <-
-        runSession
-            (request (setPath defaultRequest path))
-            app
-    simpleStatus resp `shouldBe` status200
-  where
-    path =
-        "/tx/"
-            <> txIdHex
-            <> "?timeout="
-            <> bshow timeout
-    bshow =
-        BS.pack
-            . map (fromIntegral . fromEnum)
-            . show
 
 -- -------------------------------------------------
 -- Bracket

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -114,6 +114,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.HTTP.API (API)
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
+import Cardano.MPFS.HTTP.SubmitScope (txTouchesMpfs)
 import Cardano.MPFS.HTTP.Swagger
     ( SwaggerAPI
     , swaggerServer
@@ -2102,6 +2103,18 @@ txSubmitHandler ctx (SubmitRequest (Hex txCbor)) = do
                     err400
                     "decode failed"
                     (T.pack (show msg))
+    -- Scope gate (#343): the server is a fact-provider
+    -- for the MPFS cage, not a general-purpose relay.
+    -- Reject any tx that touches none of the cage
+    -- contract surface (state-token policy / cage
+    -- address / request output) before it reaches the
+    -- node.
+    unless (txTouchesMpfs (cfgCage ctx) tx)
+        $ throwError
+        $ submitError
+            err400
+            "not an MPFS operation"
+            "this service only submits MPFS operations"
     result <-
         liftIO
             $ Sub.submitTx (submitter ctx) tx

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -114,7 +114,11 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.HTTP.API (API)
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
-import Cardano.MPFS.HTTP.SubmitScope (txTouchesMpfs)
+import Cardano.MPFS.HTTP.SubmitScope
+    ( SpentInput (..)
+    , spentTxIns
+    , txTouchesMpfs
+    )
 import Cardano.MPFS.HTTP.Swagger
     ( SwaggerAPI
     , swaggerServer
@@ -177,6 +181,7 @@ import Cardano.MPFS.Indexer.Reads
     , readNamedRequestUtxo
     , readRequestUtxosAt
     , readSnapshot
+    , readSpentTxOuts
     , readStateUtxoAt
     , readTrieFact
     , readTrieFacts
@@ -2092,6 +2097,29 @@ submitError base errTxt detailTxt =
             [("Content-Type", "application/json")]
         }
 
+-- | Resolve a transaction's spent inputs against the
+-- indexed UTxO set for the @POST \/tx\/submit@ scope
+-- gate, reading them all inside ONE indexer transaction.
+-- An input the indexer does not know is 'UnresolvedSpent';
+-- an input whose indexed bytes fail to decode is likewise
+-- treated as 'UnresolvedSpent' so the gate never
+-- hard-rejects a transaction on it.
+resolveSpentInputs
+    :: Context IO -> ConwayTx -> IO [SpentInput]
+resolveSpentInputs ctx tx = do
+    resolved <-
+        runIndexerTx ctx
+            $ readSpentTxOuts (spentTxIns tx)
+    pure (map toSpentInput resolved)
+  where
+    toSpentInput (_, Nothing) = UnresolvedSpent
+    toSpentInput (_, Just bytes) =
+        case decodeIndexedTxOutEither
+            "tx/submit.spent_input"
+            bytes of
+            Right out -> ResolvedSpent out
+            Left _ -> UnresolvedSpent
+
 txSubmitHandler
     :: Context IO -> SubmitRequest -> Handler SubmitResponse
 txSubmitHandler ctx (SubmitRequest (Hex txCbor)) = do
@@ -2105,11 +2133,17 @@ txSubmitHandler ctx (SubmitRequest (Hex txCbor)) = do
                     (T.pack (show msg))
     -- Scope gate (#343): the server is a fact-provider
     -- for the MPFS cage, not a general-purpose relay.
-    -- Reject any tx that touches none of the cage
-    -- contract surface (state-token policy / cage
-    -- address / request output) before it reaches the
-    -- node.
-    unless (txTouchesMpfs (cfgCage ctx) tx)
+    -- Resolve the tx's spent inputs against the indexed
+    -- UTxO view, then reject only a tx that touches none
+    -- of the cage contract surface — no cage mint, no
+    -- cage output, and no spent cage-owned UTxO. The
+    -- input check is what admits spend-only operations
+    -- (retract, sweep) that leave no mint or output
+    -- fingerprint; an input the indexer cannot resolve is
+    -- treated conservatively so a valid op is never
+    -- false-rejected because the server view lags.
+    spentInputs <- liftIO $ resolveSpentInputs ctx tx
+    unless (txTouchesMpfs (cfgCage ctx) spentInputs tx)
         $ throwError
         $ submitError
             err400

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/SubmitScope.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/SubmitScope.hs
@@ -5,14 +5,36 @@
 --
 -- The MPFS server is a fact-provider for the MPFS cage
 -- contract, not a general-purpose transaction relay.
--- 'txTouchesMpfs' is the cheap, purely structural gate
+-- 'txTouchesMpfs' is the cheap, mostly-structural gate
 -- that @POST \/tx\/submit@ runs on a decoded
 -- transaction before relaying it to the node: it admits
 -- only transactions that interact with the cage contract
--- surface (the state-token policy, the cage state
--- address, or a request output at this cage's request
--- validator) and rejects everything else — most plainly,
+-- surface and rejects everything else — most plainly,
 -- value transfers that have nothing to do with MPFS.
+--
+-- A transaction touches the cage surface when any of the
+-- following hold:
+--
+--   * it mints or burns under the cage state-token
+--     policy (boot, end);
+--   * it has an output locked by the cage state script
+--     (boot, update, reject) or a request output at this
+--     cage's per-token request validator address (request
+--     create);
+--   * it /spends/ a cage-owned UTxO — a state UTxO at the
+--     cage state address or a request UTxO at a request
+--     validator address. This last clause is what admits
+--     spend-only operations (retract, sweep) that produce
+--     no cage mint and no cage output.
+--
+-- 'txTouchesMpfs' stays pure: the caller resolves the
+-- transaction's spent inputs against the server's indexed
+-- UTxO view (see 'spentTxIns' and
+-- 'Cardano.MPFS.Indexer.Reads.readSpentTxOuts') and passes
+-- the resolved 'SpentInput's in. An input the indexer
+-- cannot resolve is conservatively treated as touching the
+-- cage, so a transaction is never false-rejected because
+-- the server's view lags the chain.
 --
 -- The mint and state-output recognition is reused from
 -- "Cardano.MPFS.Indexer.Event" so the gate cannot drift
@@ -21,6 +43,8 @@
 -- per-token request validator address.
 module Cardano.MPFS.HTTP.SubmitScope
     ( txTouchesMpfs
+    , SpentInput (..)
+    , spentTxIns
     ) where
 
 import Data.Foldable (toList)
@@ -28,8 +52,12 @@ import Lens.Micro ((^.))
 
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Api.Tx (bodyTxL)
-import Cardano.Ledger.Api.Tx.Body (outputsTxBodyL)
+import Cardano.Ledger.Api.Tx.Body
+    ( inputsTxBodyL
+    , outputsTxBodyL
+    )
 import Cardano.Ledger.Api.Tx.Out (addrTxOutL)
+import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Tx.Ledger (ConwayTx)
 
 import Cardano.MPFS.Core.Types (ConwayEra, TxOut)
@@ -45,30 +73,72 @@ import Cardano.MPFS.TxBuilder.Real.Internal
     ( requestAddrFromCfg
     )
 
+-- | A transaction's spent input, resolved against the
+-- server's indexed UTxO view, as consumed by
+-- 'txTouchesMpfs'.
+data SpentInput
+    = -- | The indexer resolved this spent input to a known
+      -- UTxO; the gate inspects the decoded 'TxOut' to see
+      -- whether it sits on the cage surface.
+      ResolvedSpent !(TxOut ConwayEra)
+    | -- | The indexer could not resolve this spent input —
+      -- its UTxO view may lag the chain. The gate treats
+      -- such an input conservatively (as if it touched the
+      -- cage) and so never hard-rejects a transaction on an
+      -- unknown input alone; a stale or unknown input is
+      -- the node's concern, not the gate's.
+      UnresolvedSpent
+    deriving (Eq, Show)
+
+-- | The transaction inputs the @POST \/tx\/submit@ scope
+-- gate must resolve against the indexed UTxO view: the
+-- body's spent inputs. Reference inputs are excluded — a
+-- referenced cage UTxO (e.g. retract\/sweep reference the
+-- state UTxO) is not what the operation acts on.
+spentTxIns :: ConwayTx -> [TxIn]
+spentTxIns tx =
+    toList (tx ^. bodyTxL . inputsTxBodyL)
+
 -- | Does this transaction touch the MPFS cage contract
--- surface, given the server's cage configuration?
+-- surface, given the server's cage configuration and the
+-- server's view of its spent inputs?
 --
 -- This is the @POST \/tx\/submit@ scope gate. It admits a
--- transaction iff its body shows any of:
+-- transaction iff any of the following hold:
 --
 --   * a mint or burn under the cage policy (boot, end);
 --   * an output locked by the cage state script (boot,
 --     update, reject);
 --   * a request output: a 'RequestDatum'-bearing output
 --     sitting at THIS cage's request validator address for
---     the token the datum names (request create).
+--     the token the datum names (request create);
+--   * a spent input resolved to a cage-owned UTxO — a
+--     state UTxO at the cage state address (end, update,
+--     reject) or a request UTxO at this cage's request
+--     validator address (retract, sweep), the latter being
+--     the only fingerprint a spend-only operation leaves.
 --
--- A plain value transfer touches none of these and is
--- rejected.
-txTouchesMpfs :: CageConfig -> ConwayTx -> Bool
-txTouchesMpfs cfg tx =
+-- An 'UnresolvedSpent' input is treated as touching the
+-- cage, so the gate is conservative: it rejects only a
+-- transaction that is definitely non-MPFS — no cage mint,
+-- no cage output, and every spent input resolved to a
+-- non-cage UTxO. A plain value transfer is rejected; any
+-- real MPFS operation is admitted.
+txTouchesMpfs :: CageConfig -> [SpentInput] -> ConwayTx -> Bool
+txTouchesMpfs cfg spentInputs tx =
     mintsCagePolicy scriptHash tx
-        || any (isCageStateOutput scriptHash) outputs
-        || any (isCageRequestOutput cfg) outputs
+        || any touchesCageSurface outputs
+        || any spentTouchesCage spentInputs
   where
     scriptHash = cfgScriptHash cfg
     outputs =
         toList (tx ^. bodyTxL . outputsTxBodyL)
+    touchesCageSurface txOut =
+        isCageStateOutput scriptHash txOut
+            || isCageRequestOutput cfg txOut
+    spentTouchesCage UnresolvedSpent = True
+    spentTouchesCage (ResolvedSpent txOut) =
+        touchesCageSurface txOut
 
 -- | 'True' iff the output is a request output bound to
 -- THIS cage: it carries a 'RequestDatum' and sits at the

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/SubmitScope.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/SubmitScope.hs
@@ -1,0 +1,93 @@
+-- |
+-- Module      : Cardano.MPFS.HTTP.SubmitScope
+-- Description : Structural scope gate for POST /tx/submit
+-- License     : Apache-2.0
+--
+-- The MPFS server is a fact-provider for the MPFS cage
+-- contract, not a general-purpose transaction relay.
+-- 'txTouchesMpfs' is the cheap, purely structural gate
+-- that @POST \/tx\/submit@ runs on a decoded
+-- transaction before relaying it to the node: it admits
+-- only transactions that interact with the cage contract
+-- surface (the state-token policy, the cage state
+-- address, or a request output at this cage's request
+-- validator) and rejects everything else — most plainly,
+-- value transfers that have nothing to do with MPFS.
+--
+-- The mint and state-output recognition is reused from
+-- "Cardano.MPFS.Indexer.Event" so the gate cannot drift
+-- from how the indexer classifies the same transaction;
+-- request outputs are additionally bound to this cage's
+-- per-token request validator address.
+module Cardano.MPFS.HTTP.SubmitScope
+    ( txTouchesMpfs
+    ) where
+
+import Data.Foldable (toList)
+import Lens.Micro ((^.))
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Api.Tx (bodyTxL)
+import Cardano.Ledger.Api.Tx.Body (outputsTxBodyL)
+import Cardano.Ledger.Api.Tx.Out (addrTxOutL)
+import Cardano.Tx.Ledger (ConwayTx)
+
+import Cardano.MPFS.Core.Types (ConwayEra, TxOut)
+import Cardano.MPFS.Indexer.Event
+    ( isCageStateOutput
+    , mintsCagePolicy
+    , requestOutputToken
+    )
+import Cardano.MPFS.TxBuilder.Config
+    ( CageConfig (cfgScriptHash, network)
+    )
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( requestAddrFromCfg
+    )
+
+-- | Does this transaction touch the MPFS cage contract
+-- surface, given the server's cage configuration?
+--
+-- This is the @POST \/tx\/submit@ scope gate. It admits a
+-- transaction iff its body shows any of:
+--
+--   * a mint or burn under the cage policy (boot, end);
+--   * an output locked by the cage state script (boot,
+--     update, reject);
+--   * a request output: a 'RequestDatum'-bearing output
+--     sitting at THIS cage's request validator address for
+--     the token the datum names (request create).
+--
+-- A plain value transfer touches none of these and is
+-- rejected.
+txTouchesMpfs :: CageConfig -> ConwayTx -> Bool
+txTouchesMpfs cfg tx =
+    mintsCagePolicy scriptHash tx
+        || any (isCageStateOutput scriptHash) outputs
+        || any (isCageRequestOutput cfg) outputs
+  where
+    scriptHash = cfgScriptHash cfg
+    outputs =
+        toList (tx ^. bodyTxL . outputsTxBodyL)
+
+-- | 'True' iff the output is a request output bound to
+-- THIS cage: it carries a 'RequestDatum' and sits at the
+-- request validator address derived for the datum's token
+-- via 'requestAddrFromCfg'. Matched by payment credential,
+-- so an optional stake part is ignored. A crafted
+-- 'RequestDatum' at any other script address is rejected.
+isCageRequestOutput :: CageConfig -> TxOut ConwayEra -> Bool
+isCageRequestOutput cfg txOut =
+    case requestOutputToken txOut of
+        Just tid ->
+            paymentOf (txOut ^. addrTxOutL)
+                == paymentOf
+                    ( requestAddrFromCfg
+                        cfg
+                        tid
+                        (network cfg)
+                    )
+        Nothing -> False
+  where
+    paymentOf (Addr _ pc _) = Just pc
+    paymentOf (AddrBootstrap _) = Nothing

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
@@ -29,6 +29,11 @@ module Cardano.MPFS.Indexer.Event
     , detectCageEvents
     , detectCageEventsDetailed
     , inversesOf
+
+      -- * Scope recognition (for the /tx/submit gate)
+    , mintsCagePolicy
+    , isCageStateOutput
+    , requestOutputToken
     ) where
 
 import Control.Exception (Exception (..), throw)
@@ -565,6 +570,65 @@ inversesOf lookupToken lookupReq = \case
             Just (txIn, ts) ->
                 [InvRestoreToken tid txIn ts]
             Nothing -> []
+
+-- --------------------------------------------------------
+-- Scope recognition for the /tx/submit gate
+-- --------------------------------------------------------
+--
+-- These tx-body recognition primitives are reused by the
+-- @POST \/tx\/submit@ scope gate
+-- ("Cardano.MPFS.HTTP.SubmitScope") so it cannot drift
+-- from how the indexer classifies the same transaction.
+-- They are purely structural and resolve no inputs;
+-- spend-only events such as retract leave no mint or
+-- output fingerprint and are therefore not recognised
+-- here. The gate keys 'mintsCagePolicy' and
+-- 'isCageStateOutput' to the configured cage script
+-- hash, and binds 'requestOutputToken' outputs to the
+-- per-token request validator address.
+
+-- | 'True' iff the transaction mints or burns any asset
+-- under the cage policy (the cage script hash viewed as
+-- a 'PolicyID'). Mirrors the @mintDetections@ key in
+-- 'detectCageEventsDetailed' (boot, end).
+mintsCagePolicy :: ScriptHash -> ConwayTx -> Bool
+mintsCagePolicy scriptHash tx =
+    let MultiAsset ma = tx ^. bodyTxL . mintTxBodyL
+    in  Map.member (PolicyID scriptHash) ma
+
+-- | 'True' iff the output is locked by the cage state
+-- script — its payment credential is the cage script
+-- hash. Matched by payment credential (not the full
+-- address) to mirror 'findStateDatumWithToken' (boot,
+-- update, reject).
+isCageStateOutput
+    :: ScriptHash -> TxOut ConwayEra -> Bool
+isCageStateOutput scriptHash txOut =
+    case txOut ^. addrTxOutL of
+        Addr _ (ScriptHashObj sh) _ ->
+            sh == scriptHash
+        _ -> False
+
+-- | If the output is a request output — a
+-- script-address output carrying a 'RequestDatum' —
+-- return the target 'TokenId' the request names;
+-- otherwise 'Nothing'. Mirrors 'detectRequest'. The
+-- caller is expected to check the output sits at that
+-- token's request validator address, since the per-cage
+-- request script hash is parametrised by the token and
+-- cannot be enumerated up front.
+requestOutputToken :: TxOut ConwayEra -> Maybe TokenId
+requestOutputToken txOut =
+    case txOut ^. addrTxOutL of
+        Addr _ (ScriptHashObj _) _ ->
+            case extractDatum txOut of
+                Just
+                    ( RequestDatum
+                            OnChainRequest{requestToken = ocTid}
+                        ) ->
+                        Just (tokenIdFromOnChain ocTid)
+                _ -> Nothing
+        _ -> Nothing
 
 -- --------------------------------------------------------
 -- On-chain → off-chain conversion

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
@@ -579,13 +579,17 @@ inversesOf lookupToken lookupReq = \case
 -- @POST \/tx\/submit@ scope gate
 -- ("Cardano.MPFS.HTTP.SubmitScope") so it cannot drift
 -- from how the indexer classifies the same transaction.
--- They are purely structural and resolve no inputs;
--- spend-only events such as retract leave no mint or
--- output fingerprint and are therefore not recognised
--- here. The gate keys 'mintsCagePolicy' and
--- 'isCageStateOutput' to the configured cage script
--- hash, and binds 'requestOutputToken' outputs to the
--- per-token request validator address.
+-- They are purely structural and resolve no inputs:
+-- spend-only events such as retract and sweep leave no
+-- mint or output fingerprint, so the gate recognises
+-- those by applying the SAME 'isCageStateOutput' /
+-- request-address checks to the transaction's spent
+-- inputs after resolving them against the indexed UTxO
+-- set (see 'Cardano.MPFS.HTTP.SubmitScope.txTouchesMpfs').
+-- The gate keys 'mintsCagePolicy' and 'isCageStateOutput'
+-- to the configured cage script hash, and binds
+-- 'requestOutputToken' outputs to the per-token request
+-- validator address.
 
 -- | 'True' iff the transaction mints or burns any asset
 -- under the cage policy (the cage script hash viewed as

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Reads.hs
@@ -39,6 +39,7 @@ module Cardano.MPFS.Indexer.Reads
     , readStateUtxoAt
     , readNamedRequestUtxo
     , readRequestUtxosAt
+    , readSpentTxOuts
     , readUtxoSetAt
     , readTrieFact
     , readTrieFacts
@@ -358,6 +359,33 @@ readUtxoWitness txIn =
                                     <> ", key: "
                                     <> lazyHex key
                                     <> ")"
+
+-- | Resolve a transaction's spent inputs against the
+-- indexed UTxO set inside ONE indexer transaction. Each
+-- entry pairs a 'TxIn' with 'Just' the raw indexed
+-- @TxOut@ CBOR bytes when the indexer knows the UTxO, or
+-- 'Nothing' when the UTxO is absent from the (possibly
+-- lagging) view.
+--
+-- This feeds the @POST \/tx\/submit@ scope gate
+-- ("Cardano.MPFS.HTTP.SubmitScope"), which recognises
+-- spend-only cage operations (retract, sweep) by their
+-- spent request UTxO. No CSMT inclusion proof is
+-- generated — the gate only inspects the resolved
+-- 'TxOut', and treats a 'Nothing' as an unresolved input
+-- it must not hard-reject on.
+readSpentTxOuts
+    :: [TxIn]
+    -> IndexerTx [(TxIn, Maybe ByteString)]
+readSpentTxOuts txIns =
+    IndexerTx
+        $ mapColumns InUtxo
+        $ traverse resolveOne txIns
+  where
+    resolveOne txIn = do
+        let key = serialize (natVersion @11) txIn
+        mTxOut <- query KVCol key
+        pure (txIn, BSL.toStrict <$> mTxOut)
 
 -- | Read the current state UTxO for a token at the state
 -- validator address and return it with a CSMT inclusion proof.

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/SubmitScopeSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/SubmitScopeSpec.hs
@@ -4,12 +4,17 @@
 -- License     : Apache-2.0
 --
 -- Exercises 'txTouchesMpfs' directly on the cage-event
--- transaction fixtures: every MPFS op shape (boot, end,
--- update, request) is admitted, a plain value transfer
--- is rejected, recognition is keyed to the configured
--- cage, and a request output is bound to this cage's
--- per-token request validator address — a crafted
--- 'RequestDatum' at any other script address is rejected.
+-- transaction fixtures. It proves the gate admits EVERY
+-- real MPFS operation the system can submit — including
+-- the spend-only ones (retract, sweep) that leave no cage
+-- mint or output and are recognised only by their spent
+-- request UTxO — while still rejecting a plain value
+-- transfer whose inputs all resolve to non-cage UTxOs.
+-- It also pins the conservative stale-input policy: an
+-- unresolved spent input is never grounds for a
+-- false-reject, and pins that recognition stays keyed to
+-- the configured cage (wrong cage / wrong request address
+-- are rejected).
 module Cardano.MPFS.HTTP.SubmitScopeSpec
     ( spec
     ) where
@@ -37,13 +42,20 @@ import Cardano.MPFS.Generators
     , genTxIn
     )
 import Cardano.MPFS.HTTP.AtomicReadFixture (testCageConfig)
-import Cardano.MPFS.HTTP.SubmitScope (txTouchesMpfs)
+import Cardano.MPFS.HTTP.SubmitScope
+    ( SpentInput (..)
+    , txTouchesMpfs
+    )
 import Cardano.MPFS.Indexer.TxFixtures
     ( mkBootTx
     , mkBurnTx
     , mkPlainTx
     , mkRequestTxAt
+    , mkRequestTxOutAt
+    , mkRetractTx
+    , mkStateTxOut
     , mkUpdateTx
+    , mkWalletTxOut
     , wrongScriptHash
     )
 import Cardano.MPFS.TxBuilder.Config
@@ -70,6 +82,14 @@ wrongScriptAddr =
         (ScriptHashObj wrongScriptHash)
         StakeRefNull
 
+-- | A single resolved non-cage wallet input — the kind
+-- every transaction carries to pay fees. Present in the
+-- positive structural cases to prove mint\/output
+-- recognition admits a tx even when its inputs are
+-- non-cage.
+walletSpent :: [SpentInput]
+walletSpent = [ResolvedSpent mkWalletTxOut]
+
 spec :: Spec
 spec =
     describe
@@ -85,6 +105,7 @@ spec =
                 $ \(tid, ts, seed) ->
                     txTouchesMpfs
                         testCageConfig
+                        walletSpent
                         (mkBootTx tid ts seed)
                         `shouldBe` True
 
@@ -94,6 +115,7 @@ spec =
                 $ \(tid, dummy) ->
                     txTouchesMpfs
                         testCageConfig
+                        walletSpent
                         (mkBurnTx tid dummy)
                         `shouldBe` True
 
@@ -108,6 +130,7 @@ spec =
                 $ \(tid, ts, r, stateIn) ->
                     txTouchesMpfs
                         testCageConfig
+                        walletSpent
                         (mkUpdateTx tid ts r [] stateIn)
                         `shouldBe` True
 
@@ -123,14 +146,96 @@ spec =
                                 Testnet
                     in  txTouchesMpfs
                             testCageConfig
+                            walletSpent
                             (mkRequestTxAt reqAddr req dummy)
                             `shouldBe` True
 
-            it "rejects a plain value-transfer tx (no MPFS surface)"
+            it
+                "accepts a retract tx (spends a request UTxO; \
+                \no cage mint or output)"
+                $ forAll genReqAndTwoInputs
+                $ \(tid, req, reqIn, extraIn) ->
+                    let reqAddr =
+                            requestAddrFromCfg
+                                testCageConfig
+                                tid
+                                Testnet
+                        spent =
+                            [ ResolvedSpent
+                                (mkRequestTxOutAt reqAddr req)
+                            , ResolvedSpent mkWalletTxOut
+                            ]
+                    in  txTouchesMpfs
+                            testCageConfig
+                            spent
+                            (mkRetractTx reqIn extraIn)
+                            `shouldBe` True
+
+            it
+                "accepts a sweep tx (spends a request UTxO; \
+                \no cage mint or output)"
+                $ forAll genReqAndTwoInputs
+                $ \(tid, req, reqIn, extraIn) ->
+                    let reqAddr =
+                            requestAddrFromCfg
+                                testCageConfig
+                                tid
+                                Testnet
+                        spent =
+                            [ ResolvedSpent mkWalletTxOut
+                            , ResolvedSpent
+                                (mkRequestTxOutAt reqAddr req)
+                            ]
+                    in  -- Sweep is structurally a request-UTxO
+                        -- spend like retract; the gate ignores
+                        -- the redeemer, so 'mkRetractTx' models
+                        -- both spend-only shapes.
+                        txTouchesMpfs
+                            testCageConfig
+                            spent
+                            (mkRetractTx reqIn extraIn)
+                            `shouldBe` True
+
+            it
+                "accepts a spend-only op that spends the cage \
+                \state UTxO (no cage output)"
+                $ forAll
+                    ( (,,)
+                        <$> genTokenId
+                        <*> genTokenState
+                        <*> genTxIn
+                    )
+                $ \(tid, ts, dummy) ->
+                    let spent =
+                            [ ResolvedSpent (mkStateTxOut tid ts)
+                            , ResolvedSpent mkWalletTxOut
+                            ]
+                    in  txTouchesMpfs
+                            testCageConfig
+                            spent
+                            (mkPlainTx dummy)
+                            `shouldBe` True
+
+            it
+                "admits a tx with an unresolved spent input \
+                \(conservative: never false-reject on a \
+                \lagging view)"
                 $ forAll genTxIn
                 $ \dummy ->
                     txTouchesMpfs
                         testCageConfig
+                        [UnresolvedSpent]
+                        (mkPlainTx dummy)
+                        `shouldBe` True
+
+            it
+                "rejects a plain value-transfer tx (inputs \
+                \resolve to non-cage UTxOs)"
+                $ forAll genTxIn
+                $ \dummy ->
+                    txTouchesMpfs
+                        testCageConfig
+                        walletSpent
                         (mkPlainTx dummy)
                         `shouldBe` False
 
@@ -144,6 +249,7 @@ spec =
                 $ \(tid, ts, seed) ->
                     txTouchesMpfs
                         otherCfg
+                        walletSpent
                         (mkBootTx tid ts seed)
                         `shouldBe` False
 
@@ -154,12 +260,32 @@ spec =
                 $ \(_tid, req, dummy) ->
                     txTouchesMpfs
                         testCageConfig
+                        walletSpent
                         ( mkRequestTxAt
                             wrongScriptAddr
                             req
                             dummy
                         )
                         `shouldBe` False
+
+            it
+                "rejects a spent RequestDatum at a wrong \
+                \script address"
+                $ forAll genReqAndInput
+                $ \(_tid, req, dummy) ->
+                    let spent =
+                            [ ResolvedSpent
+                                ( mkRequestTxOutAt
+                                    wrongScriptAddr
+                                    req
+                                )
+                            , ResolvedSpent mkWalletTxOut
+                            ]
+                    in  txTouchesMpfs
+                            testCageConfig
+                            spent
+                            (mkPlainTx dummy)
+                            `shouldBe` False
 
             it
                 "rejects a RequestDatum at another token's \
@@ -173,6 +299,7 @@ spec =
                                 Testnet
                     in  txTouchesMpfs
                             testCageConfig
+                            walletSpent
                             ( mkRequestTxAt
                                 wrongReqAddr
                                 req
@@ -185,6 +312,12 @@ spec =
         req <- genRequest tid
         dummy <- genTxIn
         pure (tid, req, dummy)
+    genReqAndTwoInputs = do
+        tid <- genTokenId
+        req <- genRequest tid
+        reqIn <- genTxIn
+        extraIn <- genTxIn `suchThat` (/= reqIn)
+        pure (tid, req, reqIn, extraIn)
     genReqAndOtherToken = do
         tid <- genTokenId
         other <- genTokenId `suchThat` (/= tid)

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/SubmitScopeSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/SubmitScopeSpec.hs
@@ -1,0 +1,193 @@
+-- |
+-- Module      : Cardano.MPFS.HTTP.SubmitScopeSpec
+-- Description : Tests for the /tx/submit Level-1 scope gate
+-- License     : Apache-2.0
+--
+-- Exercises 'txTouchesMpfs' directly on the cage-event
+-- transaction fixtures: every MPFS op shape (boot, end,
+-- update, request) is admitted, a plain value transfer
+-- is rejected, recognition is keyed to the configured
+-- cage, and a request output is bound to this cage's
+-- per-token request validator address — a crafted
+-- 'RequestDatum' at any other script address is rejected.
+module Cardano.MPFS.HTTP.SubmitScopeSpec
+    ( spec
+    ) where
+
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Test.QuickCheck (forAll, suchThat)
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.BaseTypes (Network (Testnet))
+import Cardano.Ledger.Credential
+    ( Credential (ScriptHashObj)
+    , StakeReference (StakeRefNull)
+    )
+
+import Cardano.MPFS.Generators
+    ( genRequest
+    , genRoot
+    , genTokenId
+    , genTokenState
+    , genTxIn
+    )
+import Cardano.MPFS.HTTP.AtomicReadFixture (testCageConfig)
+import Cardano.MPFS.HTTP.SubmitScope (txTouchesMpfs)
+import Cardano.MPFS.Indexer.TxFixtures
+    ( mkBootTx
+    , mkBurnTx
+    , mkPlainTx
+    , mkRequestTxAt
+    , mkUpdateTx
+    , wrongScriptHash
+    )
+import Cardano.MPFS.TxBuilder.Config
+    ( CageConfig (cfgScriptHash)
+    )
+import Cardano.MPFS.TxBuilder.Real.Internal
+    ( requestAddrFromCfg
+    )
+
+-- | A cage config for a DIFFERENT cage, used to prove
+-- the gate is keyed to the configured cage identity. It
+-- reuses the valid request-validator bytes from
+-- 'testCageConfig' but overrides the state script hash.
+otherCfg :: CageConfig
+otherCfg =
+    testCageConfig{cfgScriptHash = wrongScriptHash}
+
+-- | A wrong script address that is neither the cage
+-- state address nor any per-token request address.
+wrongScriptAddr :: Addr
+wrongScriptAddr =
+    Addr
+        Testnet
+        (ScriptHashObj wrongScriptHash)
+        StakeRefNull
+
+spec :: Spec
+spec =
+    describe
+        "txTouchesMpfs (/tx/submit Level-1 scope gate)"
+        $ do
+            it "accepts a boot tx (mints the state-token policy)"
+                $ forAll
+                    ( (,,)
+                        <$> genTokenId
+                        <*> genTokenState
+                        <*> genTxIn
+                    )
+                $ \(tid, ts, seed) ->
+                    txTouchesMpfs
+                        testCageConfig
+                        (mkBootTx tid ts seed)
+                        `shouldBe` True
+
+            it "accepts an end tx (burns the state-token policy)"
+                $ forAll
+                    ((,) <$> genTokenId <*> genTxIn)
+                $ \(tid, dummy) ->
+                    txTouchesMpfs
+                        testCageConfig
+                        (mkBurnTx tid dummy)
+                        `shouldBe` True
+
+            it "accepts an update tx (output at the cage address)"
+                $ forAll
+                    ( (,,,)
+                        <$> genTokenId
+                        <*> genTokenState
+                        <*> genRoot
+                        <*> genTxIn
+                    )
+                $ \(tid, ts, r, stateIn) ->
+                    txTouchesMpfs
+                        testCageConfig
+                        (mkUpdateTx tid ts r [] stateIn)
+                        `shouldBe` True
+
+            it
+                "accepts a request-create tx at this cage's \
+                \request address"
+                $ forAll genReqAndInput
+                $ \(tid, req, dummy) ->
+                    let reqAddr =
+                            requestAddrFromCfg
+                                testCageConfig
+                                tid
+                                Testnet
+                    in  txTouchesMpfs
+                            testCageConfig
+                            (mkRequestTxAt reqAddr req dummy)
+                            `shouldBe` True
+
+            it "rejects a plain value-transfer tx (no MPFS surface)"
+                $ forAll genTxIn
+                $ \dummy ->
+                    txTouchesMpfs
+                        testCageConfig
+                        (mkPlainTx dummy)
+                        `shouldBe` False
+
+            it "rejects a boot tx keyed to a different cage"
+                $ forAll
+                    ( (,,)
+                        <$> genTokenId
+                        <*> genTokenState
+                        <*> genTxIn
+                    )
+                $ \(tid, ts, seed) ->
+                    txTouchesMpfs
+                        otherCfg
+                        (mkBootTx tid ts seed)
+                        `shouldBe` False
+
+            it
+                "rejects a RequestDatum at a wrong script \
+                \address"
+                $ forAll genReqAndInput
+                $ \(_tid, req, dummy) ->
+                    txTouchesMpfs
+                        testCageConfig
+                        ( mkRequestTxAt
+                            wrongScriptAddr
+                            req
+                            dummy
+                        )
+                        `shouldBe` False
+
+            it
+                "rejects a RequestDatum at another token's \
+                \request address"
+                $ forAll genReqAndOtherToken
+                $ \(req, other, dummy) ->
+                    let wrongReqAddr =
+                            requestAddrFromCfg
+                                testCageConfig
+                                other
+                                Testnet
+                    in  txTouchesMpfs
+                            testCageConfig
+                            ( mkRequestTxAt
+                                wrongReqAddr
+                                req
+                                dummy
+                            )
+                            `shouldBe` False
+  where
+    genReqAndInput = do
+        tid <- genTokenId
+        req <- genRequest tid
+        dummy <- genTxIn
+        pure (tid, req, dummy)
+    genReqAndOtherToken = do
+        tid <- genTokenId
+        other <- genTokenId `suchThat` (/= tid)
+        req <- genRequest tid
+        dummy <- genTxIn
+        pure (req, other, dummy)

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
@@ -16,6 +16,7 @@ module Cardano.MPFS.Indexer.TxFixtures
       mkBootTx
     , mkBurnTx
     , mkRequestTx
+    , mkRequestTxAt
     , mkUpdateTx
     , mkRetractTx
     , mkPlainTx
@@ -201,7 +202,21 @@ mkRequestTx
     -> TxIn
     -- ^ Dummy input
     -> ConwayTx
-mkRequestTx Request{..} dummyInput =
+mkRequestTx = mkRequestTxAt testCageAddr
+
+-- | Build a request transaction whose 'RequestDatum'
+-- output sits at the given address. Lets a test place
+-- the request output at the per-token request validator
+-- address (or, adversarially, at a wrong script
+-- address).
+mkRequestTxAt
+    :: Addr
+    -- ^ Address to lock the request output at
+    -> Request
+    -> TxIn
+    -- ^ Dummy input
+    -> ConwayTx
+mkRequestTxAt addr Request{..} dummyInput =
     let onChainTid = mkOnChainTid requestToken
         KeyHash ownerH = requestOwner
         onChainOp = toOnChainOp requestValue
@@ -221,7 +236,7 @@ mkRequestTx Request{..} dummyInput =
                     }
         txOut =
             mkBasicTxOut
-                testCageAddr
+                addr
                 (inject (Coin 2_000_000))
                 & datumTxOutL
                     .~ mkInlineDatum

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
@@ -22,11 +22,17 @@ module Cardano.MPFS.Indexer.TxFixtures
     , mkPlainTx
     , mkBootRequestTx
 
+      -- * TxOut builders (resolved spent inputs)
+    , mkRequestTxOutAt
+    , mkStateTxOut
+    , mkWalletTxOut
+
       -- * Test script hash
     , testScriptHash
     , wrongScriptHash
     , testPolicyId
     , testCageAddr
+    , testWalletAddr
     ) where
 
 import Data.ByteString.Short qualified as SBS
@@ -101,11 +107,13 @@ import Cardano.MPFS.Core.OnChain
 import Cardano.MPFS.Core.Types
     ( AssetName (..)
     , Coin (..)
+    , ConwayEra
     , Operation (..)
     , Request (..)
     , Root (..)
     , TokenId (..)
     , TokenState (..)
+    , TxOut
     )
 import Cardano.MPFS.TxBuilder.Real.Internal
     ( mkInlineDatum
@@ -143,6 +151,23 @@ testCageAddr =
     Addr
         Testnet
         (ScriptHashObj testScriptHash)
+        StakeRefNull
+
+-- | A plain wallet (key-hash) address on Testnet (28
+-- bytes of 0xCC). Used to build resolved non-cage spent
+-- inputs that the scope gate must NOT mistake for the
+-- cage surface.
+testWalletAddr :: Addr
+testWalletAddr =
+    Addr
+        Testnet
+        ( KeyHashObj
+            $ KeyHash
+            $ fromJust
+            $ hashFromStringAsHex @Blake2b_224
+                "cccccccccccccccccccccccccccc\
+                \cccccccccccccccccccccccccccc"
+        )
         StakeRefNull
 
 -- | Build a boot transaction: mints +1 token and
@@ -216,7 +241,23 @@ mkRequestTxAt
     -> TxIn
     -- ^ Dummy input
     -> ConwayTx
-mkRequestTxAt addr Request{..} dummyInput =
+mkRequestTxAt addr req dummyInput =
+    let txOut = mkRequestTxOutAt addr req
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL
+                    .~ Set.singleton dummyInput
+                & outputsTxBodyL
+                    .~ StrictSeq.singleton txOut
+    in  mkBasicTx body
+
+-- | Build a request 'TxOut' ('RequestDatum'-bearing)
+-- locked at the given address. This is exactly the output
+-- 'mkRequestTxAt' produces, exposed on its own so a test
+-- can use it as a resolved spent input — the fingerprint
+-- the scope gate matches for retract\/sweep.
+mkRequestTxOutAt :: Addr -> Request -> TxOut ConwayEra
+mkRequestTxOutAt addr Request{..} =
     let onChainTid = mkOnChainTid requestToken
         KeyHash ownerH = requestOwner
         onChainOp = toOnChainOp requestValue
@@ -234,20 +275,38 @@ mkRequestTxAt addr Request{..} dummyInput =
                     , requestSubmittedAt =
                         requestSubmittedAt
                     }
-        txOut =
-            mkBasicTxOut
-                addr
-                (inject (Coin 2_000_000))
-                & datumTxOutL
-                    .~ mkInlineDatum
-                        (toPlcData reqDatum)
-        body =
-            mkBasicTxBody
-                & inputsTxBodyL
-                    .~ Set.singleton dummyInput
-                & outputsTxBodyL
-                    .~ StrictSeq.singleton txOut
-    in  mkBasicTx body
+    in  mkBasicTxOut
+            addr
+            (inject (Coin 2_000_000))
+            & datumTxOutL
+                .~ mkInlineDatum
+                    (toPlcData reqDatum)
+
+-- | Build a cage state 'TxOut' (state token + inline
+-- 'StateDatum') locked at the cage state address — the
+-- output 'mkBootTx' produces, exposed on its own for use
+-- as a resolved spent input (end\/update\/reject spend the
+-- state UTxO).
+mkStateTxOut :: TokenId -> TokenState -> TxOut ConwayEra
+mkStateTxOut tid ts =
+    let assetName = unTokenId tid
+        mintMA =
+            MultiAsset
+                $ Map.singleton testPolicyId
+                $ Map.singleton assetName 1
+        outValue =
+            MaryValue (Coin 2_000_000) mintMA
+    in  mkBasicTxOut testCageAddr outValue
+            & datumTxOutL
+                .~ mkInlineDatum
+                    (toPlcData (mkStateDatum ts (root ts)))
+
+-- | Build a plain wallet 'TxOut' at a key-hash address
+-- with no datum — a resolved non-cage spent input, the
+-- kind a plain value transfer spends.
+mkWalletTxOut :: TxOut ConwayEra
+mkWalletTxOut =
+    mkBasicTxOut testWalletAddr (inject (Coin 2_000_000))
 
 -- | Build an update transaction: spends the state
 -- input with a Modify redeemer, outputs new state.

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -23,6 +23,7 @@ import Cardano.MPFS.HTTP.RequestUpdateFactsSpec qualified as RequestUpdateFactsS
 import Cardano.MPFS.HTTP.RequestsSpec qualified as RequestsSpec
 import Cardano.MPFS.HTTP.RetractFactsSpec qualified as RetractFactsSpec
 import Cardano.MPFS.HTTP.StatusSpec qualified as StatusSpec
+import Cardano.MPFS.HTTP.SubmitScopeSpec qualified as SubmitScopeSpec
 import Cardano.MPFS.HTTP.SubmitSpec qualified as SubmitSpec
 import Cardano.MPFS.HTTP.TokenFactsSpec qualified as TokenFactsSpec
 import Cardano.MPFS.HTTP.TokenSpec qualified as TokenSpec
@@ -86,6 +87,7 @@ main =
                 RequestsSpec.spec
                 StatusSpec.spec
                 SubmitSpec.spec
+                SubmitScopeSpec.spec
                 TokenFactsSpec.spec
                 TokenSpec.spec
                 TokensSpec.spec

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -59,6 +59,18 @@ id, token state, request payload) by decoding the inline datum of the
 witnessed `TxOut`; the server's job is to provide that provable
 material, not to interpret it.
 
+`POST /submit` accepts **only MPFS operations**. Before relaying, it
+runs a cheap structural scope gate on the decoded tx body: the tx must
+mint or burn the cage state-token policy, lock an output at the cage
+state address, or produce a request output — a `RequestDatum`-bearing
+output sitting at this cage's per-token request validator address
+(`requestAddrFromCfg` for the token named in the datum), so a crafted
+`RequestDatum` at any other script address is rejected. Anything that
+touches none of the cage contract surface — a plain ADA transfer, say —
+is rejected with a typed `400 "this service only submits MPFS
+operations"`. This is abuse prevention at the gateway, not a new trust
+boundary; the on-chain validators remain authoritative.
+
 The 502 era-history failure was fixed by carrying live era history in
 `GET /eval-context` and deriving `EpochInfo` from it in the reactor.
 `ScriptContext` `POSIXTimeRange` costs now use the same era clock as the

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -59,15 +59,32 @@ id, token state, request payload) by decoding the inline datum of the
 witnessed `TxOut`; the server's job is to provide that provable
 material, not to interpret it.
 
-`POST /submit` accepts **only MPFS operations**. Before relaying, it
-runs a cheap structural scope gate on the decoded tx body: the tx must
-mint or burn the cage state-token policy, lock an output at the cage
-state address, or produce a request output — a `RequestDatum`-bearing
-output sitting at this cage's per-token request validator address
-(`requestAddrFromCfg` for the token named in the datum), so a crafted
-`RequestDatum` at any other script address is rejected. Anything that
-touches none of the cage contract surface — a plain ADA transfer, say —
-is rejected with a typed `400 "this service only submits MPFS
+`POST /submit` accepts **only MPFS operations**. Before relaying, the
+server runs a cheap scope gate on the decoded tx. A transaction is
+admitted when it touches the cage contract surface in any of these ways:
+
+- it mints or burns the cage state-token policy (boot, end);
+- it locks an output at the cage state address (boot, update, reject);
+- it produces a request output — a `RequestDatum`-bearing output sitting
+  at this cage's per-token request validator address
+  (`requestAddrFromCfg` for the token named in the datum), so a crafted
+  `RequestDatum` at any other script address is rejected (request
+  create);
+- it **spends** a cage-owned UTxO — the cage state UTxO or a request
+  UTxO at a request validator address. This input-aware clause is what
+  admits the spend-only operations **retract** and **sweep**, which
+  refund or reclaim a request UTxO and so leave no cage mint and no cage
+  output.
+
+The mint and output checks are purely structural, but the spend check
+needs the chain: the handler resolves the tx's spent inputs against the
+indexer's UTxO set (one atomic read) and feeds the resolved `TxOut`s
+into the pure predicate. The gate is conservative — an input the indexer
+cannot resolve (its view may lag the chain) is treated as touching the
+cage, so a valid operation is never false-rejected; only a transaction
+that is definitely non-MPFS (no cage mint, no cage output, every spent
+input resolved to a non-cage UTxO) — a plain ADA transfer, say — is
+rejected, with a typed `400 "this service only submits MPFS
 operations"`. This is abuse prevention at the gateway, not a new trust
 boundary; the on-chain validators remain authoritative.
 


### PR DESCRIPTION
## Summary
- Add a Level-1 structural scope gate for `POST /tx/submit` before relay.
- Accept only transactions that touch the MPFS surface by mint/burn, cage-state output, request output at this cage's derived per-token request validator address, or a resolved spent cage/request UTxO.
- Admit spend-only MPFS operations such as retract and sweep by resolving spent inputs against the indexed UTxO set before calling the pure scope predicate.
- Keep stale-index behavior conservative: unresolved spent inputs do not cause a hard reject; definitely non-MPFS value transfers with resolved non-cage inputs still reject.
- Reject plain/non-MPFS transactions with typed `400` detail: `this service only submits MPFS operations`.
- Flip the submit e2e plain ADA-transfer expectation from `200` to the new `400` contract and document the write boundary.

Fixes #343

## Verification
- `nix develop -c cabal build cardano-mpfs-offchain:test:unit-tests cardano-mpfs-offchain:test:e2e-tests -O0` passed locally; both suites linked.
- `./gate.sh` passed locally: nix build + swagger check, unit `441/0`, unit-client `205/0`, unit-workflows `36/0`, unit-cli `10/0`, format-check, hlint `No hints`.
