### PR TITLE
feat(#378): bump onchain to staking-script release, wire cfgStakeScript

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -100,8 +100,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/cardano-foundation/cardano-mpfs-onchain
-  tag: 457c1cbcbbf622d0e583a3e9c0b413de079f315a
-  --sha256: 19m88h0ga5s09vrqqglj0wbwy4knvi9yy4mab9hwdb8mrrfdh5ig
+  tag: 39bf3302fce7c7097b432767606a9485a9faa940
+  --sha256: 1xk64xdhv53d6zq4qv1xsawaad4jkinfi9ld5sv9ixnqn8axj29b
   subdir: haskell
 
 constraints:

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Boot.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Boot.hs
@@ -364,6 +364,7 @@ bootStateDatum cfg ownerAddr =
                 in  c
             , stateProcessTime = defaultProcessTime cfg
             , stateRetractTime = defaultRetractTime cfg
+            , stateStakeScript = Nothing
             }
 
 txInToRef :: TxIn -> OnChainTxOutRef

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Reactor.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Reactor.hs
@@ -374,7 +374,7 @@ operationSeries (OpUpdate old new) =
         <> "new" .= bytesHex new
 
 stateSeries :: Text -> OnChainTokenState -> Series
-stateSeries tokenId OnChainTokenState{..} =
+stateSeries tokenId OnChainTokenState{stateStakeScript = _, ..} =
     "datum" .= ("state" :: Text)
         <> "token_id" .= tokenId
         <> "owner" .= builtinHex stateOwner

--- a/cardano-mpfs-cage-tx/test/Cardano/MPFS/Client/Cage/ReactorSpec.hs
+++ b/cardano-mpfs-cage-tx/test/Cardano/MPFS/Client/Cage/ReactorSpec.hs
@@ -357,6 +357,7 @@ stateTxOut =
                 , stateMaxFee = 1_000_000
                 , stateProcessTime = 60_000
                 , stateRetractTime = 30_000
+                , stateStakeScript = Nothing
                 }
     stateValue =
         MaryValue

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
@@ -651,6 +651,7 @@ stateTxOut cfg asset =
                 , stateMaxFee = 1_000_000
                 , stateProcessTime = 60_000
                 , stateRetractTime = 30_000
+                , stateStakeScript = Nothing
                 }
 
 walletTxOutBytes :: ByteString

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RejectSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RejectSpec.hs
@@ -690,6 +690,7 @@ sampleOnChainTokenState =
         , stateMaxFee = 1_000_000
         , stateProcessTime = 60_000
         , stateRetractTime = 30_000
+        , stateStakeScript = Nothing
         }
 
 expectedRootBytes :: ByteString

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RetractSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RetractSpec.hs
@@ -498,6 +498,7 @@ stateTxOut stateAddr cfg asset =
                 , stateMaxFee = 1_000_000
                 , stateProcessTime = 60_000
                 , stateRetractTime = 30_000
+                , stateStakeScript = Nothing
                 }
 
 walletTxOutBytes :: ByteString

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/UpdateSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/UpdateSpec.hs
@@ -882,6 +882,7 @@ stateTxOut cfg asset root =
                 , stateMaxFee = 1_000_000
                 , stateProcessTime = 60_000
                 , stateRetractTime = 30_000
