### PR TITLE
chore(ci): use org CI_APP creds for tap mint in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,8 @@ jobs:
         id: tap-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.TAP_APP_ID }}
-          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           owner: lambdasistemi
           repositories: homebrew-tap
 


### PR DESCRIPTION
`release.yml` minted the homebrew-tap token from repo-level `TAP_APP_ID`/`TAP_APP_PRIVATE_KEY`; `darwin-release.yml` already uses the org-level `vars.CI_APP_ID`/`secrets.CI_APP_PRIVATE_KEY` (same `lambdasistemi-ci` App). This aligns both. After merge the repo-level `TAP_APP_*` secrets are unreferenced and will be deleted. Final step of the org PAT→App consolidation.