### PR TITLE
fix(indexer): resume chain-sync at the tip, prune by k blocks

### DIFF
--- a/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
+++ b/cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
@@ -331,6 +331,7 @@ test-suite unit-tests
     Cardano.MPFS.Indexer.InverseSpec
     Cardano.MPFS.Indexer.PersistentSpec
     Cardano.MPFS.Indexer.ReadsSpec
+    Cardano.MPFS.Indexer.ResumeSpec
     Cardano.MPFS.Indexer.RollbackSpec
     Cardano.MPFS.Indexer.TxFixtures
     Cardano.MPFS.Indexer.UnifiedSpec

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs
@@ -50,6 +50,9 @@ module Cardano.MPFS.Application
       -- * Lifecycle
     , withApplication
 
+      -- * Chain-sync resume
+    , resumePoints
+
       -- * RocksDB setup
     , dbConfig
     , allColumnFamilies
@@ -154,7 +157,8 @@ import Cardano.UTxOCSMT.Application.Run.Config
     , prisms
     )
 import Cardano.UTxOCSMT.Bootstrap.Genesis
-    ( genesisStabilityWindow
+    ( genesisSecurityParam
+    , genesisStabilityWindow
     , genesisUtxoPairs
     , readByronGenesisUtxoPairs
     , readShelleyGenesis
@@ -351,6 +355,13 @@ withApplication cfg action = do
             NetworkMagic (sgNetworkMagic genesis)
         stabilityWindow =
             genesisStabilityWindow genesis
+        -- Security parameter k in BLOCKS (max Cardano
+        -- rollback depth, e.g. 2160). Distinct from the
+        -- stability window above, which is 3k/f in SLOTS.
+        -- See #355: the rollback history is pruned by k
+        -- (blocks), not by the slot window.
+        securityParamK =
+            genesisSecurityParam genesis
 
     withDBCF
         (dbPath cfg)
@@ -490,15 +501,7 @@ withApplication cfg action = do
                             $ CFStore.queryHistory
                                 InRollbacks
                     let startPts :: [Point]
-                        startPts
-                            | null history =
-                                [Network.Point Origin]
-                            | otherwise =
-                                [ cageCheckpointToPoint
-                                    s
-                                    (fromMaybe (BlockId mempty) (rpMeta rp))
-                                | (s, rp) <- history
-                                ]
+                        startPts = resumePoints history
 
                     -- Initialize Phase:
                     -- Existing DB: toFollowing replays journal
@@ -568,6 +571,7 @@ withApplication cfg action = do
                                     cageIntersector =
                                         mkCageIntersector
                                             (fromIntegral stabilityWindow)
+                                            (fromIntegral securityParamK)
                                             run
                                             backendInit
                                             csmtArmageddon
@@ -759,6 +763,38 @@ seedGenesis genesis mByronPath st runner ops = do
     insertPair (k, v) =
         CSMT.transact runner
             $ csmtInsert ops k v
+
+-- | Build the chain-sync intersection candidates from
+-- the persisted rollback history.
+--
+-- 'CFStore.queryHistory' returns rollback points
+-- oldest-first (it iterates @firstEntry@ → @nextEntry@,
+-- ascending slot). ChainSync @findIntersect@ requires the
+-- opposite: the node returns the /first/ offered point
+-- that is on its chain, so clients must list candidates
+-- newest-first. Offering them oldest-first makes the node
+-- intersect at the oldest retained point and replay the
+-- entire history (~1.1M slots on restart, see #355).
+--
+-- We therefore reverse the history so the newest point
+-- (closest to the tip) is offered first — the node
+-- intersects at the tip with near-zero replay. The full
+-- history is still offered, in descending order, so that
+-- a node which rolled back past our tip can still find a
+-- deeper common point.
+--
+-- An empty history (fresh database) resumes from
+-- 'Origin'.
+resumePoints
+    :: [(SlotNo, RollbackPoint inv BlockId)]
+    -> [Point]
+resumePoints [] = [Network.Point Origin]
+resumePoints history =
+    [ cageCheckpointToPoint
+        s
+        (fromMaybe (BlockId mempty) (rpMeta rp))
+    | (s, rp) <- reverse history
+    ]
 
 -- | Convert a cage checkpoint to a chain
 -- intersection 'Point'.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/CageFollower.hs
@@ -91,9 +91,25 @@ phaseProofReadsReady (InRestoration _) = False
 
 -- | Build an 'Intersector' for the cage follower.
 -- Phase is threaded through continuations (no IORef).
+--
+-- The two depth parameters are deliberately decoupled
+-- (see #355): the stability window governs /when/ the
+-- phase flips from restoration to following (a slot
+-- distance from the tip), while the security parameter
+-- @k@ governs /how many/ rollback points are retained (a
+-- block count). They are derived from the same genesis
+-- @k@ but have different units, so conflating them keeps
+-- a window ~60× too deep.
 mkCageIntersector
     :: Int
-    -- ^ Security parameter (stability window)
+    -- ^ Stability window in slots: phase-transition
+    -- threshold (restoration → following). A block is
+    -- \"within the window\" when @slot + window >= tip@.
+    -> Int
+    -- ^ Security parameter @k@ in blocks: rollback-history
+    -- pruning depth. The store keeps @k + 1@ points
+    -- (@k@ for the max Cardano rollback plus one fence
+    -- post), never fewer than @k@.
     -> ( forall a
           . Transaction
                 IO
@@ -129,7 +145,8 @@ mkCageIntersector
     -- ^ Current phase
     -> Intersector Point SlotNo Fetched
 mkCageIntersector
-    securityParam
+    stabilityWindowSlots
+    securityParamK
     run
     backendInit
     armageddon
@@ -140,7 +157,8 @@ mkCageIntersector
             { intersectFound = \_point ->
                 pure
                     $ mkCageFollower
-                        securityParam
+                        stabilityWindowSlots
+                        securityParamK
                         run
                         backendInit
                         armageddon
@@ -150,7 +168,8 @@ mkCageIntersector
             , intersectNotFound =
                 pure
                     ( mkCageIntersector
-                        securityParam
+                        stabilityWindowSlots
+                        securityParamK
                         run
                         backendInit
                         armageddon
@@ -169,7 +188,11 @@ mkCageIntersector
 -- block processing.
 mkCageFollower
     :: Int
-    -- ^ Security parameter (stability window)
+    -- ^ Stability window in slots: phase-transition
+    -- threshold (restoration → following).
+    -> Int
+    -- ^ Security parameter @k@ in blocks: rollback-history
+    -- pruning depth (keeps @k + 1@ points).
     -> ( forall a
           . Transaction
                 IO
@@ -202,7 +225,8 @@ mkCageFollower
     -- ^ Current phase
     -> Follower Point SlotNo Fetched
 mkCageFollower
-    securityParam
+    stabilityWindowSlots
+    securityParamK
     run
     backendInit
     armageddon
@@ -219,18 +243,22 @@ mkCageFollower
         rollFwd phase fetched tipSlot = do
             let slot =
                     pointToSlot (fetchedPoint fetched)
+                -- Phase transition uses the stability
+                -- window in SLOTS (distance from tip).
                 withinWindow =
                     unSlotNo slot
-                        + fromIntegral securityParam
+                        + fromIntegral stabilityWindowSlots
                         >= unSlotNo tipSlot
             setProofReadsReady False
             phase' <-
+                -- Pruning uses the security parameter k in
+                -- BLOCKS (rollback-history depth).
                 processBlock
                     nullTracer
                     withinWindow
                     run
                     InRollbacks
-                    securityParam
+                    securityParamK
                     slot
                     fetched
                     phase
@@ -276,7 +304,8 @@ mkCageFollower
                                 pure
                                     $ Reset
                                     $ mkCageIntersector
-                                        securityParam
+                                        stabilityWindowSlots
+                                        securityParamK
                                         run
                                         backendInit
                                         armageddon

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ResumeSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/ResumeSpec.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Cardano.MPFS.Indexer.ResumeSpec
+-- Description : Chain-sync resume-point ordering (#355)
+-- License     : Apache-2.0
+--
+-- Tests that 'resumePoints' orders the ChainSync
+-- intersection candidates newest-first. The rollback
+-- history is persisted oldest-first, but ChainSync
+-- @findIntersect@ intersects at the /first/ offered
+-- point on the node's chain, so candidates must be
+-- offered newest-first. Offering them oldest-first made
+-- the node intersect ~1.1M slots behind the tip and
+-- replay the whole history on restart (#355).
+module Cardano.MPFS.Indexer.ResumeSpec (spec) where
+
+import Data.ByteString (ByteString)
+
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Point (WithOrigin (..))
+
+import Cardano.MPFS.Application (resumePoints)
+import Cardano.MPFS.Core.Types
+    ( BlockId (..)
+    , SlotNo (..)
+    )
+import ChainFollower.Rollbacks.Types (RollbackPoint (..))
+
+-- | A rollback point carrying a block id as its
+-- per-point metadata (the only field 'resumePoints'
+-- reads). The inverse-operation type is irrelevant
+-- here, so it is fixed to @()@.
+mkPoint :: ByteString -> RollbackPoint () BlockId
+mkPoint h =
+    RollbackPoint
+        { rpInverses = []
+        , rpMeta = Just (BlockId h)
+        }
+
+-- | Extract the slots of a candidate list, in order.
+candidateSlots :: [Network.Point a] -> [WithOrigin SlotNo]
+candidateSlots = map Network.pointSlot
+
+spec :: Spec
+spec =
+    describe
+        "resumePoints (chain-sync intersection ordering, #355)"
+        $ do
+            it
+                "offers candidates newest-first (descending slot)"
+                $ do
+                    -- queryHistory yields points oldest-first.
+                    let history =
+                            [ (SlotNo 100, mkPoint "a")
+                            , (SlotNo 200, mkPoint "b")
+                            , (SlotNo 300, mkPoint "c")
+                            ]
+                    candidateSlots (resumePoints history)
+                        `shouldBe` [ At (SlotNo 300)
+                                   , At (SlotNo 200)
+                                   , At (SlotNo 100)
+                                   ]
+
+            it
+                "puts the newest (tip) point first so the node intersects at the tip"
+                $ do
+                    let history =
+                            [ (SlotNo s, mkPoint "x")
+                            | s <- [10, 20 .. 100]
+                            ]
+                    case resumePoints history of
+                        [] -> fail "expected non-empty candidates"
+                        (first : _) ->
+                            Network.pointSlot first
+                                `shouldBe` At (SlotNo 100)
+
+            it
+                "resumes from Origin on empty history"
+                $ resumePoints []
+                `shouldBe` [Network.Point Origin]

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/UnifiedSpec.hs
@@ -20,7 +20,7 @@ import Control.Concurrent.Async
     ( concurrently_
     , replicateConcurrently_
     )
-import Control.Monad (forM_, replicateM_)
+import Control.Monad (foldM_, forM_, replicateM_)
 import Control.Tracer (nullTracer)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
@@ -815,6 +815,64 @@ spec = describe "Unified 14-CF" $ do
                                     fail "expected Following"
                         InFollowing _ _ ->
                             fail "expected Restoration"
+
+        it
+            "prunes rollback history to k+1 points by block count, not slot span (#355)"
+            $ do
+                withUnifiedDB $ \transact -> do
+                    let csmtOps =
+                            mkCSMTOps testFromKV testHashing
+                        -- Security parameter k in BLOCKS. The
+                        -- followed slots below span far more
+                        -- than k, so retaining exactly k+1
+                        -- points proves the pruning depth is a
+                        -- block count (k), never the slot
+                        -- stability window.
+                        k = 3 :: Int
+                        phase0 =
+                            InRestoration
+                                (mkComposedRestoring csmtOps)
+                    -- Restore one block, then enter Following.
+                    phase1 <-
+                        processBlock
+                            nullTracer
+                            False
+                            transact
+                            InRollbacks
+                            k
+                            (1 :: SlotNo)
+                            ([CageBoot tokA stRefA tokStateA], [])
+                            phase0
+                    following <- case phase1 of
+                        InRestoration r ->
+                            Backend.toFollowing r
+                        InFollowing _ _ ->
+                            fail "expected Restoration"
+                    transact
+                        $ Store.armageddonSetup
+                            InRollbacks
+                            (1 :: SlotNo)
+                            (Just (BlockId mempty))
+                    -- Follow 8 empty blocks at slots 2..9
+                    -- (a 9-slot span, far wider than k).
+                    foldM_
+                        ( \phase s ->
+                            processBlock
+                                nullTracer
+                                False
+                                transact
+                                InRollbacks
+                                k
+                                s
+                                ([], [])
+                                phase
+                        )
+                        (InFollowing 1 following)
+                        [2 .. 9 :: SlotNo]
+                    count <-
+                        transact
+                            $ Store.countPoints InRollbacks
+                    count `shouldBe` k + 1
 
     describe "full wiring (openCSMTOps + trie manager + Runner)" $ do
         it "restore + follow + rollback with openCSMTOps" $ do

--- a/cardano-mpfs-offchain/test/main.hs
+++ b/cardano-mpfs-offchain/test/main.hs
@@ -37,6 +37,7 @@ import Cardano.MPFS.Indexer.FollowerSpec qualified as CageFollowerSpec
 import Cardano.MPFS.Indexer.InverseSpec qualified as InverseSpec
 import Cardano.MPFS.Indexer.PersistentSpec qualified as PersistentStateSpec
 import Cardano.MPFS.Indexer.ReadsSpec qualified as ReadsSpec
+import Cardano.MPFS.Indexer.ResumeSpec qualified as ResumeSpec
 import Cardano.MPFS.Indexer.RollbackSpec qualified as RollbackSpec
 import Cardano.MPFS.Indexer.UnifiedSpec qualified as UnifiedSpec
 import Cardano.MPFS.OnChainSpec qualified as OnChainSpec
@@ -76,6 +77,7 @@ main =
                 ArmageddonSpec.spec
                 ReadsSpec.spec
                 UnifiedSpec.spec
+                ResumeSpec.spec
                 RollbackSpec.spec
                 BootFactsSpec.spec
                 RequestInsertFactsSpec.spec


### PR DESCRIPTION
## Summary

On restart the indexer's ChainSync resumed ~1.1M slots behind the tip and replayed for tens of minutes (root cause in #355, reproduced prod-safe). Two stacked defects:

### Bug 1 — resume candidates offered in the wrong order (the replay trigger)
`startPts` was built from `CFStore.queryHistory InRollbacks`, which returns rollback points **oldest-first** (its haddock: *"from oldest to newest … useful for querying per-point metadata"*), and handed to ChainSync `findIntersect` **unreversed**. `findIntersect` intersects at the *first* offered point on the node's chain, so clients must offer candidates **newest-first**. Oldest-first made the node intersect at the deepest retained point and replay everything since.

**Fix:** extract the ordering into a pure, tested `resumePoints` that reverses the history (newest-first), keeping the empty → `Origin` branch. The full history is still offered, in descending order, so a node that rolled back past our tip can still find a deeper common point.

### Bug 2 — rollback window pruned by the wrong unit (why it was ~60× too deep)
The history was pruned to `genesisStabilityWindow` points, but that value is `3k/f` in **slots** (~129,600 on preprod) being used as a **block count** — retaining tens of days of rollback points instead of `k`.

**Fix:** decouple the two uses inside `CageFollower` (no chain-follower signature change — `processBlock` already takes the slot-window flag and `k` separately):
- phase-transition threshold (`withinWindow`) stays the stability window in **slots**;
- pruning depth becomes the security parameter **k in blocks** (`genesisSecurityParam`).

Pruning keeps `k+1 ≥ k` points, so it remains **rollback-safe** (no Cardano rollback is deeper than `k`).

## Tests
- `Cardano.MPFS.Indexer.ResumeSpec`: `resumePoints` orders candidates newest-first; head = tip; empty → `Origin`.
- `Cardano.MPFS.Indexer.UnifiedSpec`: following blocks across a 9-slot span with `k=3` retains exactly `k+1=4` rollback points — proving the pruning depth is a block count, not the slot window.
- `./gate.sh` green (full nix build + all unit suites + format-check + hlint).

## Notes / follow-up
chain-follower's `Runner.readCheckpoint` is documented "use this on startup to determine the intersection point" but returns only `Maybe slot` (no block hash), so the app reaches for the metadata-oriented `queryHistory` instead and has to re-impose ChainSync's newest-first ordering by hand. Worth a follow-up in chain-follower to expose a hash-bearing, newest-first "intersection candidates" helper so the ordering convention lives next to the protocol that requires it. Out of scope here.

Refs #355
