### PR TITLE
SPA: decode witnessed tx_out via reactor

### DIFF
--- a/cardano-mpfs-cage-tx/cardano-mpfs-cage-tx.cabal
+++ b/cardano-mpfs-cage-tx/cardano-mpfs-cage-tx.cabal
@@ -102,12 +102,18 @@ test-suite byte-identity
     , base
     , base16-bytestring      >=1.0 && <1.1
     , bytestring
+    , cardano-crypto-class
     , cardano-ledger-api
     , cardano-ledger-binary
+    , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-mpfs-cage
     , cardano-mpfs-cage-tx
     , cardano-tx-tools
+    , containers
     , hspec
+    , microlens
+    , plutus-tx
     , process
     , QuickCheck
     , text

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Reactor.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Reactor.hs
@@ -18,7 +18,16 @@ import Cardano.Ledger.Alonzo.Scripts
     ( fromPlutusScript
     , mkPlutusScript
     )
+import Cardano.Ledger.Api.Scripts.Data
+    ( Data (..)
+    , Datum (..)
+    , binaryDataToData
+    )
 import Cardano.Ledger.Api.Tx (addrTxWitsL, witsTxL)
+import Cardano.Ledger.Api.Tx.Out
+    ( datumTxOutL
+    , valueTxOutL
+    )
 import Cardano.Ledger.BaseTypes
     ( Network (..)
     )
@@ -26,6 +35,7 @@ import Cardano.Ledger.Binary
     ( Annotator
     , Decoder
     , decCBOR
+    , decodeFull
     , decodeFullAnnotator
     , natVersion
     )
@@ -35,13 +45,26 @@ import Cardano.Ledger.Core
     , hashScript
     )
 import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Mary.Value
+    ( AssetName (..)
+    , MaryValue (..)
+    , MultiAsset (..)
+    )
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
 import Cardano.Ledger.Plutus.Language
     ( Language (PlutusV3)
     , Plutus (..)
     , PlutusBinary (..)
     )
-import Cardano.MPFS.Cage.Ledger (ConwayEra)
+import Cardano.MPFS.Cage.Ledger (ConwayEra, TxOut)
+import Cardano.MPFS.Cage.Types
+    ( CageDatum (..)
+    , OnChainOperation (..)
+    , OnChainRequest (..)
+    , OnChainRoot (..)
+    , OnChainTokenId (..)
+    , OnChainTokenState (..)
+    )
 import Cardano.MPFS.Client.Cage.Boot (bootCageTxWithEval)
 import Cardano.MPFS.Client.Cage.BuildError (BuildError)
 import Cardano.MPFS.Client.Cage.Config (CageConfig (..))
@@ -86,14 +109,18 @@ import Data.Aeson
     ( FromJSON
     , Object
     , Result (..)
+    , Series
     , Value
     , eitherDecodeStrict
     , fromJSON
+    , pairs
     , withObject
     , (.!=)
     , (.:)
     , (.:?)
+    , (.=)
     )
+import Data.Aeson.Encoding (encodingToLazyByteString)
 import Data.Aeson.Types
     ( Parser
     , parseEither
@@ -104,8 +131,10 @@ import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short
     ( ShortByteString
+    , fromShort
     , toShort
     )
+import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -117,6 +146,11 @@ import Lens.Micro
     , (^.)
     )
 import PlutusTx.Builtins qualified as PlutusTx
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    , BuiltinData (..)
+    )
+import PlutusTx.IsData.Class (fromBuiltinData)
 
 -- The facts types are decoded through 'fromJSON' in the op branch; we
 -- only need their instances in scope.
@@ -148,6 +182,7 @@ dispatch = withObject "Envelope" $ \o -> do
         "retract" -> dispatchRetract o
         "reject" -> dispatchReject o
         "end" -> dispatchEnd o
+        "decode" -> dispatchDecode o
         "self_test_integer_to_byte_string" ->
             pure selfTestIntegerToByteString
         "self_test_bitwise_conversions" ->
@@ -261,6 +296,117 @@ dispatchReject o = do
             policyValue <- o .:? "wallet_policy"
             policy <- parseWalletPolicyMaybe policyValue
             pure (buildReject evalCtx cfg policy verified)
