### PR TITLE
ci(release): mint homebrew-tap token from a GitHub App (drop the stored PAT)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,9 +156,21 @@ jobs:
             "${{ steps.package.outputs.tarball }}" \
             --clobber
 
+      # Mint a short-lived (1h) token scoped to ONLY homebrew-tap with
+      # contents:write, from the GitHub App's private key. No long-lived PAT
+      # is stored or rotated; the token cannot touch any other repo.
+      - name: Mint a scoped tap token
+        id: tap-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          owner: lambdasistemi
+          repositories: homebrew-tap
+
       - name: Update homebrew tap
         env:
-          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+          TAP_TOKEN: ${{ steps.tap-token.outputs.token }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.package.outputs.version }}"


### PR DESCRIPTION
Replaces the manually-rotated `TAP_TOKEN` PAT with a per-run token minted by `actions/create-github-app-token`, scoped to **only** `lambdasistemi/homebrew-tap` with `contents:write`. The token lives 1h, is created from the app's private key at runtime, and can't reach any other repo — no long-lived secret to rotate.

## One-time setup required before this works (repo secrets)
- `TAP_APP_ID` — the GitHub App's numeric id
- `TAP_APP_PRIVATE_KEY` — the app's `.pem` private key

The old `TAP_TOKEN` secret can be deleted once this is in.

This is the v0.2.0 Homebrew-tap failure fix (expired PAT), done the durable way.