+                , stateStakeScript = Nothing
                 }
 
 requestTxOut :: Coin -> Addr -> OnChainRequest -> TxOut ConwayEra

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Fixtures.hs
@@ -293,6 +293,7 @@ stateDatumTerm root =
         [ constr
             0
             [ CBOR.TBytes (BS.replicate 28 0xAA)
+            , constr 1 []
             , CBOR.TBytes root
             , CBOR.TInteger 1_000_000
             , CBOR.TInteger 60_000

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReactorSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Verify/ReactorSpec.hs
@@ -11,6 +11,8 @@ module Cardano.MPFS.Client.Verify.ReactorSpec
     ( spec
     ) where
 
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
 import Data.Aeson
     ( Value (..)
     , eitherDecodeStrict'
@@ -28,6 +30,7 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short (ShortByteString, fromShort)
 import Data.Text (Text)
+import Data.Word (Word64)
 import System.Environment (getEnv)
 import Test.Hspec
     ( Spec
@@ -37,12 +40,54 @@ import Test.Hspec
     , shouldSatisfy
     )
 
+import CSMT (Direction (..), Standalone (StandaloneCSMTCol))
+import CSMT.Backend.Pure (runPureTransaction)
+import CSMT.Core.CBOR (renderCompletenessProof)
+import CSMT.Core.Hash
+    ( Hash
+    , byteStringToKey
+    , renderHash
+    )
+import CSMT.Hashes (mkHash)
+import CSMT.Proof.Completeness (CompletenessProof, generateProof)
+import CSMT.Test.Lib
+    ( evalPureFromEmptyDB
+    , getRootHashM
+    , hashCodecs
+    , insertMHash
+    )
+
+import Cardano.Ledger.BaseTypes (Network (Testnet))
 import Cardano.MPFS.API.Encoding (Hex (..))
-import Cardano.MPFS.API.Types (UnsignedTxResponse (..))
+import Cardano.MPFS.API.Types
+    ( ChainPointJSON (..)
+    , RequestsResponse (..)
+    , TokenIdJSON (..)
+    , TokenSetWitness (..)
+    , TokenUtxoEntry (..)
+    , TokensResponse (..)
+    , TxInJSON (..)
+    , UnsignedTxResponse (..)
+    , UtxoEntryRefOnly (..)
+    , UtxoRef (..)
+    , UtxoSetWitness (..)
+    , VerificationSnapshot (..)
+    , WitnessedRequest (..)
+    , WitnessedUtxo (..)
+    )
 import Cardano.MPFS.Cage.Blueprint
     ( Blueprint
     , extractCompiledCode
     , loadBlueprint
+    )
+import Cardano.MPFS.Cage.Ledger (Coin (..))
+import Cardano.MPFS.Client.Cage.Config
+    ( CageConfig (..)
+    , computeScriptHash
+    )
+import Cardano.MPFS.Client.Cage.Identity
+    ( cageSetPrefixFromCfg
+    , requestSetPrefixFromCfg
     )
 import Cardano.MPFS.Client.Facts
     ( BootFacts (..)
@@ -81,29 +126,31 @@ spec = describe "runEnvelope" $ do
             (envelope "boot" honestBootTrustedRoot (object []))
         `shouldSatisfy` hasPrefix "bad_facts: "
 
-    describe "read-side ops captured from umpfs.plutimus.com" $ do
-        it "verifies a raw /tokens response" $ do
-            cfg <- cageConfigValue
-            payload <- fixtureValue "tokens.json"
+    describe "read-side ops" $ do
+        it "verifies a /tokens response" $ do
+            cfg <- parsedCageConfig
+            cfgValue <- cageConfigValue
+            let (tr, payload) = genTokensPayload cfg
             runEnvelope
                 ( envelopeWithCage
                     "verify_tokens"
-                    (trustedRootOf payload)
+                    tr
                     payload
-                    cfg
+                    cfgValue
                 )
                 `shouldBe` "verify_ok"
 
-        it "verifies a raw /tokens/:id/requests response" $ do
-            cfg <- cageConfigValue
-            payload <- fixtureValue "token-requests.json"
+        it "verifies a /tokens/:id/requests response" $ do
+            cfg <- parsedCageConfig
+            cfgValue <- cageConfigValue
+            let (tr, payload) = genRequestsPayload cfg syntheticTokenId
             runEnvelope
                 ( snapshotEnvelope
                     "verify_snapshot"
-                    requestsTokenId
-                    (trustedRootOf payload)
+                    syntheticTokenIdHex
+                    tr
                     payload
-                    cfg
+                    cfgValue
                 )
                 `shouldBe` "verify_ok"
 
@@ -129,27 +176,29 @@ spec = describe "runEnvelope" $ do
                 `shouldBe` "verify_ok"
 
         it "rejects a tampered /tokens response" $ do
-            cfg <- cageConfigValue
-            payload <- fixtureValue "tokens.json"
+            cfg <- parsedCageConfig
+            cfgValue <- cageConfigValue
+            let (tr, payload) = genTokensPayload cfg
             runEnvelope
                 ( envelopeWithCage
                     "verify_tokens"
-                    (trustedRootOf payload)
+                    tr
                     (tamperSnapshotRoot payload)
-                    cfg
+                    cfgValue
                 )
                 `shouldSatisfy` hasPrefix "verify_error: "
 
         it "rejects a tampered /tokens/:id/requests response" $ do
-            cfg <- cageConfigValue
-            payload <- fixtureValue "token-requests.json"
+            cfg <- parsedCageConfig
+            cfgValue <- cageConfigValue
+            let (tr, payload) = genRequestsPayload cfg syntheticTokenId
             runEnvelope
                 ( snapshotEnvelope
                     "verify_snapshot"
-                    requestsTokenId
-                    (trustedRootOf payload)
+                    syntheticTokenIdHex
+                    tr
                     (tamperSnapshotRoot payload)
-                    cfg
+                    cfgValue
                 )
                 `shouldSatisfy` hasPrefix "verify_error: "
 
@@ -308,9 +357,148 @@ requireCompiledCode prefix blueprint =
 scriptHex :: ShortByteString -> Hex
 scriptHex = Hex . fromShort
 
-requestsTokenId :: Text
-requestsTokenId =
-    "976821dbd0922f93cda689da92a6faf1894c8151bc86d6c8f725ec089aaacbc6"
+parsedCageConfig :: IO CageConfig
+parsedCageConfig = do
+    blueprintPath <- getEnv "MPFS_BLUEPRINT"
+    eBlueprint <- loadBlueprint blueprintPath
+    blueprint <- case eBlueprint of
+        Left err -> fail ("loadBlueprint failed: " <> err)
+        Right bp -> pure bp
+    stateBytes <- requireCompiledCode "state." blueprint
+    requestBytes <- requireCompiledCode "request." blueprint
+    pure
+        CageConfig
+            { cageScriptBytes = stateBytes
+            , requestScriptBytes = requestBytes
+            , cfgScriptHash = computeScriptHash stateBytes
+            , defaultProcessTime = 60_000
+            , defaultRetractTime = 30_000
+            , defaultTip = Coin 1_000_000
+            , network = Testnet
+            }
+
+-- | Build a minimal in-memory CSMT with one entry under @prefix@ plus
+-- two diverging siblings, and return the CSMT root bytes and a
+-- completeness witness for that prefix.
+genCsmtRow :: [Direction] -> (ByteString, UtxoSetWitness)
+genCsmtRow prefix = evalPureFromEmptyDB $ do
+    let entryKey = prefix <> byteStringToKey (encodeTxIn fakeTxId 0)
+    insertMHash entryKey (mkHash fakeTxOut)
+    insertMHash (divergeAt 0) (mkHash "sibling-0")
+    insertMHash (divergeAt 127) (mkHash "sibling-127")
+    mProof <-
+        runPureTransaction hashCodecs
+            $ generateProof StandaloneCSMTCol [] prefix
+    rootBs <- maybe BS.empty renderHash <$> getRootHashM
+    let proofBs = case mProof of
+            Just p -> renderCompletenessProof (p :: CompletenessProof Hash)
+            Nothing -> error "genCsmtRow: completeness proof missing"
+    pure
+        ( rootBs
+        , UtxoSetWitness
+            { uswEntries =
+                [ UtxoEntryRefOnly
+                    { uerRef =
+                        UtxoRef
+                            { urTxId = Hex fakeTxId
+                            , urTxIx = 0
+                            }
+                    , uerTxOutCbor = Hex fakeTxOut
+                    }
+                ]
+            , uswCompletenessProof = Hex proofBs
+            }
+        )
+  where
+    divergeAt n =
+        case splitAt n prefix of
+            (before, L : _) -> before <> [R] <> byteStringToKey (BS.pack [fromIntegral n])
+            (before, R : _) -> before <> [L] <> byteStringToKey (BS.pack [fromIntegral n])
+            _ -> byteStringToKey (BS.pack [fromIntegral n])
+
+encodeTxIn :: ByteString -> Word64 -> ByteString
+encodeTxIn txIdBs txIx =
+    CBOR.toStrictByteString
+        $ mconcat
+            [ CBOR.encodeListLen 2
+            , CBOR.encodeBytes txIdBs
+            , CBOR.encodeWord64 txIx
+            ]
+
+fakeTxId :: ByteString
+fakeTxId = BS.replicate 32 0x42
+
+fakeTxOut :: ByteString
+fakeTxOut = "fake-txout-cbor"
+
+snapshotWithRoot :: ByteString -> VerificationSnapshot
+snapshotWithRoot rootBs =
+    VerificationSnapshot
+        { vsUtxoRoot = Hex rootBs
+        , vsChainPoint =
+            ChainPointJSON
+                { cpSlot = 0
+                , cpBlockId = Hex (BS.replicate 32 0)
+                }
+        }
+
+genTokensPayload :: CageConfig -> (TrustedRoot, Value)
+genTokensPayload cfg =
+    let (rootBs, tokenSet) = genCsmtRow (cageSetPrefixFromCfg cfg)
+        resp =
+            TokensResponse
+                { trsSnapshot = snapshotWithRoot rootBs
+                , trsTokens =
+                    TokenSetWitness
+                        { tswEntries =
+                            [ TokenUtxoEntry
+                                { tueRef =
+                                    UtxoRef
+                                        { urTxId = Hex fakeTxId
+                                        , urTxIx = 0
+                                        }
+                                , tueTxOutCbor = Hex fakeTxOut
+                                }
+                            ]
+                        , tswCompletenessProof =
+                            uswCompletenessProof tokenSet
+                        }
+                }
+    in  (TrustedRoot (Hex rootBs), toJSON resp)
+
+genRequestsPayload
+    :: CageConfig -> TokenIdJSON -> (TrustedRoot, Value)
+genRequestsPayload cfg token =
+    let requestPrefix = requestSetPrefixFromCfg cfg token
+        (rootBs, requestSet) = genCsmtRow requestPrefix
+        resp =
+            RequestsResponse
+                { rrSnapshot = snapshotWithRoot rootBs
+                , rrRequestSet = requestSet
+                , rrRequests =
+                    [ WitnessedRequest
+                        { wrUtxo =
+                            WitnessedUtxo
+                                { wuTxIn =
+                                    TxInJSON
+                                        { tjTxId = Hex fakeTxId
+                                        , tjTxIx = 0
+                                        }
+                                , wuTxOut = Hex fakeTxOut
+                                , wuProof = Hex "\x82\x01\x02"
+                                }
+                        }
+                    ]
+                }
+    in  (TrustedRoot (Hex rootBs), toJSON resp)
+
+-- | Synthetic token-ID used for the inline-generated requests fixture.
+-- Hex text "cafe" decodes to bytes [0xca, 0xfe].
+syntheticTokenId :: TokenIdJSON
+syntheticTokenId = TokenIdJSON "\xca\xfe"
+
+syntheticTokenIdHex :: Text
+syntheticTokenIdHex = "cafe"
 
 factKey :: Text
 factKey = "70616f6c696e6f"

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/BootFactsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/BootFactsSpec.hs
@@ -386,7 +386,7 @@ withE2E scripts action = do
                 action cfg ctx
 
 cageCfg :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -395,4 +395,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 5_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -71,6 +71,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     , walletBootInputs
     , withBootFactsTxBuilder
     )
@@ -688,6 +689,7 @@ withE2E scripts action = do
                     -- Let ChainSync catch up to
                     -- the tip before submitting txs
                     awaitProofReadsReady ctx'
+                    registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'
 
 -- ---------------------------------------------------------

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -792,7 +792,7 @@ extractTokenId cfg tx =
 -- | Build a 'CageConfig' from state and request script bytes.
 cageCfg
     :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -802,4 +802,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 15_000
         , defaultTip = Coin 100_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -87,7 +87,7 @@ import Cardano.MPFS.Core.Types
 import Cardano.MPFS.E2E.Helpers.Boot
     ( registerStakeCredIfNeeded
     , walletBootInputs
-    , withBootFactsTxBuilder
+    , withWalletBootTxBuilder
     )
 import Cardano.MPFS.Provider
     ( Provider (..)
@@ -443,7 +443,7 @@ withE2E scripts action = do
                         nullTracer
                     }
         withApplication appCfg $ \ctx -> do
-            let ctx' = withBootFactsTxBuilder cfg ctx
+            let ctx' = withWalletBootTxBuilder cfg ctx
             _ <-
                 queryProtocolParams
                     (provider ctx')

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -620,7 +620,7 @@ truthy value =
 -- | Build a 'CageConfig' from state and request script bytes.
 cageCfg
     :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -630,4 +630,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 30_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -85,7 +85,8 @@ import Cardano.MPFS.Core.Types
     , TokenState (..)
     )
 import Cardano.MPFS.E2E.Helpers.Boot
-    ( walletBootInputs
+    ( registerStakeCredIfNeeded
+    , walletBootInputs
     , withBootFactsTxBuilder
     )
 import Cardano.MPFS.Provider
@@ -446,6 +447,7 @@ withE2E scripts action = do
             _ <-
                 queryProtocolParams
                     (provider ctx')
+            registerStakeCredIfNeeded cfg ctx'
             action sock startMs cfg ctx'
 
 -- ---------------------------------------------------------

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -64,6 +64,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     , walletBootInputs
     , withBootFactsTxBuilder
     )
@@ -336,6 +337,7 @@ withE2E scripts action = do
                     -- Let ChainSync catch up to
                     -- the tip before submitting txs
                     awaitProofReadsReady ctx'
+                    registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'
 
 -- ---------------------------------------------------------

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -424,7 +424,7 @@ pollUntilJust timeoutSec action = go attempts
 -- | Build a 'CageConfig' from state and request script bytes.
 cageCfg
     :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -434,4 +434,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 15_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
@@ -379,7 +379,7 @@ emptySnap =
 
 cageCfg
     :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -389,4 +389,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 15_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/FactsMatrixSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/FactsMatrixSpec.hs
@@ -2035,7 +2035,7 @@ withE2E scripts action = do
                 action cfg ctx
 
 cageCfg :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -2044,4 +2044,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 5_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -448,7 +448,7 @@ withE2E scripts action = do
 
 cageCfg
     :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -458,4 +458,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 5_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -92,6 +92,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     , walletBootInputs
     , withBootFactsTxBuilder
     )
@@ -440,6 +441,7 @@ withE2E scripts action = do
                         queryProtocolParams
                             (provider ctx')
                     awaitProofReadsReady ctx'
+                    registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'
 
 -- -------------------------------------------------

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -32,14 +32,15 @@ module Cardano.MPFS.E2E.Helpers.Boot
     ( walletBootInputs
     , withBootFactsTxBuilder
     , awaitProofReadsReady
+    , registerStakeCredIfNeeded
     ) where
 
-import Control.Concurrent (threadDelay)
-import Data.ByteString qualified as BS
-import Data.Text qualified as T
-
 import Control.Applicative ((<|>))
-import Control.Monad (when)
+import Control.Concurrent (threadDelay)
+import Control.Monad (void, when)
+import Data.ByteString qualified as BS
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
 
 import Cardano.Ledger.Address (Addr)
 import Cardano.Ledger.Binary
@@ -48,6 +49,12 @@ import Cardano.Ledger.Binary
     )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Node.Client.E2E.Setup
+    ( addKeyWitness
+    , genesisAddr
+    , genesisSignKey
+    )
+import Cardano.Tx.Build qualified as Tx
 
 import Cardano.MPFS.API.Types
     ( BootFacts (..)
@@ -72,6 +79,7 @@ import Cardano.MPFS.Indexer.Reads
     , readWalletInputsAt
     )
 import Cardano.MPFS.Provider (Provider (..))
+import Cardano.MPFS.Submitter (SubmitResult (..), Submitter (..))
 import Cardano.MPFS.TxBuilder
     ( BootProof (..)
     , BundleSnapshot (..)
@@ -249,3 +257,65 @@ toClientCageConfig cfg =
         , Client.defaultTip = defaultTip cfg
         , Client.network = network cfg
         }
+
+-- | Register the cage staking credential on the devnet if
+-- 'cfgStakeScript' is set. Must be called once before any
+-- Update or End transaction; those do a zero-ADA withdrawal
+-- from the staking script, which requires the credential to
+-- be registered in the ledger rewards map first.
+-- No-op when 'cfgStakeScript' is 'Nothing'.
+registerStakeCredIfNeeded :: CageConfig -> Context IO -> IO ()
+registerStakeCredIfNeeded cfg ctx =
+    case cfgStakeScript cfg of
+        Nothing -> pure ()
+        Just (_, stakeHash) -> do
+            pp <- queryProtocolParams (provider ctx)
+            utxos <- queryUTxOs (provider ctx) genesisAddr
+            feeInput <-
+                case utxos of
+                    [] ->
+                        fail
+                            "registerStakeCredIfNeeded: \
+                            \no genesis UTxOs available"
+                    (u : _) -> pure u
+            let prog :: Tx.TxBuild NoCtx String ()
+                prog =
+                    void
+                        $ Tx.certify
+                            ( Tx.ConwayTxCertDeleg
+                                ( Tx.ConwayRegCert
+                                    (Tx.ScriptHashObj stakeHash)
+                                    Tx.SNothing
+                                )
+                            )
+                            Tx.PubKeyCert
+            result <-
+                Tx.build
+                    (Tx.mkPParamsBound pp)
+                    (Tx.InterpretIO noCtx)
+                    (\_ -> pure Map.empty)
+                    [feeInput]
+                    []
+                    genesisAddr
+                    prog
+            case result of
+                Left err ->
+                    fail
+                        $ "registerStakeCredIfNeeded: \
+                          \build failed: "
+                            <> show err
+                Right unsigned -> do
+                    let signed = addKeyWitness genesisSignKey unsigned
+                    res <- submitTx (submitter ctx) signed
+                    case res of
+                        Submitted _ -> threadDelay 5_000_000
+                        Rejected msg ->
+                            fail
+                                $ "registerStakeCredIfNeeded: \
+                                  \submit rejected: "
+                                    <> show msg
+
+data NoCtx a
+
+noCtx :: NoCtx a -> IO a
+noCtx q = case q of {}

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- |
 -- Module      : Cardano.MPFS.E2E.Helpers.Boot
@@ -31,6 +32,7 @@
 module Cardano.MPFS.E2E.Helpers.Boot
     ( walletBootInputs
     , withBootFactsTxBuilder
+    , withWalletBootTxBuilder
     , awaitProofReadsReady
     , registerStakeCredIfNeeded
     ) where
@@ -43,15 +45,12 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.Api.Tx (txIdTx)
-import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary
     ( natVersion
     , serialize'
     )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
-import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Node.Client.E2E.Setup
     ( addKeyWitness
     , genesisAddr
@@ -67,7 +66,10 @@ import Cardano.MPFS.Client.Cage.Boot (bootCageTxWithEval)
 import Cardano.MPFS.Client.Cage.Config qualified as Client
 import Cardano.MPFS.Client.Cage.Eval (decodeEvalContext)
 import Cardano.MPFS.Client.Cage.Policy (WalletPolicy (..))
-import Cardano.MPFS.Client.Facts (verifyBootFacts)
+import Cardano.MPFS.Client.Facts
+    ( unsafeVerifiedBootFacts
+    , verifyBootFacts
+    )
 import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
@@ -129,6 +131,63 @@ withBootFactsTxBuilder cfg ctx =
                         buildBootEnvelopeFromFacts cfg ctx addr
                 }
         }
+
+-- | Replace the production boot stub with a wallet-side boot
+-- that uses explicitly-provided inputs (no indexer needed).
+-- Use in test contexts where 'followerEnabled' is 'False'.
+withWalletBootTxBuilder
+    :: CageConfig
+    -> Context IO
+    -> Context IO
+withWalletBootTxBuilder cfg ctx =
+    ctx
+        { txBuilder =
+            (txBuilder ctx)
+                { bootToken = buildBootEnvelopeFromWalletInputs cfg ctx
+                }
+        }
+
+buildBootEnvelopeFromWalletInputs
+    :: CageConfig
+    -> Context IO
+    -> BundleSnapshot
+    -> [ResolvedWalletInput]
+    -> Addr
+    -> IO (ProofEnvelope BootProof)
+buildBootEnvelopeFromWalletInputs cfg ctx snap inputs _addr = do
+    pp <- queryProtocolParams (provider ctx)
+    let facts = mkBootFacts snap inputs pp
+        -- Skip proof verification: CageSpec runs without the CSMT
+        -- indexer (followerEnabled = False) so inclusion proofs are
+        -- empty. The cage TX builder only uses ueRef + ueTxOutCbor.
+        verified = unsafeVerifiedBootFacts facts
+    evalCtxWire <- evalContext ctx
+    evalCtx <-
+        case decodeEvalContext evalCtxWire of
+            Left err ->
+                fail
+                    $ "E2E boot: decodeEvalContext failed: "
+                        <> show err
+            Right v -> pure v
+    tx <-
+        case bootCageTxWithEval
+            evalCtx
+            (toClientCageConfig cfg)
+            permissiveWalletPolicy
+            verified of
+            Left err ->
+                fail
+                    $ "E2E boot: bootCageTx failed: "
+                        <> show err
+            Right v -> pure v
+    pure
+        ProofEnvelope
+            { envTx = tx
+            , envSnapshot = snap
+            , envProof =
+                BootProof
+                    (map witnessedInputFromResolved inputs)
+            }
 
 -- | Wait until the application may serve CSMT proof reads.
 awaitProofReadsReady :: Context IO -> IO ()
@@ -311,28 +370,16 @@ registerStakeCredIfNeeded cfg ctx =
                     let signed = addKeyWitness genesisSignKey unsigned
                     res <- submitTx (submitter ctx) signed
                     case res of
-                        Submitted _ -> do
+                        Submitted _ ->
                             awaitNodeConfirmed (fst feeInput)
-                            indexed <-
-                                awaitUtxo
-                                    ctx
-                                    ( TxIn
-                                        (txIdTx signed)
-                                        (TxIx 0)
-                                    )
-                                    (Just 120)
-                            case indexed of
-                                Nothing ->
-                                    fail
-                                        "registerStakeCredIfNeeded: \
-                                        \cert tx not indexed \
-                                        \within 120s"
-                                Just _ -> pure ()
-                        Rejected msg ->
-                            fail
-                                $ "registerStakeCredIfNeeded: \
-                                  \submit rejected: "
-                                    <> show msg
+                        Rejected msg
+                            | "All inputs are spent" `BS.isInfixOf` msg ->
+                                awaitNodeConfirmed (fst feeInput)
+                            | otherwise ->
+                                fail
+                                    $ "registerStakeCredIfNeeded: \
+                                      \submit rejected: "
+                                        <> show msg
   where
     awaitNodeConfirmed spentRef = go (240 :: Int)
       where

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -308,15 +308,27 @@ registerStakeCredIfNeeded cfg ctx =
                     let signed = addKeyWitness genesisSignKey unsigned
                     res <- submitTx (submitter ctx) signed
                     case res of
-                        Submitted _ ->
-                            awaitCertConfirmed (fst feeInput)
+                        Submitted _ -> do
+                            awaitNodeConfirmed (fst feeInput)
+                            awaitIndexerDropped (fst feeInput)
                         Rejected msg ->
                             fail
                                 $ "registerStakeCredIfNeeded: \
                                   \submit rejected: "
                                     <> show msg
   where
-    awaitCertConfirmed spentRef = go (120 :: Int)
+    awaitNodeConfirmed spentRef = go (240 :: Int)
+      where
+        go 0 =
+            fail
+                "registerStakeCredIfNeeded: \
+                \cert tx not confirmed on-chain after 120s"
+        go n = do
+            utxos <- queryUTxOs (provider ctx) genesisAddr
+            when (any ((== spentRef) . fst) utxos)
+                $ threadDelay 500_000
+                    >> go (n - 1)
+    awaitIndexerDropped spentRef = go (120 :: Int)
       where
         go 0 =
             fail

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -331,9 +331,9 @@ registerStakeCredIfNeeded cfg ctx =
                 Left _ ->
                     threadDelay 500_000 >> go (n - 1)
                 Right inputs ->
-                    if any (\(tin, _, _) -> tin == spentRef) inputs
-                        then threadDelay 500_000 >> go (n - 1)
-                        else pure ()
+                    when (any (\(tin, _, _) -> tin == spentRef) inputs)
+                        $ threadDelay 500_000
+                            >> go (n - 1)
 
 data NoCtx a
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -310,7 +310,11 @@ registerStakeCredIfNeeded cfg ctx =
                     case res of
                         Submitted _ -> do
                             awaitNodeConfirmed (fst feeInput)
-                            awaitIndexerDropped (fst feeInput)
+                            -- Give the chain follower an uncontested
+                            -- window to commit the cert tx block.
+                            -- Polling runIndexerTx here starves the
+                            -- follower of the shared run lock.
+                            threadDelay 15_000_000
                         Rejected msg ->
                             fail
                                 $ "registerStakeCredIfNeeded: \
@@ -328,32 +332,6 @@ registerStakeCredIfNeeded cfg ctx =
             when (any ((== spentRef) . fst) utxos)
                 $ threadDelay 500_000
                     >> go (n - 1)
-    awaitIndexerDropped spentRef = go (120 :: Int) (0 :: Int) (0 :: Int)
-      where
-        go 0 leftCount presentCount =
-            fail
-                $ "registerStakeCredIfNeeded: \
-                  \cert tx not indexed after 60s"
-                    <> " (Left="
-                    <> show leftCount
-                    <> " Present="
-                    <> show presentCount
-                    <> ")"
-        go n leftCount presentCount = do
-            eInputs <-
-                runIndexerTx
-                    ctx
-                    (readWalletInputsAt genesisAddr)
-            case eInputs of
-                Left _ ->
-                    threadDelay 500_000
-                        >> go (n - 1) (leftCount + 1) presentCount
-                Right inputs ->
-                    if any (\(tin, _, _) -> tin == spentRef) inputs
-                        then
-                            threadDelay 500_000
-                                >> go (n - 1) leftCount (presentCount + 1)
-                        else pure ()
 
 data NoCtx a
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -43,12 +43,15 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 
 import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Api.Tx (txIdTx)
+import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary
     ( natVersion
     , serialize'
     )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Plutus.ExUnits (Prices (..))
+import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Node.Client.E2E.Setup
     ( addKeyWitness
     , genesisAddr
@@ -310,11 +313,21 @@ registerStakeCredIfNeeded cfg ctx =
                     case res of
                         Submitted _ -> do
                             awaitNodeConfirmed (fst feeInput)
-                            -- Give the chain follower an uncontested
-                            -- window to commit the cert tx block.
-                            -- Polling runIndexerTx here starves the
-                            -- follower of the shared run lock.
-                            threadDelay 15_000_000
+                            indexed <-
+                                awaitUtxo
+                                    ctx
+                                    ( TxIn
+                                        (txIdTx signed)
+                                        (TxIx 0)
+                                    )
+                                    (Just 120)
+                            case indexed of
+                                Nothing ->
+                                    fail
+                                        "registerStakeCredIfNeeded: \
+                                        \cert tx not indexed \
+                                        \within 120s"
+                                Just _ -> pure ()
                         Rejected msg ->
                             fail
                                 $ "registerStakeCredIfNeeded: \

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -308,12 +308,32 @@ registerStakeCredIfNeeded cfg ctx =
                     let signed = addKeyWitness genesisSignKey unsigned
                     res <- submitTx (submitter ctx) signed
                     case res of
-                        Submitted _ -> threadDelay 5_000_000
+                        Submitted _ ->
+                            awaitCertConfirmed (fst feeInput)
                         Rejected msg ->
                             fail
                                 $ "registerStakeCredIfNeeded: \
                                   \submit rejected: "
                                     <> show msg
+  where
+    awaitCertConfirmed spentRef = go (120 :: Int)
+      where
+        go 0 =
+            fail
+                "registerStakeCredIfNeeded: \
+                \cert tx not indexed after 60s"
+        go n = do
+            eInputs <-
+                runIndexerTx
+                    ctx
+                    (readWalletInputsAt genesisAddr)
+            case eInputs of
+                Left _ ->
+                    threadDelay 500_000 >> go (n - 1)
+                Right inputs ->
+                    if any (\(tin, _, _) -> tin == spentRef) inputs
+                        then threadDelay 500_000 >> go (n - 1)
+                        else pure ()
 
 data NoCtx a
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -328,24 +328,32 @@ registerStakeCredIfNeeded cfg ctx =
             when (any ((== spentRef) . fst) utxos)
                 $ threadDelay 500_000
                     >> go (n - 1)
-    awaitIndexerDropped spentRef = go (120 :: Int)
+    awaitIndexerDropped spentRef = go (120 :: Int) (0 :: Int) (0 :: Int)
       where
-        go 0 =
+        go 0 leftCount presentCount =
             fail
-                "registerStakeCredIfNeeded: \
-                \cert tx not indexed after 60s"
-        go n = do
+                $ "registerStakeCredIfNeeded: \
+                  \cert tx not indexed after 60s"
+                    <> " (Left="
+                    <> show leftCount
+                    <> " Present="
+                    <> show presentCount
+                    <> ")"
+        go n leftCount presentCount = do
             eInputs <-
                 runIndexerTx
                     ctx
                     (readWalletInputsAt genesisAddr)
             case eInputs of
                 Left _ ->
-                    threadDelay 500_000 >> go (n - 1)
+                    threadDelay 500_000
+                        >> go (n - 1) (leftCount + 1) presentCount
                 Right inputs ->
-                    when (any (\(tin, _, _) -> tin == spentRef) inputs)
-                        $ threadDelay 500_000
-                            >> go (n - 1)
+                    if any (\(tin, _, _) -> tin == spentRef) inputs
+                        then
+                            threadDelay 500_000
+                                >> go (n - 1) leftCount (presentCount + 1)
+                        else pure ()
 
 data NoCtx a
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -1222,7 +1222,7 @@ bootAndRegister cfg ctx = do
 -- | Build a 'CageConfig' from state and request script bytes.
 cageCfg
     :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -1232,4 +1232,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 15_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -72,6 +72,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     , walletBootInputs
     , withBootFactsTxBuilder
     )
@@ -1106,6 +1107,7 @@ withE2EWithFollower enableFollower scripts action = do
                         queryProtocolParams
                             (provider ctx')
                     awaitProofReadsReady ctx'
+                    registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'
 
 -- ---------------------------------------------------------

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -75,6 +75,7 @@ import Cardano.MPFS.E2E.Helpers.Boot
     , registerStakeCredIfNeeded
     , walletBootInputs
     , withBootFactsTxBuilder
+    , withWalletBootTxBuilder
     )
 import Cardano.MPFS.Indexer.Event
     ( CageEvent (..)
@@ -1102,7 +1103,9 @@ withE2EWithFollower enableFollower scripts action = do
                             }
                 withApplication appCfg $ \ctx -> do
                     let ctx' =
-                            withBootFactsTxBuilder cfg ctx
+                            if enableFollower
+                                then withBootFactsTxBuilder cfg ctx
+                                else withWalletBootTxBuilder cfg ctx
                     _ <-
                         queryProtocolParams
                             (provider ctx')

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -957,7 +957,7 @@ withE2E scripts action = do
                     action cfg ctx'
 
 cageCfg :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -967,4 +967,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 5_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -126,6 +126,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     , walletBootInputs
     , withBootFactsTxBuilder
     )
@@ -954,6 +955,7 @@ withE2E scripts action = do
                         queryProtocolParams
                             (provider ctx')
                     awaitProofReadsReady ctx'
+                    registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'
 
 cageCfg :: CageScripts -> CageConfig

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
@@ -90,6 +90,7 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types (Coin (..))
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     , withBootFactsTxBuilder
     )
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
@@ -272,6 +273,7 @@ withE2E scripts action = do
                         queryProtocolParams
                             (provider ctx')
                     awaitProofReadsReady ctx'
+                    registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'
 
 -- -------------------------------------------------

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
@@ -280,7 +280,7 @@ withE2E scripts action = do
 
 cageCfg
     :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -290,4 +290,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 5_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokenFactsCompletenessSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokenFactsCompletenessSpec.hs
@@ -248,7 +248,7 @@ withE2E scripts action = do
                 action cfg ctx'
 
 cageCfg :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -257,6 +257,10 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 5_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }
 
 emptySnap :: BundleSnapshot

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokenFactsCompletenessSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokenFactsCompletenessSpec.hs
@@ -32,6 +32,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     , walletBootInputs
     , withBootFactsTxBuilder
     )
@@ -245,6 +246,7 @@ withE2E scripts action = do
                 let ctx' = withBootFactsTxBuilder cfg ctx
                 _ <- queryProtocolParams (provider ctx')
                 awaitProofReadsReady ctx'
+                registerStakeCredIfNeeded cfg ctx'
                 action cfg ctx'
 
 cageCfg :: CageScripts -> CageConfig

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokensCompletenessSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokensCompletenessSpec.hs
@@ -298,7 +298,7 @@ withE2E scripts action = do
                 action cfg ctx'
 
 cageCfg :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -307,6 +307,10 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 5_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }
 
 emptySnap :: BundleSnapshot

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokensCompletenessSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokensCompletenessSpec.hs
@@ -48,6 +48,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     , walletBootInputs
     , withBootFactsTxBuilder
     )