+
+-- | Decode a witnessed cage 'TxOut' (hex CBOR of the resolved output)
+-- into its inline datum and emit the provable display fields as a
+-- single @decoded:@ JSON line (issue #345). The op auto-detects a
+-- 'RequestDatum' versus a 'StateDatum' so the SPA can reconstruct the
+-- request and token-state views from witness bytes alone, after #342
+-- removed the server-side projections.
+--
+-- The decode is single-sourced through the canonical 'CageDatum'
+-- 'FromData' instance from @cardano-mpfs-cage@; no CBOR is hand-rolled.
+dispatchDecode :: Object -> Parser Text
+dispatchDecode o = decodeWitnessedTxOut <$> o .: "tx_out"
+
+decodeWitnessedTxOut :: Text -> Text
+decodeWitnessedTxOut txOutHex =
+    case decodeHex "tx_out" txOutHex >>= decodeTxOutBytes of
+        Left err -> "decode_error: " <> err
+        Right txOut -> case extractCageDatum txOut of
+            Nothing ->
+                "decode_error: tx_out carries no cage datum"
+            Just (RequestDatum request) ->
+                renderDecoded (requestSeries request)
+            Just (StateDatum tokenState) ->
+                case stateTokenIdHex txOut of
+                    Left err -> "decode_error: " <> err
+                    Right tokenId ->
+                        renderDecoded (stateSeries tokenId tokenState)
+
+-- | Decode the CBOR-encoded @TxOut@ body the server witnesses, using
+-- the same non-annotated ledger decoder the indexer uses to read it
+-- back (@Cardano.MPFS.Indexer.Reads.decodeTxOut@).
+decodeTxOutBytes :: ByteString -> Either Text (TxOut ConwayEra)
+decodeTxOutBytes bytes =
+    case decodeFull (natVersion @11) (BSL.fromStrict bytes) of
+        Left err -> Left ("tx_out cbor: " <> T.pack (show err))
+        Right txOut -> Right txOut
+
+-- | Extract an inline 'CageDatum' from a resolved 'TxOut'. Mirrors
+-- @Cardano.MPFS.Indexer.Event.extractDatum@, kept local because that
+-- module lives in the non-wasm @cardano-mpfs-offchain@ closure.
+extractCageDatum :: TxOut ConwayEra -> Maybe CageDatum
+extractCageDatum txOut =
+    case txOut ^. datumTxOutL of
+        Datum binaryData ->
+            let Data plutusData = binaryDataToData binaryData
+            in  fromBuiltinData (BuiltinData plutusData)
+        _ -> Nothing
+
+renderDecoded :: Series -> Text
+renderDecoded series =
+    "decoded: "
+        <> T.decodeUtf8
+            (BSL.toStrict (encodingToLazyByteString (pairs series)))
+
+requestSeries :: OnChainRequest -> Series
+requestSeries OnChainRequest{..} =
+    "datum" .= ("request" :: Text)
+        <> "token" .= builtinHex (unOnChainTokenId requestToken)
+        <> "owner" .= builtinHex requestOwner
+        <> "key" .= bytesHex requestKey
+        <> operationSeries requestValue
+        <> "fee" .= requestFee
+        <> "submitted_at" .= requestSubmittedAt
+
+-- | Render the request operation, preserving BOTH values of an update
+-- (the lossiness #342 called out): insert carries its new value, delete
+-- the old value being removed, update both old and new.
+operationSeries :: OnChainOperation -> Series
+operationSeries (OpInsert value) =
+    "operation" .= ("insert" :: Text) <> "new" .= bytesHex value
+operationSeries (OpDelete value) =
+    "operation" .= ("delete" :: Text) <> "old" .= bytesHex value
+operationSeries (OpUpdate old new) =
+    "operation" .= ("update" :: Text)
+        <> "old" .= bytesHex old
+        <> "new" .= bytesHex new
+
+stateSeries :: Text -> OnChainTokenState -> Series
+stateSeries tokenId OnChainTokenState{..} =
+    "datum" .= ("state" :: Text)
+        <> "token_id" .= tokenId
+        <> "owner" .= builtinHex stateOwner
+        <> "root" .= bytesHex (unOnChainRoot stateRoot)
+        <> "tip" .= stateMaxFee
+        <> "process_time" .= stateProcessTime
+        <> "retract_time" .= stateRetractTime
+
+-- | The MPFS token id is the asset name of the single native token
+-- carried by the state @TxOut@ value; the cage policy id is global and
+-- is not part of the id (mirrors the server's @txout_cbor@ contract).
+stateTokenIdHex :: TxOut ConwayEra -> Either Text Text
+stateTokenIdHex txOut =
+    case txOut ^. valueTxOutL of
+        MaryValue _ (MultiAsset assets) ->
+            case [ name
+                 | byPolicy <- Map.elems assets
+                 , (name, quantity) <- Map.toList byPolicy
+                 , quantity /= 0
+                 ] of
+                [name] -> Right (assetNameHex name)
+                [] -> Left "state tx_out carries no token"
+                _ -> Left "state tx_out carries ambiguous tokens"
+
+assetNameHex :: AssetName -> Text
+assetNameHex (AssetName name) = renderHex (fromShort name)
+
+builtinHex :: BuiltinByteString -> Text
+builtinHex (BuiltinByteString bytes) = renderHex bytes
+
+bytesHex :: ByteString -> Text
+bytesHex = renderHex
 
 runVerified
     :: (FromJSON facts)

--- a/cardano-mpfs-cage-tx/test/Cardano/MPFS/Client/Cage/ReactorSpec.hs
+++ b/cardano-mpfs-cage-tx/test/Cardano/MPFS/Client/Cage/ReactorSpec.hs
@@ -8,11 +8,40 @@ module Cardano.MPFS.Client.Cage.ReactorSpec
     ( spec
     ) where
 
+import Cardano.Crypto.Hash (hashFromBytes)
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Api.Scripts.Data
+    ( Data (..)
+    , Datum (..)
+    , dataToBinaryData
+    )
 import Cardano.Ledger.Api.Tx (mkBasicTx)
 import Cardano.Ledger.Api.Tx.Body (mkBasicTxBody)
+import Cardano.Ledger.Api.Tx.Out (datumTxOutL, mkBasicTxOut)
 import Cardano.Ledger.Api.Tx.Wits (mkBasicTxWits)
+import Cardano.Ledger.BaseTypes (Network (Testnet))
 import Cardano.Ledger.Binary (natVersion, serialize')
-import Cardano.MPFS.Cage.Ledger (Coin (..), ConwayEra)
+import Cardano.Ledger.Credential
+    ( Credential (KeyHashObj)
+    , StakeReference (StakeRefNull)
+    )
+import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Keys (KeyHash (..))
+import Cardano.Ledger.Mary.Value
+    ( AssetName (..)
+    , MaryValue (..)
+    , MultiAsset (..)
+    , PolicyID (..)
+    )
+import Cardano.MPFS.Cage.Ledger (Coin (..), ConwayEra, TxOut)
+import Cardano.MPFS.Cage.Types
+    ( CageDatum (..)
+    , OnChainOperation (..)
+    , OnChainRequest (..)
+    , OnChainRoot (..)
+    , OnChainTokenId (..)
+    , OnChainTokenState (..)
+    )
 import Cardano.MPFS.Client.Cage.BuildError
     ( BuildError (LegacyRejectRefundRequiresTopUp)
     )
@@ -25,17 +54,34 @@ import Cardano.Tx.Ledger (ConwayTx)
 import Control.Monad (forM)
 import Data.Aeson (Value, encode, object, (.=))
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as SBS
 import Data.Functor (($>))
+import Data.List (isInfixOf)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T
+import Lens.Micro ((&), (.~))
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    , BuiltinData (..)
+    )
+import PlutusTx.IsData.Class (toBuiltinData)
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
 import System.Process (readProcessWithExitCode)
-import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    )
 import Test.QuickCheck
     ( Property
     , conjoin
@@ -68,6 +114,25 @@ spec = describe "runCageEnvelope byte identity" $ do
                         \min refund 849070, final refund 849070"
                     )
             preflightLegacyExactRefund False [plan] `shouldBe` Right ()
+    describe "decode op" $ do
+        it "decodes a witnessed request tx_out, preserving old and new" $ do
+            let out = BSC.unpack (runCageEnvelope decodeRequestEnvelope)
+            out `shouldSatisfy` isInfixOf "decoded: "
+            out `shouldSatisfy` isInfixOf "\"datum\":\"request\""
+            out `shouldSatisfy` isInfixOf "\"operation\":\"update\""
+            out `shouldSatisfy` isInfixOf "\"old\":\"6f6c64\""
+            out `shouldSatisfy` isInfixOf "\"new\":\"6e6577\""
+        it "decodes a witnessed state tx_out, recovering the token id" $ do
+            let out = BSC.unpack (runCageEnvelope decodeStateEnvelope)
+            out `shouldSatisfy` isInfixOf "decoded: "
+            out `shouldSatisfy` isInfixOf "\"datum\":\"state\""
+            out `shouldSatisfy` isInfixOf "\"token_id\":\"746f6b\""
+        it "fails closed on a tx_out that carries no cage datum" $ do
+            let out = BSC.unpack (runCageEnvelope decodeNoDatumEnvelope)
+            out `shouldSatisfy` isInfixOf "decode_error: "
+        it "rejects an unknown op" $ do
+            let out = BSC.unpack (runCageEnvelope unknownOpEnvelope)
+            out `shouldSatisfy` isInfixOf "unknown_op: "
 
 byteIdentityProperty :: Property
 byteIdentityProperty =
@@ -124,6 +189,9 @@ fixedEnvelopes =
     , requestDeleteEnvelope
     , retractEnvelope
     , rejectEnvelope
+    , decodeRequestEnvelope
+    , decodeStateEnvelope
+    , decodeNoDatumEnvelope
     ]
 
 bootEnvelope :: ByteString
@@ -225,6 +293,102 @@ rejectEnvelope =
             , "wallet_policy" .= object []
             , "facts" .= object []
             ]
