### PR TITLE
fix(275): recovery, liveness and readiness contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ result-docker
 
 # MkDocs build output
 site/
+
+# Ticket-local, untracked runtime gate
+/gate.sh

--- a/specs/275-recovery-readiness/data-model.md
+++ b/specs/275-recovery-readiness/data-model.md
@@ -1,0 +1,147 @@
+# Data model — 275 recovery, liveness, readiness
+
+Fields, relationships, validation, and state invariants. No encodings beyond
+the wire shapes that are part of the published contract.
+
+## D-1 `IndexerPhase`
+
+The indexer's coarse phase, as already distinguished by the follower.
+
+| Constructor | Meaning |
+|---|---|
+| `Restoring` | rebuilding in KV-only mode; the full CSMT is not yet correct |
+| `Following` | full CSMT; blocks are applied incrementally |
+
+State invariant: `Restoring → Following` on the follower's existing
+within-stability-window transition, and `Following → Restoring` on the
+armageddon/rollback-impossible reset. Both directions must be observable;
+a one-way encoding reintroduces the #276 latch.
+
+## D-2 `FollowerMode`
+
+`FollowerEnabled | FollowerDisabled`, derived from `followerEnabled`.
+
+Validation: with `FollowerDisabled` there is no chain tip, so currency is
+vacuously satisfied and must not be evaluated.
+
+## D-3 `BootStage`
+
+Where the process is in its boot sequence, published by M-3.
+
+| Constructor | Meaning |
+|---|---|
+| `Booting BootReason` | the listener is up; the application context does not exist yet |
+| `Started` | the context is published; readiness is decided from indexer state |
+
+`BootReason` is `Opening | Recovering | Replaying (Maybe Word64)`, the last
+carrying remaining replay units when the tracer has reported them.
+
+State invariant: `Booting → Started` exactly once per process. This is a
+boot-sequence fact, not a readiness latch — readiness after `Started` is
+recomputed per request and may return to false at any time.
+
+## D-4 `ServerPhase`
+
+The published cell M-3 owns and M-2 reads.
+
+| Constructor | Carries |
+|---|---|
+| `PhaseBooting BootReason` | current boot reason |
+| `PhaseServing` | the application context |
+
+Relationship: exactly one transition per process, `PhaseBooting →
+PhaseServing`. There is no transition back; a failure terminates the process
+instead (INV-R7).
+
+## D-5 `ReadyVerdict`
+
+The result of the readiness decision.
+
+| Constructor | Carries |
+|---|---|
+| `Ready` | — |
+| `NotReady ReadyReason` | why |
+
+`ReadyReason`:
+
+| Value | Wire code | Meaning |
+|---|---|---|
+| `ReasonOpening` | `opening` | database opening, context not yet built |
+| `ReasonRecovering` | `recovering` | CSMT crash recovery in progress |
+| `ReasonReplaying` | `replaying` | retained journal replay in progress |
+| `ReasonRestoring` | `restoring` | indexer rebuilding from origin |
+| `ReasonNoChainTip` | `no-chain-tip` | following, but no tip observed yet |
+| `ReasonBehind` | `behind` | following and correct, but outside the stability window of the tip |
+| `ReasonProofsUnavailable` | `proofs-unavailable` | proof reads momentarily inconsistent |
+
+Validation: the reason is diagnostic only. Consumers gate on the HTTP status
+code; the contract published to M2-T101 says so explicitly, so that adding a
+reason later is not a breaking change.
+
+## D-6 `LiveResponse`
+
+Wire shape of `GET /live`, always HTTP 200:
+
+```json
+{"live": true}
+```
+
+Invariant: no field of this response is derived from indexer or chain state.
+A liveness answer that could be affected by recovery is not a liveness answer.
+
+## D-7 `ReadyResponse`
+
+Wire shape of `GET /ready`. HTTP 200 when ready, HTTP 503 otherwise; the body
+shape is the same in both cases so a consumer parses one type.
+
+```json
+{
+  "ready": false,
+  "reason": "replaying",
+  "checkpoint_slot": 3715222,
+  "tip_slot": 123518063,
+  "replay_remaining": 1307033
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `ready` | bool | mirrors the status code; the status code is authoritative |
+| `reason` | string or null | null exactly when `ready` is true |
+| `checkpoint_slot` | int or null | null when no checkpoint is persisted yet |
+| `tip_slot` | int or null | null when no tip has been observed |
+| `replay_remaining` | int or null | null outside retained journal replay |
+
+Rationale: this body is what preserves operator observability (FR-5) once
+`/status` and `/metrics` are gated. It reports progress; it never reports a
+root. A 503 carrying progress cannot be mistaken for a successful data read.
+
+## D-8 Gated-route error body
+
+Wire shape returned by the gate for any route outside the allowlist while not
+ready, HTTP 503:
+
+```json
+{"error": "not ready", "reason": "restoring"}
+```
+
+Invariant: the gate never emits 404 for a gated route, and never emits a body
+containing a root, a checkpoint-derived proof, or any indexer-resolved value.
+
+## D-9 Readiness relation
+
+`Ready` holds exactly when all of:
+
+1. `BootStage` is `Started`;
+2. `IndexerPhase` is `Following`;
+3. proof reads are internally consistent;
+4. currency holds — either `FollowerDisabled`, or a tip has been observed and
+   `checkpointSlot + stabilityWindowSlots >= tipSlot`.
+
+Reason precedence when several fail, most fundamental first: boot stage,
+phase, currency, proof consistency. Precedence is fixed so the reported reason
+is deterministic and testable.
+
+State invariant (INV-R5): this is a relation over current observations, not a
+stored flag. Nothing in the system may cache a `Ready` verdict across
+requests.

--- a/specs/275-recovery-readiness/data-model.md
+++ b/specs/275-recovery-readiness/data-model.md
@@ -145,3 +145,49 @@ is deterministic and testable.
 State invariant (INV-R5): this is a relation over current observations, not a
 stored flag. Nothing in the system may cache a `Ready` verdict across
 requests.
+
+## D-10 `BuildInfo`
+
+Semantic interface fixed by M2 NOTE-002; field names may follow repository
+style but the shape and the effect boundary may not change.
+
+| Field | Type | Required | Source |
+|---|---|---|---|
+| `buildVersion` | `Text` | yes | compile time |
+| `buildGitCommit` | `Text` | yes | compile time |
+| `buildImageDigest` | `Maybe Text` | no | `MPFS_IMAGE_DIGEST`, read once at startup |
+
+Validation:
+
+- a qualifying production value of `buildGitCommit` is exactly 40 lowercase
+  hex characters;
+- a present `buildImageDigest` is `sha256:` followed by exactly 64 lowercase
+  hex characters;
+- a development build may carry `unknown` or `dirty:<rev>`. These are
+  deliberately shaped so they cannot be confused with a clean SHA, and the
+  clean-source predicate must reject them.
+
+State invariant (INV-R12): the value is constructed once, before the listener
+and recovery sequence, and is immutable for the life of the process.
+
+## D-11 `VersionResponse`
+
+Wire shape of `GET /version`, always HTTP 200 while the process is alive:
+
+```json
+{
+  "version": "0.2.2",
+  "git_commit": "0f82465f5f828c2ab987a166e9e24c2368228d01",
+  "image_digest": "sha256:<64 hex>"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `version` | string | release version; never null |
+| `git_commit` | string | full commit or a development sentinel; never null |
+| `image_digest` | string or null | null when the deployment did not supply one |
+
+Invariant: no field is derived from indexer or chain state, so no recovery
+phase can affect this response. A `/version` that could 503 during replay
+would be useless for the reconciliation it exists to serve.

--- a/specs/275-recovery-readiness/functions-model.md
+++ b/specs/275-recovery-readiness/functions-model.md
@@ -1,0 +1,149 @@
+# Functions model — 275 recovery, liveness, readiness
+
+New and changed signatures with explicit argument names. No bodies, no
+algorithms, no helpers.
+
+## M-1 `Cardano.MPFS.HTTP.Readiness`
+
+```haskell
+evalReadiness
+    :: FollowerMode      -- ^ followerMode
+    -> Word64            -- ^ stabilityWindowSlots
+    -> BootStage         -- ^ bootStage
+    -> IndexerPhase      -- ^ indexerPhase
+    -> Bool              -- ^ proofsConsistent
+    -> Maybe SlotNo      -- ^ checkpointSlot
+    -> Maybe SlotNo      -- ^ observedTipSlot
+    -> ReadyVerdict
+```
+
+Total, pure, and free of `IO`. `indexerPhase` is ignored when `bootStage` is
+`Booting`, and that must be a stated property rather than an accident of
+evaluation order.
+
+```haskell
+reasonCode :: ReadyReason -> Text
+```
+
+The wire codes of D-5. Must be exhaustive over the constructor set so a new
+reason cannot silently serialize as an existing one.
+
+## M-2 `Cardano.MPFS.HTTP.Gate`
+
+```haskell
+readinessAllowlist :: [[Text]]
+```
+
+The exhaustive set of always-available path segments, currently `/live` and
+`/ready`. The only place the allowlist is written down.
+
+```haskell
+mkGate
+    :: IO ServerPhase        -- ^ readServerPhase
+    -> (Context IO -> IO ReadinessObservation)
+                             -- ^ observeContext
+    -> Application           -- ^ inner
+    -> Application
+```
+
+Answers `/live` and `/ready` itself; forwards to `inner` only when the path is
+outside the allowlist **and** the verdict is `Ready`; otherwise responds 503
+with D-8.
+
+```haskell
+observeReadiness :: Context IO -> IO ReadinessObservation
+```
+
+Gathers the live observations `evalReadiness` consumes from a published
+context. This is the only place observations are gathered, so the decision
+cannot be fed different inputs from different call sites.
+
+## M-3 `Cardano.MPFS.Server.Boot`
+
+```haskell
+data ServeConfig = ServeConfig
+    { serveAppConfig   :: AppConfig
+    , servePort        :: Int
+    , serveOnListening :: Int -> IO ()
+    }
+```
+
+`serveOnListening` receives the actually bound port and is invoked after the
+socket is bound and before recovery starts. Production passes a no-op; the
+recovery proof uses it to learn an ephemeral port and to assert ordering.
+
+```haskell
+runServer :: ServeConfig -> IO ()
+```
+
+Binds, serves the gate, runs the application concurrently, publishes the
+context, and blocks until the listener or the application terminates.
+Propagates any boot or linked-thread failure to its caller (INV-R7); it must
+not catch and continue.
+
+```haskell
+withServer :: ServeConfig -> (ServerHandle -> IO a) -> IO a
+```
+
+Bracketed form used by the recovery proof: runs the same sequence as
+`runServer` and hands back the bound port, so no test may construct its own
+boot sequence (INV-R10).
+
+## M-4 `Cardano.MPFS.HTTP.Server`
+
+```haskell
+mkApp :: Context IO -> Application
+```
+
+Unchanged signature. Its result becomes the `inner` argument of `mkGate`.
+
+## M-7 `Cardano.MPFS.Context`
+
+Three added fields on the existing record:
+
+```haskell
+    , indexerPhase         :: m IndexerPhase
+    , stabilityWindowSlots :: Word64
+    , followerMode         :: FollowerMode
+```
+
+`indexerProofsReady`, `state`, and `readMetrics` are unchanged and supply the
+remaining observations.
+
+## M-9 `exe/Serve.hs`
+
+```haskell
+main :: IO ()
+```
+
+Unchanged signature; its body may parse arguments, validate, load the
+blueprint, create the database directory, assemble `ServeConfig`, and call
+`runServer`. Any other sequencing there violates INV-R10.
+
+## M-12 test surface
+
+```haskell
+spec :: Spec
+```
+
+## M-13 test surface
+
+```haskell
+spec :: Spec
+```
+
+```haskell
+probeStatus :: Int -> Text -> IO Int
+```
+
+Issues one real HTTP request over TCP to the bound port and returns the status
+code. Must surface a connection failure as a distinct, loud outcome rather
+than as a status code, so "connect refused" can never be recorded as a pass.
+
+```haskell
+holdingReplay :: IO a -> (Tracer IO AppTrace -> IO () -> IO a) -> IO a
+```
+
+Supplies a tracer that blocks the replaying thread at `ReplayStart` and an
+action that releases it. Built on the existing application tracer seam; no
+production code exists solely to support it.

--- a/specs/275-recovery-readiness/functions-model.md
+++ b/specs/275-recovery-readiness/functions-model.md
@@ -147,3 +147,55 @@ holdingReplay :: IO a -> (Tracer IO AppTrace -> IO () -> IO a) -> IO a
 Supplies a tracer that blocks the replaying thread at `ReplayStart` and an
 action that releases it. Built on the existing application tracer seam; no
 production code exists solely to support it.
+
+## M-14 `Cardano.MPFS.BuildInfo`
+
+```haskell
+data BuildInfo = BuildInfo
+    { buildVersion     :: Text
+    , buildGitCommit   :: Text
+    , buildImageDigest :: Maybe Text
+    }
+```
+
+```haskell
+loadBuildInfo :: IO BuildInfo
+```
+
+Called once during startup, before the listener and recovery sequence. Reads
+the optional `MPFS_IMAGE_DIGEST`. Must not be called per request and must not
+be reached through `unsafePerformIO`.
+
+```haskell
+isCleanSourceCommit :: Text -> Bool
+isImmutableImageDigest :: Text -> Bool
+```
+
+Pure predicates, exported for M2-E-PUBLISH's publication gate. `isCleanSourceCommit`
+returns `False` for every development sentinel.
+
+## M-2 addendum
+
+```haskell
+mkGate
+    :: BuildInfo             -- ^ buildInfo
+    -> IO ServerPhase        -- ^ readServerPhase
+    -> (Context IO -> IO ReadinessObservation)
+                             -- ^ observeContext
+    -> Application           -- ^ inner
+    -> Application
+```
+
+`buildInfo` is supplied at construction, which is what makes the
+capture-once property structural rather than a convention.
+
+## M-3 addendum
+
+```haskell
+data ServeConfig = ServeConfig
+    { serveAppConfig   :: AppConfig
+    , servePort        :: Int
+    , serveBuildInfo   :: BuildInfo
+    , serveOnListening :: Int -> IO ()
+    }
+```

--- a/specs/275-recovery-readiness/functions-model.md
+++ b/specs/275-recovery-readiness/functions-model.md
@@ -34,8 +34,8 @@ reason cannot silently serialize as an existing one.
 readinessAllowlist :: [[Text]]
 ```
 
-The exhaustive set of always-available path segments, currently `/live` and
-`/ready`. The only place the allowlist is written down.
+The exhaustive set of always-available path segments: `/live`, `/ready` and
+`/version`. The only place the allowlist is written down.
 
 ```haskell
 mkGate
@@ -46,8 +46,11 @@ mkGate
     -> Application
 ```
 
-Answers `/live` and `/ready` itself; forwards to `inner` only when the path is
-outside the allowlist **and** the verdict is `Ready`; otherwise responds 503
+Superseded by the **M-2 addendum** below, which prepends `buildInfo`. Implement
+the addendum signature; this block records the rest of the argument list.
+
+Answers `/live`, `/ready` and `/version` itself; forwards to `inner` only when
+the path is outside the allowlist **and** the verdict is `Ready`; otherwise 503s
 with D-8.
 
 ```haskell

--- a/specs/275-recovery-readiness/modules-model.md
+++ b/specs/275-recovery-readiness/modules-model.md
@@ -119,3 +119,49 @@ recovery paths, the held-replay window, and the controls of AC-6.
 
 Replaces nothing. `CrashRecoverySpec` keeps its own state-survival scope; this
 module owns the HTTP boundary during recovery, which no existing spec covers.
+
+## Added by the C-IDENTITY amendment (M2 NOTE-001, NOTE-002)
+
+### M-14 `Cardano.MPFS.BuildInfo`
+
+Package `cardano-mpfs-offchain`, library.
+
+Owns build identity: the compile-time captured release version and full source
+commit, the optional deploy-time image digest read once at startup, and the
+pure predicates that decide whether a value qualifies as clean source or as an
+immutable digest.
+
+Depends on: nothing in this repository. Depended on by M-2 and M-3.
+
+Placement rationale: M2-E-PUBLISH must be able to feed the compile-time values
+and call the predicates from a publication gate without pulling in the HTTP
+layer or the application. A leaf module is the only placement that permits
+that. The effect boundary is fixed by the ruling: identity is loaded in `IO`,
+once; nothing exposes a pure value that secretly reads the environment.
+
+### M-15 `Cardano.MPFS.API` (shared package `cardano-mpfs-api`)
+
+Gains the `GET /version` route type and its response shape.
+
+Placement rationale: the ruling designates `/version` a **typed shared-API**
+route, so it goes in the shared package even though `/live` and `/ready` do
+not. The distinction is deliberate and worth stating: `/version` has an
+accepted typed consumer contract that other producers must not redefine, while
+`/live` and `/ready` are consumed over plain HTTP by a non-Haskell client and
+would widen the cross-compiled verifier surface for no consumer.
+
+The response carries exactly the ruling's three fields. Blueprint and script
+hashes are deliberately excluded: they are functional metadata and cannot help
+reconcile a running process to an artifact.
+
+### M-2 addendum
+
+The gate answers `/version` itself from the build identity held in its
+environment, exactly as it answers `/live` and `/ready`, and never delegates
+it inward. A route that must answer before the application context exists
+cannot be served by an application built from that context.
+
+### M-16 `Cardano.MPFS.BuildInfoSpec` (unit)
+
+Covers the predicates of M-14 including every sentinel, and the
+capture-once-immutably property of INV-R12.

--- a/specs/275-recovery-readiness/modules-model.md
+++ b/specs/275-recovery-readiness/modules-model.md
@@ -1,0 +1,121 @@
+# Modules model — 275 recovery, liveness, readiness
+
+Responsibility, dependency direction, and placement only. No bodies, imports,
+or algorithms. Signatures live in `functions-model.md`; shapes in
+`data-model.md`.
+
+## New
+
+### M-1 `Cardano.MPFS.HTTP.Readiness`
+
+Package `cardano-mpfs-offchain`, library.
+
+Owns the readiness **decision** and nothing else: given the current
+observations, is the server able to serve a correct and current root, and if
+not, why. Deliberately pure and free of `Context`, HTTP, and `IO`, so the
+decision can be exhaustively tested and mutated without a server.
+
+Depends on: core slot/phase types only. Depended on by M-2 and M-3.
+
+Placement rationale: this is the one piece every other piece asks. Keeping it
+below the HTTP layer prevents the decision from being re-derived — differently
+— in a handler, in the middleware, and in a test.
+
+### M-2 `Cardano.MPFS.HTTP.Gate`
+
+Package `cardano-mpfs-offchain`, library.
+
+Owns the default-deny readiness gate at the WAI layer: the allowlist, the 503
+response shape for gated routes, and the `/live` and `/ready` responses, which
+it answers itself rather than delegating inward. Reads the published server
+phase; asks M-1 for the verdict.
+
+Depends on: M-1, `Cardano.MPFS.HTTP.Types`. Depended on by M-3 and M-4.
+
+Placement rationale: the gate must sit in front of *every* route, including
+routes that do not exist yet and routes that exist only while the application
+context does not. A middleware is the only placement where "gated by default"
+is a property of the architecture rather than a habit.
+
+### M-3 `Cardano.MPFS.Server.Boot`
+
+Package `cardano-mpfs-offchain`, library.
+
+Owns the boot sequence: bind the listener, serve M-2's gate immediately, run
+`withApplication` concurrently, tee the application tracer into boot progress,
+publish the context when boot completes, and propagate failure so the process
+terminates. Owns the server-phase cell.
+
+Depends on: `Cardano.MPFS.Application`, M-2, `Cardano.MPFS.HTTP.Server`.
+Depended on by `exe/Serve.hs` and by the recovery e2e spec.
+
+Placement rationale (INV-R10): this exists as a library module precisely so
+that the executable and the proof run the same code. Boot logic living in
+`main` is unreachable from a test, which is how #276 shipped a green spec for
+a path it never executed.
+
+## Changed
+
+### M-4 `Cardano.MPFS.HTTP.Server`
+
+`mkApp` is wrapped by M-2's gate. Handlers keep their existing internal
+proof-read guard: that guard is a strictly stronger, instantaneous check and
+is not replaced by the readiness gate.
+
+### M-5 `Cardano.MPFS.HTTP.API`
+
+Gains the `/live` and `/ready` route types, beside the existing server-local
+metrics routes.
+
+Placement rationale (Constitution IX): these are server operational signals,
+not part of the client contract, so they must not enter the shared
+`cardano-mpfs-api` package that the WASM and JS verifier targets compile.
+
+### M-6 `Cardano.MPFS.HTTP.Types`
+
+Gains the response shapes for `/live` and `/ready`.
+
+### M-7 `Cardano.MPFS.Context`
+
+Gains the observations readiness needs that the context does not already
+expose: the indexer phase, the stability window, and the follower mode. It
+already exposes the proof-read flag, the checkpoint, and the metrics snapshot.
+
+Promotion note: these are observations, not services. They are added as plain
+fields on the existing record rather than as a new service record, because a
+record of functions for three constants would be indirection without a seam.
+
+### M-8 `Cardano.MPFS.Application`
+
+Publishes the indexer phase alongside the existing proof-read flag, so the
+phase transitions the follower already performs become observable. No change
+to block processing or transaction boundaries.
+
+### M-9 `exe/Serve.hs`
+
+Reduced to argument parsing, validation, blueprint loading, configuration
+assembly, and a call into M-3.
+
+### M-10 `scripts/deploy-preprod.sh`
+
+Waits on `/ready` instead of `/status`.
+
+### M-11 `docs/`
+
+States that `/live` is the only supervisor signal and `/ready` the dependency
+gate, and records that no HTTP healthcheck is configured in this repository.
+
+## Test modules
+
+### M-12 `Cardano.MPFS.HTTP.ReadinessSpec` (unit)
+
+Exhaustive and property-based coverage of M-1, including the follower-disabled
+case and the negative controls that prove each input is load-bearing.
+
+### M-13 `Cardano.MPFS.E2E.RecoverySignalsSpec` (e2e)
+
+The live-boundary proof: real devnet, real Warp socket, real HTTP client, both
+recovery paths, the held-replay window, and the controls of AC-6.
+
+Replaces nothing. `CrashRecoverySpec` keeps its own state-survival scope; this
+module owns the HTTP boundary during recovery, which no existing spec covers.

--- a/specs/275-recovery-readiness/plan.md
+++ b/specs/275-recovery-readiness/plan.md
@@ -12,7 +12,7 @@ Three structural moves, in this order:
    inputs on every request makes non-monotonicity structural rather than a
    behavior someone must remember to implement.
 2. **Gate data with default-deny middleware, not per-handler calls.** A WAI
-   layer in front of the whole application 503s every path outside a two-entry
+   layer in front of the whole application 503s every path outside a three-entry
    allowlist. A route added later is gated by construction; nobody has to
    remember to add a guard. This is the difference between an invariant and a
    convention.
@@ -137,7 +137,7 @@ part), and INV-R9 for those.
 | INV-R1 | the listener accepts TCP and answers `/live` before any retained-database recovery or journal replay begins | during a held replay on a retained DB, a TCP connect to the port is refused or times out |
 | INV-R2 | `/live` is 200 on every probe from listener start through the whole recovery window, including a window longer than the historical 10 s healthcheck timeout | any probe in the window is non-200 or fails to connect |
 | INV-R3 | `/ready` is 503 unless phase is following **and** the checkpoint is within the stability window of the observed tip **and** proofs are consistent; 200 otherwise | `/ready` 200 while restoring, while the tip is unobserved, or while the checkpoint is outside the window |