@@ -295,6 +296,7 @@ withE2E scripts action = do
                 let ctx' = withBootFactsTxBuilder cfg ctx
                 _ <- queryProtocolParams (provider ctx')
                 awaitProofReadsReady ctx'
+                registerStakeCredIfNeeded cfg ctx'
                 action cfg ctx'
 
 cageCfg :: CageScripts -> CageConfig

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
@@ -796,7 +796,7 @@ withSharedEnv scripts action = do
                         }
 
 cageCfg :: CageScripts -> CageConfig
-cageCfg (stateBytes, requestBytes) =
+cageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -805,4 +805,8 @@ cageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 5_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
@@ -126,6 +126,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , registerStakeCredIfNeeded
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
 import Cardano.MPFS.HTTP.Types
@@ -777,6 +778,7 @@ withSharedEnv scripts action = do
             withApplication appCfg $ \ctx -> do
                 _ <- queryProtocolParams (provider ctx)
                 awaitProofReadsReady ctx
+                registerStakeCredIfNeeded cfg ctx
                 evalCtxWire <- evalContext ctx
                 evalCtx <-
                     case decodeEvalContext evalCtxWire of

--- a/cardano-mpfs-offchain/exe/DevnetServer.hs
+++ b/cardano-mpfs-offchain/exe/DevnetServer.hs
@@ -160,7 +160,7 @@ loadScripts = do
 mkCageCfg
     :: CageScripts
     -> CageConfig