+
+-- | A @decode@ envelope over a witnessed request tx_out whose inline
+-- datum is an @update@ request, exercising the non-lossy old/new fields.
+decodeRequestEnvelope :: ByteString
+decodeRequestEnvelope = decodeEnvelope (serializeTxOut requestTxOut)
+
+-- | A @decode@ envelope over a witnessed state tx_out carrying the cage
+-- token, exercising token-id recovery from the value.
+decodeStateEnvelope :: ByteString
+decodeStateEnvelope = decodeEnvelope (serializeTxOut stateTxOut)
+
+-- | A @decode@ envelope over an output with no inline cage datum, which
+-- must fail closed.
+decodeNoDatumEnvelope :: ByteString
+decodeNoDatumEnvelope = decodeEnvelope (serializeTxOut bareTxOut)
+
+unknownOpEnvelope :: ByteString
+unknownOpEnvelope =
+    encodeStrict $ object ["op" .= ("not_a_real_op" :: Text)]
+
+decodeEnvelope :: ByteString -> ByteString
+decodeEnvelope txOutBytes =
+    encodeStrict
+        $ object
+            [ "op" .= ("decode" :: Text)
+            , "tx_out" .= hexText txOutBytes
+            ]
+
+serializeTxOut :: TxOut ConwayEra -> ByteString
+serializeTxOut = serialize' (natVersion @11)
+
+-- | A request output: ADA only plus an inline @update@ request datum.
+requestTxOut :: TxOut ConwayEra
+requestTxOut =
+    mkBasicTxOut sampleAddr (MaryValue (Coin 2_000_000) mempty)
+        & datumTxOutL .~ inlineDatum requestDatum
+  where
+    requestDatum =
+        RequestDatum
+            OnChainRequest
+                { requestToken =
+                    OnChainTokenId (BuiltinByteString "tok")
+                , requestOwner =
+                    BuiltinByteString (BS.replicate 28 7)
+                , requestKey = "key"
+                , requestValue = OpUpdate "old" "new"
+                , requestFee = 1_500_000
+                , requestSubmittedAt = 1_700_000_000_000
+                }
+
+-- | A state output carrying the cage token plus an inline state datum.
+stateTxOut :: TxOut ConwayEra
+stateTxOut =
+    mkBasicTxOut sampleAddr stateValue
+        & datumTxOutL .~ inlineDatum stateDatum
+  where
+    stateDatum =
+        StateDatum
+            OnChainTokenState
+                { stateOwner = BuiltinByteString (BS.replicate 28 0)
+                , stateRoot = OnChainRoot (BS.replicate 32 0)
+                , stateMaxFee = 1_000_000
+                , stateProcessTime = 60_000
+                , stateRetractTime = 30_000
+                }
+    stateValue =
+        MaryValue
+            (Coin 2_000_000)
+            ( MultiAsset
+                ( Map.singleton
+                    samplePolicy
+                    (Map.singleton (AssetName (SBS.toShort "tok")) 1)
+                )
+            )
+
+-- | An output with no inline datum; the decode op must fail closed.
+bareTxOut :: TxOut ConwayEra
+bareTxOut =
+    mkBasicTxOut sampleAddr (MaryValue (Coin 2_000_000) mempty)
+
+inlineDatum :: CageDatum -> Datum ConwayEra
+inlineDatum datum =
+    let BuiltinData plutusData = toBuiltinData datum
+    in  Datum (dataToBinaryData (Data plutusData))
+
+sampleAddr :: Addr
+sampleAddr =
+    case hashFromBytes (BS.replicate 28 0) of
+        Just h -> Addr Testnet (KeyHashObj (KeyHash h)) StakeRefNull
+        Nothing -> error "sampleAddr: invalid key hash"
+
+samplePolicy :: PolicyID
+samplePolicy =
+    case hashFromBytes (BS.replicate 28 1) of
+        Just h -> PolicyID (ScriptHash h)
+        Nothing -> error "samplePolicy: invalid script hash"
 
 cageConfigValue :: Value
 cageConfigValue =

