### PR TITLE
docs: align docs with current code, restructure README, add agent layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# Repository Agent Guide
+
+## What this repo is
+
+Off-chain service for
+[cardano-mpfs-onchain](https://github.com/cardano-foundation/cardano-mpfs-onchain):
+it indexes cage UTxOs from a Cardano node into RocksDB and serves a
+trust-minimized, proof-bearing REST API for Merkle Patricia Forestry
+tokens. The server is a fact provider — it returns indexed snapshots,
+UTxOs with CSMT proofs, MPF facts, and evaluation metadata; clients
+verify the facts, build and sign transactions locally, and submit
+signed CBOR via `POST /submit`.
+
+## Project structure
+
+```text
+cardano-mpfs-offchain/   server: indexer, HTTP API, e2e tests
+cardano-mpfs-api/        shared Servant API + JSON wire types
+cardano-mpfs-verify/     pure cross-target proof verifiers
+cardano-mpfs-cage-tx/    pure client-side cage tx builders + wasm reactor
+cardano-mpfs-client/     native HTTP client, re-exports verifiers
+cardano-mpfs-workflows/  verified read/write workflow helpers
+cardano-mpfs-cli/        mpfs-cli executable
+mpfs-spa/                PureScript browser SPA (HTTP + CIP-30)
+lean/                    Lean 4 formal model (Phase 4)
+docs/                    mkdocs site (architecture, CLI manual, swagger)
+specs/                   speckit feature specs, plans, and tasks
+```
+
+The MPF/CSMT trie implementation lives in the external
+[haskell-mts](https://github.com/lambdasistemi/haskell-mts) repository,
+pinned in `cabal.project`.
+
+## How to work here
+
+Use `just` recipes from `nix develop` (GHC 9.10.1 toolchain, Fourmolu,
+HLint):
+
+```bash
+just build           # cabal build all components (-O0)
+just unit            # offchain unit tests
+just unit-client     # client unit tests
+just unit-workflows  # workflows unit tests
+just unit-cli        # CLI unit tests
+just e2e             # E2E tests (spawns a cardano-node subprocess)
+just format          # apply Fourmolu formatting
+just format-check    # check formatting
+just hlint           # run HLint
+just ci              # full local CI mirror
+just update-swagger  # regenerate docs/assets/swagger.json
+just docs            # serve the mkdocs site locally
+```
+
+Source of truth:
+
+- Project constitution: `.specify/memory/constitution.md`
+  (authoritative for architectural decisions)
+- Architecture: `docs/architecture/overview.md`
+- Testing guide: `docs/architecture/testing.md`
+- Public API surface: `docs/assets/swagger.json`
+- Code maps: `NAVIGATION.md` (repo-wide),
+  `cardano-mpfs-offchain/NAVIGATION.md` (server package)
+
+## Core constraints
+
+- Use ledger-native Cardano types; do not introduce shadow ledger
+  representations.
+- Service boundaries use records of functions, not typeclasses.
+- Block processing must be atomic across RocksDB column families
+  (one block = one transaction).
+- The server is a fact provider: it MUST NOT return unsigned
+  transactions for script-bearing operations; clients build and sign
+  locally. The only server-built transaction is the owner-only
+  `/tx/sweep`.
+- `LocalStateQuery` UTxO scans are forbidden on tx-build and proof
+  paths; UTxO facts come from the indexed CSMT.
+- Proof encoding, trie hashing, and datum/redeemer construction must
+  stay compatible with the Aiken validators in `cardano-mpfs-onchain`.
+- Client verifiers are pure offline functions: no `IO`, networking,
+  filesystem, time, or non-determinism, and their dependency closure
+  must cross-compile to GHC-WASM and GHC-JS.
+
+## Spec Kit workflow
+
+Every issue starts with speckit artifacts under `specs/<issue>-<slug>/`
+before implementation: `spec.md` (requirement + acceptance criteria),
+`plan.md` (technical approach + Constitution Check), `tasks.md`
+(ordered, testable work items).
+
+## Skills
+
+Activatable procedures live under `skills/`. Load the one whose
+description matches your task:
+
+- `skills/cardano-mpfs-offchain-guide/` — repository map, build/test
+  commands, code navigation, CLI and HTTP API usage, and where to find
+  answers for user questions about this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,98 +1,11 @@
-# cardano-mpfs-offchain Development Guidelines
+# CLAUDE.md
 
-Auto-generated from active feature plans and maintained by hand where
-repo-wide guidance is stable. Last updated: 2026-05-17.
+Project guidance for AI agents lives in [AGENTS.md](AGENTS.md): repo
+structure, build/test commands, core constraints, source-of-truth
+pointers, and the Spec Kit workflow.
 
-## Source of Truth
+Activatable skills live under `skills/` — start with
+`skills/cardano-mpfs-offchain-guide/SKILL.md`.
 
-- Project constitution: `.specify/memory/constitution.md`
-- Architecture overview: `docs/architecture/overview.md`
-- Testing guide: `docs/architecture/testing.md`
-- Public API surface: `docs/assets/swagger.json`
-
-The constitution is authoritative for architectural decisions. Feature
-plans must include a Constitution Check before research and re-check it
-after design.
-
-## Active Technologies
-- Haskell GHC 9.10.1 (offchain server, verifier library); Lean 4 (formal model — `lean/` directory) + Servant (HTTP API), `cardano-mpfs-cage` (Aiken-derived on-chain types via PlutusV3 blueprint), `cardano-mpfs-client` (verifier package), `haskell-mts` (CSMT inclusion + prefix-completeness primitives, MPF inclusion + exclusion), `cardano-utxo-csmt` (CSMT runtime), `cardano-ledger-conway` (TxOut/Tx serialization), `cardano-node-clients` (N2C wiring), `chain-follower` (block stream) (243-proof-redesign)
-- RocksDB (existing CSMT + index column families) (243-proof-redesign)
-- RocksDB with 13 column families (6 UTxO from (249-atomic-boot-handler)
-- Haskell GHC 9.10.1 across all three (259-fact-provider-pivot)
-- RocksDB on the server, unchanged. No schema change. The (259-fact-provider-pivot)
-- Haskell GHC 9.10.1; Servant/Aeson boot facts API; pure
-  `cardano-mpfs-client` boot verifier and local cage helper; RocksDB
-  IndexerTx reads unchanged (261-boot-fact-provider-pivot)
-
-- Haskell with GHC 9.10.1 for native builds.
-- `cardano-mpfs-client` verifiers must remain compatible with native
-  GHC, GHC-WASM, and GHC-JS targets.
-- Nix flakes provide the development shell and CI environment.
-- Cabal drives Haskell builds inside the nix shell.
-- Fourmolu and HLint enforce formatting and linting.
-
-## Project Structure
-
-```text
-cardano-mpfs-offchain/   Main service, API, e2e tests, docs
-cardano-mpfs-client/     Offline proof-bearing response verifier
-merkle-patricia-forestry/
-                         MPF trie implementation and tests
-docs/                    Architecture, API docs, Swagger UI assets
-specs/                   Speckit feature specs, plans, and tasks
-```
-
-## Commands
-
-Use `just` recipes from `nix develop`:
-
-```bash
-just build                 # Build all components
-just unit                  # MPF/client unit tests
-just unit-offchain         # Offchain interface/unit tests
-just e2e                   # E2E tests with cardano-node subprocess
-just format                # Apply Fourmolu formatting
-just format-check          # Check formatting
-just hlint                 # Run HLint
-just ci                    # Full local CI mirror
-just update-swagger        # Regenerate docs/assets/swagger.json
-```
-
-## Core Constraints
-
-- Use ledger-native Cardano types; do not introduce shadow ledger
-  representations.
-- Service boundaries use records of functions, not typeclasses.
-- Block processing must be atomic across RocksDB column families.
-- The server is a fact-provider: it serves only proof-bearing material
-  (snapshot + UTxOs with CSMT proofs + MPF facts + protocol parameters)
-  anchored to a single indexer snapshot. The server MUST NOT return
-  unsigned transactions; the client builds and signs them locally.
-- Proof encoding, trie hashing, and datum/redeemer construction must stay
-  compatible with the Aiken validators in `cardano-mpfs-onchain`.
-- Client verifiers are pure offline functions. No `IO`, networking,
-  filesystem, time, or non-determinism in verifier paths.
-- Verifier dependencies must cross-compile to GHC-WASM and GHC-JS before
-  they are admitted.
-
-## Spec Kit Workflow
-
-Every issue starts with speckit artifacts before implementation:
-
-1. `spec.md` states the user-visible requirement and acceptance criteria.
-2. `plan.md` records the technical approach and Constitution Check.
-3. `tasks.md` decomposes the implementation into ordered, testable work.
-4. Implementation follows the task list, updating status as work lands.
-
-## Recent Changes
-- 261-boot-fact-provider-pivot: Added boot facts API planning,
-  proof-only verifier and local cage-helper design, and paired MOOG
-  cutover constraints
-- 259-fact-provider-pivot: Added Haskell GHC 9.10.1 across all three
-- 249-atomic-boot-handler: Added Haskell GHC 9.10.1
-- 243-proof-redesign: Added Haskell GHC 9.10.1 (offchain server, verifier library); Lean 4 (formal model — `lean/` directory) + Servant (HTTP API), `cardano-mpfs-cage` (Aiken-derived on-chain types via PlutusV3 blueprint), `cardano-mpfs-client` (verifier package), `haskell-mts` (CSMT inclusion + prefix-completeness primitives, MPF inclusion + exclusion), `cardano-utxo-csmt` (CSMT runtime), `cardano-ledger-conway` (TxOut/Tx serialization), `cardano-node-clients` (N2C wiring), `chain-follower` (block stream)
-
-  cryptographic replay constraints, and verifier portability principles.
-
-<!-- MANUAL ADDITIONS START -->
-<!-- MANUAL ADDITIONS END -->
+Per-feature technology notes and change history formerly tracked here
+live in each feature's `specs/<issue>-<slug>/plan.md`.

--- a/NAVIGATION.md
+++ b/NAVIGATION.md
@@ -47,19 +47,17 @@ No typeclasses -- dependencies are explicit values.
 
 | Module | Description |
 |--------|-------------|
-| [`Provider`][s-provider] | `queryUTxOs`, `queryProtocolParams`, `evaluateTx` |
+| [`Provider`][s-provider] | `queryProtocolParams`, `evaluateTx`, slot conversion; `queryUTxOs` exists but is forbidden on tx-build paths |
 | [`Submitter`][s-submitter] | `submitTx :: Tx ConwayEra -> m SubmitResult` |
-| [`TxBuilder`][s-txbuilder] | Cage protocol operations: boot, request, update, retract, end |
+| [`TxBuilder`][s-txbuilder] | Proof-envelope builders: request, update, retract, reject, end, sweep (`bootToken` errors — boot is client-side) |
 | [`State`][s-state] | `Tokens`, `Requests`, `Checkpoints` sub-records for indexed state |
-| [`Indexer`][s-indexer] | Chain follower lifecycle: `start`, `stop`, `pause`, `resume`, `getTip` |
-| [`Trie`][s-trie] | `TrieManager` -- per-token MPF trie access (`withTrie`, `createTrie`, `deleteTrie`) |
-| [`Context`][s-context] | Facade bundling all singletons + `utxoExists` into one record |
+| [`Trie`][s-trie] | `TrieManager` -- per-token MPF trie access (`withTrie`, `withSpeculativeTrie`, `createTrie`, `deleteTrie`, `hideTrie`/`unhideTrie`) |
+| [`Context`][s-context] | Facade bundling all singletons plus indexed-read primitives (`utxoExists`, `resolveUtxo`, `awaitUtxo`, `utxoRoot`, `utxoProof`, `runIndexerTx`, `evalContext`, `readMetrics`) |
 
 [s-provider]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Provider%22+path%3Alib%2FCardano%2FMPFS%2FProvider.hs&type=code
 [s-submitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Submitter%22+path%3Alib%2FCardano%2FMPFS%2FSubmitter.hs&type=code
 [s-txbuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder%22+path%3Alib%2FCardano%2FMPFS%2FTxBuilder.hs&type=code
 [s-state]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.State%22&type=code
-[s-indexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer%22+path%3Alib%2FCardano%2FMPFS%2FIndexer.hs&type=code
 [s-trie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie%22+path%3Alib%2FCardano%2FMPFS%2FTrie.hs&type=code
 [s-context]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Context%22&type=code
 
@@ -76,9 +74,13 @@ a `Context IO` into a WAI `Application`.
 | [`HTTP.Types`][s-http-types] | JSON wire types: `StatusResponse`, `TokenIdJSON`, `RequestJSON`, request bodies |
 | [`HTTP.Encoding`][s-http-enc] | `Hex` newtype for binary-as-hex JSON transport |
 | [`HTTP.Server`][s-http-server] | WAI application wiring, `mkApp`, all Servant handlers |
+| [`HTTP.SubmitScope`][s-http-scope] | `txTouchesMpfs` -- the `POST /submit` MPFS-scope gate |
+| [`HTTP.Types.Facts`][s-http-facts] | Server-side helpers for facts response types |
 | [`HTTP.Swagger`][s-http-swagger] | OpenAPI spec generation, `swaggerDoc`, Swagger UI serving |
 
 [s-http-api]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.API%22&type=code
+[s-http-scope]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.SubmitScope%22&type=code
+[s-http-facts]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Types.Facts%22&type=code
 [s-http-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Types%22&type=code
 [s-http-enc]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Encoding%22&type=code
 [s-http-server]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Server%22&type=code
@@ -94,13 +96,15 @@ WriteBatch.
 
 | Module | Description |
 |--------|-------------|
-| [`Indexer.Event`][s-idx-event] | `detectCageEvents` -- classify cage-relevant transactions into `CageEvent` |
-| [`Indexer.Follower`][s-idx-follower] | `processCageBlock`, `applyCageEvent`, `applyCageInverses` -- generic over `Monad m` |
-| [`Indexer.CageFollower`][s-idx-cage] | Unified `rollForward`/`rollBackward` -- one block = one RocksDB transaction |
+| [`Indexer.Event`][s-idx-event] | `detectCageEvents` -- classify cage-relevant transactions into `CageEvent`; scope predicates for the `/submit` gate |
+| [`Indexer.Follower`][s-idx-follower] | `detectCageBlockEvents`, `applyCageBlockEvents`, `applyCageInverses` -- generic over `Monad m` |
+| [`Indexer.CageFollower`][s-idx-cage] | `rollForward`/`rollBackward` via the chain-follower `Runner` -- one block = one RocksDB transaction |
+| [`Indexer.Backend`][s-idx-backend] | `composedInit` -- composed UTxO + cage backend (restore/follow/applyInverse) |
+| [`Indexer.ComposedInv`][s-idx-composed] | `ComposedInv` -- combined UTxO + cage inverse ops per rollback point |
+| [`Indexer.Reads`][s-idx-reads] | `IndexerTx` composable atomic read primitives for proof-bearing handlers |
 | [`Indexer.Columns`][s-idx-columns] | `AllColumns` + `UnifiedColumns` GADTs -- full DB schema |
 | [`Indexer.Codecs`][s-idx-codecs] | CBOR serialization for column key-value types |
 | [`Indexer.Persistent`][s-idx-persist] | `mkTransactionalState` (composable) + `mkPersistentState` (IO) |
-| [`Indexer.Rollback`][s-idx-rollback] | `storeRollback`, `rollbackToSlot` -- slot-based rollback via inverse ops |
 
 [s-idx-event]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Event%22&type=code
 [s-idx-follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
@@ -108,7 +112,9 @@ WriteBatch.
 [s-idx-columns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Columns%22&type=code
 [s-idx-codecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Codecs%22&type=code
 [s-idx-persist]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code
-[s-idx-rollback]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Rollback%22&type=code
+[s-idx-backend]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Backend%22&type=code
+[s-idx-composed]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.ComposedInv%22&type=code
+[s-idx-reads]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Reads%22&type=code
 
 ---
 
@@ -137,17 +143,19 @@ Each builds a full transaction with PlutusV3 script witnesses.
 | Module | Description |
 |--------|-------------|
 | [`TxBuilder.Config`][s-txb-cfg] | `CageConfig` -- script bytes, hash, time windows, network, slot params |
-| [`TxBuilder.Real`][s-txb-real] | `mkRealTxBuilder` entry point wiring Config + Provider + State + TrieManager |
-| [`TxBuilder.Real.Boot`][s-txb-boot] | Mint cage token (pick seed UTxO, derive asset name, build +1 mint) |
-| [`TxBuilder.Real.Request`][s-txb-req] | Submit insert/delete request (pay to cage address with `RequestDatum`) |
+| [`TxBuilder.Real`][s-txb-real] | `mkRealTxBuilder` entry point; `bootToken` errors (boot is built client-side from `POST /facts/boot`) |
+| [`TxBuilder.Real.Request`][s-txb-req] | Submit insert/delete/update request (pay to request address with `RequestDatum`) |
 | [`TxBuilder.Real.Update`][s-txb-upd] | Consume requests, compute proofs speculatively, update root |
 | [`TxBuilder.Real.Retract`][s-txb-ret] | Cancel pending request (spend with `Retract` redeemer) |
+| [`TxBuilder.Real.Reject`][s-txb-rej] | Owner rejection of expired requests (`Reject` redeemer) |
+| [`TxBuilder.Real.Sweep`][s-txb-sweep] | Owner-only sweep of non-legitimate request UTxOs (`POST /tx/sweep`) |
 | [`TxBuilder.Real.End`][s-txb-end] | Burn cage token (consume state with `End`, mint -1 with `Burning`) |
 | [`TxBuilder.Real.Internal`][s-txb-int] | Shared helpers: POSIX-to-slot, UTxO finders, datum extraction, redeemer indexing |
 
 [s-txb-cfg]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Config%22&type=code
 [s-txb-real]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real%22+path%3AReal.hs&type=code
-[s-txb-boot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Boot%22&type=code
+[s-txb-rej]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Reject%22&type=code
+[s-txb-sweep]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Sweep%22&type=code
 [s-txb-req]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Request%22&type=code
 [s-txb-upd]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Update%22&type=code
 [s-txb-ret]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Retract%22&type=code
@@ -195,16 +203,12 @@ Test doubles for all interfaces. No node connection required.
 | [`Mock.Provider`][s-mock-prv] | `mkMockProvider` -- returns empty UTxO sets |
 | [`Mock.Submitter`][s-mock-sub] | `mkMockSubmitter` -- rejects all transactions |
 | [`Mock.TxBuilder`][s-mock-txb] | `mkMockTxBuilder` -- throws on all operations |
-| [`Mock.Indexer`][s-mock-idx] | `mkMockIndexer` -- no-op lifecycle |
-| [`Mock.Skeleton`][s-mock-skel] | `mkSkeletonIndexer` -- IORef/MVar tracking, no chain sync |
 
 [s-mock-ctx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Context%22&type=code
 [s-mock-st]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.State%22&type=code
 [s-mock-prv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Provider%22&type=code
 [s-mock-sub]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Submitter%22&type=code
 [s-mock-txb]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.TxBuilder%22&type=code
-[s-mock-idx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Indexer%22&type=code
-[s-mock-skel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Skeleton%22&type=code
 
 ### Unit test structure
 
@@ -212,9 +216,9 @@ Tests under `test/Cardano/MPFS/`:
 
 - `BalanceSpec`, `OnChainSpec`, `ProofSpec` -- core logic
 - `StateSpec`, `TrieSpec`, `TrieManagerSpec`, `TxBuilderSpec` -- interface specs
-- `Indexer/EventSpec`, `Indexer/FollowerSpec`, `Indexer/CodecsSpec`, `Indexer/PersistentSpec`, `Indexer/RollbackSpec`, `Indexer/InverseSpec` -- indexer pipeline
+- `Indexer/EventSpec`, `Indexer/FollowerSpec`, `Indexer/CodecsSpec`, `Indexer/PersistentSpec`, `Indexer/RollbackSpec`, `Indexer/InverseSpec`, `Indexer/ArmageddonSpec`, `Indexer/ReadsSpec`, `Indexer/ResumeSpec`, `Indexer/UnifiedSpec` -- indexer pipeline
 - `Trie/PersistentSpec` -- RocksDB trie backend
-- `HTTP/StatusSpec`, `HTTP/TokensSpec`, `HTTP/TokenSpec`, `HTTP/RequestsSpec`, `HTTP/TrieSpec` -- REST API via WAI test sessions
+- `HTTP/*Spec` -- REST API via WAI test sessions: status, tokens, token, token facts, requests, trie, the eight `/facts/*` endpoints, submit, and the submit scope gate (see [testing](docs/architecture/testing.md) for the full table)
 
 ### E2E test structure
 
@@ -227,6 +231,12 @@ Tests under `e2e-test/Cardano/MPFS/E2E/`:
 - `IndexerSpec` -- detectFromTx + applyCageEvent
 - `ChainSyncSpec` -- chain sync protocol
 - `HTTPLifecycleSpec` -- full token lifecycle via HTTP API
+- `BootFactsSpec` -- boot facts verified and built client-side
+- `CrashRecoverySpec` -- cage state survives a kill during following
+- `ProofsSpec`, `TokensCompletenessSpec`, `TokenFactsCompletenessSpec` -- proof-bearing reads and completeness witnesses
+- `FactsMatrixSpec` -- facts API coverage matrix
+- `SubmitEndpointSpec` -- signed submit endpoint behavior
+- `WorkflowsIntegrationSpec` -- workflow helpers over facts
 
 ---
 
@@ -241,17 +251,18 @@ cardano-mpfs-offchain/
     HTTP/
       API.hs            Encoding.hs
       Types.hs          Server.hs
-      Swagger.hs
+      SubmitScope.hs    Swagger.hs
+      Types/Facts.hs
     Indexer/
       Event.hs          Follower.hs
-      CageFollower.hs   Columns.hs
-      Codecs.hs         Persistent.hs
-      Rollback.hs
+      CageFollower.hs   Backend.hs
+      ComposedInv.hs    Reads.hs
+      Columns.hs        Codecs.hs
+      Persistent.hs
     Mock/
       Context.hs        State.hs
       Provider.hs       Submitter.hs
-      TxBuilder.hs      Indexer.hs
-      Skeleton.hs
+      TxBuilder.hs
     Provider/
       NodeClient.hs
     Submitter/
@@ -262,14 +273,18 @@ cardano-mpfs-offchain/
     TxBuilder/
       Config.hs         Real.hs
       Real/
-        Boot.hs         Request.hs
-        Update.hs       Retract.hs
-        End.hs          Internal.hs
+        Request.hs      Update.hs
+        Retract.hs      Reject.hs
+        Sweep.hs        End.hs
+        Internal.hs
     Application.hs      Context.hs
-    Indexer.hs          Provider.hs
-    State.hs            Submitter.hs
-    Trace.hs            Trie.hs
-    TxBuilder.hs
+    Provider.hs         State.hs
+    Submitter.hs        Trace.hs
+    Trie.hs             TxBuilder.hs
+  exe/
+    Serve.hs            DevnetServer.hs
+    RunPreprod.hs       InspectDb.hs
+    TxVectors.hs        swagger/Main.hs
   test/Cardano/MPFS/
     HTTP/               Indexer/
     Trie/               BalanceSpec.hs
@@ -280,5 +295,11 @@ cardano-mpfs-offchain/
     ProviderSpec.hs     SubmitterSpec.hs
     CageSpec.hs         CageFlowSpec.hs
     IndexerSpec.hs      ChainSyncSpec.hs
-    HTTPLifecycleSpec.hs
+    HTTPLifecycleSpec.hs BootFactsSpec.hs
+    CrashRecoverySpec.hs ProofsSpec.hs
+    FactsMatrixSpec.hs  SubmitEndpointSpec.hs
+    TokensCompletenessSpec.hs
+    TokenFactsCompletenessSpec.hs
+    WorkflowsIntegrationSpec.hs
+    Helpers/Boot.hs
 ```

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,5 +1,12 @@
 # PLAN: Haskell MPFS Service
 
+> **Status: historical.** This is the original build-out plan; all of
+> its phases have shipped. Ongoing work is tracked per issue under
+> `specs/` and in [CHANGELOG.md](CHANGELOG.md). Some module names
+> below (e.g. `NodeClient.Connection`, `TxBuilder.Real.Boot`) refer
+> to the architecture as planned and have since been superseded — see
+> [docs/architecture/](docs/architecture/) for the current state.
+
 ## Goal
 
 Rewrite the MPFS (Merkle Patricia Forestry Service) in Haskell,

--- a/README.md
+++ b/README.md
@@ -5,25 +5,40 @@ Off-chain service for
 --- indexing, proof-bearing facts, and HTTP API for Cardano Merkle
 Patricia Forestry.
 
-Connects to a Cardano node via N2C, indexes cage UTxOs into RocksDB,
-and exposes a trust-minimized REST API. The server is a fact provider:
-it serves indexed snapshots, UTxOs with CSMT proofs, MPF facts, request
-sets, and ledger evaluation metadata. Clients verify those facts, build
-transactions locally, sign with their wallet, and submit signed CBOR via
-`POST /submit`.
+## What is this
+
+The server connects to a Cardano node via node-to-client (N2C),
+indexes cage UTxOs into RocksDB, and exposes a trust-minimized REST
+API. It is a fact provider: it serves indexed snapshots, UTxOs with
+CSMT proofs, MPF facts, request sets, and ledger evaluation metadata.
+Clients verify those facts, build transactions locally, sign with
+their wallet, and submit signed CBOR via `POST /submit` --- the server
+never returns unsigned transactions for script-bearing operations.
 
 The browser SPA is available at <https://umpfs.plutimus.com/spa/>. It
 uses HTTP plus CIP-30 only; protocol logic runs inside the pure Haskell
 wasm cage reactor, not in ad hoc browser code.
 
-## Dependencies
+The #62 bounded-refund validator cutover uses cage script hash
+`ad0a8eeeec8b0a5ee9930be5d6ea2e80b285fc2f3e9675a13a392dd5`. The old
+`c0f05a30...` exact-refund hash is legacy. The SPA and server both take
+validator identity from the pinned `cardano-mpfs-onchain` blueprint so
+the browser reactor and offchain indexer agree on state and per-cage
+request validator addresses.
+
+## Architecture
+
+The repository hosts seven Haskell packages plus the PureScript SPA:
 
 ```mermaid
 graph TD
-    OFFCHAIN["cardano-mpfs-offchain"]
+    OFFCHAIN["cardano-mpfs-offchain<br/><i>server: indexer + fact API</i>"]
     API["cardano-mpfs-api<br/><i>wire types</i>"]
     VERIFY["cardano-mpfs-verify<br/><i>proof verifiers</i>"]
     CAGETX["cardano-mpfs-cage-tx<br/><i>client builders</i>"]
+    CLIENT["cardano-mpfs-client<br/><i>native HTTP client</i>"]
+    WORKFLOWS["cardano-mpfs-workflows<br/><i>workflow helpers</i>"]
+    CLI["cardano-mpfs-cli<br/><i>mpfs-cli executable</i>"]
     ONCHAIN["cardano-mpfs-onchain/haskell<br/><i>cage library</i>"]
     CLIENTS["cardano-node-clients"]
     MTS["haskell-mts"]
@@ -34,6 +49,12 @@ graph TD
     OFFCHAIN -->|"Servant API<br/>JSON DTOs"| API
     VERIFY -->|"wire DTOs"| API
     CAGETX -->|"verifies facts first"| VERIFY
+    CLIENT -->|"HTTP wrappers"| API
+    CLIENT -->|"re-exports verifiers"| VERIFY
+    CLIENT -->|"local cage builders"| CAGETX
+    WORKFLOWS -->|"read + write flows"| CLIENT
+    CLI -->|"owner/requester<br/>workflows"| WORKFLOWS
+    CLI --> CLIENT
     OFFCHAIN -->|"on-chain types<br/>proof serialization<br/>blueprint loading"| ONCHAIN
     CAGETX -->|"on-chain types<br/>scripts"| ONCHAIN
     OFFCHAIN -->|"N2C provider<br/>LocalTxSubmission<br/>eval context"| CLIENTS
@@ -89,7 +110,58 @@ graph TD
   `GET /eval-context` metadata and return local unsigned transactions
   for wallet signing.
 
-## HTTP API
+- **`cardano-mpfs-client`** ---
+  native HTTP client wrappers re-exporting the verifier surface, plus
+  the `mpfs-verify` snapshot-checking executable.
+
+- **`cardano-mpfs-workflows`** ---
+  higher-level verified read/write workflows over the client surface,
+  used by the CLI.
+
+See [docs/architecture](https://lambdasistemi.github.io/cardano-mpfs-offchain/architecture/overview/)
+for the server-internal architecture.
+
+## Install
+
+- **Release tarballs** --- each
+  [GitHub release](https://github.com/lambdasistemi/cardano-mpfs-offchain/releases)
+  ships self-contained `mpfs-cli` bundles for `x86_64-linux` and
+  `aarch64-darwin` (`mpfs-cli-<version>-<platform>.tar.gz`; unpack and
+  run `bin/mpfs-cli`).
+- **Nix** --- the flake exposes the server and tools as packages:
+
+  ```bash
+  nix build .#mpfs-serve   # production server
+  nix build .#mpfs-cli     # command-line client
+  ```
+
+- **Docker** --- `just build-docker` builds the server image via Nix
+  and loads it into the local Docker daemon as
+  `ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve`.
+
+## Quickstart
+
+Query the live preprod deployment:
+
+```bash
+curl -s https://umpfs.plutimus.com/status
+```
+
+Or run everything locally --- a single-node devnet with the MPFS API
+on port 3000, then the CLI against it:
+
+```bash
+nix run .#mpfs-devnet-server -- --port 3000
+nix run .#mpfs-cli -- --help
+```
+
+The [CLI walkthrough](https://lambdasistemi.github.io/cardano-mpfs-offchain/cli/walkthrough/)
+drives the full token lifecycle (register, insert, process, get,
+delete, end) against the devnet server.
+
+## Usage
+
+### HTTP API
 
 Servant REST API wrapping the internal `Context` record-of-functions.
 The public model is facts-first: script-bearing write endpoints return
@@ -114,6 +186,7 @@ path.
 | GET | `/utxo/:txId/:txIx` | Resolve an indexed UTxO |
 | GET | `/utxo/:txId/:txIx/proof` | UTxO CSMT inclusion proof |
 | GET | `/tx/:txId?timeout=30` | Block until tx is indexed |
+| GET | `/metrics`, `/metrics/prometheus` | Server metrics (JSON / Prometheus exposition) |
 | POST | `/facts/boot` | Return boot facts for wallet-side transaction construction |
 | POST | `/facts/request/insert` | Return insert-request facts for wallet-side transaction construction |
 | POST | `/facts/request/delete` | Return delete-request facts for wallet-side transaction construction |
@@ -133,7 +206,22 @@ changing the batch.
 
 Swagger UI is served at `/swagger-ui`.
 
-## Verification client
+### CLI
+
+`mpfs-cli` drives the full owner/requester lifecycle against a server,
+signing locally with a Bech32 ed25519 key. Configuration comes from
+`MPFS_SERVER`, `MPFS_SIGNER_WALLET`, and `MPFS_BLUEPRINT` (or the
+corresponding `--server`, `--owner-key`, `--cage-config` flags):
+
+- owner: `register-token`, `token process`, `fact reject`, `token end`
+- requester: `fact insert`, `fact update`, `fact delete`, `fact retract`
+- verified reads: `token list`, `token get`, `fact list`, `fact get`,
+  `requests list`
+
+See the [CLI manual](https://lambdasistemi.github.io/cardano-mpfs-offchain/cli/)
+for flags, defaults, and troubleshooting.
+
+### Verification client
 
 The `cardano-mpfs-verify` package is the pure verifier. It is carved out
 from `cardano-mpfs-client` so the verification closure is free of IO,
@@ -164,26 +252,31 @@ envelopes on stdin and return deterministic one-line verdicts:
 `mpfs-verify-reactor` verifies envelopes and `mpfs-cage-reactor` verifies
 facts before building cage transactions.
 
-## Current validator identity
+## Documentation
 
-The #62 bounded-refund validator cutover uses cage script hash
-`ad0a8eeeec8b0a5ee9930be5d6ea2e80b285fc2f3e9675a13a392dd5`. The old
-`c0f05a30...` exact-refund hash is legacy. The SPA and server both take
-validator identity from the pinned `cardano-mpfs-onchain` blueprint so
-the browser reactor and offchain indexer agree on state and per-cage
-request validator addresses.
+The full manual lives at
+<https://lambdasistemi.github.io/cardano-mpfs-offchain/> (CLI manual,
+architecture, API reference).
 
-## Building
+For AI agents, start at [AGENTS.md](AGENTS.md).
+
+## Development
 
 ```bash
 nix develop
-just build
+just build           # cabal build all components
 just unit            # unit tests via nix run .#unit-tests
-just unit-offchain   # same unit-test flake app
+just unit-client     # client unit tests
+just unit-workflows  # workflows unit tests
+just unit-cli        # CLI unit tests
 just e2e             # E2E tests via nix run .#e2e-tests
+just format          # fourmolu
+just hlint           # lint
+just ci              # full local CI mirror
 just update-swagger  # regenerate docs/assets/swagger.json
+just docs            # serve the mkdocs site locally
 ```
 
-## Documentation
+## License
 
-https://lambdasistemi.github.io/cardano-mpfs-offchain/
+[Apache-2.0](LICENSE)

--- a/cardano-mpfs-offchain/NAVIGATION.md
+++ b/cardano-mpfs-offchain/NAVIGATION.md
@@ -1,11 +1,11 @@
-# cardano-mpfs-offchain — Semantic Navigation
+# cardano-mpfs-offchain — Package Navigation
 
-A human-readable map of the offchain library. Each section explains
-*what* the code does and *why*, with links to the source.
+A map of the `cardano-mpfs-offchain` package: the production server
+(indexer + proof-bearing HTTP API). For the repo-wide map covering all
+packages see [`../NAVIGATION.md`](../NAVIGATION.md); for prose
+architecture see [`../docs/architecture/`](../docs/architecture/).
 
 Base module: `Cardano.MPFS`
-
-[lib]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS
 
 ---
 
@@ -13,139 +13,32 @@ Base module: `Cardano.MPFS`
 
 1. [Core Domain](#core-domain)
 2. [Service Interfaces](#service-interfaces)
-3. [Node-to-Client Protocol](#node-to-client-protocol)
-4. [Transaction Builders](#transaction-builders)
-5. [Chain Indexer](#chain-indexer)
-6. [Trie Backends](#trie-backends)
+3. [HTTP Layer](#http-layer)
+4. [Chain Indexer](#chain-indexer)
+5. [Trie Backends](#trie-backends)
+6. [Node Integration](#node-integration)
 7. [Mock Implementations](#mock-implementations)
 8. [Application Wiring](#application-wiring)
+9. [Executables](#executables)
 
 ---
 
 ## Core Domain
 
-Pure types and logic with no IO dependencies. Everything else imports
-from here.
+Pure types and logic with no IO dependencies.
 
-### Types
+| Module | Purpose |
+|--------|---------|
+| [`Core.Types`][s-core-types] | `TokenId`, `Root`, `Request`, `TokenState`, `Operation`, `BlockId`, ledger re-exports |
+| [`Core.OnChain`][s-core-onchain] | Re-exports from [`cardano-mpfs-cage`][cage]: `CageDatum`, `MintRedeemer`, `UpdateRedeemer`, `ProofStep`; offchain-specific `cageScriptHash`, `cageAddr` |
+| [`Core.Proof`][s-core-proof] | Re-exports from [`cardano-mpfs-cage`][cage]: `serializeProof`, `toProofSteps` |
+| [`Core.Blueprint`][s-core-blueprint] | Re-exports from [`cardano-mpfs-cage`][cage]: CIP-57 blueprint loading, schema validation |
 
-Ledger re-exports and MPFS-specific domain types.
-
-| Type | Purpose |
-|------|---------|
-| [`TokenId`][s-TokenId] | Newtype over `AssetName` — identifies a cage token |
-| [`Root`][s-Root] | 32-byte Blake2b-256 Merkle root hash |
-| [`Request`][s-Request] | Pending insert/delete/update request with fee and timestamp |
-| [`TokenState`][s-TokenState] | On-chain token state: owner, root, fee, time windows |
-| [`Operation`][s-Operation] | `Insert` / `Delete` / `Update` — what a request asks for |
-| [`Fact`][s-Fact] | Key-value pair stored in a trie |
-| [`BlockId`][s-BlockId] | Block identifier (hash bytes) |
-
--> [Core/Types.hs:L69-L136][f-types]
-
-[s-TokenId]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+TokenId%22&type=code
-[s-Root]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+Root%22+path%3ACore&type=code
-[s-Request]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Request%22+path%3ACore%2FTypes&type=code
-[s-TokenState]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+TokenState%22+path%3ACore%2FTypes&type=code
-[s-Operation]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Operation%22+path%3ACore&type=code
-[s-Fact]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Fact%22&type=code
-[s-BlockId]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+BlockId%22&type=code
-[f-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Types.hs#L69-L136
-
-### OnChain
-
-Plutus-level datum/redeemer types matching the Aiken validator
-layout byte-for-byte. Manual `ToData`/`FromData` instances.
-
-| Type | Purpose |
-|------|---------|
-| [`CageDatum`][s-CageDatum] | `RequestDatum` or `StateDatum` — inline datum on cage UTxOs |
-| [`MintRedeemer`][s-MintRedeemer] | `Minting` / `Migrating` / `Burning` — cage policy redeemer |
-| [`UpdateRedeemer`][s-UpdateRedeemer] | `End` / `Contribute` / `Modify` / `Retract` / `Reject` — spending redeemer |
-| [`ProofStep`][s-ProofStep] | `Branch` / `Fork` / `Leaf` — on-chain Merkle proof step |
-
-Key functions:
-
-- **[`cageScriptHash`][s-cageScriptHash]**: Cage validator script hash (hardcoded from blueprint)
-  -> [Core/OnChain.hs:L668-L710][f-onchain-hash]
-- **[`cageAddr`][s-cageAddr]**: Derive cage script address for a network
-  -> [Core/OnChain.hs:L713-L718][f-onchain-addr]
-- **[`deriveAssetName`][s-deriveAssetName]**: SHA2-256(txId ++ bigEndian16(idx)) — deterministic token name
-  -> [Core/OnChain.hs:L728-L747][f-onchain-derive]
-
-[s-CageDatum]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageDatum%22&type=code
-[s-MintRedeemer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+MintRedeemer%22&type=code
-[s-UpdateRedeemer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+UpdateRedeemer%22&type=code
-[s-ProofStep]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+ProofStep%22+path%3AOnChain&type=code
-[s-cageScriptHash]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=cageScriptHash+path%3AOnChain&type=code
-[s-cageAddr]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=cageAddr+path%3AOnChain&type=code
-[s-deriveAssetName]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=deriveAssetName&type=code
-[f-onchain-hash]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L668-L710
-[f-onchain-addr]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L713-L718
-[f-onchain-derive]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/OnChain.hs#L728-L747
-
-### Blueprint
-
-CIP-57 Plutus blueprint loading and schema validation.
-
-- **[`loadBlueprint`][s-loadBlueprint]**: Parse blueprint JSON from file
-  -> [Core/Blueprint.hs:L198-L202][f-blueprint-load]
-- **[`extractCompiledCode`][s-extractCompiledCode]**: Extract hex-decoded PlutusV3 script bytes
-  -> [Core/Blueprint.hs:L262-L274][f-blueprint-extract]
-- **[`validateData`][s-validateData]**: Validate `Data` against `Schema` with `$ref` resolution
-  -> [Core/Blueprint.hs:L210-L236][f-blueprint-validate]
-- **[`applyVersion`][s-applyVersion]**: Apply version parameter to UPLC script
-  -> [Core/Blueprint.hs:L312-L346][f-blueprint-version]
-
-[s-loadBlueprint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=loadBlueprint&type=code
-[s-extractCompiledCode]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=extractCompiledCode&type=code
-[s-validateData]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=validateData+path%3ABlueprint&type=code
-[s-applyVersion]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=applyVersion&type=code
-[f-blueprint-load]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L198-L202
-[f-blueprint-extract]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L262-L274
-[f-blueprint-validate]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L210-L236
-[f-blueprint-version]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs#L312-L346
-
-### Proof
-
-Aiken-compatible proof serialization — converts MPF proofs to
-on-chain `ProofStep` lists and raw CBOR bytes.
-
-- **[`serializeProof`][s-serializeProof]**: MPF proof -> CBOR bytes (byte-identical to TypeScript reference)
-  -> [Core/Proof.hs:L54-L63][f-proof-ser]
-- **[`toProofSteps`][s-toProofSteps]**: MPF proof -> `[ProofStep]` (reverses leaf-to-root to root-to-leaf)
-  -> [Core/Proof.hs:L147-L150][f-proof-steps]
-
-[s-serializeProof]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=serializeProof&type=code
-[s-toProofSteps]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=toProofSteps&type=code
-[f-proof-ser]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Proof.hs#L54-L63
-[f-proof-steps]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Proof.hs#L147-L150
-
-### Balance
-
-Fee estimation fixpoint loop. Adds a fee-paying UTxO and change
-output, iterates `setMinFeeTx` until stable (max 10 rounds).
-
-- **[`balanceTx`][s-balanceTx]**: Pure transaction balancer
-  -> [Core/Balance.hs:L64-L153][f-balance]
-
-[s-balanceTx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=balanceTx+path%3ABalance&type=code
-[f-balance]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Balance.hs#L64-L153
-
-### Bootstrap
-
-CBOR bootstrap file for UTxO seeding on fresh databases.
-Stream-decodes entries without loading the full map into memory.
-
-- **[`encodeBootstrapFile`][s-encodeBootstrap]**: Write header + key-value entries to CBOR file
-  -> [Core/Bootstrap.hs:L69-L90][f-bootstrap-enc]
-- **[`foldBootstrapEntries`][s-foldBootstrap]**: Stream-decode with callbacks (header, then each entry)
-  -> [Core/Bootstrap.hs:L96-L135][f-bootstrap-fold]
-
-[s-encodeBootstrap]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=encodeBootstrapFile&type=code
-[s-foldBootstrap]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=foldBootstrapEntries&type=code
-[f-bootstrap-enc]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Bootstrap.hs#L69-L90
-[f-bootstrap-fold]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Bootstrap.hs#L96-L135
+[s-core-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Types%22&type=code
+[s-core-onchain]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.OnChain%22&type=code
+[s-core-proof]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Proof%22&type=code
+[s-core-blueprint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Core.Blueprint%22&type=code
+[cage]: https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/main/haskell
 
 ---
 
@@ -156,43 +49,32 @@ Every major component is a **record of functions**, polymorphic in
 
 ### Provider
 
-Read-only blockchain queries.
+Ledger metadata and evaluation via N2C LocalStateQuery.
 
-| Field | Signature |
-|-------|-----------|
-| `queryUTxOs` | `Addr -> m [(TxIn, TxOut ConwayEra)]` |
-| `queryProtocolParams` | `m (PParams ConwayEra)` |
-| `evaluateTx` | `ByteString -> m ExUnits` |
+| Field | Purpose |
+|-------|---------|
+| `queryProtocolParams` | Current `PParams ConwayEra` |
+| `evaluateTx` | Script ex-unit evaluation |
+| `posixMsToSlot` / `posixMsCeilSlot` | POSIX-ms to slot conversion |
+| `queryUTxOs` | LSQ address scan — **forbidden on tx-build paths** (cost is O(total UTxO on chain); the indexed CSMT is the fact source, see #252) |
 
--> [Provider.hs:L24-L36][f-provider]
+Real: [`mkNodeClientProvider`][s-mkNodeClientProvider] ·
+Mock: [`mkMockProvider`][s-mkMockProvider]
 
-Real: [`mkNodeClientProvider`][s-mkNodeClientProvider] (N2C LSQ)
-Mock: [`mkMockProvider`][s-mkMockProvider] (empty results)
-
-[f-provider]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Provider.hs#L24-L36
 [s-mkNodeClientProvider]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkNodeClientProvider&type=code
 [s-mkMockProvider]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockProvider&type=code
 
 ### State
 
-Token and request state with three sub-records.
+Indexed token and request state with three sub-records: `Tokens`,
+`Requests`, `Checkpoints`, plus `hoistState` natural transformations.
 
-| Sub-record | Key operations |
-|------------|----------------|
-| [`Tokens`][s-Tokens] | `getToken`, `putToken`, `removeToken`, `listTokens` |
-| [`Requests`][s-Requests] | `getRequest`, `putRequest`, `removeRequest`, `requestsByToken` |
-| [`Checkpoints`][s-Checkpoints] | `getCheckpoint`, `putCheckpoint` |
-
--> [State.hs:L30-L77][f-state]
-
-Real: [`mkPersistentState`][s-mkPersistentState] (RocksDB)
+Real: [`mkPersistentState`][s-mkPersistentState] (RocksDB) ·
+Transactional: [`mkTransactionalState`][s-mkTransactionalState] ·
 Mock: [`mkMockState`][s-mkMockState] (IORef maps)
 
-[s-Tokens]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Tokens%22&type=code
-[s-Requests]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Requests%22&type=code
-[s-Checkpoints]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Checkpoints%22&type=code
-[f-state]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/State.hs#L30-L77
 [s-mkPersistentState]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPersistentState&type=code
+[s-mkTransactionalState]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkTransactionalState&type=code
 [s-mkMockState]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockState&type=code
 
 ### TrieManager
@@ -201,403 +83,214 @@ Per-token MPF trie access. Each cage token has an isolated trie.
 
 | Field | Purpose |
 |-------|---------|
-| `withTrie` | Run action with token's trie |
-| `withSpeculativeTrie` | Speculative session (copied DB, rolled back on exit) |
+| `withTrie` | Run an action with a token's trie |
+| `withSpeculativeTrie` | Read-your-writes session, discarded on exit |
 | `createTrie` / `deleteTrie` | Lifecycle |
 | `hideTrie` / `unhideTrie` | Soft-delete for burn forward/rollback |
 
-The [`Trie m`][s-Trie] record exposes: `insert`, `delete`, `lookup`,
-`getRoot`, `getProof`, `getProofSteps`.
-
--> [Trie.hs:L32-L88][f-trie]
-
-Real: [`mkPersistentTrieManager`][s-mkPersistentTrieManager] (RocksDB, token-prefixed keys)
-Pure: [`mkPureTrieManager`][s-mkPureTrieManager] (IORef maps)
+The [`Trie m`][s-Trie] record exposes insert/delete/lookup, root, and
+proof operations.
 
 [s-Trie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+Trie+m%22&type=code
-[f-trie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie.hs#L32-L88
-[s-mkPersistentTrieManager]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPersistentTrieManager&type=code
-[s-mkPureTrieManager]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPureTrieManager&type=code
 
 ### Submitter
 
-Transaction submission. Takes a `Tx ConwayEra`, returns `Submitted TxId`
-or `Rejected reason`.
+`submitTx :: Tx ConwayEra -> m SubmitResult` — returns
+`Submitted TxId` or `Rejected reason`.
 
--> [Submitter.hs:L20-L35][f-submitter]
-
-Real: [`mkN2CSubmitter`][s-mkN2CSubmitter] (N2C LocalTxSubmission)
+Real: [`mkN2CSubmitter`][s-mkN2CSubmitter] (N2C LocalTxSubmission) ·
 Mock: [`mkMockSubmitter`][s-mkMockSubmitter] (rejects all)
 
-[f-submitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Submitter.hs#L20-L35
 [s-mkN2CSubmitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkN2CSubmitter&type=code
 [s-mkMockSubmitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockSubmitter&type=code
 
 ### TxBuilder
 
-Constructs transactions for all cage protocol operations.
+Internal proof-envelope builders. Each field consumes a
+`BundleSnapshot` plus indexed UTxO facts and returns a
+`ProofEnvelope` — the builders never query the node for UTxO state.
 
 | Field | Cage operation |
 |-------|----------------|
-| `bootToken` | Mint new cage token |
-| `requestInsert` / `requestDelete` | Submit request UTxO |
+| `bootToken` | **Errors** — server-side boot was removed; clients use `POST /facts/boot` and build locally |
+| `requestInsert` / `requestDelete` / `requestUpdate` | Submit request UTxO |
 | `updateToken` | Consume requests, update trie root |
-| `retractRequest` | Cancel pending request |
+| `retractRequest` | Cancel a pending request |
+| `rejectRequests` | Owner rejection of expired requests |
 | `endToken` | Burn cage token |
 
--> [TxBuilder.hs:L24-L56][f-txbuilder]
+The owner-only sweep transaction is not a `TxBuilder` field:
+[`sweepUtxoImpl`][s-sweepUtxoImpl] from `TxBuilder.Real` is invoked
+directly by the `POST /tx/sweep` handler.
 
-Real: [`mkRealTxBuilder`][s-mkRealTxBuilder]
+Real: [`mkRealTxBuilder`][s-mkRealTxBuilder] ·
 Mock: [`mkMockTxBuilder`][s-mkMockTxBuilder] (throws on all ops)
 
-[f-txbuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder.hs#L24-L56
 [s-mkRealTxBuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkRealTxBuilder&type=code
 [s-mkMockTxBuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockTxBuilder&type=code
-
-### Indexer
-
-Chain sync follower with lifecycle control.
-
-| Field | Purpose |
-|-------|---------|
-| `start` / `stop` | Follower lifecycle |
-| `pause` / `resume` | Temporary suspension |
-| `getTip` | Current [`ChainTip`][s-ChainTip] (slot + block hash) |
-
--> [Indexer.hs:L16-L36][f-indexer]
-
-Real: [`Indexer.Follower`][s-Follower] (block processing)
-Mock: [`mkSkeletonIndexer`][s-mkSkeletonIndexer] (no-op) / [`mkMockIndexer`][s-mkMockIndexer]
-
-[s-ChainTip]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+ChainTip%22&type=code
-[f-indexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer.hs#L16-L36
-[s-Follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
-[s-mkSkeletonIndexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkSkeletonIndexer&type=code
-[s-mkMockIndexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockIndexer&type=code
+[s-sweepUtxoImpl]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=sweepUtxoImpl&type=code
 
 ### Context
 
-Facade record bundling all singletons into one environment.
+Facade record bundling the singletons plus indexed-read primitives:
+`utxoExists`, `resolveUtxo`, `awaitUtxo`, `utxoRoot`, `utxoProof`,
+`indexerProofsReady`, `evalContext`, `runIndexerTx`, `readMetrics`,
+and the static `cfgCage`.
 
--> [Context.hs:L19-L32][f-context]
+[`runIndexerTx`][s-runIndexerTx] runs a composed `IndexerTx` read
+inside one underlying transaction — the atomicity anchor for all
+proof-bearing handlers.
 
-[f-context]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Context.hs#L19-L32
-
----
-
-## Node-to-Client Protocol
-
-Multiplexed N2C connection over a Unix socket to `cardano-node`.
-Two mini-protocols share one connection.
-
-### Connection
-
-- **[`runNodeClient`][s-runNodeClient]**: Establish multiplexed connection, launch protocol threads
-  -> [NodeClient/Connection.hs:L122-L143][f-nc-conn]
-- **[`newLSQChannel`][s-newLSQChannel]** / **[`newLTxSChannel`][s-newLTxSChannel]**: Create `TBQueue`-backed channels
-  -> [NodeClient/Connection.hs:L234-L244][f-nc-chan]
-
-[s-runNodeClient]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=runNodeClient+path%3AConnection&type=code
-[s-newLSQChannel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=newLSQChannel&type=code
-[s-newLTxSChannel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=newLTxSChannel&type=code
-[f-nc-conn]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Connection.hs#L122-L143
-[f-nc-chan]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Connection.hs#L234-L244
-
-### Channel Types
-
-| Type | Purpose |
-|------|---------|
-| [`LSQChannel`][s-LSQChannel] | `TBQueue` of `(Query, TMVar result)` pairs |
-| [`LTxSChannel`][s-LTxSChannel] | `TBQueue` of `(GenTx, TMVar result)` pairs |
-| [`SomeLSQQuery`][s-SomeLSQQuery] | Existential wrapper hiding the query result type |
-
--> [NodeClient/Types.hs:L36-L75][f-nc-types]
-
-[s-LSQChannel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+LSQChannel%22&type=code
-[s-LTxSChannel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22newtype+LTxSChannel%22&type=code
-[s-SomeLSQQuery]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+SomeLSQQuery%22&type=code
-[f-nc-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/Types.hs#L36-L75
-
-### LocalStateQuery
-
-Protocol client driven by `LSQChannel`. Acquires volatile tip per
-query (no long-lived acquired state).
-
-- **[`queryLSQ`][s-queryLSQ]**: Submit query through channel, block on `TMVar` result
-  -> [NodeClient/LocalStateQuery.hs:L124-L133][f-lsq]
-
-[s-queryLSQ]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=queryLSQ&type=code
-[f-lsq]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/LocalStateQuery.hs#L124-L133
-
-### LocalTxSubmission
-
-- **[`submitTxN2C`][s-submitTxN2C]**: Submit `GenTx` through channel, block on result
-  -> [NodeClient/LocalTxSubmission.hs:L77-L89][f-ltxs]
-
-[s-submitTxN2C]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=submitTxN2C&type=code
-[f-ltxs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/NodeClient/LocalTxSubmission.hs#L77-L89
+[s-runIndexerTx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=runIndexerTx&type=code
 
 ---
 
-## Transaction Builders
+## HTTP Layer
 
-Real implementations for all cage protocol operations. Each builds
-a full `Tx ConwayEra` with PlutusV3 script witnesses, inline datums,
-and validity intervals, then balances via [`balanceTx`][s-balanceTx].
+Servant REST API with Swagger UI. `mkApp` from `HTTP.Server` wraps a
+`Context IO` into a WAI `Application`. The canonical API type and
+wire DTOs live in the `cardano-mpfs-api` package; this layer adds the
+handlers and the server-local metrics endpoints.
 
-### Config
+| Module | Purpose |
+|--------|---------|
+| [`HTTP.API`][s-http-api] | Server-local wrapper around the shared Servant API plus `/metrics` |
+| [`HTTP.Types`][s-http-types] | Server compatibility re-exports and ledger conversion helpers |
+| [`HTTP.Types.Facts`][s-http-facts] | Assembly helpers for facts-only responses |
+| [`HTTP.Encoding`][s-http-enc] | `Hex` newtype for binary-as-hex JSON transport |
+| [`HTTP.Server`][s-http-server] | WAI wiring, `mkApp`, all handlers |
+| [`HTTP.SubmitScope`][s-http-scope] | `txTouchesMpfs` — the `POST /submit` MPFS-scope gate |
+| [`HTTP.Swagger`][s-http-swagger] | OpenAPI generation, Swagger UI at `/swagger-ui` |
 
-[`CageConfig`][s-CageConfig]: Script bytes, script hash, time windows,
-network, slot parameters.
-
--> [TxBuilder/Config.hs:L24-L41][f-txb-cfg]
-
-[s-CageConfig]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageConfig%22&type=code
-[f-txb-cfg]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs#L24-L41
-
-### Entry Point
-
-- **[`mkRealTxBuilder`][s-mkRealTxBuilder]**: Wire Config + Provider + State + TrieManager into `TxBuilder IO`
-  -> [TxBuilder/Real.hs:L56-L74][f-txb-real]
-
-[f-txb-real]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real.hs#L56-L74
-
-### Per-Operation Builders
-
-| Module | Operation | Key steps |
-|--------|-----------|-----------|
-| [`Real.Boot`][f-txb-boot] | Mint cage token | Pick seed UTxO, derive asset name, build +1 mint, create state datum |
-| [`Real.Request`][f-txb-req] | Submit request | Pay to cage address with `RequestDatum`, no script execution |
-| [`Real.Update`][f-txb-upd] | Process requests | Find state + request UTxOs, compute proofs speculatively, build `Modify` redeemer with proof lists |
-| [`Real.Retract`][f-txb-ret] | Cancel request | Spend request UTxO with `Retract` redeemer, reference state UTxO, Phase 2 validity window |
-| [`Real.End`][f-txb-end] | Burn token | Consume state with `End` spending, mint -1 with `Burning` minting |
-
-[f-txb-boot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Boot.hs#L80-L200
-[f-txb-req]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Request.hs#L56-L161
-[f-txb-upd]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs#L95-L284
-[f-txb-ret]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Retract.hs#L83-L224
-[f-txb-end]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs#L75-L178
-
-### Internal Helpers
-
-Shared helpers used by all builders.
-
-| Function | Purpose |
-|----------|---------|
-| [`posixMsToSlot`][s-posixMsToSlot] / [`posixMsCeilSlot`][s-posixMsCeilSlot] | POSIX ms -> `SlotNo` (floor/ceiling) |
-| [`findStateUtxo`][s-findStateUtxo] | Find state UTxO by policy ID + token ID in MultiAsset |
-| [`findRequestUtxos`][s-findRequestUtxos] | Find request UTxOs by decoding inline datums |
-| [`extractCageDatum`][s-extractCageDatum] | Extract `CageDatum` from inline datum in `TxOut` |
-| [`mkRequestDatum`][s-mkRequestDatum] | Build `CageDatum` for request submission |
-| [`spendingIndex`][s-spendingIndex] | Compute redeemer index of `TxIn` in sorted input set |
-| [`computeScriptIntegrity`][s-computeScriptIntegrity] | Compute `ScriptIntegrityHash` for tx body |
-
--> [TxBuilder/Real/Internal.hs][f-txb-int]
-
-[s-posixMsToSlot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=posixMsToSlot&type=code
-[s-posixMsCeilSlot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=posixMsCeilSlot&type=code
-[s-findStateUtxo]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=findStateUtxo&type=code
-[s-findRequestUtxos]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=findRequestUtxos&type=code
-[s-extractCageDatum]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=extractCageDatum&type=code
-[s-mkRequestDatum]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkRequestDatum&type=code
-[s-spendingIndex]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=spendingIndex+path%3AInternal&type=code
-[s-computeScriptIntegrity]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=computeScriptIntegrity&type=code
-[f-txb-int]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
+[s-http-api]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.API%22&type=code
+[s-http-types]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Types%22&type=code
+[s-http-facts]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Types.Facts%22&type=code
+[s-http-enc]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Encoding%22&type=code
+[s-http-server]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Server%22&type=code
+[s-http-scope]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.SubmitScope%22&type=code
+[s-http-swagger]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.HTTP.Swagger%22&type=code
 
 ---
 
 ## Chain Indexer
 
 Block-by-block processing of cage transactions with rollback support.
-All state changes in one block commit in a single RocksDB WriteBatch.
+One block = one RocksDB transaction — see
+[block processing](../docs/architecture/block-processing.md).
 
-### Event Detection
+| Module | Purpose |
+|--------|---------|
+| [`Indexer.Event`][s-idx-event] | `detectCageEvents` — classify cage-relevant txs into `CageEvent`; `CageInverseOp`; `/submit` scope predicates |
+| [`Indexer.Follower`][s-idx-follower] | `detectCageBlockEvents`, `applyCageBlockEvents`, `applyCageInverses` — generic over `Monad m` |
+| [`Indexer.CageFollower`][s-idx-cage] | `rollForward`/`rollBackward` via the chain-follower `Runner` (`processBlock`, `rollbackTo`); phase threading, armageddon reset |
+| [`Indexer.Backend`][s-idx-backend] | `composedInit` — composed UTxO + cage backend (restore/follow/applyInverse callbacks) |
+| [`Indexer.ComposedInv`][s-idx-inv] | `ComposedInv` — combined UTxO + cage inverse ops, one per rollback point |
+| [`Indexer.Reads`][s-idx-reads] | `IndexerTx` composable atomic reads: `readSnapshot`, `readUtxoWitness`, `readTrieFacts`, `readRequestUtxosAt`, … |
+| [`Indexer.Columns`][s-idx-columns] | `AllColumns` + `UnifiedColumns` GADTs — the 14-column DB schema |
+| [`Indexer.Codecs`][s-idx-codecs] | CBOR codecs for column key-value types |
+| [`Indexer.Persistent`][s-idx-persist] | `mkTransactionalState` (composable) + `mkPersistentState` (IO) |
 
-[`CageEvent`][s-CageEvent] classifies cage-relevant transactions:
-
-| Constructor | Signal |
-|-------------|--------|
-| `CageBoot` | Mint +1 under cage policy |
-| `CageRequest` | Output to cage address with `RequestDatum` |
-| `CageUpdate` | Cage input with `Modify` redeemer |
-| `CageRetract` | Cage input with `Retract` redeemer |
-| `CageBurn` | Mint -1 under cage policy |
-
-- **[`detectCageEvents`][s-detectCageEvents]**: Extract events from a transaction
-  -> [Indexer/Event.hs:L146-L154][f-idx-detect]
-- **[`inversesOf`][s-inversesOf]**: Compute [`CageInverseOp`][s-CageInverseOp] for rollback
-  -> [Indexer/Event.hs:L346-L380][f-idx-inverse]
-
-[s-CageEvent]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageEvent%22&type=code
-[s-detectCageEvents]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=detectCageEvents&type=code
-[s-inversesOf]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=inversesOf&type=code
-[s-CageInverseOp]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageInverseOp%22&type=code
-[f-idx-detect]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs#L146-L154
-[f-idx-inverse]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs#L346-L380
-
-### Block Processor (Follower)
-
-Processes each block: extract Conway txs, detect cage events, apply
-to state and trie, record inverse ops for rollback.
-
-- **[`processCageBlock`][s-processCageBlock]**: Process full block for cage events
-  -> [Indexer/Follower.hs:L86-L107][f-follower-block]
-- **[`applyCageEvent`][s-applyCageEvent]**: Apply single event to State + TrieManager
-  -> [Indexer/Follower.hs:L200-L253][f-follower-apply]
-- **[`applyCageInverses`][s-applyCageInverses]**: Replay inverse ops for rollback
-  -> [Indexer/Follower.hs:L310-L342][f-follower-inv]
-
-[s-processCageBlock]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=processCageBlock&type=code
-[s-applyCageEvent]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=applyCageEvent&type=code
-[s-applyCageInverses]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=applyCageInverses&type=code
-[f-follower-block]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L86-L107
-[f-follower-apply]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L200-L253
-[f-follower-inv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Follower.hs#L310-L342
-
-### Column Families
-
-[`AllColumns`][s-AllColumns] GADT — type-safe column family selectors for
-the shared RocksDB instance.
-
-| Column | Key | Value |
-|--------|-----|-------|
-| `CageTokens` | `TokenId` | `TokenState` |
-| `CageRequests` | `TxIn` | `Request` |
-| `CageCfg` | `()` | [`CageCheckpoint`][s-CageCheckpoint] |
-| `CageRollbacks` | `SlotNo` | `[CageInverseOp]` |
-| `TrieNodes` | prefixed bytes | trie node data |
-| `TrieKV` | prefixed bytes | key-value data |
-
--> [Indexer/Columns.hs:L49-L95][f-columns]
-
-[s-AllColumns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+AllColumns%22&type=code
-[s-CageCheckpoint]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageCheckpoint%22&type=code
-[f-columns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Columns.hs#L49-L95
-
-### Codecs
-
-CBOR serialization for all column key-value types. Uses
-`rocksdb-kv-transactions` `Prism` pattern.
-
-- **[`allCodecs`][s-allCodecs]**: `DMap` of codecs keyed by `AllColumns`
-  -> [Indexer/Codecs.hs:L93-L126][f-codecs]
-
-[s-allCodecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=allCodecs+path%3ACodecs&type=code
-[f-codecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Codecs.hs#L93-L126
-
-### Rollback
-
-Slot-based rollback by replaying stored inverse operations.
-
-- **[`storeRollback`][s-storeRollback]**: Persist inverse ops for a slot
-  -> [Indexer/Rollback.hs:L46-L56][f-rollback-store]
-- **[`rollbackToSlot`][s-rollbackToSlot]**: Replay inverses from current tip back to target slot
-  -> [Indexer/Rollback.hs:L80-L113][f-rollback-to]
-
-[s-storeRollback]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=storeRollback&type=code
-[s-rollbackToSlot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=rollbackToSlot&type=code
-[f-rollback-store]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs#L46-L56
-[f-rollback-to]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Rollback.hs#L80-L113
-
-### Persistent State
-
-RocksDB-backed `State IO` implementation.
-
-- **[`mkPersistentState`][s-mkPersistentState]**: Build State from RocksDB column families
-  -> [Indexer/Persistent.hs:L48-L56][f-persistent]
-
-[f-persistent]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Persistent.hs#L48-L56
+[s-idx-event]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Event%22&type=code
+[s-idx-follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
+[s-idx-cage]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code
+[s-idx-backend]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Backend%22&type=code
+[s-idx-inv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.ComposedInv%22&type=code
+[s-idx-reads]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Reads%22&type=code
+[s-idx-columns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Columns%22&type=code
+[s-idx-codecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Codecs%22&type=code
+[s-idx-persist]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code
 
 ---
 
 ## Trie Backends
 
-Three `TrieManager` implementations sharing the same interface.
+`TrieManager` implementations sharing the same interface.
 
-### Pure (in-memory)
+| Module | Purpose |
+|--------|---------|
+| [`Trie.Pure`][s-trie-pure] | In-memory trie backed by an `IORef`, for tests |
+| [`Trie.PureManager`][s-trie-pm] | `mkPureTrieManager` — in-memory manager keyed by `TokenId` |
+| [`Trie.Persistent`][s-trie-pers] | `mkUnifiedTrieManager` (transactional, composes into the block transaction) + `mkPersistentTrieManager` (IO, token-prefixed keys, speculative sessions) |
 
-`IORef MPFInMemoryDB` per token. Good for testing.
+[s-trie-pure]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.Pure%22&type=code
+[s-trie-pm]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.PureManager%22&type=code
+[s-trie-pers]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.Persistent%22&type=code
 
-- **[`mkPureTrie`][s-mkPureTrie]**: New empty trie backed by fresh IORef
-  -> [Trie/Pure.hs:L51-L54][f-trie-pure]
-- **[`mkPureTrieManager`][s-mkPureTrieManager]**: Manager backed by `Map TokenId (IORef MPFInMemoryDB)`
-  -> [Trie/PureManager.hs:L39-L57][f-trie-pm]
+---
 
-[s-mkPureTrie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPureTrie&type=code
-[f-trie-pure]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Pure.hs#L51-L54
-[f-trie-pm]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/PureManager.hs#L39-L57
+## Node Integration
 
-### Persistent (RocksDB)
+Thin wrappers over
+[cardano-node-clients](https://github.com/lambdasistemi/cardano-node-clients),
+which owns the N2C connection, channels, and protocol state machines.
 
-Token-prefixed keys in shared column families. Supports speculative
-sessions via transactional snapshots.
+| Module | Purpose |
+|--------|---------|
+| [`Provider.NodeClient`][s-prv-nc] | `mkNodeClientProvider` — N2C LocalStateQuery for PParams, evaluation, slot conversion, eval context |
+| [`Submitter.N2C`][s-sub-n2c] | `mkN2CSubmitter` — N2C LocalTxSubmission |
 
-- **[`mkPersistentTrieManager`][s-mkPersistentTrieManager]**: Manager from DB + two column families (nodes, kv)
-  -> [Trie/Persistent.hs:L117-L162][f-trie-pers]
-- **[`mkPrefixedTrieDB`][s-mkPrefixedTrieDB]**: Prefixed `Database` with transparent key wrapping
-  -> [Trie/Persistent.hs:L365-L409][f-trie-prefixed]
-- **[`tokenPrefix`][s-tokenPrefix]**: Serialize `TokenId` to prefix bytes
-  -> [Trie/Persistent.hs:L206-L210][f-trie-prefix]
-
-[s-mkPrefixedTrieDB]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkPrefixedTrieDB&type=code
-[s-tokenPrefix]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=tokenPrefix+path%3APersistent&type=code
-[f-trie-pers]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L117-L162
-[f-trie-prefixed]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L365-L409
-[f-trie-prefix]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Trie/Persistent.hs#L206-L210
+[s-prv-nc]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Provider.NodeClient%22&type=code
+[s-sub-n2c]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Submitter.N2C%22&type=code
 
 ---
 
 ## Mock Implementations
 
-Test doubles for all interfaces. No IO side effects, no node
-connection required.
+Test doubles. No node connection required.
 
 | Module | Constructor | Behavior |
 |--------|-------------|----------|
-| [`Mock.Context`][f-mock-ctx] | [`mkMockContext`][s-mkMockContext] | Wires all mocks into `Context IO` |
-| [`Mock.State`][f-mock-st] | [`mkMockState`][s-mkMockState] | `IORef (Map k v)` per sub-record |
-| [`Mock.Provider`][f-mock-prv] | [`mkMockProvider`][s-mkMockProvider] | Returns empty UTxO sets |
-| [`Mock.Submitter`][f-mock-sub] | [`mkMockSubmitter`][s-mkMockSubmitter] | Rejects all transactions |
-| [`Mock.TxBuilder`][f-mock-txb] | [`mkMockTxBuilder`][s-mkMockTxBuilder] | Throws on all operations |
-| [`Mock.Indexer`][f-mock-idx] | [`mkMockIndexer`][s-mkMockIndexer] | No-op lifecycle |
-| [`Mock.Skeleton`][f-mock-skel] | [`mkSkeletonIndexer`][s-mkSkeletonIndexer] | IORef/MVar tracking, no chain sync |
+| [`Mock.Context`][s-mock-ctx] | `mkMockContext` | Wires all mocks into `Context IO` |
+| [`Mock.State`][s-mock-st] | `mkMockState` | `IORef (Map k v)` per sub-record |
+| [`Mock.Provider`][s-mock-prv] | `mkMockProvider` | Empty UTxO sets, empty evaluation |
+| [`Mock.Submitter`][s-mock-sub] | `mkMockSubmitter` | Rejects all transactions |
+| [`Mock.TxBuilder`][s-mock-txb] | `mkMockTxBuilder` | Throws on all operations |
 
-[s-mkMockContext]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkMockContext&type=code
-[f-mock-ctx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Context.hs
-[f-mock-st]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/State.hs
-[f-mock-prv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Provider.hs
-[f-mock-sub]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Submitter.hs
-[f-mock-txb]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/TxBuilder.hs
-[f-mock-idx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Indexer.hs
-[f-mock-skel]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Mock/Skeleton.hs
+[s-mock-ctx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Context%22&type=code
+[s-mock-st]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.State%22&type=code
+[s-mock-prv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Provider%22&type=code
+[s-mock-sub]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Submitter%22&type=code
+[s-mock-txb]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.TxBuilder%22&type=code
 
 ---
 
 ## Application Wiring
 
-[`withApplication`][s-withApplication] creates the full `Context IO`:
+[`withApplication`][s-withApplication] creates the full `Context IO`
+with bracket lifecycle:
 
-1. Open RocksDB with all [column families][f-app-cfs]
-2. Create persistent State + TrieManager
-3. Seed from bootstrap file if fresh DB
-4. Open N2C connection (LSQ + LTxS channels)
-5. Wire Provider, Submitter, TxBuilder
-6. Bundle into `Context IO`
-7. Bracket: tear down on exit
+1. Read the Shelley genesis (network magic, stability window,
+   security parameter `k`)
+2. Open RocksDB over all 14 column families behind one unified
+   transaction runner
+3. Project cage and UTxO column subsets; check schema migration
+4. Build persistent State + TrieManager; seed genesis UTxOs on a
+   fresh DB
+5. Start the `CageFollower` on its own ChainSync N2C connection
+6. Wire Provider + Submitter on a second N2C connection (LSQ + LTxS)
+7. Bundle everything into `Context IO`; tear down on exit
 
--> [Application.hs:L123-L190][f-app]
+`AppConfig` fields: `epochSlots`, `shelleyGenesisPath`, `socketPath`,
+`dbPath`, `channelCapacity`, `cageConfig`, `byronGenesisPath`,
+`followerEnabled`, `appTracer`.
 
-| Config field | Purpose |
-|--------------|---------|
-| `networkMagic` | Mainnet / testnet identifier |
-| `socketPath` | cardano-node Unix socket |
-| `dbPath` | RocksDB directory |
-| `cageConfig` | Script bytes, time windows, slot params |
-| `bootstrapFile` | Optional CBOR file for fresh DB seeding |
-
--> [Application.hs:L76-L89][f-app-cfg]
+[`Trace`][s-trace] defines the structured `AppTrace` type and
+`jsonLinesTracer` for stderr JSON-lines logging.
 
 [s-withApplication]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=withApplication&type=code
-[f-app]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L123-L190
-[f-app-cfg]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L76-L89
-[f-app-cfs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cardano-mpfs-offchain/lib/Cardano/MPFS/Application.hs#L107-L115
+[s-trace]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trace%22&type=code
+
+---
+
+## Executables
+
+Under `exe/`:
+
+| Executable | Source | Purpose |
+|------------|--------|---------|
+| `mpfs-serve` | `Serve.hs` | Production server: `--socket`, `--db`, `--port`, `--shelley-genesis`, `--blueprint`; optional `--byron-genesis`, `--epoch-slots`, `--mainnet` |
+| `mpfs-devnet-server` | `DevnetServer.hs` | Single-node devnet + MPFS API, for E2E and SPA testing |
+| `mpfs-run-preprod` | `RunPreprod.hs` | Minimal runner to smoke-test the follower against a preprod node |
+| `cardano-mpfs-swagger` | `swagger/Main.hs` | Print the OpenAPI spec (drives `just update-swagger`) |
+| `mpfs-inspect-db` | `InspectDb.hs` | Report per-column statistics of an MPFS RocksDB database |
+| `mpfs-tx-vectors` | `TxVectors.hs` | Generate CBOR transaction test vectors |

--- a/docs/architecture/block-processing.md
+++ b/docs/architecture/block-processing.md
@@ -66,44 +66,45 @@ half-ready proof tree.
 sequenceDiagram
     participant CS as ChainSync
     participant CF as CageFollower
+    participant RUN as chain-follower Runner
     participant TX as Unified Transaction
     participant UTXO as InUtxo columns
     participant CAGE as InCage columns
+    participant RB as InRollbacks column
     participant DB as RocksDB
 
     CS->>CF: rollForward (block, tip)
-    Note over CF: extractConwayTxs (pure)<br/>compute utxoOps
-
-    CF->>TX: run (begin transaction)
+    CF->>RUN: processBlock (slot, fetched, phase)
+    RUN->>TX: run (begin transaction)
 
     rect rgb(30, 50, 80)
         Note over TX,CAGE: Step 1 — Detect cage events
+        Note over TX: extractConwayTxs (pure)
         TX->>UTXO: resolveUtxoT (read KV column)
         UTXO-->>TX: spent TxOuts
-        Note over TX: classify txs as cage events
+        Note over TX: detectCageBlockEvents
     end
 
     rect rgb(30, 70, 50)
         Note over TX,CAGE: Step 2 — Apply cage mutations
         TX->>CAGE: applyCageBlockEvents<br/>(tokens, requests, trie inserts/deletes)
-        CAGE-->>TX: inverse ops for rollback
+        CAGE-->>TX: cage inverse ops
     end
 
     rect rgb(30, 50, 80)
-        Note over TX,UTXO: Step 3 — Forward UTxO CSMT
-        TX->>UTXO: forwardTip<br/>(CSMT inserts/deletes + rollback point)
-        UTXO-->>TX: stored? (bool)
+        Note over TX,UTXO: Step 3 — Apply UTxO CSMT ops
+        TX->>UTXO: csmtInsert / csmtDelete per block change
+        UTXO-->>TX: UTxO inverse ops
     end
 
     rect rgb(30, 70, 50)
-        Note over TX,CAGE: Step 4 — Persist rollback + checkpoint
-        TX->>CAGE: storeRollbackT (slot, inverse ops)
-        TX->>CAGE: putCheckpointT (slot, blockId, active slots)
+        Note over TX,RB: Step 4 — Store rollback point
+        TX->>RB: ComposedInv (UTxO + cage inverses),<br/>prune history to k+1 points
     end
 
     TX->>DB: commit (atomic write batch)
 
-    Note over CF: post-commit: IORef counter += 1
+    Note over CF: post-commit: onCommit callback,<br/>proof-readiness flag update
 ```
 
 **Atomicity boundary**: everything inside `run $ do ...` is a single
@@ -113,9 +114,10 @@ the batch and the block is never partially applied.
 
 **Post-commit side effects** (outside the transaction):
 
-- `IORef Int` rollback counter is bumped if `forwardTip` stored a new
-  rollback point. This counter is advisory — it's reconstructed from
-  the DB at startup via `countRollbackPoints`.
+- the `onCommit` callback fires (notifying waiters such as the
+  `GET /tx/:txId` blocking endpoint), and
+- the proof-readiness flag is updated from the runner phase, so proof
+  endpoints answer "syncing" instead of reading a half-restored tree.
 
 ## Rollback: Reverting Blocks
 
@@ -127,45 +129,39 @@ sequenceDiagram
     participant CS as ChainSync
     participant CF as CageFollower
     participant TX as Unified Transaction
-    participant UTXO as InUtxo columns
+    participant RB as InRollbacks column
     participant CAGE as InCage columns
+    participant UTXO as InUtxo columns
     participant DB as RocksDB
 
     CS->>CF: rollBackward (point)
 
-    CF->>TX: run (begin transaction)
-
-    rect rgb(30, 50, 80)
-        Note over TX,UTXO: Step 1 — Rollback UTxO CSMT
-        TX->>UTXO: rollbackTip (apply inverse UTxO ops,<br/>delete rollback points after slot)
-        UTXO-->>TX: (RollbackResult, deleted count)
-    end
+    CF->>TX: run rollbackTo (target slot)
+    TX->>RB: pop rollback points newer than target
 
     alt RollbackSucceeded
-        rect rgb(30, 70, 50)
-            Note over TX,CAGE: Step 2 — Rollback cage state
-            TX->>CAGE: rollbackToSlotT<br/>(replay cage inverses in reverse,<br/>delete cage rollback entries,<br/>update checkpoint)
+        loop each popped ComposedInv, newest first
+            TX->>CAGE: applyCageInverses<br/>(cage inverses, reversed)
+            TX->>UTXO: csmtInsert / csmtDelete<br/>(UTxO inverses, reversed)
         end
         TX->>DB: commit (atomic write batch)
-        Note over CF: post-commit: IORef counter -= deleted
         CF-->>CS: Progress (continue following)
-    else RollbackImpossible
-        Note over TX: no cage rollback — keep consistent
-        TX->>DB: commit (no-op write batch)
-        CF->>UTXO: sampleRollbackPoints
-        alt has rollback points
-            CF-->>CS: Rewind (try different intersection)
-        else no rollback points
-            CF-->>CS: Reset (start from Origin)
-        end
+    else RollbackImpossible — no points stored yet
+        Note over CF: target predates indexed history,<br/>nothing to undo — continue
+        CF-->>CS: Progress
+    else RollbackImpossible — points exist
+        Note over CF: armageddon — wipe database,<br/>re-enter restoration
+        CF-->>CS: Reset (start from Origin)
     end
 ```
 
-**Key invariant**: cage rollback only runs when UTxO rollback
-succeeds. This ensures both subsystems stay in sync. When rollback is
-impossible (the target slot doesn't exist as a UTxO rollback point),
-neither subsystem is modified — the follower instead resets the
-ChainSync intersection.
+**Key invariant**: a rollback either replays the stored `ComposedInv`
+inverses — cage state first, then UTxO CSMT, each list in reverse
+order — inside one atomic transaction, or it modifies nothing. When
+the target slot is older than the retained rollback history, the
+follower wipes the database (the armageddon action) and rebuilds from
+Origin in restoration mode rather than guessing at an intermediate
+state.
 
 ## Crash Safety
 
@@ -176,7 +172,7 @@ graph TD
         B --> C["writes accumulate in batch"]
         C --> D{"crash?"}
         D -->|before commit| E["batch discarded<br/>DB unchanged<br/>block replayed on restart"]
-        D -->|after commit| F["block fully applied<br/>IORef reconstructed from DB"]
+        D -->|after commit| F["block fully applied<br/>runner re-intersects on restart"]
     end
 ```
 
@@ -187,14 +183,16 @@ graph TD
         B --> C["UTxO + cage inverses applied"]
         C --> D{"crash?"}
         D -->|before commit| E["batch discarded<br/>DB at pre-rollback state<br/>rollback retried on restart"]
-        D -->|after commit| F["rollback fully applied<br/>IORef reconstructed from DB"]
+        D -->|after commit| F["rollback fully applied<br/>runner re-intersects on restart"]
     end
 ```
 
-The `IORef Int` rollback counter is the only mutable state outside
-RocksDB. It is reconstructed at startup by scanning the rollback
-points column (`countRollbackPoints`), so a crash never leaves it
-permanently inconsistent.
+All indexer state lives in RocksDB. The runner phase
+(restoration/following) is threaded through continuations — no
+mutable counters exist outside the database — and on restart the
+follower re-intersects ChainSync from the stored rollback points, so
+a crash can never leave volatile state inconsistent with the
+committed batch.
 
 ## mapColumns Lifting
 
@@ -220,20 +218,27 @@ Each sub-transaction reads and writes its own column families.
 `mapColumns` lifts them into the unified namespace so they can be
 sequenced inside a single `do` block and committed together.
 
-## Bypassing the Update Continuation
+## Runner and Backend Composition
 
-The `cardano-utxo-csmt` library exports an `Update` record that wraps
-`forwardTip` and `rollbackTip` with auto-commit and threads a
-rollback point counter through continuations. The `CageFollower`
-bypasses this:
+The block-processing machinery is split between this repository and
+the `chain-follower` library:
 
-- Calls `forwardTip` and `rollbackTip` directly (pure `Transaction`
-  values, not auto-committing)
-- Manages the rollback point counter via an `IORef Int`
-- Handles `RollbackResult` (succeeded/impossible) itself
+- **`chain-follower` `Runner`** (`processBlock`, `rollbackTo`) owns
+  the generic concerns: storing one `ComposedInv` rollback point per
+  followed block in the `InRollbacks` column, pruning the history to
+  `k + 1` points (the security parameter in blocks, see #355), and
+  managing the phase transition between restoration and following
+  (governed by the stability window in slots).
+- **`Indexer.Backend.composedInit`** supplies the business logic as
+  `restore` / `follow` / `applyInverse` callbacks: cage event
+  detection, cage state and trie mutations, and UTxO CSMT operations.
 
-This is necessary because the `Update` continuation commits each
-operation separately, violating the one-block-one-commit invariant.
+During **restoration** (replaying blocks far from the tip) the
+backend applies mutations without collecting inverses and runs the
+CSMT in KVOnly mode; on the phase flip to **following**, `toFull`
+replays the CSMT journal and subsequent blocks collect full
+`ComposedInv` inverses. The cage checkpoint is derived from the
+latest stored rollback point rather than written separately.
 
 ## Transactional vs IO Layers
 
@@ -272,16 +277,18 @@ transactional layer).
 
 | Module | Role |
 |--------|------|
-| [`Indexer.CageFollower`][s-cage-follower] | Unified `rollForward` / `rollBackward` |
-| [`Indexer.Follower`][s-follower] | `detectCageBlockEvents`, `applyCageBlockEvents` |
+| [`Indexer.CageFollower`][s-cage-follower] | `rollForward` / `rollBackward` via the chain-follower `Runner` |
+| [`Indexer.Backend`][s-backend] | `composedInit` — restore/follow/applyInverse callbacks |
+| [`Indexer.Follower`][s-follower] | `detectCageBlockEvents`, `applyCageBlockEvents`, `applyCageInverses` |
+| [`Indexer.ComposedInv`][s-composed-inv] | `ComposedInv` — combined UTxO + cage inverse ops |
 | [`Indexer.Columns`][s-columns] | `UnifiedColumns` GADT (14 CFs) |
-| [`Indexer.Rollback`][s-rollback] | `storeRollbackT`, `rollbackToSlotT` |
 | [`Indexer.Persistent`][s-persistent] | `mkTransactionalState`, `mkPersistentState` |
 | [`Trie.Persistent`][s-trie-pers] | `mkUnifiedTrieManager`, `mkPersistentTrieManager` |
 
 [s-cage-follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code
+[s-backend]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Backend%22&type=code
 [s-follower]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Follower%22&type=code
+[s-composed-inv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.ComposedInv%22&type=code
 [s-columns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Columns%22&type=code
-[s-rollback]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Rollback%22&type=code
 [s-persistent]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Persistent%22&type=code
 [s-trie-pers]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie.Persistent%22&type=code

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -107,22 +107,27 @@ graph TD
     TM["TrieManager<br/>(per-token MPF tries)"]
     ST["State<br/>(tokens, requests, checkpoints)"]
     READS["Indexer Reads<br/>(atomic proof queries)"]
-    IDX["Indexer<br/>(ChainSync)"]
+    IDX["CageFollower<br/>(ChainSync indexer)"]
     SUB["Submitter<br/>(N2C LocalTxSubmission)"]
     TXB["TxBuilder<br/>(internal proof envelopes<br/>/tx/sweep + legacy native paths)"]
     NODE["Cardano Node<br/>(Unix socket)"]
 
     APP --> CTX
+    APP --> IDX
     CTX --> PRV
     CTX --> TM
     CTX --> ST
     CTX --> READS
-    CTX --> IDX
     CTX --> SUB
     CTX --> TXB
     PRV --> NODE
     SUB --> NODE
+    IDX --> NODE
 ```
+
+The `CageFollower` is not a `Context` field: `Application` drives it on
+its own ChainSync connection, and `Context` observes its output through
+the atomic `runIndexerTx` read primitives and the proof-readiness flag.
 
 ## Application Wiring
 
@@ -238,7 +243,6 @@ modules live under `Cardano.MPFS`.
 | [`State`][s-state] | `Tokens`, `Requests`, `Checkpoints` sub-records |
 | [`Trie`][s-trie] | `TrieManager` — per-token MPF trie access |
 | [`TxBuilder`][s-txbuilder] | internal proof-envelope builders and `/tx/sweep`; browser-facing script-bearing transactions are built client-side from facts |
-| [`Indexer`][s-indexer] | Chain follower lifecycle (`start`, `stop`, `getTip`) |
 | [`Submitter`][s-submitter] | `submitTx :: Tx ConwayEra -> m SubmitResult` |
 | [`Application`][s-application] | `withApplication` — wiring and lifecycle |
 
@@ -247,7 +251,6 @@ modules live under `Cardano.MPFS`.
 [s-state]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.State%22&type=code
 [s-trie]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Trie%22+path%3Alib%2FCardano%2FMPFS%2FTrie.hs&type=code
 [s-txbuilder]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder%22+path%3Alib%2FCardano%2FMPFS%2FTxBuilder.hs&type=code
-[s-indexer]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer%22+path%3Alib%2FCardano%2FMPFS%2FIndexer.hs&type=code
 [s-submitter]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Submitter%22+path%3Alib%2FCardano%2FMPFS%2FSubmitter.hs&type=code
 [s-application]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Application%22&type=code
 
@@ -280,13 +283,15 @@ The shared API and DTO definitions live in `cardano-mpfs-api`:
 
 | Module | Purpose |
 |--------|---------|
-| [`Indexer.CageFollower`][s-idx-cage] | Unified `rollForward`/`rollBackward` — [one block = one transaction](block-processing.md) |
+| [`Indexer.CageFollower`][s-idx-cage] | chain-follower `Runner` integration: `processBlock`/`rollbackTo` — [one block = one transaction](block-processing.md) |
+| [`Indexer.Backend`][s-idx-backend] | `composedInit` — composed UTxO + cage backend (restore/follow/applyInverse callbacks) |
 | [`Indexer.Event`][s-idx-event] | [`detectCageEvents`][s-detect] — cage tx classification |
-| [`Indexer.Follower`][s-idx-follower] | `detectCageBlockEvents`, `applyCageBlockEvents` — generic over `Monad m` |
+| [`Indexer.Follower`][s-idx-follower] | `detectCageBlockEvents`, `applyCageBlockEvents`, `applyCageInverses` — generic over `Monad m` |
+| [`Indexer.ComposedInv`][s-idx-inv] | `ComposedInv` — combined UTxO + cage inverse ops stored per rollback point |
+| [`Indexer.Reads`][s-idx-reads] | `IndexerTx` composable read primitives (`readSnapshot`, `readUtxoWitness`, `readTrieFacts`, …) |
 | [`Indexer.Persistent`][s-idx-persist] | `mkTransactionalState` (composable) + `mkPersistentState` (IO) |
 | [`Indexer.Columns`][s-idx-columns] | [`AllColumns`][s-allcolumns] + [`UnifiedColumns`][s-unifiedcols] GADTs — full DB schema |
 | [`Indexer.Codecs`][s-idx-codecs] | CBOR serialization for column key-value types |
-| [`Indexer.Rollback`][s-idx-rollback] | `storeRollbackT`, `rollbackToSlotT` — transactional rollback |
 
 [s-idx-cage]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.CageFollower%22&type=code
 [s-idx-event]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Event%22&type=code
@@ -297,8 +302,9 @@ The shared API and DTO definitions live in `cardano-mpfs-api`:
 [s-allcolumns]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+AllColumns%22&type=code
 [s-unifiedcols]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+UnifiedColumns%22&type=code
 [s-idx-codecs]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Codecs%22&type=code
-[s-idx-rollback]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Rollback%22&type=code
-[s-inverseop]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22data+CageInverseOp%22&type=code
+[s-idx-backend]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Backend%22&type=code
+[s-idx-inv]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.ComposedInv%22&type=code
+[s-idx-reads]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Indexer.Reads%22&type=code
 
 ### Node integration — thin wrappers over [cardano-node-clients](https://github.com/lambdasistemi/cardano-node-clients)
 
@@ -315,11 +321,12 @@ The shared API and DTO definitions live in `cardano-mpfs-api`:
 | Module | Purpose |
 |--------|---------|
 | [`TxBuilder.Config`][s-txb-cfg] | `CageConfig` loading |
-| [`TxBuilder.Real`][s-txb-real] | [`mkRealTxBuilder`][s-mkrealtxb] entry point |
-| [`TxBuilder.Real.Boot`][s-txb-boot] | Mint cage token |
-| [`TxBuilder.Real.Request`][s-txb-req] | Submit insert/delete request |
+| [`TxBuilder.Real`][s-txb-real] | [`mkRealTxBuilder`][s-mkrealtxb] entry point; `bootToken` errors — boot moved to `POST /facts/boot` plus client-side construction |
+| [`TxBuilder.Real.Request`][s-txb-req] | Submit insert/delete/update request |
 | [`TxBuilder.Real.Update`][s-txb-upd] | Consume requests, update root |
 | [`TxBuilder.Real.Retract`][s-txb-ret] | Cancel pending request |
+| [`TxBuilder.Real.Reject`][s-txb-rej] | Owner rejection of expired requests |
+| [`TxBuilder.Real.Sweep`][s-txb-sweep] | Owner-only sweep of non-legitimate request UTxOs (`POST /tx/sweep`) |
 | [`TxBuilder.Real.End`][s-txb-end] | Burn cage token |
 | [`TxBuilder.Real.Internal`][s-txb-int] | Shared helpers, POSIX-to-slot conversion |
 
@@ -344,7 +351,8 @@ UTxO state. The public browser path uses facts endpoints plus the
 [s-txb-cfg]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Config%22&type=code
 [s-txb-real]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real%22+path%3AReal.hs&type=code
 [s-mkrealtxb]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=mkRealTxBuilder&type=code
-[s-txb-boot]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Boot%22&type=code
+[s-txb-rej]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Reject%22&type=code
+[s-txb-sweep]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Sweep%22&type=code
 [s-txb-req]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Request%22&type=code
 [s-txb-upd]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Update%22&type=code
 [s-txb-ret]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.TxBuilder.Real.Retract%22&type=code
@@ -369,7 +377,7 @@ UTxO state. The public browser path uses facts endpoints plus the
 | [`Mock.Context`][s-mock-ctx] | [`withMockContext`][s-withmock] — full mock wiring |
 | [`Mock.Provider`][s-mock-prv] | In-memory UTxO store |
 | [`Mock.State`][s-mock-st] | [`mkMockState`][s-mkmockst] — `IORef`-backed state |
-| [`Mock.Submitter`][s-mock-sub] | Always-succeeds submitter |
+| [`Mock.Submitter`][s-mock-sub] | Rejects all transactions ("not connected") |
 | [`Mock.TxBuilder`][s-mock-txb] | [`mkMockTxBuilder`][s-mkmocktxb] — placeholder builder |
 
 [s-mock-ctx]: https://github.com/lambdasistemi/cardano-mpfs-offchain/search?q=%22module+Cardano.MPFS.Mock.Context%22&type=code

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -49,6 +49,7 @@ The REST API is exercised through WAI test sessions against a mock
 | `RejectFactsSpec` | `POST /facts/reject`, including request subset selection |
 | `EndFactsSpec` | `POST /facts/end` |
 | `SubmitSpec` | `POST /submit` signed transaction submission |
+| `SubmitScopeSpec` | `POST /submit` MPFS-scope gate — non-MPFS transactions are rejected |
 
 Client tests cover `verifyTokenState`, `verifyTokenFacts`,
 `verifyTokenRequests`, the `verify*Facts` family, CSMT replay failures,
@@ -68,12 +69,14 @@ just e2e             # same app, with optional --match support
 
 ### How It Works
 
-The test harness (`Cardano.MPFS.E2E.Devnet`) manages a
-single-node devnet:
+The test harness (`Cardano.Node.Client.E2E.Devnet` from the
+[cardano-node-clients](https://github.com/lambdasistemi/cardano-node-clients)
+package, used as `withCardanoNode`) manages a single-node devnet:
 
-1. **Genesis files** are checked into `e2e-test/genesis/`. They
-   define a testnet with magic 42, 0.1s slots, all hard forks at
-   epoch 0 (instant Conway).
+1. **Genesis files** ship with the `devnet-genesis` package of
+   `cardano-node-clients`; the flake apps export their location as
+   `E2E_GENESIS_DIR`. They define a testnet with magic 42, 0.1s
+   slots, all hard forks at epoch 0 (instant Conway).
 
 2. **At startup**, the harness copies genesis files to a temp
    directory and patches `systemStart` to current UTC time + 5
@@ -109,6 +112,10 @@ single-node devnet:
   `GET /tx/:txId` blocking endpoint
 - **ProofsSpec** — proof-bearing reads and facts checked against the
   indexed trusted root
+- **BootFactsSpec** — `POST /facts/boot`: verify facts, build the
+  boot transaction locally, submit, and confirm indexing
+- **CrashRecoverySpec** — kill the service during following and
+  verify cage state survives the restart
 - **TokensCompletenessSpec** — token set completeness witnesses
 - **TokenFactsCompletenessSpec** — fact enumeration completeness
 - **FactsMatrixSpec** — local-cluster matrix for facts endpoints,

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,8 @@ The current bounded-refund cage script hash is
 
 ## Documentation
 
+- [Installation](installation.md) --- release tarballs, Nix packages, Docker image, running `mpfs-serve`
+- [CLI manual](cli/index.md) --- `mpfs-cli` commands, walkthrough, troubleshooting
 - [Architecture Overview](architecture/overview.md) --- system diagram, fact-provider flow, dependency graph, module hierarchy
 - [Block Processing](architecture/block-processing.md) --- one block = one RocksDB transaction over UTxO CSMT, cage state, and MPF tries
 - [Data Sources](architecture/data-sources.md) --- ChainSync, indexed proof reads, `GET /eval-context`, and submission flow

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,60 @@
+# Installation
+
+## Release tarballs
+
+Each [GitHub release](https://github.com/lambdasistemi/cardano-mpfs-offchain/releases)
+ships self-contained `mpfs-cli` bundles for `x86_64-linux` and
+`aarch64-darwin`:
+
+```bash
+tar -xzf mpfs-cli-<version>-x86_64-linux.tar.gz
+./mpfs-cli-<version>/bin/mpfs-cli --help
+```
+
+The bundle carries its own libraries and loader, so no Nix or Haskell
+toolchain is needed on the target machine.
+
+## Nix
+
+The flake exposes the server and tools as packages:
+
+```bash
+nix build .#mpfs-serve   # production server
+nix build .#mpfs-cli     # command-line client
+nix run .#mpfs-devnet-server -- --port 3000   # devnet + API, for testing
+```
+
+## Docker
+
+`just build-docker` builds the server image via Nix and loads it into
+the local Docker daemon as
+`ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve`, tagged with
+the flake version.
+
+## Running the server
+
+`mpfs-serve` connects to a running cardano-node through its Unix
+socket:
+
+```bash
+mpfs-serve \
+  --socket /path/to/node.socket \
+  --db /path/to/db \
+  --port 3000 \
+  --shelley-genesis /path/to/shelley-genesis.json \
+  --blueprint /path/to/cage.json
+```
+
+| Flag | Required | Meaning |
+|------|----------|---------|
+| `--socket` | yes | cardano-node N2C Unix socket |
+| `--db` | yes | RocksDB directory (created if missing) |
+| `--port` | no (default 3000) | HTTP listen port |
+| `--shelley-genesis` | yes | Shelley genesis JSON (network magic, stability window, security parameter) |
+| `--blueprint` | yes | CIP-57 cage blueprint JSON (validator identity) |
+| `--byron-genesis` | no | Byron genesis JSON |
+| `--epoch-slots` | no (default 21600) | Byron epoch slots |
+| `--mainnet` | no (default testnet) | Address network discriminator |
+
+The service logs JSON lines on stderr and serves Swagger UI at
+`/swagger-ui`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,9 +6,12 @@ Each [GitHub release](https://github.com/lambdasistemi/cardano-mpfs-offchain/rel
 ships self-contained `mpfs-cli` bundles for `x86_64-linux` and
 `aarch64-darwin`:
 
+The tarball unpacks `bin/`, `lib/`, and `libexec/` into the current
+directory:
+
 ```bash
-tar -xzf mpfs-cli-<version>-x86_64-linux.tar.gz
-./mpfs-cli-<version>/bin/mpfs-cli --help
+mkdir mpfs-cli && tar -xzf mpfs-cli-<version>-x86_64-linux.tar.gz -C mpfs-cli
+./mpfs-cli/bin/mpfs-cli --help
 ```
 
 The bundle carries its own libraries and loader, so no Nix or Haskell

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,8 +54,9 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - CLI:
-      - Overview: cli/index.md
+  - Installation: installation.md
+  - User manual:
+      - CLI: cli/index.md
       - Walkthrough: cli/walkthrough.md
       - Troubleshooting: cli/troubleshooting.md
   - Architecture:

--- a/skills/cardano-mpfs-offchain-guide/SKILL.md
+++ b/skills/cardano-mpfs-offchain-guide/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: cardano-mpfs-offchain-guide
+description: Guide to the lambdasistemi/cardano-mpfs-offchain repository — the off-chain fact-provider service for Cardano Merkle Patricia Forestry (MPFS). Load when working in this repo or answering questions about it. Covers the seven Haskell packages (cardano-mpfs-offchain server, cardano-mpfs-api, cardano-mpfs-verify, cardano-mpfs-cage-tx, cardano-mpfs-client, cardano-mpfs-workflows, cardano-mpfs-cli), the mpfs-spa PureScript browser SPA, executables (mpfs-serve, mpfs-cli, mpfs-devnet-server, mpfs-cage-reactor, mpfs-verify-reactor), the proof-bearing HTTP API (GET /tokens, /utxo, POST /facts/boot, /facts/update, /submit, /tx/sweep, swagger-ui), the RocksDB cage indexer (CageFollower, one block = one transaction, CSMT, MPF tries), CIP-30 wallet signing, environment variables MPFS_SERVER, MPFS_SIGNER_WALLET, MPFS_BLUEPRINT, and the just/nix/cabal build and test commands (just unit, just e2e, just ci).
+---
+
+# cardano-mpfs-offchain guide
+
+## Repository map
+
+| Path | Purpose |
+|------|---------|
+| `cardano-mpfs-offchain/` | Server package: RocksDB cage indexer, Servant HTTP API, executables (`exe/`), unit tests (`test/`), E2E tests (`e2e-test/`) |
+| `cardano-mpfs-api/` | Shared Servant API type and JSON wire DTOs |
+| `cardano-mpfs-verify/` | Pure proof verifiers (`verifyTokenState`, `verify*Facts`); compiles native, wasm32-wasi, GHC-JS |
+| `cardano-mpfs-cage-tx/` | Pure client-side cage transaction builders (`*WithEval`) and the `mpfs-cage-reactor` executable |
+| `cardano-mpfs-client/` | Native HTTP client wrappers; re-exports the verifier surface; `mpfs-verify` executable |
+| `cardano-mpfs-workflows/` | Verified read/write workflows over the client surface |
+| `cardano-mpfs-cli/` | `mpfs-cli` executable (owner/requester lifecycle) |
+| `mpfs-spa/` | PureScript + Halogen browser SPA, talks HTTP + CIP-30, runs the wasm cage reactor |
+| `lean/` | Lean 4 formal model of the Phase 4 proof design |
+| `docs/` | mkdocs site: installation, CLI manual, architecture, swagger |
+| `specs/` | Speckit feature specs/plans/tasks, one directory per issue |
+| `nix/`, `flake.nix` | haskell.nix project, wasm targets, SPA derivation, docker image |
+| `deploy/` | SPA nginx/Docker deployment |
+| `scripts/` | E2E and deployment shell scripts |
+
+Code maps with per-module detail: `NAVIGATION.md` (repo root) and
+`cardano-mpfs-offchain/NAVIGATION.md` (server package).
+
+## Build, test, run
+
+Everything runs from `nix develop` via `just`:
+
+```bash
+just build           # cabal build all (-O0)
+just unit            # offchain unit tests (nix run .#unit-tests)
+just unit-client     # client unit tests
+just unit-workflows  # workflows unit tests
+just unit-cli        # CLI unit tests
+just e2e             # E2E: spawns a cardano-node devnet subprocess
+just e2e-spa         # Playwright SPA test against a local devnet
+just format          # fourmolu
+just hlint           # hlint
+just ci              # full local CI mirror
+just update-swagger  # regenerate docs/assets/swagger.json
+just docs            # mkdocs serve
+```
+
+Pass a test pattern with `just unit "pattern"` / `just e2e "pattern"`.
+Direct flake apps: `nix run .#mpfs-devnet-server -- --port 3000`,
+`nix run .#mpfs-cli -- --help`, `nix build .#mpfs-serve`.
+
+## Navigating the code
+
+- **Server entry point**: `cardano-mpfs-offchain/exe/Serve.hs`
+  (`mpfs-serve` flags) → `Cardano.MPFS.Application.withApplication`
+  (full wiring: RocksDB, two N2C connections, Context) →
+  `Cardano.MPFS.HTTP.Server.mkApp` (all handlers).
+- **HTTP API type**: `cardano-mpfs-api/lib/Cardano/MPFS/API.hs`
+  (canonical Servant API); wire types in `Cardano.MPFS.API.Types*`.
+- **Indexer**: `Cardano.MPFS.Indexer.CageFollower` (chain-follower
+  Runner integration), `Indexer.Backend` (`composedInit` business
+  logic), `Indexer.Follower` (event detection/application/inverses),
+  `Indexer.Columns` (14-column DB schema), `Indexer.Reads` (atomic
+  `IndexerTx` reads used by handlers via `Context.runIndexerTx`).
+- **Service records**: `Provider`, `State`, `Trie`, `Submitter`,
+  `TxBuilder`, `Context` — records of functions, no typeclasses;
+  mocks under `Cardano.MPFS.Mock.*`.
+- **Verifiers**: `cardano-mpfs-verify/lib/Cardano/MPFS/Client/`
+  (`Verify.Read`, `Facts`, `Verify.Completeness`, `Verify.MPF`).
+- **Client builders**: `cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/`
+  (one module per operation; `Reactor` is the JSON-envelope
+  dispatcher compiled to wasm).
+- **CLI**: `cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Options.hs` is the
+  authoritative command/flag tree; `Run.hs` drives the workflows.
+- To find a feature: grep `cardano-mpfs-api` for the endpoint type,
+  then the handler in `HTTP/Server.hs`, then the verifier in
+  `cardano-mpfs-verify` and the builder in `cardano-mpfs-cage-tx`.
+
+## Using the service and CLI
+
+Server (needs a synced cardano-node socket):
+
+```bash
+mpfs-serve --socket node.socket --db ./db --port 3000 \
+  --shelley-genesis shelley-genesis.json --blueprint cage.json
+```
+
+CLI configuration: `MPFS_SERVER` (base URL), `MPFS_SIGNER_WALLET`
+(Bech32 `ed25519_sk1...` key file), `MPFS_BLUEPRINT` (cage blueprint
+JSON). Lifecycle: `register-token` → `fact insert/update/delete`
+(requester) → `token process` (owner folds requests) → `fact get` /
+`fact list` (verified reads) → `fact retract` / `fact reject` →
+`token end`. All write commands verify server facts locally, build,
+sign, and submit; `--json` gives machine-readable output.
+
+Live deployment: <https://umpfs.plutimus.com> (API) and
+<https://umpfs.plutimus.com/spa/> (browser SPA). Swagger UI at
+`/swagger-ui` on any running server.
+
+## Answering questions
+
+- "What is this / how does it work?" — README **What is this** and
+  `docs/architecture/overview.md` (fact-provider model, submit gate).
+- "How do I install / run it?" — `docs/installation.md`; README
+  **Install** and **Quickstart**.
+- "What endpoints exist?" — README **HTTP API** table;
+  `docs/assets/swagger.json` is generated from the code
+  (`just update-swagger`) and is always current.
+- "How do I use the CLI?" — `docs/cli/index.md` (manual),
+  `docs/cli/walkthrough.md` (full lifecycle),
+  `docs/cli/troubleshooting.md` (409s, key formats, timing windows).
+- "How is block processing atomic?" —
+  `docs/architecture/block-processing.md`.
+- "Which node protocols are used?" —
+  `docs/architecture/data-sources.md` (ChainSync, LSQ, LTxS; no
+  Ogmios).
+- "How is it tested?" — `docs/architecture/testing.md`.
+- "Why is the API facts-first / why no unsigned txs?" —
+  `.specify/memory/constitution.md` and README **What is this**.
+- Validator identity questions: the current cage script hash is in
+  README **What is this**; identity comes from the pinned
+  `cardano-mpfs-onchain` blueprint (flake input + cabal.project pin).


### PR DESCRIPTION
Documentation review against the current code (org docs-sweep). Docs-only diff: markdown plus the mkdocs nav. `docs/architecture/dependencies.md` (machine-generated, drift-gated) is untouched.

## What was inaccurate

- `docs/architecture/overview.md`, `docs/architecture/block-processing.md`, and both `NAVIGATION.md` files referenced modules that no longer exist: `Indexer.Rollback` (`storeRollbackT`/`rollbackToSlotT`), `TxBuilder.Real.Boot`, `Mock.Indexer`, `Mock.Skeleton`, and a lib-root `Indexer` record. Rollback is now owned by chain-follower's `Runner` (`processBlock`/`rollbackTo`) over `Backend.composedInit`, with `ComposedInv` rollback points and `applyCageInverses`.
- `block-processing.md` described the superseded mechanism: direct `forwardTip`/`rollbackTip` calls, an `IORef` rollback counter reconstructed via `countRollbackPoints`, separate checkpoint writes, and a "Rewind" path on impossible rollback. Current code threads the phase through continuations, derives the checkpoint from the latest rollback point, and wipes/rebuilds (armageddon) when the target predates history.
- `testing.md` attributed the E2E harness to a local `Cardano.MPFS.E2E.Devnet` module and claimed genesis files are "checked into `e2e-test/genesis/`"; the harness is `Cardano.Node.Client.E2E.Devnet` from cardano-node-clients and genesis ships with its `devnet-genesis` package (`E2E_GENESIS_DIR`). The spec tables were missing `SubmitScopeSpec`, `BootFactsSpec`, `CrashRecoverySpec`.
- `cardano-mpfs-offchain/NAVIGATION.md` documented the pre-pivot architecture (local `NodeClient/` layer, `Core.Balance`, `Core.Bootstrap`, server-side boot builder, `CageRollbacks` column). Rewritten against the tree.
- The overview's singleton diagram drew the indexer as a `Context` field; `Context` has no such field — `Application` drives the `CageFollower` and `Context` reads through `runIndexerTx`. `Mock.Submitter` was described as always-succeeds; it rejects.
- Root `CLAUDE.md` claimed a `merkle-patricia-forestry/` directory that does not exist (the trie lives in the haskell-mts pin).

## What changed

- Factual fixes above, plus `PLAN.md` marked historical.
- README restructured to the shared section order (what is this / architecture / install / quickstart / usage / documentation / development / license); the dependency diagram gains the three packages it omitted (`cardano-mpfs-client`, `cardano-mpfs-workflows`, `cardano-mpfs-cli`) with edges matching the cabal build-depends; metrics endpoints added to the API table.
- New `docs/installation.md` (release tarball layout per release.yml, nix packages, docker image — local load only, CI does not publish it; `mpfs-serve` flags per `exe/Serve.hs`); mkdocs nav gains Installation and groups the CLI pages as the user manual.
- Agent layer: `AGENTS.md` (portable guidance, corrected structure), `skills/cardano-mpfs-offchain-guide/SKILL.md`, `CLAUDE.md` reduced to a thin pointer. The speckit-generated per-feature notes formerly in CLAUDE.md remain available in `specs/*/plan.md`.

## Verification

- Endpoint table checked row-by-row against `cardano-mpfs-api/lib/Cardano/MPFS/API.hs`, `HTTP/Server.hs`, and `docs/assets/swagger.json` (26 paths, in sync).
- CLI docs checked against `cardano-mpfs-cli` `Options.hs`/`Run.hs`/`Cage.hs` (commands, flags, env vars, defaults).
- Module tables and diagrams checked node-by-node against the tree and export lists (`Indexer/*`, `TxBuilder/*`, `Mock/*`, `Context`, `TrieManager`, `TxBuilder` records).
- All 13 mermaid blocks in the touched files render with mermaid-cli 11.12.0.
- `mkdocs build --strict` run with the same shell the deploy workflow uses (`nix develop github:paolino/dev-assets?dir=mkdocs`).