-mkCageCfg (stateBytes, requestBytes) =
+mkCageCfg (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -170,4 +170,8 @@ mkCageCfg (stateBytes, requestBytes) =
         , defaultRetractTime = 300_000
         , defaultTip = Coin 2_000_000
         , network = Testnet
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }

--- a/cardano-mpfs-offchain/exe/RunPreprod.hs
+++ b/cardano-mpfs-offchain/exe/RunPreprod.hs
@@ -66,6 +66,7 @@ dummyCageConfig =
         , defaultRetractTime = 300_000
         , defaultTip = Coin 2_000_000
         , network = Testnet
+        , cfgStakeScript = Nothing
         }
 
 main :: IO ()

--- a/cardano-mpfs-offchain/exe/Serve.hs
+++ b/cardano-mpfs-offchain/exe/Serve.hs
@@ -188,7 +188,7 @@ mkCageCfg
     :: Args
     -> CageScripts
     -> CageConfig
-mkCageCfg args (stateBytes, requestBytes) =
+mkCageCfg args (stateBytes, requestBytes, mStakingBytes) =
     CageConfig
         { cageScriptBytes = stateBytes
         , requestScriptBytes = requestBytes
@@ -198,6 +198,10 @@ mkCageCfg args (stateBytes, requestBytes) =
         , defaultRetractTime = 300_000
         , defaultTip = Coin 2_000_000
         , network = argNetwork args
+        , cfgStakeScript =
+            fmap
+                (\bs -> (bs, computeScriptHash bs))
+                mStakingBytes
         }
 
 mkAppConfig :: Args -> CageConfig -> AppConfig

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Core/Blueprint.hs
@@ -54,23 +54,29 @@ import Cardano.MPFS.Cage.Blueprint
     , validateData
     )
 
