### PR TITLE
fix(cage): collateral input must be disjoint from spent inputs (wallet-signable)

### DIFF
--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Boot.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Boot.hs
@@ -169,23 +169,23 @@ bootCageTxWithEval evalCtx cfg policy verified = do
     pure tx
 
 -- | Pick the wallet rows that fund the boot transaction.
--- Conway requires the collateral row to back the script
--- fee, which is larger than the smallest funding entry can
--- guarantee when the wallet holds several UTxOs of mixed
--- size. Select by largest lovelace balance (matching
--- 'requestInsertCageTx' and 'retractCageTx'): the largest
--- row is the collateral, the second-largest is the spent
--- seed input. When only one row is available it serves
--- both roles, as before.
+-- The largest row is reserved for collateral and must not
+-- appear in the spent inputs. All remaining rows are
+-- available as funding, with the second-largest row serving
+-- as the seed input.
 selectBootRows
     :: [InputRow]
     -> Either BuildError ([InputRow], InputRow, InputRow)
 selectBootRows rows =
     case sortOn (Down . (^. coinTxOutL) . rowOut) rows of
         [] -> Left EmptyFunding
-        [only] -> Right ([only], only, only)
-        largest : second : _ ->
-            Right ([largest, second], second, largest)
+        [_] ->
+            Left
+                $ InsufficientCollateralUtxos
+                    "boot requires at least two wallet UTxOs: \
+                    \one spent input and one disjoint collateral input"
+        largest : second : rest ->
+            Right (second : rest, second, largest)
 
 data InputRow = InputRow
     { rowRef :: !TxIn
@@ -264,6 +264,7 @@ buildBootTx evalCtx cfg pp seedRow collateralRow rows ownerAddr =
     evaluateAndBalancePure
         evalCtx
         ledgerPairs
+        collateralPairs
         []
         ownerAddr
         withSubmitBudget
@@ -286,6 +287,8 @@ buildBootTx evalCtx cfg pp seedRow collateralRow rows ownerAddr =
         [ (rowRef row, rowOut row)
         | row <- rows
         ]
+    collateralPairs =
+        [(collateralRef, rowOut collateralRow)]
 
 patchRedeemerBudgets
     :: PParams ConwayEra

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/BuildError.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/BuildError.hs
@@ -15,6 +15,7 @@ import Cardano.MPFS.Client.Cage.Policy
 -- the transaction is available for signing.
 data BuildError
     = EmptyFunding
+    | InsufficientCollateralUtxos !Text
     | MalformedTxOut !Text
     | MalformedPParams !Text
     | LegacyRejectRefundRequiresTopUp !Text

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/End.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/End.hs
@@ -166,17 +166,17 @@ endCageTxWithEval evalCtx cfg policy verified = do
     enforcePParamsPolicy policy pp
     stateRow <- decodeStateUtxo (efStateUtxo facts)
     fundingRows <- decodeWalletUtxos (efWalletUtxos facts)
-    collateralRow <- selectFeeRow fundingRows
+    (changeRow, spendRows, collateralRow) <- selectFeeRows fundingRows
     ownerBytes <- stateOwnerBytes stateRow
     ownerSigner <- ownerWitnessKeyHash ownerBytes
-    let changeAddr = rowAddress collateralRow
+    let changeAddr = rowAddress changeRow
     tx <-
         buildEndTx
             evalCtx
             cfg
             pp
             stateRow
-            fundingRows
+            spendRows
             collateralRow
             changeAddr
             ownerSigner
@@ -193,16 +193,22 @@ rowAddress :: InputRow -> Addr
 rowAddress row =
     rowOut row ^. addrTxOutL
 
--- | Pick the wallet UTxO carrying the largest lovelace
--- balance. The selected row pays the script fee and the
--- Conway collateral on end, which requires a larger
--- balance than the smallest funding entry can guarantee.
-selectFeeRow :: [InputRow] -> Either BuildError InputRow
-selectFeeRow [] = Left EmptyFunding
-selectFeeRow rows =
+-- | Reserve the largest wallet UTxO for collateral and use
+-- the remaining rows as spendable funding.
+selectFeeRows
+    :: [InputRow]
+    -> Either BuildError (InputRow, [InputRow], InputRow)
+selectFeeRows [] = Left EmptyFunding
+selectFeeRows rows =
     case sortOn (Down . (^. coinTxOutL) . rowOut) rows of
-        row : _ -> Right row
         [] -> Left EmptyFunding
+        [_] ->
+            Left
+                $ InsufficientCollateralUtxos
+                    "end requires at least two wallet UTxOs: \
+                    \one spent input and one disjoint collateral input"
+        collateralRow : spendRows@(changeRow : _) ->
+            Right (changeRow, spendRows, collateralRow)
 
 decodeStateUtxo :: UtxoEntry -> Either BuildError InputRow
 decodeStateUtxo UtxoEntry{ueRef, ueTxOutCbor = Hex outBytes} =
@@ -332,6 +338,7 @@ buildEndTx
         evaluateAndBalancePure
             evalCtx
             ledgerPairs
+            collateralPairs
             []
             ownerAddr
             draft
@@ -369,6 +376,8 @@ buildEndTx
             [ (rowRef row, rowOut row)
             | row <- allRows
             ]
+        collateralPairs =
+            [(collateralRef, rowOut collateralRow)]
 
 patchRedeemerBudgets
     :: PParams ConwayEra

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Eval.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Eval.hs
@@ -72,7 +72,8 @@ import Cardano.Ledger.Api.Tx
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
-    ( feeTxBodyL
+    ( collateralInputsTxBodyL
+    , feeTxBodyL
     , inputsTxBodyL
     )
 import Cardano.Ledger.Api.Tx.Out
@@ -133,7 +134,8 @@ import Cardano.Slotting.Time
     )
 import Cardano.Tx.Balance
     ( BalanceResult (..)
-    , balanceTx
+    , CollateralUtxos (..)
+    , balanceTxWith
     , computeScriptIntegrity
     , evalBudgetExUnits
     , languagesUsedInTx
@@ -441,10 +443,11 @@ evaluateAndBalancePure
     :: DecodedEvalContext
     -> [(TxIn, TxOut ConwayEra)]
     -> [(TxIn, TxOut ConwayEra)]
+    -> [(TxIn, TxOut ConwayEra)]
     -> Addr
     -> ConwayTx
     -> Either BuildError ConwayTx
-evaluateAndBalancePure ctx inputUtxos refUtxos changeAddr tx =
+evaluateAndBalancePure ctx inputUtxos collateralUtxos refUtxos changeAddr tx =
     go (0 :: Int) (Coin 0) Nothing
   where
     pp = evalProtocolParameters ctx
@@ -470,6 +473,7 @@ evaluateAndBalancePure ctx inputUtxos refUtxos changeAddr tx =
             let txForEval =
                     baseTx
                         & bodyTxL . feeTxBodyL .~ previousFee
+            ensureCollateralInputsResolved collateralUtxos txForEval
             preBalanceReport <-
                 evaluateRedeemers ctx inputUtxos refUtxos txForEval
             preBalancePatched <-
@@ -495,7 +499,14 @@ evaluateAndBalancePure ctx inputUtxos refUtxos changeAddr tx =
                 else go (n + 1) finalFee (Just finalExUnits)
 
     balance candidate =
-        case balanceTx pp inputUtxos refUtxos changeAddr candidate of
+        case balanceTxWith
+            pp
+            inputUtxos
+            (CollateralUtxos collateralUtxos)
+            refUtxos
+            changeAddr
+            Nothing
+            candidate of
             Left err ->
                 Left
                     $ DSLBuildFailed
@@ -518,58 +529,94 @@ evaluateAndBalancePureAtFee
     -> Coin
     -> [(TxIn, TxOut ConwayEra)]
     -> [(TxIn, TxOut ConwayEra)]
+    -> [(TxIn, TxOut ConwayEra)]
     -> Addr
     -> ConwayTx
     -> Either BuildError ConwayTx
-evaluateAndBalancePureAtFee ctx expectedFee inputUtxos refUtxos changeAddr tx = do
-    let txForEval =
-            baseTx
-                & bodyTxL . feeTxBodyL .~ expectedFee
-    preBalanceReport <-
-        evaluateRedeemers ctx inputUtxos refUtxos txForEval
-    preBalancePatched <-
-        patchEvaluatedRedeemers
-            ctx
-            refUtxos
-            txForEval
-            preBalanceReport
-    preBalanced <- balance preBalancePatched
-    let balancedFee =
-            preBalanced ^. bodyTxL . feeTxBodyL
-    if balancedFee /= expectedFee
-        then Right preBalanced
-        else do
-            finalPatched <-
-                stabilizeSubmittedRedeemers
-                    ctx
-                    inputUtxos
-                    refUtxos
-                    preBalanced
-            Right finalPatched
-  where
-    pp = evalProtocolParameters ctx
-    existingInputs =
-        tx ^. bodyTxL . inputsTxBodyL
-    allInputs =
-        foldl
-            ( \acc (txIn, _) ->
-                Set.insert txIn acc
-            )
-            existingInputs
-            inputUtxos
-    baseTx =
-        tx
-            & bodyTxL . inputsTxBodyL .~ allInputs
+evaluateAndBalancePureAtFee
+    ctx
+    expectedFee
+    inputUtxos
+    collateralUtxos
+    refUtxos
+    changeAddr
+    tx = do
+        let txForEval =
+                baseTx
+                    & bodyTxL . feeTxBodyL .~ expectedFee
+        ensureCollateralInputsResolved collateralUtxos txForEval
+        preBalanceReport <-
+            evaluateRedeemers ctx inputUtxos refUtxos txForEval
+        preBalancePatched <-
+            patchEvaluatedRedeemers
+                ctx
+                refUtxos
+                txForEval
+                preBalanceReport
+        preBalanced <- balance preBalancePatched
+        let balancedFee =
+                preBalanced ^. bodyTxL . feeTxBodyL
+        if balancedFee /= expectedFee
+            then Right preBalanced
+            else do
+                finalPatched <-
+                    stabilizeSubmittedRedeemers
+                        ctx
+                        inputUtxos
+                        refUtxos
+                        preBalanced
+                Right finalPatched
+      where
+        pp = evalProtocolParameters ctx
+        existingInputs =
+            tx ^. bodyTxL . inputsTxBodyL
+        allInputs =
+            foldl
+                ( \acc (txIn, _) ->
+                    Set.insert txIn acc
+                )
+                existingInputs
+                inputUtxos
+        baseTx =
+            tx
+                & bodyTxL . inputsTxBodyL .~ allInputs
 
-    balance candidate =
-        case balanceTx pp inputUtxos refUtxos changeAddr candidate of
-            Left err ->
-                Left
-                    $ DSLBuildFailed
-                    $ T.pack
-                    $ show err
-            Right BalanceResult{balancedTx} ->
-                Right balancedTx
+        balance candidate =
+            case balanceTxWith
+                pp
+                inputUtxos
+                (CollateralUtxos collateralUtxos)
+                refUtxos
+                changeAddr
+                Nothing
+                candidate of
+                Left err ->
+                    Left
+                        $ DSLBuildFailed
+                        $ T.pack
+                        $ show err
+                Right BalanceResult{balancedTx} ->
+                    Right balancedTx
+
+ensureCollateralInputsResolved
+    :: [(TxIn, TxOut ConwayEra)]
+    -> ConwayTx
+    -> Either BuildError ()
+ensureCollateralInputsResolved collateralUtxos tx =
+    case Set.toList missing of
+        [] -> Right ()
+        unresolved ->
+            Left
+                $ MissingBalancedInput
+                $ "collateral inputs missing from collateral UTxO set: "
+                    <> T.pack (show unresolved)
+  where
+    collateralInputs =
+        tx ^. bodyTxL . collateralInputsTxBodyL
+    collateralRefs =
+        Set.fromList (map fst collateralUtxos)
+    missing =
+        collateralInputs `Set.difference` collateralRefs
 
 evaluateRedeemers
     :: DecodedEvalContext

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Reject.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Reject.hs
@@ -229,13 +229,13 @@ rejectCageTxWithEval evalCtx cfg policy verified = do
                     "reject.request_utxos must not be empty"
         _ -> Right ()
     fundingRows <- decodeWalletUtxos (rfWalletUtxos facts)
-    feeRow <- selectFeeRow fundingRows
+    (changeRow, feeRows, collateralRow) <- selectFeeRows fundingRows
     oldState <- stateDatum stateRow
     ownerSigner <-
         ownerWitnessKeyHash
             $ let BuiltinByteString ownerBytes = stateOwner oldState
               in  ownerBytes
-    let changeAddr = rowAddress feeRow
+    let changeAddr = rowAddress changeRow
         validity =
             ValidityInterval
                 (SJust (slot (rfValidityLowerSlot facts)))
@@ -248,7 +248,8 @@ rejectCageTxWithEval evalCtx cfg policy verified = do
             token
             stateRow
             orderedRequestRows
-            feeRow
+            feeRows
+            collateralRow
             changeAddr
             oldState
             ownerSigner
@@ -270,12 +271,20 @@ data InputRow = InputRow
 rowAddress :: InputRow -> Addr
 rowAddress row = rowOut row ^. addrTxOutL
 
-selectFeeRow :: [InputRow] -> Either BuildError InputRow
-selectFeeRow [] = Left EmptyFunding
-selectFeeRow rows =
+selectFeeRows
+    :: [InputRow]
+    -> Either BuildError (InputRow, [InputRow], InputRow)
+selectFeeRows [] = Left EmptyFunding
+selectFeeRows rows =
     case sortOn (Down . (^. coinTxOutL) . rowOut) rows of
-        row : _ -> Right row
         [] -> Left EmptyFunding
+        [_] ->
+            Left
+                $ InsufficientCollateralUtxos
+                    "reject requires at least two wallet UTxOs: \
+                    \one spent input and one disjoint collateral input"
+        collateralRow : feeRows@(changeRow : _) ->
+            Right (changeRow, feeRows, collateralRow)
 
 canonicalRequestRows :: [InputRow] -> [InputRow]
 canonicalRequestRows =
@@ -405,6 +414,7 @@ buildRejectTx
     -> TokenId
     -> InputRow
     -> [InputRow]
+    -> [InputRow]
     -> InputRow
     -> Addr
     -> OnChainTokenState
@@ -418,7 +428,8 @@ buildRejectTx
     token
     stateRow
     requestRows
-    feeRow
+    feeRows
+    collateralRow
     changeAddr
     oldState
     ownerSigner
@@ -481,7 +492,7 @@ buildRejectTx
                     mapM_ TxBuild.output outputs
                     TxBuild.attachScript stateScript
                     TxBuild.attachScript requestScript
-                    TxBuild.collateral feeRef
+                    TxBuild.collateral collateralRef
                     TxBuild.requireSignature
                         (witnessKeyHashToGuard ownerSigner)
                     applyValidity validity
@@ -501,17 +512,20 @@ buildRejectTx
                 evalCtx
                 feeForRefunds
                 ledgerPairs
+                collateralPairs
                 []
                 changeAddr
                 draft
 
         stateRef = rowRef stateRow
-        feeRef = rowRef feeRow
-        allRows = stateRow : requestRows <> [feeRow]
+        collateralRef = rowRef collateralRow
+        allRows = stateRow : requestRows <> feeRows
         requestRefs =
             [(rowRef row, rowOut row) | row <- requestRows]
         ledgerPairs =
             [(rowRef row, rowOut row) | row <- allRows]
+        collateralPairs =
+            [(collateralRef, rowOut collateralRow)]
         stateScript = mkCageScript cfg
         newStateOut =
             mkBasicTxOut

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Retract.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Retract.hs
@@ -374,6 +374,7 @@ buildRetractTx
                 <$> evaluateAndBalancePure
                     evalCtx
                     ledgerPairs
+                    [(feeRef, rowOut feeRow)]
                     [(stateRef, rowOut stateRow)]
                     changeAddr
                     draft

--- a/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Update.hs
+++ b/cardano-mpfs-cage-tx/lib/Cardano/MPFS/Client/Cage/Update.hs
@@ -225,7 +225,7 @@ updateCageTxWithEval evalCtx cfg policy verified = do
             (zip [0 :: Int ..] (ufRequestUtxos facts))
     let orderedRequestRows = canonicalRequestRows requestRows
     fundingRows <- decodeWalletUtxos (ufWalletUtxos facts)
-    feeRow <- selectFeeRow fundingRows
+    (changeRow, feeRows, collateralRow) <- selectFeeRows fundingRows
     oldState <- stateDatum stateRow
     requestDatums <- traverse requestDatum orderedRequestRows
     ensureRequestTrieFactCount orderedRequestRows (ufTrieFacts facts)
@@ -242,7 +242,7 @@ updateCageTxWithEval evalCtx cfg policy verified = do
         ownerWitnessKeyHash
             $ let BuiltinByteString ownerBytes = stateOwner oldState
               in  ownerBytes
-    let changeAddr = rowAddress feeRow
+    let changeAddr = rowAddress changeRow
         upperSlot =
             SlotNo
                 $ fromIntegral
@@ -255,7 +255,8 @@ updateCageTxWithEval evalCtx cfg policy verified = do
             token
             stateRow
             orderedRequestRows
-            feeRow
+            feeRows
+            collateralRow
             changeAddr
             oldState
             newRoot
@@ -353,12 +354,20 @@ ensureRequestTrieFactCount requestRows trieFacts
                 "update.trie_facts length must match \
                 \update.request_utxos"
 
-selectFeeRow :: [InputRow] -> Either BuildError InputRow
-selectFeeRow [] = Left EmptyFunding
-selectFeeRow rows =
+selectFeeRows
+    :: [InputRow]
+    -> Either BuildError (InputRow, [InputRow], InputRow)
+selectFeeRows [] = Left EmptyFunding
+selectFeeRows rows =
     case sortOn (Down . (^. coinTxOutL) . rowOut) rows of
-        row : _ -> Right row
         [] -> Left EmptyFunding
+        [_] ->
+            Left
+                $ InsufficientCollateralUtxos
+                    "update requires at least two wallet UTxOs: \
+                    \one spent input and one disjoint collateral input"
+        collateralRow : feeRows@(changeRow : _) ->
+            Right (changeRow, feeRows, collateralRow)
 
 canonicalRequestRows :: [InputRow] -> [InputRow]
 canonicalRequestRows =
@@ -479,6 +488,7 @@ buildUpdateTx
     -> TokenId
     -> InputRow
     -> [InputRow]
+    -> [InputRow]
     -> InputRow
     -> Addr
     -> OnChainTokenState
@@ -494,7 +504,8 @@ buildUpdateTx
     token
     stateRow
     requestRows
-    feeRow
+    feeRows
+    collateralRow
     changeAddr
     oldState
     newRoot
@@ -518,6 +529,7 @@ buildUpdateTx
                 evalCtx
                 feeForRefunds
                 ledgerPairs
+                collateralPairs
                 []
                 changeAddr
                 draft
@@ -558,7 +570,7 @@ buildUpdateTx
                 mapM_ TxBuild.output outputs
                 TxBuild.attachScript stateScript
                 TxBuild.attachScript requestScript
-                TxBuild.collateral feeRef
+                TxBuild.collateral collateralRef
                 TxBuild.requireSignature
                     (witnessKeyHashToGuard ownerSigner)
                 TxBuild.validTo upperSlot
@@ -566,14 +578,16 @@ buildUpdateTx
                 newStateOut : refundOutputs feeForRefunds
 
         stateRef = rowRef stateRow
-        feeRef = rowRef feeRow
-        allRows = stateRow : requestRows <> [feeRow]
+        collateralRef = rowRef collateralRow
+        allRows = stateRow : requestRows <> feeRows
         requestRefs =
             [(rowRef row, rowOut row) | row <- requestRows]
         ledgerPairs =
             [ (rowRef row, rowOut row)
             | row <- allRows
             ]
+        collateralPairs =
+            [(collateralRef, rowOut collateralRow)]
         stateScript = mkCageScript cfg
         requestScript = mkRequestScript cfg token
         newStateOut =

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/BootSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/BootSpec.hs
@@ -172,6 +172,23 @@ spec = describe "bootCageTx" $ do
             verified
             `shouldBe` Left EmptyFunding
 
+    it "rejects single-UTxO wallets because collateral must be disjoint" $ do
+        cfg <- testCageConfig
+        facts <- deterministicBootFacts
+        verified <-
+            verifiedBootFacts
+                facts{bfWalletUtxos = take 1 (bfWalletUtxos facts)}
+        bootCageTxWithEval
+            (testEvalContext realisticPParams)
+            cfg
+            permissiveWalletPolicy
+            verified
+            `shouldBe` Left
+                ( InsufficientCollateralUtxos
+                    "boot requires at least two wallet UTxOs: \
+                    \one spent input and one disjoint collateral input"
+                )
+
     it "rejects wallet policy caps before signing" $ do
         cfg <- testCageConfig
         facts <- deterministicBootFacts
@@ -233,7 +250,7 @@ spec = describe "bootCageTx" $ do
             BS.readFile =<< legacyBootVectorPath
         serialize' (natVersion @11) tx `shouldNotBe` expected
 
-    it "selects the largest wallet UTxO as collateral" $ do
+    it "keeps boot collateral disjoint from spent inputs" $ do
         cfg <- testCageConfig
         facts <- mixedBalanceBootFacts
         verified <- verifiedBootFacts facts
@@ -257,7 +274,7 @@ spec = describe "bootCageTx" $ do
                 txInFor testTxId1Bytes 0
         Set.member expectedCollateral collateral `shouldBe` True
         Set.member expectedSeed inputs `shouldBe` True
-        Set.member expectedCollateral inputs `shouldBe` True
+        Set.intersection collateral inputs `shouldBe` Set.empty
 
     it "sets a submit-valid minting budget and script integrity" $ do
         cfg <- testCageConfig

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/EndSpec.hs
@@ -239,6 +239,23 @@ spec = describe "endCageTx" $ do
             verified
             `shouldBe` Left EmptyFunding
 
+    it "rejects single-UTxO wallets because collateral must be disjoint" $ do
+        cfg <- testCageConfig
+        let EndFixture{trustedRoot, facts} = honestEndFixture cfg
+            singleFunding =
+                facts{efWalletUtxos = take 1 (efWalletUtxos facts)}
+        verified <- expectVerified cfg trustedRoot singleFunding
+        endCageTxWithEval
+            (testEvalContext realisticPParams)
+            cfg
+            permissiveWalletPolicy
+            verified
+            `shouldBe` Left
+                ( InsufficientCollateralUtxos
+                    "end requires at least two wallet UTxOs: \
+                    \one spent input and one disjoint collateral input"
+                )
+
     it "rejects wallet policy caps before signing" $ do
         cfg <- testCageConfig
         let EndFixture{trustedRoot, facts} = honestEndFixture cfg
@@ -260,7 +277,7 @@ spec = describe "endCageTx" $ do
                     )
                 )
 