--- a/mpfs-spa/src/MpfsSpa/App.purs
+++ b/mpfs-spa/src/MpfsSpa/App.purs
@@ -1460,7 +1460,7 @@ requestRow
         ]
     , M.tableCell {} [ M.chip { label: opLabel req.operation, size: "small", color: "primary", variant: "outlined" } ]
     , keyCell req.key
-    , M.tableCell {} [ M.typography { variant: "body2" } [ R.text (maybe "" valueText req.value) ] ]
+    , M.tableCell {} [ M.typography { variant: "body2" } [ R.text (requestValueText req) ] ]
     , requestOwnerCell walletOwnerHash req.owner
     , M.tableCell {}
         [ M.chip { label: formatAgeMillis (nowMillis - req.submittedAt), size: "small", variant: "outlined" } ]
@@ -1814,6 +1814,14 @@ factText (Key key) = displayUtf8Hex key
 
 valueText :: Value -> String
 valueText (Value value) = displayUtf8Hex value
+
+-- | Render a pending request's value cell, showing both sides of an
+-- | update (old -> new) and the single value for inserts/deletes.
+requestValueText :: PendingRequest -> String
+requestValueText req =
+  case req.oldValue of
+    Just old -> valueText old <> " -> " <> maybe "" valueText req.value
+    Nothing -> maybe "" valueText req.value
 
 unKey :: Key -> String
 unKey (Key key) = key

--- a/mpfs-spa/src/MpfsSpa/CageHelpers/Reactor.js
+++ b/mpfs-spa/src/MpfsSpa/CageHelpers/Reactor.js
@@ -1,0 +1,13 @@
+// Thin wrapper over globalThis.runCageReactor, seeded by src/bootstrap.js.
+
+export const runCageReactorImpl = (stdinText) => () => {
+  if (typeof globalThis.runCageReactor !== "function") {
+    return Promise.resolve({
+      stdout: "",
+      stderr: "runCageReactor is not installed",
+      exitOk: false,
+    });
+  }
+
+  return globalThis.runCageReactor(stdinText);
+};