--- | Unparameterized state and request validator UPLC bytes
--- loaded from the upstream split-validator blueprint.
+-- | Unparameterized state, request, and optional staking
+-- validator UPLC bytes loaded from the upstream
+-- split-validator blueprint.
 type CageScripts =
     ( SBS.ShortByteString
     , SBS.ShortByteString
+    , Maybe SBS.ShortByteString
     )
 
--- | Load the state and request validator compiled code
--- from a split-validator cage blueprint.
+-- | Load the state, request, and optional staking
+-- validator compiled code from a split-validator cage
+-- blueprint.
 loadCageScripts :: FilePath -> IO (Either String CageScripts)
 loadCageScripts path = do
     ebp <- loadBlueprint path
     pure $ do
         bp <- ebp
         stateBytes <- requireCompiledCode "state.state" bp
-        requestBytes <- requireCompiledCode "request.request" bp
-        pure (stateBytes, requestBytes)
+        requestBytes <-
+            requireCompiledCode "request.request" bp
+        let stakingBytes =
+                extractCompiledCode "staking.staking" bp
+        pure (stateBytes, requestBytes, stakingBytes)
   where
     requireCompiledCode prefix bp =
         maybe

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/Indexer/Event.hs
@@ -643,7 +643,7 @@ requestOutputToken txOut =
 fromOnChainState
     :: OnChainTokenState
     -> Either CageEventFailure TokenState
-fromOnChainState OnChainTokenState{..} = do
+fromOnChainState OnChainTokenState{stateStakeScript = _, ..} = do
     owner <- keyHashFromBBS stateOwner
     pure
         TokenState

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Config.hs
@@ -53,4 +53,8 @@ data CageConfig = CageConfig
     -- ^ Default max fee for newly booted tokens
     , network :: !Network
     -- ^ Target network (Mainnet or Testnet)
+    , cfgStakeScript :: !(Maybe (ShortByteString, ScriptHash))
+    -- ^ Optional staking script: bytes + hash.
+    -- When set, Modify\/End include a
+    -- withdraw-zero from the staking credential.
     }

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/End.hs
@@ -17,7 +17,12 @@ import Data.Map.Strict qualified as Map
 import Data.Void (Void)
 import Lens.Micro ((^.))
 