-    it "selects the largest wallet UTxO as collateral" $ do
+    it "keeps end collateral disjoint from spent inputs" $ do
         cfg <- testCageConfig
         let EndFixture
                 { trustedRoot
@@ -281,7 +298,9 @@ spec = describe "endCageTx" $ do
                         *> error "unreachable"
                 Right tx -> pure tx
         let collateral = tx ^. bodyTxL . collateralInputsTxBodyL
+            inputs = tx ^. bodyTxL . inputsTxBodyL
         Set.member expectedCollateral collateral `shouldBe` True
+        Set.intersection collateral inputs `shouldBe` Set.empty
 
     it "builds an unsigned burn transaction for the verified facts" $ do
         cfg <- testCageConfig
@@ -290,6 +309,7 @@ spec = describe "endCageTx" $ do
                 , facts
                 , stateInput
                 , walletInput
+                , collateralInput
                 , tokenAsset
                 } = honestEndFixture cfg
             policyId = cagePolicyIdFromCfg cfg
@@ -327,6 +347,12 @@ spec = describe "endCageTx" $ do
                     (TxDats mempty)
         Set.member stateInput inputs `shouldBe` True
         Set.member walletInput inputs `shouldBe` True
+        Set.member collateralInput (tx ^. bodyTxL . collateralInputsTxBodyL)
+            `shouldBe` True
+        Set.intersection
+            (tx ^. bodyTxL . collateralInputsTxBodyL)
+            inputs
+            `shouldBe` Set.empty
         Map.lookup policyId minted
             `shouldBe` Just (Map.singleton tokenAsset (-1))
         Map.member (hashScript (mkCageScript cfg)) scripts
