### PR TITLE
feat(http): /facts/boot accepts multiple wallet addresses

### DIFF
--- a/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
+++ b/cardano-mpfs-api/lib/Cardano/MPFS/API/Types.hs
@@ -607,17 +607,24 @@ instance FromJSON RequestsResponse where
 
 -- | @POST \/tx\/boot@ request body.
 newtype BootRequest = BootRequest
-    { brAddr :: Hex
-    -- ^ Address (hex-encoded serialized)
+    { brAddr :: [Hex]
+    -- ^ Addresses (hex-encoded serialized)
     }
 
 instance ToJSON BootRequest where
     toJSON BootRequest{..} =
-        object ["address" .= brAddr]
+        object ["addresses" .= brAddr]
 
 instance FromJSON BootRequest where
-    parseJSON = withObject "BootRequest" $ \o ->
-        BootRequest <$> o .: "address"
+    parseJSON = withObject "BootRequest" $ \o -> do
+        mAddresses <- o .:? "addresses"
+        case mAddresses of
+            Just addresses ->
+                pure (BootRequest addresses)
+            Nothing ->
+                BootRequest
+                    . maybe [] pure
+                    <$> o .:? "address"
 
 -- | Request body for inserting a key-value pair.
 data InsertRequest = InsertRequest
@@ -1259,8 +1266,8 @@ instance ToSchema StatusResponse where
 
 instance ToSchema BootRequest where
     declareNamedSchema _ = do
-        hexSchema <-
-            declareSchemaRef (Proxy @Hex)
+        addressesSchema <-
+            declareSchemaRef (Proxy @[Hex])
         pure
             $ Swagger.NamedSchema
                 (Just "BootRequest")
@@ -1269,10 +1276,10 @@ instance ToSchema BootRequest where
                 ?~ Swagger.SwaggerObject
             & properties
                 .~ fromList
-                    [("address", hexSchema)]
-            & required .~ ["address"]
+                    [("addresses", addressesSchema)]
+            & required .~ ["addresses"]
             & description
-                ?~ "Boot a new token"
+                ?~ "Boot a new token; legacy address field is also accepted"
 
 instance ToSchema InsertRequest where
     declareNamedSchema _ = do

--- a/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
+++ b/cardano-mpfs-cli/lib/Cardano/MPFS/CLI/Run.hs
@@ -140,7 +140,7 @@ run App{appOutput, appCommand} = case appCommand of
             cageConfig
             trustedRoot
             (applyBootTiming processTimeMs retractTimeMs)
-            BootRequest
+            (BootRequest . pure)
             registerToken
     FactInsert{..} -> do
         tid <- decodeToken token

--- a/cardano-mpfs-client/test/Cardano/MPFS/Client/HttpSpec.hs
+++ b/cardano-mpfs-client/test/Cardano/MPFS/Client/HttpSpec.hs
@@ -206,7 +206,7 @@ writeEndpointCases :: [EndpointCase]
 writeEndpointCases =
     [ EndpointCase
         ["facts", "boot"]
-        (Aeson.toJSON bootFactsParams)
+        bootFactsRequest
         (Aeson.encode honestBootFacts)
         ( \http ->
             voidRight
@@ -276,6 +276,10 @@ writeEndpointCases =
 
 bootFactsParams :: BootFactsParams
 bootFactsParams = BootFactsParams sampleAddress
+
+bootFactsRequest :: Aeson.Value
+bootFactsRequest =
+    Aeson.object ["addresses" Aeson..= [sampleAddress]]
 
 honestBootFacts :: Wire.BootFacts
 honestBootFacts =

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/BootFactsSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/BootFactsSpec.hs
@@ -229,7 +229,7 @@ postBootFacts app addr = do
             "/facts/boot"
             BootRequest
                 { brAddr =
-                    Hex (serialiseAddr addr)
+                    [Hex (serialiseAddr addr)]
                 }
     simpleStatus resp `shouldBe` status200
     case eitherDecode (simpleBody resp) of

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/FactsMatrixSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/FactsMatrixSpec.hs
@@ -1372,7 +1372,7 @@ postBootFacts app addr =
     postFactsRequest
         app
         "/facts/boot"
-        BootRequest{brAddr = Hex (serialiseAddr addr)}
+        BootRequest{brAddr = [Hex (serialiseAddr addr)]}
         "boot row"
         "BootFacts"
 

--- a/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
+++ b/cardano-mpfs-offchain/e2e-test/Cardano/MPFS/E2E/WorkflowsIntegrationSpec.hs
@@ -424,7 +424,7 @@ genesisHex :: Hex
 genesisHex = Hex (serialiseAddr genesisAddr)
 
 bootReq :: BootRequest
-bootReq = BootRequest{brAddr = genesisHex}
+bootReq = BootRequest{brAddr = [genesisHex]}
 
 insertReq :: TokenId -> ByteString -> ByteString -> InsertRequest
 insertReq tokenId key value =

--- a/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
+++ b/cardano-mpfs-offchain/lib/Cardano/MPFS/HTTP/Server.hs
@@ -33,6 +33,7 @@ import Control.Monad (forM, unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as AesonKey
+import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as BSL
@@ -847,22 +848,22 @@ requireIndexerRead =
     either (throwInternal . indexerReadErrorMessage) pure
 
 -- | @POST \/facts\/boot@. Reads snapshot and wallet
--- inputs at the owner address inside ONE indexer
+-- inputs at the owner addresses inside ONE indexer
 -- transaction, then returns facts for wallet-side
 -- boot transaction construction.
 factsBootHandler
     :: Context IO
     -> BootRequest
     -> Handler BootFacts
-factsBootHandler ctx (BootRequest addrHex) = do
-    addr <- requireAddr addrHex
+factsBootHandler ctx (BootRequest addrHexes) = do
+    addrs <- traverse requireAddr (dedupeAddressHexes addrHexes)
     (mSnap, eInputs) <-
         runProofIndexerTx ctx
             $ do
                 snap <- readSnapshot
-                ins <- readWalletInputsAt addr
+                ins <- traverse readWalletInputsAt addrs
                 pure (snap, ins)
-    inputs <- requireIndexerRead eInputs
+    inputs <- requireIndexerRead (concat <$> sequence eInputs)
     case mSnap of
         Nothing ->
             throwError
@@ -872,7 +873,7 @@ factsBootHandler ctx (BootRequest addrHex) = do
                         \snapshot unavailable"
                     }
         Just snap
-            | null inputs ->
+            | not (null addrs) && null inputs ->
                 throwError
                     err400
                         { errBody =
@@ -885,6 +886,16 @@ factsBootHandler ctx (BootRequest addrHex) = do
                         $ queryProtocolParams
                             (provider ctx)
                 pure (mkBootFacts snap inputs pp)
+
+dedupeAddressHexes :: [Hex] -> [Hex]
+dedupeAddressHexes =
+    go Set.empty
+  where
+    go _ [] = []
+    go seen (h@(Hex bytes) : rest)
+        | BS.null bytes = go seen rest
+        | Set.member bytes seen = go seen rest
+        | otherwise = h : go (Set.insert bytes seen) rest
 
 -- | Build the facts-only boot response from an indexed
 -- snapshot, resolved wallet inputs, and protocol

--- a/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/BootFactsSpec.hs
+++ b/cardano-mpfs-offchain/test/Cardano/MPFS/HTTP/BootFactsSpec.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      : Cardano.MPFS.HTTP.BootFactsSpec
@@ -8,6 +10,7 @@ module Cardano.MPFS.HTTP.BootFactsSpec (spec) where
 
 import Data.Aeson
     ( ToJSON (toJSON)
+    , decode
     , eitherDecode
     , encode
     , object
@@ -17,9 +20,11 @@ import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Types (Value (..))
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy.Char8 qualified as BL
+import Data.Either (isRight)
 import Network.HTTP.Types
     ( hContentType
     , methodPost
+    , status200
     , status400
     , status503
     )
@@ -38,18 +43,27 @@ import Test.Hspec
     , expectationFailure
     , it
     , shouldBe
+    , shouldSatisfy
     )
-import Test.QuickCheck (generate)
+import Test.QuickCheck (generate, suchThat)
 
-import Cardano.Ledger.Address (serialiseAddr)
+import Cardano.Ledger.Address (Addr, serialiseAddr)
 import Cardano.Ledger.Api.PParams (emptyPParams)
+import Cardano.Ledger.Api.Tx.Out (TxOut, mkBasicTxOut)
+import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Binary (natVersion, serialize')
 
+import Cardano.MPFS.Client.TrustedRoot (TrustedRoot (..))
+import Cardano.MPFS.Client.Verify (verifyBootFacts)
 import Cardano.MPFS.Context (Context (..))
 import Cardano.MPFS.Core.Types
     ( BlockId (..)
+    , Coin (..)
+    , ConwayEra
     , SlotNo (..)
     )
 import Cardano.MPFS.Generators (genTxIn)
+import Cardano.MPFS.HTTP.AtomicReadFixture (withProofIndexer)
 import Cardano.MPFS.HTTP.Encoding (Hex (..))
 import Cardano.MPFS.HTTP.Server
     ( mkApp
@@ -57,7 +71,15 @@ import Cardano.MPFS.HTTP.Server
     )
 import Cardano.MPFS.HTTP.StatusSpec (mkTestContext)
 import Cardano.MPFS.HTTP.Swagger (renderSwaggerJSON)
-import Cardano.MPFS.Indexer.TxFixtures (testCageAddr)
+import Cardano.MPFS.HTTP.Types
+    ( BootFacts (..)
+    , VerificationSnapshot (..)
+    )
+import Cardano.MPFS.Indexer.TxFixtures
+    ( testCageAddr
+    , testWalletAddr
+    )
+import Cardano.MPFS.Provider (Provider (..))
 import Cardano.MPFS.TxBuilder (BundleSnapshot (..))
 
 spec :: Spec
@@ -84,6 +106,70 @@ spec = describe "POST /facts/boot" $ do
                 mkTestContext
         resp <- postJson ctx "/facts/boot" validBootRequest
         simpleStatus resp `shouldBe` status503
+
+    it
+        "returns the union of wallet UTxOs for unique addresses \
+        \against one snapshot root"
+        $ do
+            txInA <- generate genTxIn
+            txInB <- generate (genTxIn `suchThat` (/= txInA))
+            ctx0 <- mkBootTestContext
+            let outA = walletTxOutBytes testWalletAddr
+                outB = walletTxOutBytes testCageAddr
+            withProofIndexer
+                Nothing
+                [(txInA, outA), (txInB, outB)]
+                ctx0
+                $ \root ctx -> do
+                    resp <-
+                        postJson
+                            ctx
+                            "/facts/boot"
+                            ( multiAddressBootRequest
+                                [ testWalletAddr
+                                , testCageAddr
+                                , testWalletAddr
+                                ]
+                            )
+                    simpleStatus resp `shouldBe` status200
+                    case decode (simpleBody resp) of
+                        Just body@BootFacts{..} -> do
+                            vsUtxoRoot bfSnapshot
+                                `shouldBe` Hex root
+                            length bfWalletUtxos `shouldBe` 2
+                            verifyBootFacts
+                                (TrustedRoot (vsUtxoRoot bfSnapshot))
+                                body
+                                `shouldSatisfy` isRight
+                        Nothing ->
+                            expectationFailure
+                                "Expected BootFacts JSON"
+
+    it "keeps accepting the legacy single address request body" $ do
+        txIn <- generate genTxIn
+        ctx0 <- mkBootTestContext
+        withProofIndexer
+            Nothing
+            [(txIn, walletTxOutBytes testWalletAddr)]
+            ctx0
+            $ \root ctx -> do
+                resp <-
+                    postJson
+                        ctx
+                        "/facts/boot"
+                        (singleAddressBootRequest testWalletAddr)
+                simpleStatus resp `shouldBe` status200
+                case decode (simpleBody resp) of
+                    Just body@BootFacts{..} -> do
+                        vsUtxoRoot bfSnapshot `shouldBe` Hex root
+                        length bfWalletUtxos `shouldBe` 1
+                        verifyBootFacts
+                            (TrustedRoot (vsUtxoRoot bfSnapshot))
+                            body
+                            `shouldSatisfy` isRight
+                    Nothing ->
+                        expectationFailure
+                            "Expected BootFacts JSON"
 
     it "documents facts route and omits legacy boot route"
         $ case eitherDecode renderSwaggerJSON of
@@ -149,11 +235,49 @@ badBootRequest = "{\"address\":\"00\"}"
 
 validBootRequest :: String
 validBootRequest =
+    singleAddressBootRequest testCageAddr
+
+singleAddressBootRequest :: Addr -> String
+singleAddressBootRequest addr =
     BL.unpack
         $ encode
         $ object
-            [ "address" .= Hex (serialiseAddr testCageAddr)
+            ["address" .= Hex (serialiseAddr addr)]
+
+multiAddressBootRequest :: [Addr] -> String
+multiAddressBootRequest addrs =
+    BL.unpack
+        $ encode
+        $ object
+            [ "addresses"
+                .= fmap
+                    (Hex . serialiseAddr)
+                    addrs
             ]
+
+walletTxOutBytes :: Addr -> ByteString
+walletTxOutBytes addr =
+    serialize'
+        (natVersion @11)
+        ( mkBasicTxOut
+            addr
+            (inject (Coin 2_000_000))
+            :: TxOut ConwayEra
+        )
+
+mkBootTestContext :: IO (Context IO)
+mkBootTestContext =
+    fmap
+        ( \ctx ->
+            ctx
+                { provider =
+                    (provider ctx)
+                        { queryProtocolParams =
+                            pure emptyPParams
+                        }
+                }
+        )
+        mkTestContext
 
 postJson
     :: Context IO

--- a/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/RegisterTokenSpec.hs
+++ b/cardano-mpfs-workflows/test/Cardano/MPFS/Workflows/RegisterTokenSpec.hs
@@ -82,8 +82,8 @@ spec = describe "registerToken" $ do
                     Left err ->
                         expectationFailure
                             ("request body did not decode: " <> err)
-                    Right (BootRequest addr) ->
-                        addr `shouldBe` brAddr bootRequest
+                    Right (BootRequest addrs) ->
+                        addrs `shouldBe` brAddr bootRequest
 
     it "maps a transport failure to WorkflowHttpError" $ do
         ref <- newIORef (Nothing :: Maybe (Text, ByteString))
@@ -135,7 +135,7 @@ recordingClient ref response =
         pure response
 
 bootRequest :: BootRequest
-bootRequest = BootRequest{brAddr = Hex (BS.replicate 28 0x42)}
+bootRequest = BootRequest{brAddr = [Hex (BS.replicate 28 0x42)]}
 
 trustedRootBytes :: ByteString
 trustedRootBytes = BS.replicate 32 0x07

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -24,14 +24,17 @@
             "type": "object"
         },
         "BootRequest": {
-            "description": "Boot a new token",
+            "description": "Boot a new token; legacy address field is also accepted",
             "properties": {
-                "address": {
-                    "$ref": "#/definitions/Hex"
+                "addresses": {
+                    "items": {
+                        "$ref": "#/definitions/Hex"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
-                "address"
+                "addresses"
             ],
             "type": "object"
         },


### PR DESCRIPTION
`POST /facts/boot` now accepts `{"addresses":[...]}` (a list of wallet addresses) and returns the merged `wallet_utxos`, each with an inclusion proof against the single snapshot root. Back-compat: `{"address":"..."}` still accepted.

Unblocks the browser register path: the SPA sources coins from CIP-30 `getUtxos()` and sends the full address set, so a wallet whose coins are spread across addresses (incl. an enterprise addr) is seen in full.

Server/API only — no onchain, no reactor, no cage-tx changes.

Refs lambdasistemi/cardano-mpfs-browser#91