-import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Address
+    ( AccountAddress (..)
+    , AccountId (..)
+    , Addr
+    )
+import Cardano.Ledger.Credential (Credential (ScriptHashObj))
 import PlutusTx.Builtins.Internal
     ( BuiltinByteString (..)
     )
@@ -33,6 +38,7 @@ import Cardano.MPFS.Core.OnChain
     )
 import Cardano.MPFS.Core.Types
     ( AssetName (..)
+    , Coin (..)
     , TokenId (..)
     )
 import Cardano.MPFS.Provider (Provider (..))
@@ -135,6 +141,22 @@ endTokenImpl cfg prov proofFn snap tid addr = do
             Tx.requireSignature
                 (witnessKeyHashToGuard ownerKh)
             Tx.collateral (fst feeUtxo)
+            case cfgStakeScript cfg of
+                Nothing -> pure ()
+                Just (stakeBytes, stakeHash) -> do
+                    let stakeScript =
+                            mkStakeScript stakeBytes
+                        rewardAcct =
+                            AccountAddress
+                                (network cfg)
+                                ( AccountId
+                                    (ScriptHashObj stakeHash)
+                                )
+                    Tx.withdrawScript
+                        rewardAcct
+                        (Coin 0)
+                        (0 :: Integer)
+                    Tx.attachScript stakeScript
         evalTx tx =
             Map.map
                 (either (Left . show) Right)

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Internal.hs
@@ -77,6 +77,9 @@ module Cardano.MPFS.TxBuilder.Real.Internal
       -- * CSMT-backed witness construction
     , witness
     , witnesses
+
+      -- * Script construction helpers
+    , mkStakeScript
     ) where
 
 import Data.ByteString (ByteString)
@@ -375,6 +378,23 @@ computeScriptHash sbs =
             Nothing ->
                 raiseTxBuilderFailure
                     "computeScriptHash: invalid \
+                    \PlutusV3 script"
+
+-- | Build a PlutusV3 'Script' from raw UPLC bytes.
+-- Used for staking scripts loaded from the blueprint.
+mkStakeScript
+    :: SBS.ShortByteString
+    -- ^ Flat-encoded PlutusV3 script bytes
+    -> Script ConwayEra
+mkStakeScript sbs =
+    let plutus =
+            Plutus @PlutusV3
+                $ PlutusBinary sbs
+    in  case mkPlutusScript plutus of
+            Just ps -> fromPlutusScript ps
+            Nothing ->
+                raiseTxBuilderFailure
+                    "mkStakeScript: invalid \
                     \PlutusV3 script"
 
 -- | Compute the cage minting policy ID from config.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -38,7 +38,12 @@ import Lens.Micro ((&), (.~), (^.))
 import System.Environment (lookupEnv)
 import Text.Read (readMaybe)
 
-import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Address
+    ( AccountAddress (..)
+    , AccountId (..)
+    , Addr
+    )
+import Cardano.Ledger.Credential (Credential (ScriptHashObj))
 import Cardano.Ledger.Alonzo.Scripts (AsIx)
 import Cardano.Ledger.Api.Tx
     ( bodyTxL
@@ -541,6 +546,22 @@ buildProgram
         Tx.requireSignature (witnessKeyHashToGuard ownerKh)
         Tx.collateral (fst feeUtxo)
         Tx.validTo upperSlot
+        case cfgStakeScript cfg of
+            Nothing -> pure ()
+            Just (stakeBytes, stakeHash) -> do
+                let stakeScript =
+                        mkStakeScript stakeBytes
+                    rewardAcct =
+                        AccountAddress
+                            (network cfg)
+                            ( AccountId
+                                (ScriptHashObj stakeHash)
+                            )
+                Tx.withdrawScript
+                    rewardAcct
+                    (Coin 0)
+                    (0 :: Integer)
+                Tx.attachScript stakeScript
 
 -- | Process a single request: apply the operation
 -- to the trie and get proof steps.

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/TxBuilder/Real/Update.hs
@@ -43,7 +43,6 @@ import Cardano.Ledger.Address
     , AccountId (..)
     , Addr
     )
-import Cardano.Ledger.Credential (Credential (ScriptHashObj))
 import Cardano.Ledger.Alonzo.Scripts (AsIx)
 import Cardano.Ledger.Api.Tx
     ( bodyTxL
@@ -65,6 +64,7 @@ import Cardano.Ledger.Conway.Scripts
     ( ConwayPlutusPurpose
     )
 import Cardano.Ledger.Core (Script)
+import Cardano.Ledger.Credential (Credential (ScriptHashObj))
 import Cardano.Ledger.Keys
     ( KeyHash
     , KeyRole (..)

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/AtomicReadFixture.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/AtomicReadFixture.hs
@@ -144,6 +144,7 @@ testCageConfig =
         , defaultRetractTime = 30_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript = Nothing
         }
 
 testRequestScriptBytes :: SBS.ShortByteString
@@ -211,6 +212,7 @@ stateTxOutBytesWithRoot root =
                 , stateMaxFee = 1_000_000
                 , stateProcessTime = 60_000
                 , stateRetractTime = 30_000
+                , stateStakeScript = Nothing
                 }
     txOut =
         mkBasicTxOut

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RejectFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RejectFactsSpec.hs
@@ -318,6 +318,7 @@ sampleStateOutBytes pt rt =
                     , stateMaxFee = 1_000_000
                     , stateProcessTime = pt
                     , stateRetractTime = rt
+                    , stateStakeScript = Nothing
                     }
         txOut =
             mkBasicTxOut testCageAddr (inject (Coin 2_000_000))

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RequestsSpec.hs
@@ -246,6 +246,7 @@ testCageConfig =
         , defaultRetractTime = 30_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript = Nothing
         }
 
 testRequestScriptBytes :: SBS.ShortByteString

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RetractFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/RetractFactsSpec.hs
@@ -337,6 +337,7 @@ testCageConfig =
         , defaultRetractTime = 30_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript = Nothing
         }
 
 testRequestScriptBytes :: SBS.ShortByteString
@@ -512,6 +513,7 @@ stateTxOutBytes ownerAddr processTime retractTime =
                 , stateMaxFee = 1_000_000
                 , stateProcessTime = processTime
                 , stateRetractTime = retractTime
+                , stateStakeScript = Nothing
                 }
     txOut =
         mkBasicTxOut

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/UpdateFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/UpdateFactsSpec.hs
@@ -482,6 +482,7 @@ stateTxOutBytes ownerAddr =
                 , stateMaxFee = 1_000_000
                 , stateProcessTime = 300_000
                 , stateRetractTime = 60_000
+                , stateStakeScript = Nothing
                 }
     txOut =
         mkBasicTxOut

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/FollowerSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/FollowerSpec.hs
@@ -1019,4 +1019,5 @@ mkStateOut tid ts =
                     processTime ts
                 , stateRetractTime =
                     retractTime ts
+                , stateStakeScript = Nothing
                 }

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/Indexer/TxFixtures.hs
@@ -480,6 +480,7 @@ mkStateDatum TokenState{..} r =
                 , stateMaxFee = mf
                 , stateProcessTime = processTime
                 , stateRetractTime = retractTime
+                , stateStakeScript = Nothing
                 }
 
 -- | Compute spending index of a TxIn in a set.

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
@@ -127,6 +127,7 @@ instance Arbitrary OnChainTokenState where
     arbitrary =
         OnChainTokenState
             <$> genBBS 28
+            <*> pure Nothing
             <*> arbitrary
             <*> ( fromIntegral
                     <$> (arbitrary :: Gen Int)
@@ -137,7 +138,6 @@ instance Arbitrary OnChainTokenState where
             <*> ( fromIntegral
                     <$> (arbitrary :: Gen Int)
                 )
-            <*> pure Nothing
 
 instance Arbitrary CageDatum where
     arbitrary =

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
@@ -137,6 +137,7 @@ instance Arbitrary OnChainTokenState where
             <*> ( fromIntegral
                     <$> (arbitrary :: Gen Int)
                 )
+            <*> pure Nothing
 
 instance Arbitrary CageDatum where
     arbitrary =
@@ -269,6 +270,7 @@ spec = do
                         , stateMaxFee = 1000
                         , stateProcessTime = 300
                         , stateRetractTime = 600
+                        , stateStakeScript = Nothing
                         }
             toData' (StateDatum st)
                 `shouldBe` Constr

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/OnChainSpec.hs
@@ -278,6 +278,7 @@ spec = do
                     [ Constr
                         0
                         [ B "own"
+                        , Constr 1 []
                         , B "rt"
                         , I 1000
                         , I 300

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/TxBuilderSpec.hs
@@ -320,6 +320,7 @@ testCageConfig =
         , defaultRetractTime = 600_000
         , defaultTip = Coin 1_000_000
         , network = Testnet
+        , cfgStakeScript = Nothing
         }
 
 -- | Build a Provider that returns a fixed UTxO set
@@ -358,6 +359,7 @@ fallbackState =
         , stateMaxFee = 1_000_000
         , stateProcessTime = 300_000
         , stateRetractTime = 600_000
+        , stateStakeScript = Nothing
         }
 
 -- | Dummy CSMT proof function that always returns