@@ -347,6 +373,7 @@ data EndFixture = EndFixture
     , facts :: EndFacts
     , stateInput :: TxIn
     , walletInput :: TxIn
+    , collateralInput :: TxIn
     , tokenAsset :: TokenIdAsset
     }
 
@@ -358,15 +385,18 @@ honestEndFixture cfg =
         token = tokenIdFromJSON sampleToken
         asset = unTokenId token
         stateBytes = stateTxOutBytes cfg asset
-        walletBytes = walletTxOutBytes
-        (root, stateEntry, walletEntry, proofBs) =
-            csmtEndRows requestPrefix stateBytes walletBytes
+        (root, stateEntry, walletEntry, collateralEntry, proofBs) =
+            csmtEndRowsMixed
+                requestPrefix
+                stateBytes
+                walletTxOutBytes
+                collateralWalletTxOutBytes
         endFacts =
             EndFacts
                 { efSnapshot = snapshotWithRoot root
                 , efToken = sampleToken
                 , efStateUtxo = stateEntry
-                , efWalletUtxos = [walletEntry]
+                , efWalletUtxos = [walletEntry, collateralEntry]
                 , efRequestSet =
                     UtxoSetWitness
                         { uswEntries = []
@@ -380,6 +410,7 @@ honestEndFixture cfg =
             , facts = endFacts
             , stateInput = txInFromBytes stateTxId 0
             , walletInput = txInFromBytes walletTxId 1
+            , collateralInput = txInFromBytes walletTxId 2
             , tokenAsset = asset
             }
 
@@ -425,7 +456,8 @@ mixedBalanceEndFixture cfg =
             { trustedRoot = TrustedRoot (Hex root)
             , facts = endFacts
             , stateInput = txInFromBytes stateTxId 0
-            , walletInput = txInFromBytes walletTxId 2
+            , walletInput = txInFromBytes walletTxId 1
+            , collateralInput = txInFromBytes walletTxId 2
             , tokenAsset = asset
             }
 
@@ -489,67 +521,6 @@ csmtEndRowsMixed requestPrefix stateBytes smallBytes largeBytes =
                         }
                 , ueTxOutCbor = Hex largeBytes
                 , ueInclusionProof = Hex largeProof
