### PR TITLE
chore(ci): mint homebrew-tap token from CI App in darwin-release

### DIFF
--- a/.github/workflows/darwin-release.yml
+++ b/.github/workflows/darwin-release.yml
@@ -87,9 +87,18 @@ jobs:
             "$SERVE_TARBALL" \
             "$CLI_TARBALL"
 
+      - name: Mint a scoped tap token
+        id: tap-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: lambdasistemi
+          repositories: homebrew-tap
+
       - name: Update homebrew tap
         env:
-          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+          TAP_TOKEN: ${{ steps.tap-token.outputs.token }}
         run: |
           VERSION=$(cat /tmp/version.txt)
           TAG="darwin-${VERSION}"


### PR DESCRIPTION
`darwin-release.yml` still authenticated the homebrew-tap push with the `TAP_TOKEN` PAT, while `release.yml` already mints a short-lived token from the `lambdasistemi-ci` App. This aligns `darwin-release.yml` to the same pattern (App token scoped to `homebrew-tap`). After merge, `secrets.TAP_TOKEN` is unused in this repo and can be deleted. Part of the org PAT→App consolidation.