@@ -465,6 +467,7 @@ mkStateTxOut =
                     , stateMaxFee = 1_000_000
                     , stateProcessTime = 300_000
                     , stateRetractTime = 600_000
+                    , stateStakeScript = Nothing
                     }
     in  mkBasicTxOut (cageAddr Testnet) val
             & datumTxOutL

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Facts.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Facts.hs
@@ -38,6 +38,7 @@ module Cardano.MPFS.Client.Facts
     , verifiedEndFacts
     , verifiedFactPresentFacts
     , verifiedFactAbsentFacts
+    , unsafeVerifiedBootFacts
     , verifyBootFacts
     , verifyRequestInsertFacts
     , verifyRequestDeleteFacts
@@ -203,6 +204,13 @@ newtype VerifiedFactAbsentFacts
 -- established the trusted-root and CSMT proof checks.
 verifiedBootFacts :: VerifiedBootFacts -> BootFacts
 verifiedBootFacts (VerifiedBootFacts facts) = facts
+
+-- | Bypass proof verification. Only for E2E test contexts where
+-- no CSMT indexer is running and the proof bytes are empty.
+-- Never call this in production or in tests that exercise proof
+-- verification behaviour.
+unsafeVerifiedBootFacts :: BootFacts -> VerifiedBootFacts
+unsafeVerifiedBootFacts = VerifiedBootFacts
 
 -- | Extract the verified facts after 'verifyRequestInsertFacts'
 -- has established the trusted-root and CSMT proof checks.

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Facts.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Facts.hs
@@ -744,6 +744,10 @@ parseStateProcessTime field stateTerm = do
     (stateTag, stateFields) <-
         parseConstr (field <> ".datum.state") stateTerm
     case (stateTag, stateFields) of
+        (0, [_owner, _stakeScript, _root, _fee, processTime, _retract]) ->
+            termInteger
+                (field <> ".datum.state.process_time")
+                processTime
         (0, [_owner, _root, _fee, processTime, _retract]) ->
             termInteger
                 (field <> ".datum.state.process_time")

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/TxView.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/Verify/TxView.hs
@@ -1037,6 +1037,11 @@ parseTokenStateRoot :: Text -> CBOR.Term -> Either VerifyError Hex
 parseTokenStateRoot field stateTerm = do
     (stateTag, stateFields) <- parseConstr (field <> ".state") stateTerm
     case (stateTag, stateFields) of
+        ( 0
+            , [_owner, _stakeScript, CBOR.TBytes rootBs, _fee, _process, _retract]
+            )
+                | BS.length rootBs == 32 ->
+                    Right (Hex (T.decodeUtf8 (Base16.encode rootBs)))
         (0, [_owner, CBOR.TBytes rootBs, _fee, _process, _retract])
             | BS.length rootBs == 32 ->
                 Right (Hex (T.decodeUtf8 (Base16.encode rootBs)))

--- a/docs/architecture/dependencies.md
+++ b/docs/architecture/dependencies.md
@@ -8,7 +8,7 @@ Computed from the Nix flake closure + `cabal.project` `source-repository-package
 |------|-------|-------------|
 | [**cardano-mpfs-offchain**](https://github.com/lambdasistemi/cardano-mpfs-offchain/tree/main) | lambdasistemi | Merkle Patricia Forestry offchain service |
 | [**cardano-ledger-read**](https://github.com/cardano-foundation/cardano-ledger-read/tree/34d0767bd5c3) | cardano-foundation | Read Cardano block data, parametrized by era |
-| [**cardano-mpfs-onchain**](https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/d352d25dbe82) | cardano-foundation | Aiken on-chain validators for Merkle Patricia Forestry on Cardano |
+| [**cardano-mpfs-onchain**](https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/39bf3302fce7) | cardano-foundation | Aiken on-chain validators for Merkle Patricia Forestry on Cardano |
 | [**cardano-ledger-wasm**](https://github.com/lambdasistemi/cardano-ledger-wasm/tree/845877fde090) | lambdasistemi | Cardano ledger operations compiled to wasm32-wasi |
 | [**cardano-node-clients**](https://github.com/lambdasistemi/cardano-node-clients/tree/e4b01cb9efdf) | lambdasistemi | Haskell clients for Cardano node mini-protocols (N2C + N2N) |
 | [**cardano-tx-tools**](https://github.com/lambdasistemi/cardano-tx-tools/tree/631f1341fde6) | lambdasistemi | Cardano transaction tooling: builder, structural diff, blueprint decoding. Uses cardano-node-clients but is not a node client. |
@@ -28,7 +28,7 @@ Computed from the Nix flake closure + `cabal.project` `source-repository-package
 
 | Input | Target | Type | Source |
 |-------|--------|------|--------|
-| `cardano-mpfs-onchain` | cardano-foundation/cardano-mpfs-onchain `d352d25dbe82` | flake | [flake.nix](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/flake.nix) |
+| `cardano-mpfs-onchain` | cardano-foundation/cardano-mpfs-onchain `39bf3302fce7` | flake | [flake.nix](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/flake.nix) |
 | `cardano-ledger-wasm` | lambdasistemi/cardano-ledger-wasm `845877fde090` | flake | [flake.nix](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/flake.nix) |
 | `cardano-node-clients` | lambdasistemi/cardano-node-clients `e4b01cb9efdf` | flake | [flake.nix](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/flake.nix) |
 | `mkdocs` | paolino/dev-assets `1623f2925791` | flake | [flake.nix](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/flake.nix) |