-| INV-R4 | every route outside the `{/live, /ready}` allowlist returns 503 while `/ready` is 503 | any gated route returns 2xx during a not-ready window, or returns 200 with a null or stale root |
+| INV-R4 | every route outside the `{/live, /ready, /version}` allowlist returns 503 while `/ready` is 503 | any gated route returns 2xx during a not-ready window, or returns 200 with a null or stale root |
 | INV-R5 | readiness returns to 503 when correctness or currency is lost after having been true | readiness stays 200 across a forced restoration/armageddon reset |
 | INV-R6 | INV-R1..R4 hold on the retained-reopen path **and** the empty/lost-database path | either path is unproven, or proven only in-process |
 | INV-R7 | a boot or linked-thread failure terminates the process non-zero and closes the listener | after an injected boot failure the listener still answers and the process stays alive |
@@ -160,9 +160,26 @@ part), and INV-R9 for those.
 | VI Test locally first | pass — devnet subprocess plus in-process Warp; no Docker, no external service |
 | VII Nix reproducibility | pass — all commands run through `nix develop` / `just` |
 | VIII Pure offline verification | pass — no verifier changes; the readiness decision is itself a pure function |
-| IX One verifier, many targets | pass — `/live` and `/ready` are declared in the offchain-only `Cardano.MPFS.HTTP.API`, not in the shared `cardano-mpfs-api`, so the WASM/JS client surface is unchanged |
+| IX One verifier, many targets | pass with the re-check below — `/live` and `/ready` stay in the offchain-only `Cardano.MPFS.HTTP.API`, but the C-IDENTITY amendment places `/version` in the shared `cardano-mpfs-api`, which *is* a cross-compiled target |
 