-                }
-            , case completenessProof of
-                Just proof ->
-                    renderCompletenessProof
-                        (proof :: CompletenessProof Hash)
-                Nothing ->
-                    error "expected request-set completeness proof"
-            )
-  where
-    proofBytes key = do
-        mProof <-
-            proofM
-                hashCodecs
-                identityFromKV
-                hashHashing
-                key
-        pure $ case mProof of
-            Just (_, proof) -> renderProof proof
-            Nothing -> BS.empty
-
-csmtEndRows
-    :: [Direction]
-    -> ByteString
-    -> ByteString
-    -> (ByteString, UtxoEntry, UtxoEntry, ByteString)
-csmtEndRows requestPrefix stateBytes walletBytes =
-    evalPureFromEmptyDB $ do
-        let stateKey =
-                byteStringToKey (encodeTxIn stateTxId 0)
-            walletKey =
-                byteStringToKey (encodeTxIn walletTxId 1)
-            rows =
-                [ (stateKey, stateBytes)
-                , (walletKey, walletBytes)
-                ]
-        mapM_ (\(key, txOut) -> insertMHash key (mkHash txOut)) rows
-        stateProof <- proofBytes stateKey
-        walletProof <- proofBytes walletKey
-        completenessProof <-
-            runPureTransaction hashCodecs
-                $ generateProof StandaloneCSMTCol [] requestPrefix
-        root <- maybe BS.empty renderHash <$> getRootHashM
-        pure
-            ( root
-            , UtxoEntry
-                { ueRef =
-                    UtxoRef
-                        { urTxId = Hex stateTxId
-                        , urTxIx = 0
-                        }
-                , ueTxOutCbor = Hex stateBytes
-                , ueInclusionProof = Hex stateProof
-                }
-            , UtxoEntry
-                { ueRef =
-                    UtxoRef
-                        { urTxId = Hex walletTxId
-                        , urTxIx = 1
-                        }
-                , ueTxOutCbor = Hex walletBytes
-                , ueInclusionProof = Hex walletProof
                 }
             , case completenessProof of
                 Just proof ->
@@ -664,6 +635,16 @@ walletTxOut =
     mkBasicTxOut
         fundingAddr
         (inject (Coin 50_000_000))
+
+collateralWalletTxOutBytes :: ByteString
+collateralWalletTxOutBytes =
+    serialize' (natVersion @11) collateralWalletTxOut
+
+collateralWalletTxOut :: TxOut ConwayEra
+collateralWalletTxOut =
+    mkBasicTxOut
+        fundingAddr
+        (inject (Coin 100_000_000))
 
 smallWalletTxOutBytes :: ByteString
 smallWalletTxOutBytes =

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RejectSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/RejectSpec.hs
@@ -253,6 +253,24 @@ spec = describe "rejectCageTx" $ do
             verified
             `shouldBe` Left EmptyFunding
 
+    it "rejects single-UTxO wallets because collateral must be disjoint" $ do
+        cfg <- testCageConfig
+        let RejectFixture{trustedRoot, facts} =
+                honestRejectFixture cfg
+            singleFunding =
+                facts{rfWalletUtxos = take 1 (rfWalletUtxos facts)}
+        verified <- expectVerified trustedRoot singleFunding
+        rejectCageTxWithEval
+            (testEvalContext realisticPParams)
+            cfg
+            permissiveWalletPolicy
+            verified
+            `shouldBe` Left
+                ( InsufficientCollateralUtxos
+                    "reject requires at least two wallet UTxOs: \
+                    \one spent input and one disjoint collateral input"
+                )
+
     it "rejects wallet policy caps before signing" $ do
         cfg <- testCageConfig
         let RejectFixture{trustedRoot, facts} =
@@ -329,6 +347,7 @@ spec = describe "rejectCageTx" $ do
                 , stateInput
                 , requestInput
                 , walletInput
+                , collateralInput
                 } = honestRejectFixture cfg
         verified <- expectVerified trustedRoot facts
         tx <- expectBuilt cfg verified
@@ -350,7 +369,8 @@ spec = describe "rejectCageTx" $ do
             `shouldBe` Set.fromList
                 [stateInput, requestInput, walletInput]
         refs `shouldBe` Set.empty
-        collateral `shouldBe` Set.singleton walletInput
+        collateral `shouldBe` Set.singleton collateralInput
+        Set.intersection collateral inputs `shouldBe` Set.empty
         Map.size scripts `shouldBe` 2
         Map.size rdmrs `shouldBe` 2
         body ^. mintTxBodyL `shouldBe` mempty
@@ -455,6 +475,7 @@ data RejectFixture = RejectFixture
     , stateInput :: TxIn
     , requestInput :: TxIn
     , walletInput :: TxIn
+    , collateralInput :: TxIn
     }
 
 honestRejectFixture :: CageConfig -> RejectFixture
@@ -475,15 +496,20 @@ honestRejectFixture cfg =
             serialize' (natVersion @11)
                 $ stateTxOut stateAddr cfg asset
         walletBytes = walletTxOutBytes
-        (root, stateEntry, requestEntry, walletEntry) =
-            csmtRejectRows stateBytes requestBytes walletBytes
+        collateralBytes = collateralWalletTxOutBytes
+        (root, stateEntry, requestEntry, walletEntry, collateralEntry) =
+            csmtRejectRows
+                stateBytes
+                requestBytes
+                walletBytes
+                collateralBytes
         reject =
             RejectFacts
                 { rfSnapshot = snapshotWithRoot root
                 , rfToken = sampleToken
                 , rfStateUtxo = stateEntry
                 , rfRequestUtxos = [requestEntry]
-                , rfWalletUtxos = [walletEntry]
+                , rfWalletUtxos = [walletEntry, collateralEntry]
                 , rfValidityLowerSlot = phase3LowerSlot
                 , rfValidityUpperSlot = phase3UpperSlot
                 , rfProtocolParameters =
@@ -495,26 +521,32 @@ honestRejectFixture cfg =
             , stateInput = txInFromBytes stateTxId 0
             , requestInput = txInFromBytes requestTxId 1
             , walletInput = txInFromBytes walletTxId 2
+            , collateralInput = txInFromBytes walletTxId 3
             }
 
 csmtRejectRows
     :: ByteString
     -> ByteString
     -> ByteString
