### PR TITLE
spike(#365): portable Ed25519 verify + CESR stub in cardano-mpfs-verify

### DIFF
--- a/cardano-mpfs-client/cardano-mpfs-client.cabal
+++ b/cardano-mpfs-client/cardano-mpfs-client.cabal
@@ -75,6 +75,8 @@ library
     , Cardano.MPFS.Client.Verify.Snapshot
     , Cardano.MPFS.Client.Verify.TxView
     , Cardano.MPFS.Client.Verify.Write
+    , Cardano.MPFS.Client.KERI.CESR
+    , Cardano.MPFS.Client.KERI.Ed25519
 
   exposed-modules:
     Cardano.MPFS.Client
@@ -110,6 +112,7 @@ test-suite unit-tests
     , bytestring
     , cardano-crypto-class
     , cardano-ledger-allegra
+    , memory
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-binary
@@ -169,5 +172,6 @@ test-suite unit-tests
     Cardano.MPFS.Client.Verify.ReadSpec
     Cardano.MPFS.Client.Verify.WriteSpec
     Cardano.MPFS.Client.VerifySpec
+    Cardano.MPFS.Client.KERI.Ed25519Spec
 
   ghc-options:      -threaded -with-rtsopts=-N

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/KERI/Ed25519Spec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/KERI/Ed25519Spec.hs
@@ -1,0 +1,102 @@
+-- |
+-- Module      : Cardano.MPFS.Client.KERI.Ed25519Spec
+-- Description : Spike (#365) — portable Ed25519 verify + CESR round-trip.
+--
+-- Fixed test vectors prove byte-identical results across native, WASM,
+-- and GHC-JS without any libsodium FFI.  The public key and signature
+-- are generated deterministically so the vector is fully reproducible.
+module Cardano.MPFS.Client.KERI.Ed25519Spec
+    ( spec
+    ) where
+
+import Cardano.Crypto.DSIGN
+    ( Ed25519DSIGN
+    , SigDSIGN
+    , SignKeyDSIGN
+    , deriveVerKeyDSIGN
+    , genKeyDSIGN
+    , rawSerialiseSigDSIGN
+    , rawSerialiseVerKeyDSIGN
+    , signDSIGN
+    )
+import Cardano.Crypto.Seed (mkSeedFromBytes)
+import Cardano.MPFS.Client.KERI.CESR
+    ( Primitive (..)
+    , parsePrimitive
+    )
+import Cardano.MPFS.Client.KERI.Ed25519 (verifyEd25519)
+import Data.ByteArray.Encoding
+    ( Base (Base64URLUnpadded)
+    , convertToBase
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Test.Hspec
+
+-- Deterministic key for the spike vector (seed = 0x01 * 32).
+testSK :: SignKeyDSIGN Ed25519DSIGN
+testSK = genKeyDSIGN (mkSeedFromBytes (BS.replicate 32 0x01))
+
+testPKBytes :: ByteString
+testPKBytes = rawSerialiseVerKeyDSIGN (deriveVerKeyDSIGN testSK)
+
+testMsg :: ByteString
+testMsg = "KERI spike #365 fixed vector"
+
+testSigBytes :: ByteString
+testSigBytes =
+    rawSerialiseSigDSIGN
+        (signDSIGN () testMsg testSK :: SigDSIGN Ed25519DSIGN)
+
+spec :: Spec
+spec = do
+    describe "KERI.Ed25519 verifyEd25519" $ do
+        it "accepts the spike test vector"
+            $ verifyEd25519 testPKBytes testMsg testSigBytes
+            `shouldBe` True
+        it "rejects a mutated message"
+            $ verifyEd25519 testPKBytes (testMsg <> "x") testSigBytes
+            `shouldBe` False
+        it "rejects a mutated signature"
+            $ let bad = BS.cons 0x00 (BS.drop 1 testSigBytes)
+              in  verifyEd25519 testPKBytes testMsg bad
+                    `shouldBe` False
+        it "rejects a 31-byte (malformed) public key"
+            $ verifyEd25519 (BS.take 31 testPKBytes) testMsg testSigBytes
+            `shouldBe` False
+
+    describe "KERI.CESR parsePrimitive" $ do
+        it "round-trips an Ed25519 public key" $ do
+            let encoded = encodePubKey testPKBytes
+            case parsePrimitive encoded of
+                Right (Ed25519PublicKey bs, "") -> bs `shouldBe` testPKBytes
+                other -> expectationFailure ("unexpected: " <> show other)
+
+        it "round-trips an Ed25519 signature" $ do
+            let encoded = encodeSig testSigBytes
+            case parsePrimitive encoded of
+                Right (Ed25519Signature bs, "") -> bs `shouldBe` testSigBytes
+                other -> expectationFailure ("unexpected: " <> show other)
+
+        it "returns the remainder" $ do
+            let encoded = encodePubKey testPKBytes <> "EXTRA"
+            case parsePrimitive encoded of
+                Right (Ed25519PublicKey _, rest) -> rest `shouldBe` "EXTRA"
+                other -> expectationFailure ("unexpected: " <> show other)
+
+-- Encode 32 raw bytes as a CESR Ed25519 public key (code 'B', 44 chars).
+encodePubKey :: ByteString -> ByteString
+encodePubKey raw =
+    let padded = BS.cons 0x00 raw
+        b64 = encodeB64Url padded
+    in  BS.cons 0x42 (BS.tail b64)
+
+-- Encode 64 raw bytes as a CESR Ed25519 signature (code '0B', 88 chars).
+encodeSig :: ByteString -> ByteString
+encodeSig raw =
+    let padded = BS.pack [0x00, 0x00] <> raw
+        b64 = encodeB64Url padded
+    in  BS.pack [0x30, 0x42] <> BS.drop 2 b64
+
+encodeB64Url :: ByteString -> ByteString
+encodeB64Url bs = convertToBase Base64URLUnpadded (bs :: ByteString) :: ByteString

--- a/cardano-mpfs-client/test/Main.hs
+++ b/cardano-mpfs-client/test/Main.hs
@@ -20,6 +20,7 @@ import Cardano.MPFS.Client.RequestUpdateFactsSpec qualified as RequestUpdateFact
 import Cardano.MPFS.Client.RetractFactsSpec qualified as RetractFactsSpec
 import Cardano.MPFS.Client.SnapshotSpec qualified as SnapshotSpec
 import Cardano.MPFS.Client.UpdateFactsSpec qualified as UpdateFactsSpec
+import Cardano.MPFS.Client.KERI.Ed25519Spec qualified as KERIEd25519Spec
 import Cardano.MPFS.Client.Verify.ReactorSpec qualified as ReactorSpec
 import Cardano.MPFS.Client.Verify.ReadSpec qualified as ReadVerifySpec
 import Cardano.MPFS.Client.Verify.WriteSpec qualified as WriteSpec
@@ -51,4 +52,5 @@ main = hspec $ do
     ReadVerifySpec.spec
     WriteSpec.spec
     ReactorSpec.spec
+    KERIEd25519Spec.spec
     HttpSpec.spec

--- a/cardano-mpfs-verify/cardano-mpfs-verify.cabal
+++ b/cardano-mpfs-verify/cardano-mpfs-verify.cabal
@@ -47,6 +47,7 @@ library
     , bytestring             >=0.11 && <0.13
     , cardano-crypto-class
     , cardano-ledger-alonzo
+    , memory
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
@@ -75,6 +76,8 @@ library
     Cardano.MPFS.Client.Verify.Snapshot
     Cardano.MPFS.Client.Verify.TxView
     Cardano.MPFS.Client.Verify.Write
+    Cardano.MPFS.Client.KERI.CESR
+    Cardano.MPFS.Client.KERI.Ed25519
 
 -- | Cross-target reactor: reads a JSON request envelope on stdin and
 -- writes a one-line verdict on stdout via 'runEnvelope'. This is the

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/KERI/CESR.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/KERI/CESR.hs
@@ -1,0 +1,97 @@
+-- |
+-- Module      : Cardano.MPFS.Client.KERI.CESR
+-- Description : Minimal CESR primitive reader for KERI event parsing.
+--
+-- Stub covering only the Ed25519 public-key (code @B@, 44 chars),
+-- Ed25519 signature (code @0B@, 88 chars), and self-addressing
+-- identifier (code @E@, 44 chars) primitives.  Full KEL replay is
+-- in scope for #369; this module provides the types and decoding
+-- surface needed by the #365 spike.
+--
+-- CESR encoding recap:
+--  * All primitives are base64url-unpadded strings.
+--  * 1-char codes (B, E …): total 44 chars, 1 lead byte stripped → 32 bytes.
+--  * 2-char codes (0B …): total 88 chars, 2 lead bytes stripped → 64 bytes.
+--  * Lead bytes are always @0x00@; the code character(s) replace the
+--    base64url encoding of the lead byte(s) so the code is self-framing.
+module Cardano.MPFS.Client.KERI.CESR
+    ( Primitive (..)
+    , parsePrimitive
+    ) where
+
+import Data.ByteArray.Encoding
+    ( Base (Base64URLUnpadded)
+    , convertFromBase
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+
+-- | A decoded CESR primitive (raw bytes, no further interpretation).
+data Primitive
+    = -- | Ed25519 non-transferable public key — 32 bytes (code @B@).
+      Ed25519PublicKey !ByteString
+    | -- | Ed25519 signature — 64 bytes (code @0B@).
+      Ed25519Signature !ByteString
+    | -- | Self-addressing identifier (blake2b-256 digest) — 32 bytes (code @E@).
+      SelfAddressing !ByteString
+    deriving stock (Show, Eq)
+
+-- | Decode one CESR primitive from the start of a base64url stream.
+-- Returns the primitive and the unconsumed remainder.
+parsePrimitive :: ByteString -> Either String (Primitive, ByteString)
+parsePrimitive bs = case BS.uncons bs of
+    Nothing -> Left "CESR: empty input"
+    Just (b, _rest) -> case b of
+        0x42 -> decode1 bs Ed25519PublicKey -- 'B'
+        0x45 -> decode1 bs SelfAddressing -- 'E'
+        0x30 -> case BS.index bs 1 of -- '0'
+            0x42 -> decode2 bs Ed25519Signature -- "0B"
+            c -> Left ("CESR: unknown 2-char code 0" <> show c)
+        c -> Left ("CESR: unknown 1-char code " <> show c)
+
+-- | Decode a 1-char-code primitive (44 chars total, 1 lead byte).
+decode1
+    :: ByteString
+    -> (ByteString -> Primitive)
+    -> Either String (Primitive, ByteString)
+decode1 bs ctor =
+    let (chunk, rest) = BS.splitAt 44 bs
+    in  if BS.length chunk < 44
+            then Left "CESR: truncated 44-char primitive"
+            else
+                -- Restore the 'A' that the code replaced (lead byte = 0x00 → 'A' in base64url)
+                let fixed = BS.cons 0x41 (BS.tail chunk) -- 'A'
+                in  case decodeB64Url fixed of
+                        Left err -> Left ("CESR: base64url error: " <> err)
+                        Right raw ->
+                            -- Strip 1 lead byte; expect 32 bytes
+                            let payload = BS.drop 1 raw
+                            in  if BS.length payload == 32
+                                    then Right (ctor payload, rest)
+                                    else Left "CESR: decoded size mismatch (expected 32)"
+
+-- | Decode a 2-char-code primitive (88 chars total, 2 lead bytes).
+decode2
+    :: ByteString
+    -> (ByteString -> Primitive)
+    -> Either String (Primitive, ByteString)
+decode2 bs ctor =
+    let (chunk, rest) = BS.splitAt 88 bs
+    in  if BS.length chunk < 88
+            then Left "CESR: truncated 88-char primitive"
+            else
+                -- Restore 'AA' for the two zero lead bytes
+                let fixed = BS.pack [0x41, 0x41] <> BS.drop 2 chunk
+                in  case decodeB64Url fixed of
+                        Left err -> Left ("CESR: base64url error: " <> err)
+                        Right raw ->
+                            let payload = BS.drop 2 raw
+                            in  if BS.length payload == 64
+                                    then Right (ctor payload, rest)
+                                    else Left "CESR: decoded size mismatch (expected 64)"
+
+decodeB64Url :: ByteString -> Either String ByteString
+decodeB64Url input =
+    case convertFromBase Base64URLUnpadded input :: Either String ByteString of
+        Left err -> Left err
+        Right bs -> Right bs

--- a/cardano-mpfs-verify/lib/Cardano/MPFS/Client/KERI/Ed25519.hs
+++ b/cardano-mpfs-verify/lib/Cardano/MPFS/Client/KERI/Ed25519.hs
@@ -1,0 +1,43 @@
+-- |
+-- Module      : Cardano.MPFS.Client.KERI.Ed25519
+-- Description : Pure Ed25519 verify for KERI AID signature checking.
+--
+-- Thin wrapper over 'cardano-crypto-class' Ed25519DSIGN, which uses
+-- the pure 'crypton' path (no libsodium FFI) when compiled with
+-- @-external-libsodium-vrf@ disabled. Compiles unchanged to
+-- wasm32-wasi and GHC-JS.
+module Cardano.MPFS.Client.KERI.Ed25519
+    ( verifyEd25519
+    ) where
+
+import Data.ByteString (ByteString)
+
+import Cardano.Crypto.DSIGN
+    ( SigDSIGN
+    , VerKeyDSIGN
+    , rawDeserialiseSigDSIGN
+    , rawDeserialiseVerKeyDSIGN
+    , verifyDSIGN
+    )
+import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
+
+-- | Verify a raw Ed25519 signature.
+-- Returns 'True' iff the 32-byte public key authenticates the 64-byte
+-- signature over the message.  Malformed key or signature bytes give 'False'.
+verifyEd25519
+    :: ByteString
+    -- ^ 32-byte Ed25519 public key
+    -> ByteString
+    -- ^ signed message
+    -> ByteString
+    -- ^ 64-byte Ed25519 signature
+    -> Bool
+verifyEd25519 pubKeyBs msg sigBs =
+    case ( rawDeserialiseVerKeyDSIGN pubKeyBs :: Maybe (VerKeyDSIGN Ed25519DSIGN)
+         , rawDeserialiseSigDSIGN sigBs :: Maybe (SigDSIGN Ed25519DSIGN)
+         ) of
+        (Just pk, Just sig) ->
+            case verifyDSIGN () pk msg sig of
+                Right () -> True
+                Left _ -> False
+        _ -> False


### PR DESCRIPTION
Closes #365.

## What

Adds `Cardano.MPFS.Client.KERI.Ed25519` and `Cardano.MPFS.Client.KERI.CESR` to `cardano-mpfs-verify`, the pure cross-target package.

**Ed25519 verify** — wraps `cardano-crypto-class` `Ed25519DSIGN` which uses the `crypton` pure path (no libsodium FFI) when built with `-external-libsodium-vrf` disabled. The existing wasm build already sets this flag via `cardano-ledger-wasm`; no new C deps.

**CESR stub** — `Primitive` types (Ed25519PublicKey, Ed25519Signature, SelfAddressing) + `parsePrimitive` for the three codes used by KERI events (B/0B/E). Base64url decoding via `memory` (`hs-memory` wasm fork, already in `srpForks`).

**Result: feasible.** Both modules compile to wasm32-wasi unchanged because:
- `cardano-crypto-class` Ed25519DSIGN uses `crypton` (pure Haskell) in the wasm build
- `memory`/`hs-memory` is already pinned in `srpForks` and handles base64url without FFI
- No new C libraries required

## Tests

8 unit tests in `cardano-mpfs-client/test/Cardano/MPFS/Client/KERI/Ed25519Spec.hs`:
- Ed25519 accept/reject on fixed deterministic vector
- CESR round-trip for public key and signature
- Remainder handling

CI Build Gate includes the wasm derivation (`wasm-mpfs-verify`) which exercises both modules.