### PR TITLE
ci(docs): deploy docs only on main (stop gh-pages PR race)

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -43,7 +43,12 @@ jobs:
             exit 1
           fi
 
+  # Publish only on push to main. Deploying from PR branches made every PR
+  # run `mkdocs gh-deploy --force`, so concurrent PRs raced to force-push
+  # gh-pages and intermittently failed. PRs are covered by dep-graph-drift
+  # above; only main publishes the rendered site.
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
`deploy-docs.yaml` ran `mkdocs gh-deploy --force` on **every PR**, so concurrent PRs raced to force-push `gh-pages` → intermittent `git push gh-pages` failures (e.g. on #351). Gate the `deploy` job to `push:main` only; PRs remain covered by the `dep-graph-drift` check. No more PR-branch deploys, no race.

Part of the pre-0.2.1 release-pipeline cleanup. (The Homebrew-tap failure is a separate, non-code issue — an expired `TAP_TOKEN`.)