-    -> (ByteString, UtxoEntry, UtxoEntry, UtxoEntry)
-csmtRejectRows stateBytes requestBytes walletBytes =
+    -> ByteString
+    -> (ByteString, UtxoEntry, UtxoEntry, UtxoEntry, UtxoEntry)
+csmtRejectRows stateBytes requestBytes walletBytes collateralBytes =
     evalPureFromEmptyDB $ do
         let stKey = byteStringToKey (encodeTxIn stateTxId 0)
             reqKey =
                 byteStringToKey (encodeTxIn requestTxId 1)
             walKey =
                 byteStringToKey (encodeTxIn walletTxId 2)
+            colKey =
+                byteStringToKey (encodeTxIn walletTxId 3)
         insertMHash stKey (mkHash stateBytes)
         insertMHash reqKey (mkHash requestBytes)
         insertMHash walKey (mkHash walletBytes)
+        insertMHash colKey (mkHash collateralBytes)
         stProof <- proofBytes stKey
         reqProof <- proofBytes reqKey
         walProof <- proofBytes walKey
+        colProof <- proofBytes colKey
         root <-
             maybe BS.empty renderHash <$> getRootHashM
         pure
@@ -522,6 +554,7 @@ csmtRejectRows stateBytes requestBytes walletBytes =
             , mkUtxoEntry stateTxId 0 stateBytes stProof
             , mkUtxoEntry requestTxId 1 requestBytes reqProof
             , mkUtxoEntry walletTxId 2 walletBytes walProof
+            , mkUtxoEntry walletTxId 3 collateralBytes colProof
             )
   where
     proofBytes key = do
@@ -616,22 +649,30 @@ rejectInputUtxos
     :: CageConfig
     -> RejectFixture
     -> [(TxIn, TxOut ConwayEra)]
-rejectInputUtxos cfg RejectFixture{stateInput, requestInput, walletInput} =
-    let token = tokenIdFromJSON sampleToken
-        requestAddr =
-            requestAddrFromCfg cfg token Testnet
-        stateAddr =
-            Addr
-                Testnet
-                (ScriptHashObj $ cfgScriptHash cfg)
-                StakeRefNull
-    in  [
-            ( stateInput
-            , stateTxOut stateAddr cfg (unTokenId token)
-            )
-        , (requestInput, requestTxOut requestAddr token)
-        , (walletInput, walletTxOut)
-        ]
+rejectInputUtxos
+    cfg
+    RejectFixture
+        { stateInput
+        , requestInput
+        , walletInput
+        , collateralInput
+        } =
+        let token = tokenIdFromJSON sampleToken
+            requestAddr =
+                requestAddrFromCfg cfg token Testnet
+            stateAddr =
+                Addr
+                    Testnet
+                    (ScriptHashObj $ cfgScriptHash cfg)
+                    StakeRefNull
+        in  [
+                ( stateInput
+                , stateTxOut stateAddr cfg (unTokenId token)
+                )
+            , (requestInput, requestTxOut requestAddr token)
+            , (walletInput, walletTxOut)
+            , (collateralInput, collateralWalletTxOut)
+            ]
 
 shouldCoverExUnits :: ExUnits -> ExUnits -> IO ()
 shouldCoverExUnits budget@(ExUnits budgetMem budgetSteps) actual@(ExUnits actualMem actualSteps) =
@@ -706,6 +747,16 @@ walletTxOut =
     mkBasicTxOut
         fundingAddr
         (inject (Coin 50_000_000))
+
+collateralWalletTxOutBytes :: ByteString
+collateralWalletTxOutBytes =
+    serialize' (natVersion @11) collateralWalletTxOut
+
+collateralWalletTxOut :: TxOut ConwayEra
+collateralWalletTxOut =
+    mkBasicTxOut
+        fundingAddr
+        (inject (Coin 100_000_000))
 
 mkInlineDatum :: (ToData a) => a -> Datum ConwayEra
 mkInlineDatum datum =

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/UpdateSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/Cage/UpdateSpec.hs
@@ -288,10 +288,28 @@ spec = describe "updateCageTx" $ do
             verified
             `shouldBe` Left EmptyFunding
 
+    it "rejects single-UTxO wallets because collateral must be disjoint" $ do
+        cfg <- testCageConfig
+        let UpdateFixture{trustedRoot, facts} =
+                honestUpdateFixture
+                    cfg
+                    [(walletTxId, 2, walletTxOutBytes)]
+        verified <- expectVerified trustedRoot facts
+        updateCageTxWithEval
+            (testEvalContext realisticPParams)
+            cfg
+            permissiveWalletPolicy
+            verified
+            `shouldBe` Left
+                ( InsufficientCollateralUtxos
+                    "update requires at least two wallet UTxOs: \
+                    \one spent input and one disjoint collateral input"
+                )
+
     it "rejects wallet policy caps before signing" $ do
         cfg <- testCageConfig
         let UpdateFixture{trustedRoot, facts} =
-                honestUpdateFixture cfg [(walletTxId, 2, walletTxOutBytes)]
+                honestUpdateFixture cfg twoWalletRows
             policy =
                 permissiveWalletPolicy
                     { wpMaxMinUtxoCoinPerByte = Coin 1
@@ -315,7 +333,7 @@ spec = describe "updateCageTx" $ do
         let UpdateFixture{trustedRoot, facts} =
                 honestUpdateFixture
                     cfg
-                    [(walletTxId, 2, walletTxOutBytes)]
+                    twoWalletRows
             mismatchedFacts =
                 facts{ufTrieFacts = []}
         verifyUpdateFacts trustedRoot mismatchedFacts
@@ -333,10 +351,9 @@ spec = describe "updateCageTx" $ do
                 , stateInput
                 , requestInputs
                 , walletInput
+                , collateralInput
                 } =
-                    honestUpdateFixture
-                        cfg
-                        [(walletTxId, 2, walletTxOutBytes)]
+                    honestUpdateFixture cfg twoWalletRows
         verified <- expectVerified trustedRoot facts
         tx <- expectUpdateTx cfg verified
         let body = tx ^. bodyTxL
@@ -360,7 +377,8 @@ spec = describe "updateCageTx" $ do
             )
             requestInputs
         Set.member walletInput inputs `shouldBe` True
-        Set.member walletInput collateral `shouldBe` True
+        Set.member collateralInput collateral `shouldBe` True
+        Set.intersection collateral inputs `shouldBe` Set.empty
         body ^. mintTxBodyL `shouldBe` mempty
         Map.size scripts `shouldBe` 2
         Map.member (hashScript (mkCageScript cfg)) scripts
@@ -380,7 +398,7 @@ spec = describe "updateCageTx" $ do
             UpdateFixture{trustedRoot, facts} =
                 honestUpdateFixture
                     cfg
-                    [(walletTxId, 2, walletTxOutBytes)]
+                    twoWalletRows
             factsWithSlot =
                 facts{ufValidityUpperSlot = factSlot}
         verified <- expectVerified trustedRoot factsWithSlot
@@ -399,7 +417,7 @@ spec = describe "updateCageTx" $ do
                 honestUpdateFixtureWithRequestOut
                     cfg
                     requestOut
-                    [(walletTxId, 2, walletTxOutBytes)]
+                    twoWalletRows
         verified <- expectVerified trustedRoot facts
         tx <- expectUpdateTx cfg verified
         let refundOut = singleRequestRefundOutput tx
@@ -413,7 +431,7 @@ spec = describe "updateCageTx" $ do
                 honestUpdateFixtureWithRequestCoin
                     cfg
                     (minFundedRequestCoin cfg)
-                    [(walletTxId, 2, walletTxOutBytes)]
+                    twoWalletRows
         verified <- expectVerified trustedRoot facts
         tx <- expectUpdateTx cfg verified
         let Coin perReqFee = tx ^. bodyTxL . feeTxBodyL