--- a/mpfs-spa/src/MpfsSpa/CageHelpers/Reactor.purs
+++ b/mpfs-spa/src/MpfsSpa/CageHelpers/Reactor.purs
@@ -1,0 +1,105 @@
+-- | Stdin/stdout bridge to the Haskell WASM cage reactor.
+-- |
+-- | Owns the single `globalThis.runCageReactor` FFI boundary plus the
+-- | thin parsers over the reactor's stable one-line verdicts. It lives in
+-- | its own module so both the cage-helper layer (`MpfsSpa.CageHelpers.Wasm`)
+-- | and the HTTP layer (`MpfsSpa.Http`, which decodes witnessed `tx_out`
+-- | bytes through the reactor `decode` op) can call the reactor without a
+-- | circular import.
+module MpfsSpa.CageHelpers.Reactor
+  ( ReactorResult
+  , decodeTxOut
+  , parseCageTxOutput
+  , parseSignedTxOutput
+  , runCageReactor
+  ) where
+
+import Prelude
+
+import Control.Promise (Promise, toAffE)
+import Data.Argonaut.Core (Json, fromObject, fromString, stringify)
+import Data.Argonaut.Parser (jsonParser)
+import Data.Array (head)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.String.CodeUnits as CU
+import Data.String.Common as String
+import Data.String.Pattern (Pattern(..))
+import Data.Tuple (Tuple(..))
+import Effect (Effect)
+import Effect.Aff (Aff)
+import Foreign.Object as Object
+
+import MpfsSpa.Types (CageError(..))
+
+type ReactorResult =
+  { stdout :: String
+  , stderr :: String
+  , exitOk :: Boolean
+  }
+
+foreign import runCageReactorImpl :: String -> Effect (Promise ReactorResult)
+
+runCageReactor :: String -> Aff ReactorResult
+runCageReactor = toAffE <<< runCageReactorImpl
+
+-- | Decode a witnessed `tx_out` (hex CBOR of the resolved output) into its
+-- | inline-datum display fields by calling the reactor `decode` op. Returns
+-- | the decoded JSON object on success, or a typed `CageError` on any
+-- | reactor or parse failure (fail-closed; never fabricates values).
+decodeTxOut :: String -> Aff (Either CageError Json)
+decodeTxOut txOutHex = do
+  result <- runCageReactor (buildDecodeEnvelope txOutHex)
+  pure (parseDecodedOutput result)
+
+buildDecodeEnvelope :: String -> String
+buildDecodeEnvelope txOutHex =
+  stringify
+    ( fromObject
+        ( Object.fromFoldable
+            [ Tuple "op" (fromString "decode")
+            , Tuple "tx_out" (fromString txOutHex)
+            ]
+        )
+    )
+
+parseDecodedOutput :: ReactorResult -> Either CageError Json
+parseDecodedOutput result
+  | not result.exitOk = Left (CageError (firstMessage result))
+  | otherwise =
+      case CU.stripPrefix (Pattern "decoded: ") (firstLine result.stdout) of
+        Just payload ->
+          case jsonParser (String.trim payload) of
+            Right json -> Right json
+            Left err -> Left (CageError ("decode parse: " <> err))
+        Nothing -> Left (CageError (firstMessage result))
+
+parseCageTxOutput :: ReactorResult -> Either CageError String
+parseCageTxOutput = parsePrefixedOutput "cage_tx: "
+
+parseSignedTxOutput :: ReactorResult -> Either CageError String
+parseSignedTxOutput = parsePrefixedOutput "signed_tx: "
+
+parsePrefixedOutput :: String -> ReactorResult -> Either CageError String
+parsePrefixedOutput prefix result
+  | not result.exitOk =
+      Left (CageError (firstMessage result))
+  | otherwise =
+      case CU.stripPrefix (Pattern prefix) (firstLine result.stdout) of
+        Just hex | String.trim hex /= "" -> Right (String.trim hex)
+        _ -> Left (CageError (firstMessage result))
+
+firstMessage :: ReactorResult -> String
+firstMessage result =
+  let
+    err = String.trim result.stderr
+    out = String.trim result.stdout
+  in
+    if err /= "" then err
+    else if out /= "" then firstLine out
+    else "reactor returned no output"
+
+firstLine :: String -> String
+firstLine text =
+  String.trim
+    (fromMaybe text (head (String.split (Pattern "\n") text)))

--- a/mpfs-spa/src/MpfsSpa/CageHelpers/Wasm.js
+++ b/mpfs-spa/src/MpfsSpa/CageHelpers/Wasm.js
@@ -1,17 +1,3 @@
-// Thin wrapper over globalThis.runCageReactor, seeded by src/bootstrap.js.
-
-export const runCageReactorImpl = (stdinText) => () => {
-  if (typeof globalThis.runCageReactor !== "function") {
-    return Promise.resolve({
-      stdout: "",
-      stderr: "runCageReactor is not installed",
-      exitOk: false,
-    });
-  }
-
-  return globalThis.runCageReactor(stdinText);
-};
-
 // UTF-8 encode a user-typed string to a lowercase hex string, so the
 // /facts/request/* fields (Hex on the wire) accept plain text like
 // "start"/"amaru" instead of requiring the user to pre-hex-encode.

--- a/mpfs-spa/src/MpfsSpa/CageHelpers/Wasm.purs
+++ b/mpfs-spa/src/MpfsSpa/CageHelpers/Wasm.purs
@@ -4,27 +4,18 @@
 -- | the reactor's stable stdout line. All transaction construction and witness
 -- | assembly remains inside the Haskell WASM reactor.
 module MpfsSpa.CageHelpers.Wasm
-  ( ReactorResult
-  , assembleTx
+  ( assembleTx
   , buildBootEnvelope
-  , parseCageTxOutput
-  , parseSignedTxOutput
-  , runCageReactor
   , wasmCageHelpers
   ) where
 
 import Prelude
 
 import Control.Promise (Promise, toAffE)
-import Data.Array (head)
 import Data.Argonaut.Core (Json, fromNumber, fromObject, fromString, stringify)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Either (Either(..))
 import Data.Int (toNumber)
-import Data.Maybe (Maybe(..), fromMaybe)
-import Data.String.CodeUnits as CU
-import Data.String.Common as String
-import Data.String.Pattern (Pattern(..))
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Aff (Aff)
@@ -32,6 +23,11 @@ import Effect.Class (liftEffect)
 import Foreign.Object as Object
 
 import MpfsSpa.CageHelpers (CageHelpers, CageResult)
+import MpfsSpa.CageHelpers.Reactor
+  ( parseCageTxOutput
+  , parseSignedTxOutput
+  , runCageReactor
+  )
 import MpfsSpa.Config (serverConfig, walletPolicyJson)
 import MpfsSpa.Http (Config, getEvalContext, getTrustedRoot, postBootFacts)
 import MpfsSpa.Types
@@ -46,12 +42,6 @@ import MpfsSpa.Types
   , WalletAddr(..)
   )
 
-type ReactorResult =
-  { stdout :: String
-  , stderr :: String
-  , exitOk :: Boolean
-  }
-
 type RawResponse =
   { ok :: Boolean
   , status :: Int
@@ -59,17 +49,12 @@ type RawResponse =
   , text :: String
   }
 