-Re-check after design: unchanged. No waiver required.
+Re-check after design: **IX changed and was re-checked.** The original wording
+justified itself by the shared package being untouched, and the C-IDENTITY
+amendment made that false. `nix/wasm-targets.nix` patches
+`cardano-mpfs-api/cardano-mpfs-api.cabal` and builds it among the three
+wasm32-wasi packages, and `cardano-mpfs-verify` depends on it. Adding the
+`/version` route type and its response record therefore does widen the
+cross-compiled surface.
+
+It still passes, for a reason that has to be stated rather than assumed: the
+addition is a Servant route type plus an Aeson record over `Text` and
+`Maybe Text`, using only dependencies that `cardano-mpfs-api` already carries
+into the wasm build. No part of build identity is evaluated there —
+`loadBuildInfo` is `IO` and lives in the offchain-only `Cardano.MPFS.BuildInfo`
+(M-14), which no verifier target depends on.
+
+This is not left to argument. The `build` leg of the ticket gate builds
+`.#wasm-mpfs-verify`, so a `/version` addition that breaks the wasm target
+fails the gate rather than surviving to CI. No waiver required.
 
 ## Risks
 

--- a/specs/275-recovery-readiness/plan.md
+++ b/specs/275-recovery-readiness/plan.md
@@ -1,0 +1,168 @@
+# Plan — 275 recovery, liveness, readiness
+
+Base: `origin/main` @ `0f82465f5f828c2ab987a166e9e24c2368228d01`.
+
+## Strategy
+
+Three structural moves, in this order:
+
+1. **Make readiness a pure function of live state, never a latch.** The
+   2026-06 draft (#276) latched readiness once per process, so it could not
+   return to false when correctness was lost. Computing readiness from current
+   inputs on every request makes non-monotonicity structural rather than a
+   behavior someone must remember to implement.
+2. **Gate data with default-deny middleware, not per-handler calls.** A WAI
+   layer in front of the whole application 503s every path outside a two-entry
+   allowlist. A route added later is gated by construction; nobody has to
+   remember to add a guard. This is the difference between an invariant and a
+   convention.
+3. **Start the listener before recovery.** `Warp` runs concurrently with
+   `withApplication`; the application context is published into a `TVar` when
+   boot completes. This deletes the retained-vs-empty special case entirely:
+   both paths become "listener up, not ready, then ready".
+
+Nothing here introduces a tuned timeout, a start-period, or a stall detector.
+A-003 rejected safety that rests on an unmeasured, growing quantity, and a
+liveness stall detector would reintroduce exactly that.
+
+## Why `/live` has no failure mode
+
+`/live` answers 200 whenever it answers at all. Progress is enforced by
+termination, not by a probe threshold: if boot or any linked worker thread
+fails, the exception propagates out of the server action, `withAsync` closes
+the listener, and the process exits non-zero. The supervisor then observes a
+dead container rather than a 503.
+
+This is what makes INV-R7 load-bearing. Without it the design has a zombie
+state — listener up, `/live` 200 forever, `/ready` 503 forever, supervisor
+never acting — which is a worse outage than the one being fixed, because it is
+silent. INV-R7 is therefore not a nicety; it is the other half of FR-1.
+
+## Readiness inputs
+
+READY is computed from, and only from:
+
+- follower mode (`followerEnabled`);
+- the genesis stability window, in slots;
+- boot stage (booting, with a reason) or indexer phase (restoring/following);
+- the internal proof-read consistency flag;
+- the latest persisted checkpoint slot;
+- the most recently observed chain tip slot.
+
+Currency is `checkpoint + stabilityWindow >= tip`. This is the same threshold
+the follower already uses for its restoration→following transition, so the
+change introduces no new tunable. With the follower disabled there is no tip
+and currency is vacuous.
+
+## Live boundary
+
+Diagnostic question — *what system boundary does this exercise that the unit
+suite cannot?*
+
+Three, and each is exactly where the previous attempt failed:
+
+| Boundary | Why units cannot see it | Proof |
+|---|---|---|
+| TCP accept during recovery | in-process WAI needs no socket and no listener; #276's spec passed while the real path had no listener at all | connect and probe from an HTTP client against a bound port |
+| boot ordering | ordering is a property of the real boot sequence, not of any handler | hold replay open via the application tracer, probe during the hold |
+| retained-database reopen | a fresh temp DB never replays a journal | reopen a database populated by a real devnet run |
+
+Therefore `./gate.sh` carries a live-boundary smoke: a real `cardano-node`
+devnet subprocess (`withCardanoNode`, Constitution VI — no Docker), a real
+Warp socket, and a real HTTP client. No operator follow-up is deferred.
+
+**The barrier is an existing production seam, not a test hook.** The
+application tracer already receives `TraceReplay ReplayStart` from the
+replaying thread. A test tracer that blocks there holds replay open for as
+long as the test wants — deterministically, with no sleep-and-hope and no
+production code that exists only for tests. The server's own progress tracer
+runs *before* the configured tracer in the tee, so `/ready` still reports
+`replaying` while the configured tracer is blocked.
+
+## Falsifiability
+
+Every assertion ships with a control proving it can fail (AC-6). Specifically:
+
+- **positive control on the probe itself** — the probe helper must report
+  failure when pointed at a closed port, so "connect succeeded" is not
+  vacuously true;
+- **negative control per boundary** — an injected variant that violates the
+  invariant must make exactly the corresponding assertion red: readiness
+  forced true early (INV-R4 fails), listener started after replay (INV-R1
+  fails), readiness latched (INV-R5 fails);
+- **quantities in the passing output** — the held window prints the duration
+  actually held against the target, so a pass that held 0 s is distinguishable
+  from a pass that held 12 s.
+
+The pure readiness function makes most controls cheap: mutate one input, assert
+the verdict flips.
+
+## Slices
+
+Both slices are bisect-safe: S1 alone removes the "200 with a null or stale
+root" lie; S2 alone would be meaningless without S1's signals.
+
+### S1 — signals surface and default-deny data gating
+
+Adds `/live` and `/ready`, the pure readiness function, the readiness
+middleware, the Context fields readiness needs, the regenerated Swagger, the
+deployment-helper change, and the documentation of signal roles. Boot order is
+untouched.
+
+Provable today over real TCP on the empty-database path, because that path
+already has a listener.
+
+Invariants: INV-R3, INV-R4, INV-R5, INV-R8, INV-R9 (for those).
+
+### S2 — listener before recovery
+
+Extracts the boot sequence out of `exe/Serve.hs` into a library module that
+starts Warp first and publishes the context when boot completes; `main` keeps
+only argument handling. Adds the real-TCP recovery proof across both paths.
+
+Invariants: INV-R1, INV-R2, INV-R6, INV-R7, INV-R10, INV-R9 (for those).
+
+## Invariant mandate
+
+| ID | Must hold | Observable failure |
+|---|---|---|
+| INV-R1 | the listener accepts TCP and answers `/live` before any retained-database recovery or journal replay begins | during a held replay on a retained DB, a TCP connect to the port is refused or times out |
+| INV-R2 | `/live` is 200 on every probe from listener start through the whole recovery window, including a window longer than the historical 10 s healthcheck timeout | any probe in the window is non-200 or fails to connect |
+| INV-R3 | `/ready` is 503 unless phase is following **and** the checkpoint is within the stability window of the observed tip **and** proofs are consistent; 200 otherwise | `/ready` 200 while restoring, while the tip is unobserved, or while the checkpoint is outside the window |
+| INV-R4 | every route outside the `{/live, /ready}` allowlist returns 503 while `/ready` is 503 | any gated route returns 2xx during a not-ready window, or returns 200 with a null or stale root |
+| INV-R5 | readiness returns to 503 when correctness or currency is lost after having been true | readiness stays 200 across a forced restoration/armageddon reset |
+| INV-R6 | INV-R1..R4 hold on the retained-reopen path **and** the empty/lost-database path | either path is unproven, or proven only in-process |
+| INV-R7 | a boot or linked-thread failure terminates the process non-zero and closes the listener | after an injected boot failure the listener still answers and the process stays alive |
+| INV-R8 | no repository-owned artifact treats `/status` or `/ready` as a supervisor signal; the deployment helper waits on `/ready` | `scripts/deploy-preprod.sh` polls `/status`, or any repository artifact configures an HTTP healthcheck |
+| INV-R9 | every assertion behind INV-R1..R7 is demonstrated able to fail by a control the gate executes | a control is described in prose but never run, or does not go red when its invariant is violated |
+| INV-R10 | the boot function exercised by the recovery proof is the exact function `mpfs-serve` runs | `main` contains boot sequencing the proof does not exercise |
+
+## Constitution check
+
+| Principle | Verdict |
+|---|---|
+| I Ledger-native types | pass — no new domain types; slots stay `SlotNo` |
+| II Records of functions | pass — new readiness inputs are fields on the `Context` record of functions |
+| III Atomic block processing | pass — untouched |
+| IV Client-side tx construction | pass — the new routes return operational signals, never transactions |
+| V Aiken compatibility | pass — untouched |
+| VI Test locally first | pass — devnet subprocess plus in-process Warp; no Docker, no external service |
+| VII Nix reproducibility | pass — all commands run through `nix develop` / `just` |
+| VIII Pure offline verification | pass — no verifier changes; the readiness decision is itself a pure function |
+| IX One verifier, many targets | pass — `/live` and `/ready` are declared in the offchain-only `Cardano.MPFS.HTTP.API`, not in the shared `cardano-mpfs-api`, so the WASM/JS client surface is unchanged |
+
+Re-check after design: unchanged. No waiver required.
+
+## Risks
+
+- **Existing specs assert `/status` 200 before readiness.** Updating them is in
+  scope for S1 and is a behavior change, not a test weakening; each such edit
+  must be justified against FR-4 in the commit body.
+- **`followerEnabled = False` fixtures.** Currency must be vacuous in that
+  mode or a large part of the e2e suite hangs waiting for a tip that never
+  arrives. This is an explicit case in the pure function and needs its own
+  test.
+- **Devnet replay is fast.** Without the tracer barrier the not-ready window
+  would be too short to observe, and the test would pass vacuously. The
+  barrier is what makes AC-1 non-vacuous, so a control must prove the barrier
+  actually held.

--- a/specs/275-recovery-readiness/plan.md
+++ b/specs/275-recovery-readiness/plan.md
@@ -112,7 +112,14 @@ untouched.
 Provable today over real TCP on the empty-database path, because that path
 already has a listener.
 
-Invariants: INV-R3, INV-R4, INV-R5, INV-R8, INV-R9 (for those).
+Invariants: INV-R3, INV-R4, INV-R5, INV-R8, INV-R11 (in-context part), INV-R12,
+INV-R13, and INV-R9 for those.
+
+The `/version` route, `BuildInfo`, and the identity predicates land here rather
+than in a later slice for two reasons: the allowlist must be written exactly
+once, and M2-E-PUBLISH is blocked on this interface. Proving `/version` answers
+*before the context exists* needs the boot restructure and therefore belongs to
+S2, but the route, schema, capture, and predicates do not.
 
 ### S2 — listener before recovery
 
@@ -120,7 +127,8 @@ Extracts the boot sequence out of `exe/Serve.hs` into a library module that
 starts Warp first and publishes the context when boot completes; `main` keeps
 only argument handling. Adds the real-TCP recovery proof across both paths.
 
-Invariants: INV-R1, INV-R2, INV-R6, INV-R7, INV-R10, INV-R9 (for those).
+Invariants: INV-R1, INV-R2, INV-R6, INV-R7, INV-R10, INV-R11 (pre-context
+part), and INV-R9 for those.
 
 ## Invariant mandate
 
@@ -136,6 +144,9 @@ Invariants: INV-R1, INV-R2, INV-R6, INV-R7, INV-R10, INV-R9 (for those).
 | INV-R8 | no repository-owned artifact treats `/status` or `/ready` as a supervisor signal; the deployment helper waits on `/ready` | `scripts/deploy-preprod.sh` polls `/status`, or any repository artifact configures an HTTP healthcheck |
 | INV-R9 | every assertion behind INV-R1..R7 is demonstrated able to fail by a control the gate executes | a control is described in prose but never run, or does not go red when its invariant is violated |
 | INV-R10 | the boot function exercised by the recovery proof is the exact function `mpfs-serve` runs | `main` contains boot sequencing the proof does not exercise |
+| INV-R11 | `/version` returns 200 with mandatory version and full commit whenever the process is alive, including before the context exists and throughout replay | `/version` is 503, 404, or missing a mandatory field during a held replay |
+| INV-R12 | build identity is captured once before the listener/replay sequence and is immutable thereafter | mutating `MPFS_IMAGE_DIGEST` after startup changes a `/version` response, or the value is read per request |
+| INV-R13 | a development sentinel can never satisfy the clean-source predicate, and a digest must be `sha256:` plus 64 hex | `unknown` or `dirty:<rev>` passes the clean-source predicate |
 
 ## Constitution check
 
@@ -166,3 +177,15 @@ Re-check after design: unchanged. No waiver required.
   would be too short to observe, and the test would pass vacuously. The
   barrier is what makes AC-1 non-vacuous, so a control must prove the barrier
   actually held.
+
+## Where build identity lives
+
+`/version` must answer 200 **before the application context exists**, so build
+identity cannot live on `Context`. It is captured by `loadBuildInfo` during
+startup, placed in the server's HTTP environment beside the server-phase cell,
+and answered by the same layer that answers `/live` and `/ready`.
+
+That placement is what makes INV-R11 and INV-R12 hold together: a value the
+gate already holds cannot be re-read per request, and a route the gate answers
+itself cannot become unavailable when the context is absent. Putting identity
+on `Context` would satisfy the schema and fail the contract.

--- a/specs/275-recovery-readiness/spec.md
+++ b/specs/275-recovery-readiness/spec.md
@@ -76,6 +76,16 @@ so wiring one restarts a healthy, recovering process.
 - **FR-9** `mpfs-serve`'s `main` performs no boot sequencing of its own beyond
   argument parsing and validation; the boot function proven by the recovery
   tests is the exact function production runs.
+- **FR-10** `GET /version` returns 200 whenever the process is alive —
+  including before the application context exists and throughout replay —
+  carrying a mandatory release version, a mandatory full build-time commit,
+  and an optional deploy-time image digest.
+- **FR-11** Build identity is captured exactly once, during startup and before
+  the listener/replay sequence, and is thereafter immutable. No per-request
+  environment read and no `unsafePerformIO`.
+- **FR-12** A development build may report an unmistakable sentinel, but a
+  sentinel can never satisfy the clean-source predicate that qualifies a
+  published artifact.
 
 ## Route classification
 
@@ -86,6 +96,7 @@ Always available — exactly:
 
 - `GET /live`
 - `GET /ready`
+- `GET /version` (C-IDENTITY, amended into C-SIGNALS by M2 NOTE-001)
 
 Gated (503 while not ready) — everything else, which today means all of
 `Cardano.MPFS.API` (`Shared.API`) including `GET /status`, `GET /metrics`,
@@ -93,12 +104,14 @@ Gated (503 while not ready) — everything else, which today means all of
 
 Gating the Swagger assets and `/metrics` is deliberate: C-SIGNALS names the
 always-available operational surfaces exhaustively, and a default-deny gate
-with a two-entry allowlist cannot drift. Operator observability during the
+with a three-entry allowlist cannot drift. Operator observability during the
 not-ready window is preserved by FR-5 instead of by exempting `/metrics`.
 
-`GET /version` is C-IDENTITY, produced by M2-E-PUBLISH, and is out of scope
-here. The exempt set MUST be an explicit allowlist so that adding `/version`
-later is a one-line change and not a re-architecture.
+M2 NOTE-001 and NOTE-002 assign this ticket the whole Haskell side of
+`/version`: the shared route, the schema, the handler, `Cardano.MPFS.BuildInfo`
+and its startup capture. M2-E-PUBLISH owns the later build-system injection of
+the compile-time values, the OCI labels, and the release record, and must not
+edit these files in parallel.
 
 ## Readiness definition
 
@@ -138,17 +151,26 @@ HTTP client — never `Network.Wai.Test`.
   window of the observed tip, even though the phase is following and the root
   is correct.
 - **AC-5** A boot failure exits the process non-zero and closes the listener.
-- **AC-6** Every assertion behind AC-1..AC-5 is demonstrated **able to fail**
+- **AC-6** Every assertion behind AC-1..AC-5 and AC-9..AC-11 is demonstrated **able to fail**
   by an explicit negative control that is executed by the gate, not merely
   asserted in prose.
 - **AC-7** `scripts/deploy-preprod.sh` polls `/ready`; no repository artifact
   polls `/status` for readiness or configures an HTTP healthcheck.
 - **AC-8** `docs/assets/swagger.json` is regenerated and the repository
   `swagger-up-to-date` check passes.
+- **AC-9** `GET /version` returns 200 with the mandatory fields during the
+  same held-replay window in which every gated route returns 503.
+- **AC-10** Mutating `MPFS_IMAGE_DIGEST` after startup does not change any
+  `/version` response.
+- **AC-11** The clean-source predicate rejects every sentinel value, and the
+  digest predicate rejects anything that is not `sha256:` plus 64 hex
+  characters. Both are demonstrated able to fail.
 
 ## Out of scope
 
-- `GET /version` and artifact identity (C-IDENTITY, M2-E-PUBLISH).
+- Build-system injection of the compile-time identity values, OCI labels,
+  image publication, and the release record (M2-E-PUBLISH). This ticket ships
+  the Haskell interface those consume, and nothing beyond it.
 - Any production or external deployment configuration, including compose files
   and autoheal policy. This ticket must not add an HTTP healthcheck anywhere.
 - moog-side consumption (M2-T101).

--- a/specs/275-recovery-readiness/spec.md
+++ b/specs/275-recovery-readiness/spec.md
@@ -1,0 +1,167 @@
+# Spec — 275 recovery, liveness, readiness
+
+Issue: lambdasistemi/cardano-mpfs-offchain#275
+Branch: `fix/275-recovery-readiness`
+Base: `origin/main` @ `0f82465f5f828c2ab987a166e9e24c2368228d01`
+Milestone contract: M2 `C-SIGNALS` (`/tmp/mpfs/lane/M2-LEDGER.md`), ruling
+`A-003`.
+
+Supersedes the closed, unmerged draft PR #276 (branch
+`275-mpfs-v2-startup-replay`, head `62df0ba`). That branch is retained as
+defect evidence only; none of its code is authoritative here. Its readiness
+latch was startup-monotonic, its `/status` stayed 200 during restoration, and
+its `StartupReadinessSpec` used in-process `Network.Wai.Test` against a fresh
+temporary database — it never started Warp and never reopened a populated
+database, so it proved neither recovery path.
+
+## Problem
+
+`mpfs-serve` conflates three distinct operational questions into one
+observable surface, and answers two of them wrongly.
+
+1. On an ordinary restart against a retained RocksDB, `withApplication`
+   completes CSMT recovery and synchronous journal replay (`toFollowing`)
+   **before** invoking the callback in which `Serve.hs` starts Warp. During
+   that window no listener exists: a probe is refused or times out. On
+   2026-08-24 that window exceeded the 10 s healthcheck timeout and autoheal
+   killed the container repeatedly.
+2. On a lost/empty database the listener does exist, but `GET /status` returns
+   **200** with `utxo_root: null` and progressive checkpoint fields while the
+   indexer is still restoring.
+3. On a retained-but-stale database the indexer enters `InFollowing`
+   immediately and serves a **correct but arbitrarily stale** root. On
+   2026-05-19 `/status` reported `checkpoint_slot=3715222` against
+   `tip_slot=123518063`.
+
+There is no `/live` and no `/ready`. A supervisor therefore has only
+"does an HTTP request succeed", which is false during legitimate recovery —
+so wiring one restarts a healthy, recovering process.
+
+## Users and stories
+
+- **US-1 — supervisor.** As the process supervisor I probe exactly one signal
+  that distinguishes "this process must be restarted" from "this process is
+  recovering", so I never kill a healthy replay.
+- **US-2 — moog-v2 canary (M2-T101).** As a dependent service I gate on one
+  signal that is true only when MPFS can serve a correct and current root, so
+  I never consume a stale or absent root.
+- **US-3 — operator.** As an operator I can observe recovery progress
+  throughout the not-ready window without any route claiming a root it does
+  not have.
+- **US-4 — deployer.** As the repository deployment helper I wait for
+  readiness, not for "the port answers".
+
+## Functional requirements
+
+- **FR-1** `GET /live` returns 200 whenever the process is alive, from the
+  moment the listener binds, throughout recovery, and thereafter. It is the
+  only supervisor signal.
+- **FR-2** The HTTP listener binds and answers `/live` **before** any retained
+  database recovery or journal replay begins.
+- **FR-3** `GET /ready` returns 503 until the server can serve a correct and
+  current root, and 200 from then on, returning to 503 whenever correctness or
+  currency is lost.
+- **FR-4** Every gated route returns 503 while `/ready` is 503. No gated route
+  ever returns 2xx carrying a null or stale root.
+- **FR-5** The 503 body of `/ready` carries recovery diagnostics (reason,
+  phase, checkpoint slot, tip slot) so US-3 keeps observability without any
+  gated route answering.
+- **FR-6** A failure during boot terminates the process with a non-zero exit
+  and closes the listener. The service never parks as "alive forever, never
+  ready".
+- **FR-7** `scripts/deploy-preprod.sh` waits on `/ready`, never on `/status`.
+- **FR-8** Repository documentation states that `/live` is the only supervisor
+  signal and `/ready` is the dependency gate. No repository-owned artifact
+  configures an HTTP healthcheck (the M2 interim ruling).
+- **FR-9** `mpfs-serve`'s `main` performs no boot sequencing of its own beyond
+  argument parsing and validation; the boot function proven by the recovery
+  tests is the exact function production runs.
+
+## Route classification
+
+The readiness gate is an explicit allowlist and is default-deny: a route added
+later is gated unless someone deliberately exempts it.
+
+Always available — exactly:
+
+- `GET /live`
+- `GET /ready`
+
+Gated (503 while not ready) — everything else, which today means all of
+`Cardano.MPFS.API` (`Shared.API`) including `GET /status`, `GET /metrics`,
+`GET /metrics/prometheus`, and the static Swagger assets.
+
+Gating the Swagger assets and `/metrics` is deliberate: C-SIGNALS names the
+always-available operational surfaces exhaustively, and a default-deny gate
+with a two-entry allowlist cannot drift. Operator observability during the
+not-ready window is preserved by FR-5 instead of by exempting `/metrics`.
+
+`GET /version` is C-IDENTITY, produced by M2-E-PUBLISH, and is out of scope
+here. The exempt set MUST be an explicit allowlist so that adding `/version`
+later is a one-line change and not a re-architecture.
+
+## Readiness definition
+
+READY ⟺
+
+- the indexer is in the **following** phase (full CSMT, not restoring), **and**
+- the latest checkpoint slot is within the genesis **stability window** of the
+  most recently observed chain tip slot, **and**
+- proof reads are internally consistent.
+
+When the chain follower is disabled (`followerEnabled = False`), currency is
+vacuous and readiness follows the internal proof-read flag alone.
+
+Rationale for the currency term: A-003 forbids serving "a stale root", and the
+2026-05-19 incident is exactly a correct-but-stale root. The stability window is
+already the threshold the follower uses for its restoration→following
+transition, so no new tunable is introduced. This is deliberately **not** a
+supervisor-visible timeout: nothing here is tuned against an unmeasured,
+growing quantity.
+
+## Acceptance criteria
+
+Evidence must be produced over **real Warp/TCP** — a bound socket probed by an
+HTTP client — never `Network.Wai.Test`.
+
+- **AC-1** Retained-database reopen: while journal replay is deliberately held
+  open for longer than the historical 10 s healthcheck window, a TCP client
+  connects and `/live` returns 200 on every probe; `/ready` and every gated
+  route return 503 on every probe; no gated route returns 2xx. After replay is
+  released, `/ready` reaches 200 and gated routes serve.
+- **AC-2** Empty/lost database: the same observations across the restoration
+  window.
+- **AC-3** Readiness returns to 503 after correctness is lost following a
+  period of readiness (restoration reset / armageddon path), and gated routes
+  return to 503 with it.
+- **AC-4** Readiness is 503 while the checkpoint is outside the stability
+  window of the observed tip, even though the phase is following and the root
+  is correct.
+- **AC-5** A boot failure exits the process non-zero and closes the listener.
+- **AC-6** Every assertion behind AC-1..AC-5 is demonstrated **able to fail**
+  by an explicit negative control that is executed by the gate, not merely
+  asserted in prose.
+- **AC-7** `scripts/deploy-preprod.sh` polls `/ready`; no repository artifact
+  polls `/status` for readiness or configures an HTTP healthcheck.
+- **AC-8** `docs/assets/swagger.json` is regenerated and the repository
+  `swagger-up-to-date` check passes.
+
+## Out of scope
+
+- `GET /version` and artifact identity (C-IDENTITY, M2-E-PUBLISH).
+- Any production or external deployment configuration, including compose files
+  and autoheal policy. This ticket must not add an HTTP healthcheck anywhere.
+- moog-side consumption (M2-T101).
+- Recovery *performance*: this ticket makes recovery observable and safe, not
+  faster.
+- Redesigning the facts API.
+
+## Rejection behavior
+
+- A gated route while not ready: HTTP 503 with a JSON error body. Never 200
+  with a null or stale root, and never 404.
+- `/ready` while not ready: HTTP 503 with the diagnostic body of FR-5.
+- A timeout-tuning workaround, or a second in-process-WAI test, is a rejected
+  solution shape, not an acceptable fallback. If listener-before-replay proves
+  structurally infeasible, that is an upward blocker with evidence, not a
+  licence to weaken the contract.