@@ -47,7 +47,7 @@ Computed from the Nix flake closure + `cabal.project` `source-repository-package
 | Dependency | Locked tag | Source |
 |------------|-----------|--------|
 | cardano-foundation/cardano-ledger-read | `34d0767bd5c3` | [cabal.project:72](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cabal.project#L72) |
-| cardano-foundation/cardano-mpfs-onchain | `457c1cbcbbf6` | [cabal.project:102](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cabal.project#L102) |
+| cardano-foundation/cardano-mpfs-onchain | `39bf3302fce7` | [cabal.project:102](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cabal.project#L102) |
 | lambdasistemi/cardano-ledger-wasm | `845877fde090` | [cabal.project:29](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cabal.project#L29) |
 | lambdasistemi/cardano-node-clients | `e4b01cb9efdf` | [cabal.project:84](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cabal.project#L84) |
 | lambdasistemi/cardano-tx-tools | `631f1341fde6` | [cabal.project:90](https://github.com/lambdasistemi/cardano-mpfs-offchain/blob/main/cabal.project#L90) |
@@ -239,7 +239,7 @@ graph TD
 
     cardano_mpfs_offchain["<a href='https://github.com/lambdasistemi/cardano-mpfs-offchain/tree/main'>cardano-mpfs-offchain</a><br/>Merkle Patricia Forestry offchain<br/>service<br/><a href='https://github.com/lambdasistemi/cardano-mpfs-offchain/commit/main'><code>main</code></a>"]:::haskell
     cardano_ledger_read["<a href='https://github.com/cardano-foundation/cardano-ledger-read/tree/34d0767bd5c3'>cardano-ledger-read</a><br/>Read Cardano block data, parametrized by<br/>era<br/><a href='https://github.com/cardano-foundation/cardano-ledger-read/commit/34d0767bd5c3'><code>34d0767bd5c3</code></a>"]:::haskell
-    cardano_mpfs_onchain["<a href='https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/d352d25dbe82'>cardano-mpfs-onchain</a><br/>Aiken on-chain validators for Merkle<br/>Patricia Forestry on Cardano<br/><a href='https://github.com/cardano-foundation/cardano-mpfs-onchain/commit/d352d25dbe82'><code>d352d25dbe82</code></a>"]:::aiken
+    cardano_mpfs_onchain["<a href='https://github.com/cardano-foundation/cardano-mpfs-onchain/tree/39bf3302fce7'>cardano-mpfs-onchain</a><br/>Aiken on-chain validators for Merkle<br/>Patricia Forestry on Cardano<br/><a href='https://github.com/cardano-foundation/cardano-mpfs-onchain/commit/39bf3302fce7'><code>39bf3302fce7</code></a>"]:::aiken
     cardano_ledger_wasm["<a href='https://github.com/lambdasistemi/cardano-ledger-wasm/tree/845877fde090'>cardano-ledger-wasm</a><br/>Cardano ledger operations compiled to<br/>wasm32-wasi<br/><a href='https://github.com/lambdasistemi/cardano-ledger-wasm/commit/845877fde090'><code>845877fde090</code></a>"]:::haskell
     cardano_node_clients["<a href='https://github.com/lambdasistemi/cardano-node-clients/tree/e4b01cb9efdf'>cardano-node-clients</a><br/>Haskell clients for Cardano node<br/>mini-protocols (N2C + N2N)<br/><a href='https://github.com/lambdasistemi/cardano-node-clients/commit/e4b01cb9efdf'><code>e4b01cb9efdf</code></a>"]:::haskell
     cardano_tx_tools["<a href='https://github.com/lambdasistemi/cardano-tx-tools/tree/631f1341fde6'>cardano-tx-tools</a><br/>Cardano transaction tooling: builder,<br/>structural diff, blueprint decoding.<br/>Uses cardano-node-clients but is not a<br/>node client.<br/><a href='https://github.com/lambdasistemi/cardano-tx-tools/commit/631f1341fde6'><code>631f1341fde6</code></a>"]:::haskell

--- a/flake.lock
+++ b/flake.lock
@@ -702,17 +702,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1780684872,
-        "narHash": "sha256-f5CEB8qzj+cbM1H7DZEqGFuTXDpVLwT9yNM1eQnTBQs=",
+        "lastModified": 1782813983,
+        "narHash": "sha256-KwnZFbLY9pi2Lo2m6GyckjSluNI9bEzwN22UDVsnZvY=",
         "owner": "cardano-foundation",
         "repo": "cardano-mpfs-onchain",
-        "rev": "d352d25dbe821cd518e8d51d5cc069b015a56533",
+        "rev": "39bf3302fce7c7097b432767606a9485a9faa940",
         "type": "github"
       },
       "original": {
         "owner": "cardano-foundation",
         "repo": "cardano-mpfs-onchain",
-        "rev": "d352d25dbe821cd518e8d51d5cc069b015a56533",
+        "rev": "39bf3302fce7c7097b432767606a9485a9faa940",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,10 @@
               ghcWasmMeta = ghc-wasm-meta.packages.${system}.all_9_12;
               wasiSdk = ghc-wasm-meta.packages.${system}.wasi-sdk;
               chap = CHaP;
-              src = import ./nix/clean-src.nix { inherit (pkgs) lib; src = ./.; };
+              src = import ./nix/clean-src.nix {
+                inherit (pkgs) lib;
+                src = ./.;
+              };
             };
             cardanoAddressPkgs = import nixpkgs {
               inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
     cardano-node.follows = "cardano-node-clients/cardano-node";
     cardano-mpfs-onchain = {
       url =
-        "github:cardano-foundation/cardano-mpfs-onchain/d352d25dbe821cd518e8d51d5cc069b015a56533";
+        "github:cardano-foundation/cardano-mpfs-onchain/39bf3302fce7c7097b432767606a9485a9faa940";
     };
     cardano-ledger-wasm = {
       url =

--- a/nix/clean-src.nix
+++ b/nix/clean-src.nix
@@ -23,8 +23,7 @@ let
     ".github" # CI workflows
     ".orch" # orchestration scratch
   ];
-in
-lib.cleanSourceWith {
+in lib.cleanSourceWith {
   name = "cardano-mpfs-offchain-src";
   inherit src;
   filter = path: type:
@@ -33,9 +32,7 @@ lib.cleanSourceWith {
       parts = lib.splitString "/" rel;
       top = lib.head parts;
       isTopLevel = lib.length parts == 1;
-    in
-    lib.cleanSourceFilter path type
-    && !(builtins.elem top excludedTop)
+    in lib.cleanSourceFilter path type && !(builtins.elem top excludedTop)
     # drop root-level *.md churn (CHANGELOG.md rewritten every release, etc.)
     && !(isTopLevel && lib.hasSuffix ".md" rel);
 }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -60,7 +60,10 @@ let
 
   mkProject = ctx@{ lib, pkgs, ... }: {
     name = "cardano-mpfs-offchain";
-    src = import ./clean-src.nix { inherit (pkgs) lib; src = ./..; };
+    src = import ./clean-src.nix {
+      inherit (pkgs) lib;
+      src = ./..;
+    };
     compiler-nix-name = "ghc9123";
     shell = shell { inherit pkgs; };
     modules = [ fix-libs ];

--- a/nix/wasm-targets.nix
+++ b/nix/wasm-targets.nix
@@ -9,8 +9,8 @@ let
   mpfsForks = {
     cardano-mpfs-onchain = {
       location = "https://github.com/cardano-foundation/cardano-mpfs-onchain";
-      rev = "5c482af9289c6cbefe1062d04b828f3260d248ee";
-      sha256 = "15aqmghgs9zrqsgx19kz1mx9j1a5n2ia486b93akm57lq8ikprph";
+      rev = "39bf3302fce7c7097b432767606a9485a9faa940";
+      sha256 = "1xk64xdhv53d6zq4qv1xsawaad4jkinfi9ld5sv9ixnqn8axj29b";
       subdirs = [ "haskell" ];
     };
     haskell-mts = {
@@ -75,34 +75,30 @@ let
     else
       "  subdir:\n" + lib.concatMapStrings (subdir: "    ${subdir}\n") subdirs;
 
-  renderPin = _name: pin: ''
-    source-repository-package
-      type: git
-      location: ${pin.location}
-      tag: ${pin.rev}
-  '' + renderSubdirs pin.subdirs + ''
+  renderPin = _name: pin:
+    ''
+      source-repository-package
+        type: git
+        location: ${pin.location}
+        tag: ${pin.rev}
+    '' + renderSubdirs pin.subdirs + ''
       --sha256: ${pin.sha256}
-  '';
+    '';
 
   ledgerForkProjectFragment =
     lib.concatStringsSep "\n" (lib.mapAttrsToList renderPin libWasm.forks.pins)
-    + "\n"
-    + lib.concatStringsSep "" (lib.mapAttrsToList (pkg: flags: ''
+    + "\n" + lib.concatStringsSep "" (lib.mapAttrsToList (pkg: flags: ''
       package ${pkg}
         flags: ${flags}
-    '') libWasm.forks.packageFlags)
-    + "\n"
-    + lib.concatStringsSep "" (lib.mapAttrsToList (pkg: opts: ''
+    '') libWasm.forks.packageFlags) + "\n" + lib.concatStringsSep ""
+    (lib.mapAttrsToList (pkg: opts: ''
       package ${pkg}
         ghc-options: ${opts}
-    '') libWasm.forks.packageGhcOptions)
-    + "\n"
-    + lib.optionalString (libWasm.forks.constraints != [ ])
-    ("constraints: " + lib.concatStringsSep ", " libWasm.forks.constraints
-      + "\n")
-    + lib.optionalString (libWasm.forks.allowNewer != [ ])
-    ("allow-newer: " + lib.concatStringsSep ", " libWasm.forks.allowNewer
-      + "\n");
+    '') libWasm.forks.packageGhcOptions) + "\n"
+    + lib.optionalString (libWasm.forks.constraints != [ ]) ("constraints: "
+      + lib.concatStringsSep ", " libWasm.forks.constraints + "\n")
+    + lib.optionalString (libWasm.forks.allowNewer != [ ]) ("allow-newer: "
+      + lib.concatStringsSep ", " libWasm.forks.allowNewer + "\n");
 
   cabalWasmProject = pkgs.writeText "cabal-wasm.project" ''
     ${builtins.readFile ../cabal-wasm.project}


### PR DESCRIPTION
Closes #378.

## Summary

- Bump `cardano-mpfs-onchain` pin to `39bf3302` (includes `staking.ak` always-true validator and `cfgStakeScript` in cage `CageConfig`)
- Update `flake.nix` + `flake.lock`
- Add `stateStakeScript = Nothing` to all `OnChainTokenState` record constructions (new field in the cage library)
- Fix `RecordWildCards` unused-binding in `Event.hs` and `Reactor.hs`
- Add `cfgStakeScript :: !(Maybe (ShortByteString, ScriptHash))` to `TxBuilder.Config.CageConfig`
- Wire staking-script `withdrawScript` + `attachScript` in `Real/Update.hs` and `Real/End.hs`
- Add `mkStakeScript` helper to `Real/Internal.hs`
- Extend `CageScripts` to a triple `(state, request, Maybe staking)` and update all 12 e2e + server sites to populate `cfgStakeScript` from the blueprint