-foreign import runCageReactorImpl :: String -> Effect (Promise ReactorResult)
-
 foreign import postJsonImpl :: String -> String -> Effect (Promise RawResponse)
 
 -- | UTF-8 encode a user-typed string to a lowercase hex string. Trie
 -- keys/values travel as `Hex` on the wire, so plain text entered in the
 -- forms (e.g. "start"/"amaru") must be hex-encoded before POST.
 foreign import encodeUtf8Hex :: String -> String
-
-runCageReactor :: String -> Aff ReactorResult
-runCageReactor = toAffE <<< runCageReactorImpl
 
 wasmCageHelpers :: CageHelpers
 wasmCageHelpers =
@@ -168,12 +153,6 @@ buildAssembleEnvelope unsignedTx witnessSet =
         , Tuple "witness_set" (fromString witnessSet)
         ]
     )
-
-parseCageTxOutput :: ReactorResult -> Either CageError String
-parseCageTxOutput = parsePrefixedOutput "cage_tx: "
-
-parseSignedTxOutput :: ReactorResult -> Either CageError String
-parseSignedTxOutput = parsePrefixedOutput "signed_tx: "
 
 requestCageTx
   :: String
@@ -304,30 +283,6 @@ cageConfigJson cfg =
     , Tuple "default_tip" (intJson cfg.defaultTip)
     , Tuple "network" (fromString cfg.network)
     ]
-
-parsePrefixedOutput :: String -> ReactorResult -> Either CageError String
-parsePrefixedOutput prefix result
-  | not result.exitOk =
-      Left (CageError (firstMessage result))
-  | otherwise =
-      case CU.stripPrefix (Pattern prefix) (firstLine result.stdout) of
-        Just hex | String.trim hex /= "" -> Right (String.trim hex)
-        _ -> Left (CageError (firstMessage result))
-
-firstMessage :: ReactorResult -> String
-firstMessage result =
-  let
-    err = String.trim result.stderr
-    out = String.trim result.stdout
-  in
-    if err /= "" then err
-    else if out /= "" then firstLine out
-    else "reactor returned no output"
-
-firstLine :: String -> String
-firstLine text =
-  String.trim
-    (fromMaybe text (head (String.split (Pattern "\n") text)))
 
 intJson :: Int -> Json
 intJson = fromNumber <<< toNumber

--- a/mpfs-spa/src/MpfsSpa/Http.purs
+++ b/mpfs-spa/src/MpfsSpa/Http.purs
@@ -30,24 +30,27 @@ import Prelude
 import Control.Promise (Promise, toAffE)
 import Data.Argonaut.Core (Json, stringify)
 import Data.Argonaut.Decode (decodeJson)
-import Data.Argonaut.Decode.Combinators ((.:))
+import Data.Argonaut.Decode.Combinators ((.:), (.:?))
 import Data.Argonaut.Decode.Error (JsonDecodeError(..), printJsonDecodeError)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable, toNullable)
-import Data.Traversable (traverse)
+import Data.Traversable (sequence, traverse)
 import Effect (Effect)
 import Effect.Aff (Aff)
 
+import MpfsSpa.CageHelpers.Reactor (decodeTxOut)
 import MpfsSpa.Types
-  ( Key(..)
-  , RequestId
+  ( CageError
+  , Key(..)
+  , RequestId(..)
   , TokenId(..)
   , TrustedRoot(..)
   , Value(..)
   , WalletAddr(..)
+  , cageErrorMessage
   )
 
 -- | Server connection config. `baseUrl` has no trailing slash.
@@ -63,12 +66,17 @@ type TokenState =
   }
 
 -- | A pending request for display + retract. `requestId` is the request