--- a/specs/275-recovery-readiness/tasks.md
+++ b/specs/275-recovery-readiness/tasks.md
@@ -6,13 +6,14 @@ frozen gate.
 
 ## S0 — ticket setup (ticket owner)
 
-- [ ] T001 Ignore `/gate.sh` in `.gitignore` (repository carries no ignore
+- [x] T001 Ignore `/gate.sh` in `.gitignore` (repository carries no ignore
       entry today; the previous ticket added and dropped a tracked gate).
-- [ ] T002 Commit the Spec Kit contract for this ticket.
+- [x] T002 Commit the Spec Kit contract for this ticket.
 
 ## S1 — signals surface and default-deny data gating
 
-Invariants: INV-R3, INV-R4, INV-R5, INV-R8, and INV-R9 for those.
+Invariants: INV-R3, INV-R4, INV-R5, INV-R8, INV-R11 (in-context part),
+INV-R12, INV-R13, and INV-R9 for those.
 
 - [ ] T101 RED: unit spec for `evalReadiness` covering every reason of D-5,
       the reason precedence of D-9, and the `FollowerDisabled` case; each case
@@ -28,7 +29,7 @@ Invariants: INV-R3, INV-R4, INV-R5, INV-R8, and INV-R9 for those.
       checkpoint is outside the stability window of the observed tip.
 - [ ] T105 Implement `Cardano.MPFS.HTTP.Readiness` (M-1).
 - [ ] T106 Implement `Cardano.MPFS.HTTP.Gate` (M-2), default-deny with the
-      two-entry allowlist.
+      three-entry allowlist of `/live`, `/ready` and `/version`.
 - [ ] T107 Add the `/live` and `/ready` route types (M-5) and response shapes
       (M-6).
 - [ ] T108 Expose the readiness observations on `Context` (M-7) and publish
@@ -43,12 +44,42 @@ Invariants: INV-R3, INV-R4, INV-R5, INV-R8, and INV-R9 for those.
 - [ ] T113 Document the signal roles: `/live` is the only supervisor signal,
       `/ready` is the dependency gate, and this repository configures no HTTP
       healthcheck.
+
+### Added by the C-IDENTITY amendment (M2 NOTE-001, NOTE-002)
+
+Invariants INV-R11 (in-context part), INV-R12, INV-R13; acceptance AC-9
+(in-context part), AC-10, AC-11.
+
+- [ ] T115 RED: unit spec for the M-14 predicates covering every sentinel
+      value and every malformed digest, each with the control that proves the
+      predicate can reject and can accept (AC-11, INV-R13).
+- [ ] T116 RED: real-TCP spec on the empty-database path asserting `GET
+      /version` returns 200 with its mandatory fields in the same window in
+      which `/ready` and every gated route return 503 (AC-9, in-context part).
+- [ ] T117 RED: spec asserting that mutating `MPFS_IMAGE_DIGEST` after startup
+      changes no `/version` response, accompanied by the control that proves
+      the variable is load-bearing when read at startup (AC-10, INV-R12).
+- [ ] T118 Implement `Cardano.MPFS.BuildInfo` (M-14): the `BuildInfo` value,
+      `loadBuildInfo` in `IO`, and the two pure predicates. No per-request
+      environment read and no `unsafePerformIO`.
+- [ ] T119 Add the `GET /version` route type and its response shape to the
+      shared `Cardano.MPFS.API` (M-15), and register M-14 in the offchain
+      cabal file.
+- [ ] T120 Capture build identity once during startup, before the
+      listener/replay sequence, and hold it in the gate environment (M-2
+      addendum, INV-R12).
+- [ ] T121 Answer `/version` from the gate itself, never by delegating inward
+      to an application built from the context (M-2 addendum, INV-R11).
+
+### Slice close
+
 - [ ] T114 Run the frozen S1 gate green, with every S1 control demonstrated
       red on injection.
 
 ## S2 — listener before recovery
 
-Invariants: INV-R1, INV-R2, INV-R6, INV-R7, INV-R10, and INV-R9 for those.
+Invariants: INV-R1, INV-R2, INV-R6, INV-R7, INV-R10, INV-R11 (pre-context
+part), and INV-R9 for those.
 
 - [ ] T201 RED: real-TCP recovery spec on the retained-reopen path — populate
       a database against a real devnet, reopen it with replay held open past
@@ -72,6 +103,9 @@ Invariants: INV-R1, INV-R2, INV-R6, INV-R7, INV-R10, and INV-R9 for those.
       window reports `opening`/`recovering`/`replaying`.
 - [ ] T209 Register the recovery spec in the e2e entry point so it is
       executed, not merely compiled.
+- [ ] T211 RED: assert `GET /version` returns 200 with its mandatory fields
+      during the held-replay window of T201, before the application context
+      exists (AC-9, pre-context part, INV-R11).
 - [ ] T210 Run the frozen S2 gate green, with every S2 control demonstrated
       red on injection.
 

--- a/specs/275-recovery-readiness/tasks.md
+++ b/specs/275-recovery-readiness/tasks.md
@@ -1,0 +1,84 @@
+# Tasks — 275 recovery, liveness, readiness
+
+Slice IDs are the unit of dispatch, audit, and commit. A slice is complete
+only when every task under it is checked and its invariants are proven by the
+frozen gate.
+
+## S0 — ticket setup (ticket owner)
+
+- [ ] T001 Ignore `/gate.sh` in `.gitignore` (repository carries no ignore
+      entry today; the previous ticket added and dropped a tracked gate).
+- [ ] T002 Commit the Spec Kit contract for this ticket.
+
+## S1 — signals surface and default-deny data gating
+
+Invariants: INV-R3, INV-R4, INV-R5, INV-R8, and INV-R9 for those.
+
+- [ ] T101 RED: unit spec for `evalReadiness` covering every reason of D-5,
+      the reason precedence of D-9, and the `FollowerDisabled` case; each case
+      accompanied by the control that proves the input is load-bearing.
+- [ ] T102 RED: real-TCP spec on the empty-database path asserting every
+      gated route is 503 while `/ready` is 503, including `/status`,
+      `/metrics`, and `/metrics/prometheus`, and that `/live` is 200
+      throughout.
+- [ ] T103 RED: spec asserting readiness returns to 503 after correctness is
+      lost, and that no verdict is cached across requests.
+- [ ] T104 RED: spec asserting `/ready` reports `behind` — and gated routes
+      503 — when the phase is following and the root correct but the
+      checkpoint is outside the stability window of the observed tip.
+- [ ] T105 Implement `Cardano.MPFS.HTTP.Readiness` (M-1).
+- [ ] T106 Implement `Cardano.MPFS.HTTP.Gate` (M-2), default-deny with the
+      two-entry allowlist.
+- [ ] T107 Add the `/live` and `/ready` route types (M-5) and response shapes
+      (M-6).
+- [ ] T108 Expose the readiness observations on `Context` (M-7) and publish
+      the indexer phase from the application (M-8).
+- [ ] T109 Wrap `mkApp` with the gate (M-4), leaving the existing internal
+      proof-read guard in place.
+- [ ] T110 Reconcile existing specs that assert a gated route is 200 before
+      readiness; justify each edit against FR-4 in the commit body.
+- [ ] T111 Regenerate `docs/assets/swagger.json` and pass the repository
+      `swagger-up-to-date` check.
+- [ ] T112 Point `scripts/deploy-preprod.sh` at `/ready` (INV-R8).
+- [ ] T113 Document the signal roles: `/live` is the only supervisor signal,
+      `/ready` is the dependency gate, and this repository configures no HTTP
+      healthcheck.
+- [ ] T114 Run the frozen S1 gate green, with every S1 control demonstrated
+      red on injection.
+
+## S2 — listener before recovery
+
+Invariants: INV-R1, INV-R2, INV-R6, INV-R7, INV-R10, and INV-R9 for those.
+
+- [ ] T201 RED: real-TCP recovery spec on the retained-reopen path — populate
+      a database against a real devnet, reopen it with replay held open past
+      the historical 10 s window, and assert `/live` 200 on every probe while
+      `/ready` and every gated route are 503; then release and assert the
+      flip. The passing output must report the duration actually held.
+- [ ] T202 RED: the same assertions across the empty/lost-database path
+      (INV-R6).
+- [ ] T203 RED: control proving the probe helper reports failure against a
+      closed port, so "connected" is never vacuous.
+- [ ] T204 RED: control proving the held-replay barrier actually held, so
+      AC-1 cannot pass on a window of zero length.
+- [ ] T205 RED: spec asserting a boot failure terminates and closes the
+      listener (INV-R7).
+- [ ] T206 Implement `Cardano.MPFS.Server.Boot` (M-3): bind first, serve the
+      gate, run the application concurrently, tee the tracer into boot
+      progress, publish the context, propagate failure.
+- [ ] T207 Reduce `exe/Serve.hs` to argument handling and a `runServer` call
+      (M-9, INV-R10).
+- [ ] T208 Wire `BootStage` into the readiness decision so the pre-context
+      window reports `opening`/`recovering`/`replaying`.
+- [ ] T209 Register the recovery spec in the e2e entry point so it is
+      executed, not merely compiled.
+- [ ] T210 Run the frozen S2 gate green, with every S2 control demonstrated
+      red on injection.
+
+## S3 — finalization (ticket owner)
+
+- [ ] T301 Full ticket gate green through a quiet receipt recorder.
+- [ ] T302 Finalization audit over the PR range and this task list.
+- [ ] T303 PR body records the 2026-05-19 and 2026-08-24 production evidence
+      and maps it to the shipped contract, per the issue's acceptance
+      criteria.


### PR DESCRIPTION
Closes #275.

Draft. Planning only so far: the branch currently carries the Spec Kit contract
and an ignore entry, and no production behaviour has changed.

## What the contract specifies

`mpfs-serve` today does all of its expensive boot work — CSMT recovery and a
synchronous follower catch-up — *before* Warp binds a socket, so a node
restoring a retained database is not merely unready, it is unreachable. This
branch specifies the C-SIGNALS contract that separates the two questions a
supervisor and a dependency ask:

- `GET /live` — 200 whenever the process is alive, including throughout
  legitimate replay. The only supervisor signal. No failure mode; progress is
  enforced by process termination, not by a probe threshold.
- `GET /ready` — 503 until the server can serve a correct and current root,
  200 from then on, and back to 503 whenever correctness or currency is lost.
  A pure function of current state, never a latch. Never a supervisor signal.
  Its 503 body carries reason, phase, checkpoint slot and tip slot, so
  operator observability survives the not-ready window.
- `GET /version` — 200 whenever the process is alive, carrying release
  version, full build-time commit and an optional deploy-time image digest.
- Everything else — including `/status`, `/metrics`, `/metrics/prometheus`
  and the static Swagger assets — returns 503 while `/ready` is 503. The gate
  is default-deny over a three-entry allowlist, so a route added later is
  gated unless someone deliberately exempts it.

The listener binds before retained-database recovery begins, and build
identity is held by the gate rather than by the application context, because
`/version` must answer before that context exists.

## Relation to the closed PR #276

#276 latched readiness once per process, kept `/status` at 200 during
restoration, and proved its behaviour with in-process `Network.Wai.Test`
against a fresh temporary database — so it exercised neither recovery path.
No code from that branch is reused. Acceptance here requires real Warp/TCP
evidence over both the retained-reopen and empty/lost-database paths, with a
negative control demonstrating every boundary assertion able to fail.

## Contents

`specs/275-recovery-readiness/` — spec, plan, modules/data/functions models and
the task list: 12 requirements, 13 invariants (INV-R1..INV-R13), 11 acceptance
criteria, three slices (S1 signals surface and default-deny gating plus
`/version`/`BuildInfo`; S2 listener-before-recovery and the real-TCP recovery
proof; S3 finalization).

`.gitignore` — ignore the ticket-local untracked `./gate.sh`.