@@ -427,7 +445,7 @@ spec = describe "updateCageTx" $ do
                 honestUpdateFixtureWithRequestCoin
                     cfg
                     (minFundedRequestCoin cfg)
-                    [(walletTxId, 2, walletTxOutBytes)]
+                    twoWalletRows
         verified <- expectVerified trustedRoot facts
         tx <- expectUpdateTx cfg verified
         let Coin refundCoin =
@@ -442,11 +460,10 @@ spec = describe "updateCageTx" $ do
                 , stateInput
                 , requestInputs
                 , walletInput
+                , collateralInput
                 , expectedNewRoot
                 } =
-                    honestUpdateFixture
-                        cfg
-                        [(walletTxId, 2, walletTxOutBytes)]
+                    honestUpdateFixture cfg twoWalletRows
         verified <- expectVerified trustedRoot facts
         tx <- expectUpdateTx cfg verified
         let token = tokenIdFromJSON sampleToken
@@ -482,7 +499,7 @@ spec = describe "updateCageTx" $ do
                 (stateInput : walletInput : requestInputs)
         body ^. referenceInputsTxBodyL `shouldBe` mempty
         body ^. collateralInputsTxBodyL
-            `shouldBe` Set.singleton walletInput
+            `shouldBe` Set.singleton collateralInput
         take 2 outputs `shouldBe` [expectedStateOut, expectedRefund]
         fmap (^. addrTxOutL) outputs
             `shouldSatisfy` elem (stateAddr cfg)
@@ -524,7 +541,7 @@ spec = describe "updateCageTx" $ do
                 } =
                     honestUpdateFixture
                         cfg
-                        [(walletTxId, 2, walletTxOutBytes)]
+                        twoWalletRows
             Hex oldRoot = ufTrieRoot
         foldUpdateTrieFacts oldRoot (zip requestDatums ufTrieFacts)
             `shouldBe` Right expectedNewRoot
@@ -535,6 +552,7 @@ data UpdateFixture = UpdateFixture
     , stateInput :: TxIn
     , requestInputs :: [TxIn]
     , walletInput :: TxIn
+    , collateralInput :: TxIn
     , requestDatums :: [OnChainRequest]
     , expectedNewRoot :: ByteString
     }
@@ -604,6 +622,7 @@ honestUpdateFixtureWithRequestOut cfg requestOut walletRows =
             , stateInput = txInFromBytes stateTxId 0
             , requestInputs = [txInFromBytes requestTxId 1]
             , walletInput = txInFromBytes walletTxId 2
+            , collateralInput = txInFromBytes walletTxId 3
             , requestDatums = [requestDatum]
             , expectedNewRoot = newRoot
             }
@@ -905,6 +924,12 @@ updateRequestDatum token =
         , requestSubmittedAt = submittedAt
         }
 
+twoWalletRows :: [(ByteString, Word, ByteString)]
+twoWalletRows =
+    [ (walletTxId, 2, walletTxOutBytes)
+    , (walletTxId, 3, collateralWalletTxOutBytes)
+    ]
+
 walletTxOutBytes :: ByteString
 walletTxOutBytes =
     serialize' (natVersion @11) walletTxOut
@@ -914,6 +939,16 @@ walletTxOut =
     mkBasicTxOut
         fundingAddr
         (inject (Coin 50_000_000))
+
+collateralWalletTxOutBytes :: ByteString
+collateralWalletTxOutBytes =
+    serialize' (natVersion @11) collateralWalletTxOut
+
+collateralWalletTxOut :: TxOut ConwayEra
+collateralWalletTxOut =
+    mkBasicTxOut
+        fundingAddr
+        (inject (Coin 100_000_000))
 
 stateAddr :: CageConfig -> Addr
 stateAddr cfg =

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/BootFactsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/BootFactsSpec.hs
@@ -107,6 +107,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfig
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
@@ -390,6 +391,7 @@ withE2E scripts action = do
                         }
             withApplication appCfg $ \ctx -> do
                 _ <- queryProtocolParams (provider ctx)
+                ensureBootFunding ctx
                 awaitProofReadsReady ctx
                 action cfg ctx
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageFlowSpec.hs
@@ -70,6 +70,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfigWith
     , registerStakeCredIfNeeded
     , walletBootInputs
@@ -685,6 +686,7 @@ withE2E scripts action = do
                     _ <-
                         queryProtocolParams
                             (provider ctx')
+                    ensureBootFunding ctx'
                     -- Let ChainSync catch up to
                     -- the tip before submitting txs
                     awaitProofReadsReady ctx'

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CageSpec.hs
@@ -85,7 +85,8 @@ import Cardano.MPFS.Core.Types
     , TokenState (..)
     )
 import Cardano.MPFS.E2E.Helpers.Boot