--- | UTxO reference (`tx_id#tx_ix`) from the witness.
+-- | UTxO reference (`tx_id#tx_ix`) from the witness. `value` is the
+-- | primary value to show (the inserted value for inserts, the removed
+-- | value for deletes, the new value for updates); `oldValue` carries an
+-- | update's previous value so updates can display BOTH sides. All fields
+-- | are decoded from the witnessed `tx_out` inline datum.
 type PendingRequest =
   { token :: TokenId
   , owner :: String
   , key :: Key
   , value :: Maybe Value
+  , oldValue :: Maybe Value
   , operation :: String
   , fee :: Number
   , submittedAt :: Number
@@ -133,28 +141,55 @@ getDecoded cfg path decode = do
   ej <- request "GET" (cfg.baseUrl <> path) Nothing
   pure (ej >>= (lmap printJsonDecodeError <<< decode))
 
--- | List all token ids the server knows.
+-- | List all token ids the server knows. Each token id is the asset name
+-- | of the state token inside the entry's witnessed `txout_cbor`, decoded
+-- | through the reactor rather than read from a removed projection (#345).
 getTokens :: Config -> Aff (Either String (Array TokenId))
-getTokens cfg = getDecoded cfg "/tokens" decode
-  where
-  decode j = case decodeTokensResponse j of
-    Right tokens -> Right tokens
-    Left _ -> map TokenId <$> (decodeJson j :: Either JsonDecodeError (Array String))
+getTokens cfg = do
+  ej <- request "GET" (cfg.baseUrl <> "/tokens") Nothing
+  case ej of
+    Left err -> pure (Left err)
+    Right j -> case tokenEntryTxOuts j of
+      Right hexes -> map sequence (traverse decodeTokenIdVia hexes)
+      Left _ ->
+        -- Fallback: a plain array of token-id strings carries no witness
+        -- to decode.
+        pure
+          ( lmap printJsonDecodeError
+              (map TokenId <$> (decodeJson j :: Either JsonDecodeError (Array String)))
+          )
 
 -- | Enumerate every fact in a token's trie.
 getFacts :: Config -> TokenId -> Aff (Either String (Array FactEntry))
 getFacts cfg (TokenId tid) =
   getDecoded cfg ("/tokens/" <> tid <> "/facts") decodeFacts
 
--- | Fetch a token's on-chain state.
+-- | Fetch a token's on-chain state by decoding the witnessed state
+-- | `tx_out` inline datum through the reactor (#345).
 getTokenState :: Config -> TokenId -> Aff (Either String TokenState)
-getTokenState cfg (TokenId tid) =
-  getDecoded cfg ("/tokens/" <> tid) decodeTokenState
+getTokenState cfg (TokenId tid) = do
+  ej <- request "GET" (cfg.baseUrl <> "/tokens/" <> tid) Nothing
+  case ej of
+    Left err -> pure (Left err)
+    Right j -> case stateTxOutHex j of
+      Left de -> pure (Left (printJsonDecodeError de))
+      Right hex -> do
+        decoded <- decodeTxOut hex
+        pure
+          ( reactorEither decoded
+              >>= (lmap printJsonDecodeError <<< decodeReactorState)
+          )
 
--- | Fetch a token's pending requests.
+-- | Fetch a token's pending requests, decoding each witnessed request
+-- | `tx_out` inline datum through the reactor (#345).
 getRequests :: Config -> TokenId -> Aff (Either String (Array PendingRequest))
-getRequests cfg (TokenId tid) =
-  getDecoded cfg ("/tokens/" <> tid <> "/requests") decodeRequests
+getRequests cfg (TokenId tid) = do
+  ej <- request "GET" (cfg.baseUrl <> "/tokens/" <> tid <> "/requests") Nothing
+  case ej of
+    Left err -> pure (Left err)
+    Right j -> case requestWitnesses j of
+      Left de -> pure (Left (printJsonDecodeError de))
+      Right witnesses -> map sequence (traverse decodeRequestVia witnesses)
 
 -- | Fetch the current value of a fact key (hex), if present.
 getFactValue :: Config -> TokenId -> Key -> Aff (Either String Value)
@@ -185,31 +220,62 @@ submitTx cfg signedHex = do
 -- --- decoders ---------------------------------------------------------------
 
 -- | #342 removed the server-side projections (`state.state`, `token_id`,
--- | `request`) these decoders used to read. Reconstructing them now means
--- | decoding the witnessed `tx_out` inline datum, which the SPA does not
--- | yet do - surface a typed decode failure instead of trusting removed
--- | projections.
-witnessTxOutDecoderMissing :: forall a. String -> Either JsonDecodeError a
-witnessTxOutDecoderMissing what =
-  Left
-    ( TypeMismatch
-        ( what
-            <> " requires decoding witnessed tx_out; SPA decoder not implemented"
-        )
-    )
+-- | `request`) these read paths used to trust. They are now reconstructed
+-- | by decoding the witnessed `tx_out` inline datum through the reactor
+-- | `decode` op (#345): proof-bearing bytes only, no PureScript CBOR, no
+-- | fabricated values.
 
-decodeTokenState :: Json -> Either JsonDecodeError TokenState
-decodeTokenState _ = witnessTxOutDecoderMissing "token state"
+-- | Lift a reactor `CageError` into the shared `Either String` channel.
+reactorEither :: forall a. Either CageError a -> Either String a
+reactorEither = lmap cageErrorMessage
 
-decodeTokensResponse :: Json -> Either JsonDecodeError (Array TokenId)
-decodeTokensResponse j = do
+-- | Pull each token entry's witnessed `txout_cbor` hex from a `/tokens`
+-- | response.
+tokenEntryTxOuts :: Json -> Either JsonDecodeError (Array String)
+tokenEntryTxOuts j = do
   top <- decodeJson j
   tokens <- top .: "tokens"
   (entries :: Array Json) <- tokens .: "entries"
-  traverse decodeTokenEntry entries
+  traverse tokenEntryTxOut entries
 
-decodeTokenEntry :: Json -> Either JsonDecodeError TokenId
-decodeTokenEntry _ = witnessTxOutDecoderMissing "token id"
+tokenEntryTxOut :: Json -> Either JsonDecodeError String
+tokenEntryTxOut j = do
+  entry <- decodeJson j
+  entry .: "txout_cbor"
+
+-- | Decode one token id from its witnessed state `tx_out` via the reactor.
+decodeTokenIdVia :: String -> Aff (Either String TokenId)
+decodeTokenIdVia hex = do
+  decoded <- decodeTxOut hex
+  pure
+    ( reactorEither decoded
+        >>= (lmap printJsonDecodeError <<< decodeReactorTokenId)
+    )
+
+decodeReactorTokenId :: Json -> Either JsonDecodeError TokenId
+decodeReactorTokenId j = do
+  o <- decodeJson j
+  tid <- o .: "token_id"
+  pure (TokenId tid)
+
+-- | Pull the witnessed state `tx_out` hex from a `/tokens/:id` response.
+stateTxOutHex :: Json -> Either JsonDecodeError String
+stateTxOutHex j = do
+  top <- decodeJson j
+  state <- top .: "state"
+  utxo <- state .: "utxo"
+  utxo .: "tx_out"
+
+-- | Build the display `TokenState` from the reactor-decoded state datum.
+decodeReactorState :: Json -> Either JsonDecodeError TokenState
+decodeReactorState j = do
+  o <- decodeJson j
+  owner <- o .: "owner"
+  root <- o .: "root"
+  tip <- o .: "tip"
+  processTime <- o .: "process_time"
+  retractTime <- o .: "retract_time"
+  pure { owner, root, tip, processTime, retractTime }
 
 decodeFacts :: Json -> Either JsonDecodeError (Array FactEntry)
 decodeFacts j = do
@@ -224,14 +290,66 @@ decodeFactEntry j = do
   value <- fact .: "value"
   pure { key: Key key, value: Value value }
 
-decodeRequests :: Json -> Either JsonDecodeError (Array PendingRequest)
-decodeRequests j = do
+-- | A witnessed pending request: the inline-datum `tx_out` hex to decode
+-- | plus the request UTxO reference (`tx_id#tx_ix`) for retract.
+type RequestWitness =
+  { txOutHex :: String
+  , requestId :: RequestId
+  }
+
+requestWitnesses :: Json -> Either JsonDecodeError (Array RequestWitness)
+requestWitnesses j = do
   top <- decodeJson j
   (reqs :: Array Json) <- top .: "requests"
-  traverse decodeWitnessedRequest reqs
+  traverse requestWitness reqs
 
-decodeWitnessedRequest :: Json -> Either JsonDecodeError PendingRequest
-decodeWitnessedRequest _ = witnessTxOutDecoderMissing "pending request"
+requestWitness :: Json -> Either JsonDecodeError RequestWitness
+requestWitness j = do
+  o <- decodeJson j
+  utxo <- o .: "utxo"
+  txOutHex <- utxo .: "tx_out"
+  txin <- utxo .: "tx_in"
+  txId <- txin .: "tx_id"
+  (txIx :: Int) <- txin .: "tx_ix"
+  pure { txOutHex, requestId: RequestId (txId <> "#" <> show txIx) }
+
+-- | Decode one pending request from its witnessed `tx_out` via the reactor.
+decodeRequestVia :: RequestWitness -> Aff (Either String PendingRequest)
+decodeRequestVia w = do
+  decoded <- decodeTxOut w.txOutHex
+  pure
+    ( reactorEither decoded
+        >>= (lmap printJsonDecodeError <<< decodeReactorRequest w.requestId)
+    )
+
+-- | Build a display `PendingRequest` from the reactor-decoded request
+-- | datum, preserving both sides of an update (the lossiness #342 called
+-- | out). Never fabricates a value: absent reactor fields stay `Nothing`.
+decodeReactorRequest :: RequestId -> Json -> Either JsonDecodeError PendingRequest
+decodeReactorRequest reqId j = do
+  o <- decodeJson j
+  token <- o .: "token"
+  owner <- o .: "owner"
+  key <- o .: "key"
+  operation <- o .: "operation"
+  oldVal <- o .:? "old"
+  newVal <- o .:? "new"
+  fee <- o .: "fee"
+  submittedAt <- o .: "submitted_at"
+  let
+    primaryValue = if operation == "delete" then oldVal else newVal
+    updateOldValue = if operation == "update" then oldVal else Nothing
+  pure
+    { token: TokenId token
+    , owner
+    , key: Key key
+    , value: Value <$> primaryValue
+    , oldValue: Value <$> updateOldValue
+    , operation
+    , fee
+    , submittedAt
+    , requestId: reqId
+    }
 
 decodeFactValue :: Json -> Either JsonDecodeError Value
 decodeFactValue j = do

--- a/mpfs-spa/src/MpfsSpa/Tab/Facts.purs
+++ b/mpfs-spa/src/MpfsSpa/Tab/Facts.purs
@@ -336,7 +336,7 @@ requestRow onRetract nowMillis processTime req =
     [ M.listItemText
         { primary: req.operation <> " - " <> unKey req.key
         , secondary:
-            maybe "" (\v -> "Value " <> unValue v <> " - ") req.value
+            valueLabel
               <> requestAge req
               <> " - "
               <> requestWindow req
@@ -345,6 +345,11 @@ requestRow onRetract nowMillis processTime req =
   where
   unKey (Key k) = displayUtf8Hex k
   unValue (Value v) = displayUtf8Hex v
+  valueLabel = case req.oldValue of
+    Just old ->
+      "Value " <> unValue old <> " -> " <> maybe "" unValue req.value <> " - "
+    Nothing ->
+      maybe "" (\v -> "Value " <> unValue v <> " - ") req.value
 
   requestAge r = formatAgeMillis (nowMillis - r.submittedAt)
 

--- a/mpfs-spa/test/Test/Main.purs
+++ b/mpfs-spa/test/Test/Main.purs
@@ -32,6 +32,7 @@ pendingAt submittedAt =
   , owner: "owner"
   , key: Key "key"
   , value: Nothing
+  , oldValue: Nothing
   , operation: "insert"
   , fee: 0.0
   , submittedAt


### PR DESCRIPTION
## Summary
- add a cage reactor `decode` op for witnessed `tx_out` CBOR
- route SPA token, state, and pending-request reads through the reactor decoder
- preserve update request `old -> new` rendering and add focused native/fixture coverage

## Verification
- `nix build --quiet .#mpfs-spa`
- `./gate.sh`

## Follow-up
- Playwright e2e mocks still need a decode-handler path before those mocked flows can cover the new live decoder boundary.

Refs #345
