### PR TITLE
build(nix): filter haskell/wasm source to stop spurious cache busting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
               ghcWasmMeta = ghc-wasm-meta.packages.${system}.all_9_12;
               wasiSdk = ghc-wasm-meta.packages.${system}.wasi-sdk;
               chap = CHaP;
-              src = ./.;
+              src = import ./nix/clean-src.nix { inherit (pkgs) lib; src = ./.; };
             };
             # Separate nixpkgs instance carrying the PureScript toolchain
             # overlays; kept apart from the haskell.nix `pkgs` above to avoid

--- a/nix/clean-src.nix
+++ b/nix/clean-src.nix
@@ -1,0 +1,43 @@
+# Filtered project source for the haskell.nix cabalProject and the wasm
+# reactor build.
+#
+# haskell.nix hashes this `src` into every package's build plan, so an
+# unfiltered `./.` makes *any* repo edit invalidate the whole Haskell (and
+# wasm) build cache — a docs change, a CI-workflow edit, a PureScript SPA
+# commit, or release-please's per-release CHANGELOG/version bump all force a
+# cold rebuild even though no Haskell input changed. Keep only the paths the
+# cabal build actually reads.
+#
+# Excluded paths are NOT cabal build inputs (verified: no .cabal references
+# them via data-files / extra-source-files). The PureScript SPA has its own
+# source in nix/mpfs-spa.nix; the swagger check reads docs/ directly — both
+# are unaffected by filtering them out of the Haskell source.
+{ lib, src }:
+let
+  root = toString src;
+  excludedTop = [
+    "docs" # mkdocs site + swagger.json (own derivations)
+    "specs" # speckit artifacts
+    "lean" # Lean formal model
+    "deploy" # SPA Dockerfile / nginx.conf
+    "scripts" # helper scripts
+    "mpfs-spa" # PureScript SPA (built by nix/mpfs-spa.nix, not cabal)
+    ".github" # CI workflows
+    ".orch" # orchestration scratch
+  ];
+in
+lib.cleanSourceWith {
+  name = "cardano-mpfs-offchain-src";
+  inherit src;
+  filter = path: type:
+    let
+      rel = lib.removePrefix (root + "/") (toString path);
+      parts = lib.splitString "/" rel;
+      top = lib.head parts;
+      isTopLevel = lib.length parts == 1;
+    in
+    lib.cleanSourceFilter path type
+    && !(builtins.elem top excludedTop)
+    # drop root-level *.md churn (CHANGELOG.md rewritten every release, etc.)
+    && !(isTopLevel && lib.hasSuffix ".md" rel);
+}

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -60,7 +60,7 @@ let
 
   mkProject = ctx@{ lib, pkgs, ... }: {
     name = "cardano-mpfs-offchain";
-    src = ./..;
+    src = import ./clean-src.nix { inherit (pkgs) lib; src = ./..; };
     compiler-nix-name = "ghc9123";
     shell = shell { inherit pkgs; };
     modules = [ fix-libs ];


### PR DESCRIPTION
## Problem
The cabalProject (`nix/project.nix`) and the wasm reactor target (`flake.nix`) both used an unfiltered `src = ./.`. haskell.nix hashes that source into **every package's build plan**, so *any* repo edit — a docs change, a CI-workflow edit, a PureScript-SPA commit, release-please's per-release `CHANGELOG.md`/version bump — invalidates the whole Haskell **and** wasm build cache. cachix can't help: a changed input is a new derivation hash that was never cached → cold rebuild from scratch. This is why every PR (and the SPA work in #345) triggers full ~15-40min Build Gate rebuilds.

## Fix
Add `nix/clean-src.nix`, a shared source filter that keeps only what the cabal build actually reads — the 7 `cardano-mpfs-*` packages, `cabal.project`/`cabal-wasm.project`, `nix/`, `flake.*` — and drops `docs/ specs/ lean/ deploy/ scripts/ mpfs-spa/ .github/` and root `*.md`. Applied to both the cabalProject src and the wasm-target src.

Verified the cleaned store path retains every package + `test-data/` and excludes the noise. No `.cabal` references the excluded paths (checked `data-files`/`extra-source-files`). The PureScript SPA (`nix/mpfs-spa.nix`) and the swagger check read their own sources — unaffected.

## Payoff
After this lands, doc/workflow/SPA/markdown edits no longer rebuild the Haskell+wasm world. **This PR itself still triggers a full rebuild** (it changes `flake.nix`/`nix/`, which are legitimate build inputs); the benefit shows on subsequent PRs.

## Not addressed here (follow-ups)
- Per-*release* the cabal `version:` bump still rebuilds (the version is a genuine cabal build input); a static-version + inject-at-package approach would fix that but tensions with the `sync-cabal-version` drift check.
- Moving `.#mpfs-spa`+`.#docker-image` off the per-PR required gate would further cut PR CI time.