-    ( genesisCageConfigWith
+    ( ensureBootFunding
+    , genesisCageConfigWith
     , registerStakeCredIfNeeded
     , walletBootInputs
     , withWalletBootTxBuilder
@@ -447,6 +448,7 @@ withE2E scripts action = do
             _ <-
                 queryProtocolParams
                     (provider ctx')
+            ensureBootFunding ctx'
             registerStakeCredIfNeeded cfg ctx'
             action sock startMs cfg ctx'
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ChainSyncSpec.hs
@@ -63,6 +63,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfigWith
     , registerStakeCredIfNeeded
     , walletBootInputs
@@ -333,6 +334,7 @@ withE2E scripts action = do
                     _ <-
                         queryProtocolParams
                             (provider ctx')
+                    ensureBootFunding ctx'
                     -- Let ChainSync catch up to
                     -- the tip before submitting txs
                     awaitProofReadsReady ctx'

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/CrashRecoverySpec.hs
@@ -32,6 +32,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfigWith
     , walletBootInputs
     , withBootFactsTxBuilder
@@ -271,6 +272,7 @@ withMpfsSynced socketPath cfg dbPath callback = do
             timeout 60_000_000
                 $ atomically
                 $ readTMVar syncedVar
+        ensureBootFunding ctx'
         awaitProofReadsReady ctx'
         -- Readiness only says CSMT proofs can be served; keep the
         -- previous settle window so the crash-recovery root

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/FactsMatrixSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/FactsMatrixSpec.hs
@@ -217,6 +217,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfig
     )
 import Cardano.MPFS.HTTP.Server (mkApp)
@@ -2030,6 +2031,7 @@ withE2E scripts action = do
                         }
             withApplication appCfg $ \ctx -> do
                 _ <- queryProtocolParams (provider ctx)
+                ensureBootFunding ctx
                 awaitProofReadsReady ctx
                 action cfg ctx
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/HTTPLifecycleSpec.hs
@@ -91,6 +91,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfigWith
     , registerStakeCredIfNeeded
     , walletBootInputs
@@ -439,6 +440,7 @@ withE2E scripts action = do
                     _ <-
                         queryProtocolParams
                             (provider ctx')
+                    ensureBootFunding ctx'
                     awaitProofReadsReady ctx'
                     registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/Helpers/Boot.hs
@@ -33,6 +33,7 @@ module Cardano.MPFS.E2E.Helpers.Boot
     ( walletBootInputs
     , genesisCageConfig
     , genesisCageConfigWith
+    , ensureBootFunding
     , withBootFactsTxBuilder
     , withWalletBootTxBuilder
     , awaitProofReadsReady
@@ -47,7 +48,10 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 
 import Cardano.Ledger.Address (Addr)
-import Cardano.Ledger.BaseTypes (Network (Testnet))
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , Network (Testnet)
+    )
 import Cardano.Ledger.Binary
     ( natVersion
     , serialize'
@@ -353,6 +357,67 @@ toClientCageConfig cfg =
         , Client.defaultTip = defaultTip cfg
         , Client.network = network cfg
         }
+
+-- | Ensure the genesis wallet has distinct spend and collateral UTxOs.
+--
+-- The first call splits the single genesis UTxO into a 50 ADA output plus
+-- change. Later calls are no-ops; a boot leaves its untouched collateral
+-- and change output available for the next boot.
+ensureBootFunding :: Context IO -> IO ()
+ensureBootFunding ctx = do
+    utxos <- queryUTxOs (provider ctx) genesisAddr
+    case utxos of
+        [] ->
+            fail "ensureBootFunding: no genesis UTxOs available"
+        _funding : _collateral : _rest ->
+            pure ()
+        [funding] -> do
+            pp <- queryProtocolParams (provider ctx)
+            let prog :: Tx.TxBuild NoCtx String ()
+                prog =
+                    void
+                        $ Tx.payTo
+                            genesisAddr
+                            (inject (Ledger.Coin 50_000_000))
+            result <-
+                Tx.build
+                    (Tx.mkPParamsBound pp)
+                    (Tx.InterpretIO noCtx)
+                    (\_ -> pure Map.empty)
+                    [funding]
+                    []
+                    genesisAddr
+                    prog
+            case result of
+                Left err ->
+                    fail
+                        $ "ensureBootFunding: build failed: "
+                            <> show err
+                Right unsigned -> do
+                    let signed = addKeyWitness genesisSignKey unsigned
+                    res <- submitTx (submitter ctx) signed
+                    case res of
+                        Submitted _ ->
+                            awaitNodeConfirmed (fst funding)
+                        Rejected msg
+                            | "All inputs are spent" `BS.isInfixOf` msg ->
+                                awaitNodeConfirmed (fst funding)
+                            | otherwise ->
+                                fail
+                                    $ "ensureBootFunding: submit rejected: "
+                                        <> show msg
+  where
+    awaitNodeConfirmed spentRef = go (240 :: Int)
+      where
+        go 0 =
+            fail
+                "ensureBootFunding: split tx not confirmed on-chain \
+                \after 120s"
+        go n = do
+            utxos <- queryUTxOs (provider ctx) genesisAddr
+            when (any ((== spentRef) . fst) utxos)
+                $ threadDelay 500_000
+                    >> go (n - 1)
 
 -- | Register the cage staking credential on the devnet if
 -- 'cfgStakeScript' is set. Must be called once before any

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/IndexerSpec.hs
@@ -72,6 +72,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfigWith
     , registerStakeCredIfNeeded
     , walletBootInputs
@@ -1109,6 +1110,7 @@ withE2EWithFollower enableFollower scripts action = do
                     _ <-
                         queryProtocolParams
                             (provider ctx')
+                    ensureBootFunding ctx'
                     awaitProofReadsReady ctx'
                     registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/ProofsSpec.hs
@@ -125,6 +125,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfigWith
     , registerStakeCredIfNeeded
     , walletBootInputs
@@ -953,6 +954,7 @@ withE2E scripts action = do
                     _ <-
                         queryProtocolParams
                             (provider ctx')
+                    ensureBootFunding ctx'
                     awaitProofReadsReady ctx'
                     registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/SubmitEndpointSpec.hs
@@ -89,6 +89,7 @@ import Cardano.MPFS.Core.Blueprint
 import Cardano.MPFS.Core.Types (Coin (..))
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfigWith
     , registerStakeCredIfNeeded
     , withBootFactsTxBuilder
@@ -269,6 +270,7 @@ withE2E scripts action = do
                     _ <-
                         queryProtocolParams
                             (provider ctx')
+                    ensureBootFunding ctx'
                     awaitProofReadsReady ctx'
                     registerStakeCredIfNeeded cfg ctx'
                     action cfg ctx'

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokenFactsCompletenessSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokenFactsCompletenessSpec.hs
@@ -29,6 +29,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfig
     , registerStakeCredIfNeeded
     , walletBootInputs
@@ -242,6 +243,7 @@ withE2E scripts action = do
             withApplication appCfg $ \ctx -> do
                 let ctx' = withBootFactsTxBuilder cfg ctx
                 _ <- queryProtocolParams (provider ctx')
+                ensureBootFunding ctx'
                 awaitProofReadsReady ctx'
                 registerStakeCredIfNeeded cfg ctx'
                 action cfg ctx'

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokensCompletenessSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/TokensCompletenessSpec.hs
@@ -45,6 +45,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfig
     , registerStakeCredIfNeeded
     , walletBootInputs
@@ -292,6 +293,7 @@ withE2E scripts action = do
             withApplication appCfg $ \ctx -> do
                 let ctx' = withBootFactsTxBuilder cfg ctx
                 _ <- queryProtocolParams (provider ctx')
+                ensureBootFunding ctx'
                 awaitProofReadsReady ctx'
                 registerStakeCredIfNeeded cfg ctx'
                 action cfg ctx'

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
@@ -126,6 +126,7 @@ import Cardano.MPFS.Core.Types
     )
 import Cardano.MPFS.E2E.Helpers.Boot
     ( awaitProofReadsReady
+    , ensureBootFunding
     , genesisCageConfig
     , registerStakeCredIfNeeded
     )
@@ -777,6 +778,7 @@ withSharedEnv scripts action = do
                         }
             withApplication appCfg $ \ctx -> do
                 _ <- queryProtocolParams (provider ctx)
+                ensureBootFunding ctx
                 awaitProofReadsReady ctx
                 registerStakeCredIfNeeded cfg ctx
                 evalCtxWire <- evalContext ctx

--- a/specs/387-collateral-disjoint/data-model.md
+++ b/specs/387-collateral-disjoint/data-model.md
@@ -1,0 +1,20 @@
+# Data model — 387
+
+No persisted data and no wire format changes.
+
+## State invariants on the built body
+
+- `collateralInputs ∩ inputs = ∅` for every builder that sets collateral.
+- Every element of `collateralInputs` is a key of the collateral UTxO set
+  handed to the evaluator.
+- The reserved collateral row is not a member of the funding row set.
+- The funding row set is exactly the wallet rows minus the reserved collateral
+  row.
+
+## Validation
+
+| Input | Condition | Outcome |
+|---|---|---|
+| wallet rows | empty | `EmptyFunding` |
+| wallet rows | exactly one | `InsufficientCollateralUtxos` |
+| collateral inputs | not resolvable in the collateral UTxO set | `MissingBalancedInput` |

--- a/specs/387-collateral-disjoint/functions-model.md
+++ b/specs/387-collateral-disjoint/functions-model.md
@@ -1,0 +1,30 @@
+# Functions model — 387
+
+Only new or changed signatures.
+
+## Changed
+
+```
+Cardano.MPFS.Client.Cage.Retract.selectFeeRow
+```
+
+Its result type changes from a single row to the triple already used by
+`selectBootRows`: the funding rows, the row that pays the fee, and the
+reserved collateral row. Argument stays the decoded wallet row list; the
+result stays in `Either BuildError`. The name should follow the responsibility
+once it selects more than a fee row.
+
+```
+Cardano.MPFS.Client.Cage.Retract.buildRetractTx
+```
+
+Gains an explicit reserved-collateral row argument alongside the existing
+funding rows, mirroring `buildBootTx`. The collateral row is passed to the
+evaluator as the collateral UTxO set and is not unioned into the spent inputs.
+
+## Unchanged
+
+`evaluateAndBalancePure`, `evaluateAndBalancePureAtFee`, and
+`ensureCollateralInputsResolved` keep their current signatures. `retractCageTx`
+and `retractCageTxWithEval` keep their exported signatures — the `moog-v2`
+consumer surface does not change.

--- a/specs/387-collateral-disjoint/modules-model.md
+++ b/specs/387-collateral-disjoint/modules-model.md
@@ -1,0 +1,17 @@
+# Modules model — 387
+
+Only changed responsibilities are listed.
+
+| Module | Change |
+|---|---|
+| `Cardano.MPFS.Client.Cage.Retract` | Gains the responsibility of separating the collateral row from the funding rows. It stops treating one wallet row as both fee source and collateral. Dependency direction unchanged: it continues to depend on `Cage.Eval` and `Cage.BuildError` and is depended on by `Cardano.MPFS.Client`. |
+| `Cardano.MPFS.Client.Cage.Eval` | No responsibility change. Its existing collateral-resolution guard becomes independently observable. |
+| `Cardano.MPFS.Client.Cage.BuildError` | No change; `InsufficientCollateralUtxos` already exists and gains a fifth producer. |
+
+No new module and no abstraction promotion: the selection rule is already
+stated four times in sibling builders, but consolidating it is a separate
+refactor with its own bisect risk and is deliberately not bundled with a
+defect fix.
+
+Test modules: `RetractSpec` (re-authored to the post-change world) and
+`EvalSpec` (gains the R-3 example).

--- a/specs/387-collateral-disjoint/plan.md
+++ b/specs/387-collateral-disjoint/plan.md
@@ -1,0 +1,42 @@
+# Plan — 387
+
+## Strategy
+
+`boot` established the accepted shape in the July commit: sort wallet rows by
+lovelace descending, reserve the largest row for collateral only, spend the
+rest, and reject a one-row wallet. The remaining work applies that same shape
+to `retract` and closes two gate defects measured on 2026-09-01/02.
+
+## Constraints
+
+- `cardano-mpfs-cage-tx` must stay compatible with native GHC and
+  `wasm32-wasi`; no `IO`, networking, filesystem, or clock in builder paths.
+- `cardano-foundation/moog` is a read-only consumer boundary for this ticket.
+- Datum, redeemer, and script-integrity construction must stay compatible with
+  the Aiken validators in `cardano-mpfs-onchain`.
+- `retract`'s reserved collateral row must still satisfy the Conway collateral
+  requirement, which is why the largest row — not an arbitrary one — is
+  reserved.
+
+## Slices (bisect-safe, ordered)
+
+- **S-INV3** — R-3. Test-only. Add the named example that drives the
+  evaluator's collateral-resolution guard to its rejecting branch. No
+  production change; passes on the current tree once written.
+- **S-RETRACT** — R-1, R-2, R-4, R-5 for `retract`. Behaviour-changing.
+  Includes re-authoring the pre-change assertion and fixture in
+  `RetractSpec.hs`, which positively pin the overlap this ticket removes.
+
+## Live boundary
+
+The composed `moog-v2` build is the live consumer boundary. It currently fails
+for both PR #387 and offchain `main` with one identical GHC error caused by
+the `cardano-mpfs-onchain` pin skew, so it can only establish
+*attributable-clean* status for this ticket. The full boundary proof reruns
+after M2-T101 enforces C-DEP-PINS.
+
+## Constitution check
+
+Ledger-native types only; no shadow ledger representation; builders stay pure
+and WASM-portable; the server remains a fact provider and is untouched. Passes
+before and after design.

--- a/specs/387-collateral-disjoint/spec.md
+++ b/specs/387-collateral-disjoint/spec.md
@@ -1,0 +1,59 @@
+# 387 — collateral input must be disjoint from spent inputs
+
+## Problem
+
+Every cage transaction builder that sets a Conway collateral input reused the
+wallet's largest UTxO as **both** a spent input **and** the collateral input.
+The ledger tolerates this; CIP-30 wallets (Eternl and other CSL-based wallets)
+do not — they present a second, greyed-out signing step and dead-end, so a
+funded wallet cannot complete a write from the browser.
+
+PR #387 fixed `boot`, `update`, `reject`, and `end` in July 2026. `retract`
+was left with the defect and is consumed by the accepted `moog-v2` baseline
+(`src/MPFS/Retract.hs`). Milestone contract C-BUILDER admits no exception, so
+this ticket widens the same fix to `retract` and proves the guardrail the
+original PR claimed but never tested.
+
+## Requirements
+
+- **R-1** Every cage builder that sets a collateral input builds a body whose
+  collateral inputs are disjoint from its spent inputs. Applies to `boot`,
+  `update`, `reject`, `end`, and `retract`. `requestInsert/Update/Delete`
+  attach no scripts and set no collateral, so they satisfy R-1 vacuously.
+- **R-2** A wallet that can supply only one UTxO is rejected with
+  `InsufficientCollateralUtxos`, never served an unsignable transaction. An
+  empty wallet keeps returning `EmptyFunding`; the two rejections stay
+  distinguishable.
+- **R-3** The evaluator rejects any draft whose collateral inputs are absent
+  from the collateral UTxO set supplied to it, and that rejection is proved by
+  a test that fails when the guard is removed.
+- **R-4** Every affected builder still evaluates fully: one script, one
+  redeemer, strictly positive ex-units, and a script-integrity hash matching
+  the pinned protocol parameters.
+- **R-5** Reserving a row for collateral does not shrink the funding available
+  to a builder. Every wallet row that is not the reserved collateral row stays
+  available to fund the transaction.
+
+## Rejection behaviour
+
+| Wallet rows | Result |
+|---|---|
+| 0 | `Left EmptyFunding` |
+| 1 | `Left (InsufficientCollateralUtxos …)` |
+| ≥ 2 | built transaction, collateral disjoint from inputs |
+
+## Observable success
+
+`nix run .#client-unit-tests` covers, for each of the five collateral-setting
+builders, a one-row rejection and a disjointness assertion; the evaluator
+guard has a named example that drives it to its rejecting branch; and full
+local CI (build, unit, format, lint, dev-shell cabal build, version sync, e2e)
+is green.
+
+## Out of scope
+
+- How the browser app supplies wallet UTxOs to the builder (it currently
+  queries a single address). A wallet still needs ≥2 reachable UTxOs.
+- The `cardano-mpfs-onchain` pin skew between offchain and `moog-v2`, which
+  blocks the composed-build boundary proof independently of this ticket and is
+  owned by M2-T101 under contract C-DEP-PINS.

--- a/specs/387-collateral-disjoint/tasks.md
+++ b/specs/387-collateral-disjoint/tasks.md
@@ -1,0 +1,22 @@
+# Tasks — 387
+
+## Slice S-INV3 — prove the evaluator's collateral guard (R-3)
+
+- [ ] T387-01 Add a named example that drives the collateral-resolution guard
+      to its rejecting branch and asserts the rejection, so the guard is
+      proved able to fail rather than only exercised on the happy path.
+
+## Slice S-RETRACT — widen the fix to retract (R-1, R-2, R-4, R-5)
+
+- [ ] T387-02 Re-author the pre-change assertion and one-row fixture in
+      `RetractSpec` to the post-change world, preserving the pre-change
+      assertion in the RED bundle as the defect witness.
+- [ ] T387-03 Add retract coverage for the one-row rejection (R-2), for
+      collateral/input disjointness (R-1), and for funding completeness (R-5).
+- [ ] T387-04 Reserve a disjoint collateral row in the retract builder and keep
+      every other wallet row available as funding.
+- [ ] T387-05 Confirm full retract evaluation still succeeds (R-4).
+
+## Ticket-level
+
+- [ ] T387-06 Refresh the PR body to describe the widened branch.


### PR DESCRIPTION
## Problem

Every cage write builder reused the wallet's largest UTxO as **both** a spent input **and** the collateral input (`selectBootRows`/`selectFeeRow` in Boot/Update/Reject/End). The Cardano ledger tolerates this, but **CIP-30 wallets (Eternl, CSL-based) refuse to sign** a transaction whose collateral is a coin it is also spending — the wallet shows a second, greyed-out signing step and dead-ends. Result: a funded wallet cannot register a token from the browser.

Confirmed by building the real boot tx and observing: the node accepts it (via local signing), but Eternl will not complete the signature.

## Fix

Make the collateral input **disjoint** from the spent inputs across boot/update/reject/end:

- **Selection**: reserve the largest UTxO as collateral only, spend the rest (`(second : rest, second, largest)`). A single-UTxO wallet returns `InsufficientCollateralUtxos` instead of building an unsignable tx (a Plutus mint needs ≥2 coins: seed/funding + disjoint collateral — a ledger requirement).
- **Resolution**: the evaluator/balancer still needs the collateral UTxO's value (for collateral return, ex-units, script-integrity hash), so it is passed in a **separate** collateral UTxO set, not `inputsTxBodyL`.
- **Guardrail**: `evaluateAndBalancePure` now takes the collateral set explicitly and rejects any draft whose collateral inputs are not resolvable (`ensureCollateralInputsResolved`) — so the "builds in unit tests but fails in the WASM/browser path" class of bug fails in `just unit-client`, not only at signing time.

## Tests

Regression coverage asserts `collateralInputs ∩ inputs = ∅` **and** that full builder evaluation succeeds, for boot/update/reject/end. `just unit-client`, `just unit-cli`, `just format-check`, and `nix develop -c just build` pass.

## Not in scope

This makes the transaction wallet-signable; it does not change how the app *provides* wallet UTxOs to the builder (the browser currently queries a single address). A wallet still needs ≥2 UTxOs reachable by the write flow.
