### PR TITLE
ci: publish mpfs-serve images to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,57 @@ jobs:
 
           check_cabal_version cardano-mpfs-offchain/cardano-mpfs-offchain.cabal
           check_cabal_version cardano-mpfs-cli/cardano-mpfs-cli.cabal
+
+  publish-image:
+    name: Publish mpfs-serve image
+    needs: [build, e2e]
+    # Publication is unreachable for a pull request; the alias mapping in
+    # scripts/publish-mpfs-serve-image refuses that event as well.
+    if: github.event_name != 'pull_request'
+    runs-on: nixos
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Select the registry alias
+        id: alias
+        run: |
+          set -euo pipefail
+          tag=$(scripts/publish-mpfs-serve-image \
+            --alias-for-event "${{ github.event_name }}" \
+            --ref-name "${{ github.ref_name }}" \
+            --source-sha "${{ github.sha }}")
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Publish the image to GHCR
+        id: publish
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          nix shell --inputs-from . nixpkgs#skopeo nixpkgs#jq -c \
+            scripts/publish-mpfs-serve-image \
+            --source-sha "${{ github.sha }}" \
+            --tag "${{ steps.alias.outputs.tag }}"
+
+      - name: Verify the published image starts
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! command -v docker >/dev/null 2>&1; then
+            echo "::error::no container runtime on this runner; startup cannot be proved"
+            exit 1
+          fi
+          docker --version
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+          scripts/check-mpfs-serve-image-startup "${{ steps.publish.outputs.image }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
           cp "$(cat /tmp/nix-out)/bin/mpfs-cli" /tmp/bundle/libexec/
           chmod +x /tmp/bundle/libexec/mpfs-cli
 
+          # $3 and $1 in the awk program below are awk field references, not
+          # shell expansions, so single quotes are correct here.
+          # shellcheck disable=SC2016
           LD_TRACE_LOADED_OBJECTS=1 /tmp/bundle/libexec/mpfs-cli \
             | nix shell --inputs-from . nixpkgs#gawk -c awk '/=> \// { print $3 } /^[[:space:]]*\// { print $1 }' \
             | sort -u \
@@ -190,3 +193,69 @@ jobs:
           git add Formula/mpfs-cli.rb
           git diff --cached --quiet || git commit -m "update mpfs-cli to ${TAG}"
           git push
+
+  publish-image-release:
+    name: Publish mpfs-serve release image
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: nixos
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Resolve the released commit
+        id: source
+        run: |
+          set -euo pipefail
+          {
+            echo "sha=$(git rev-parse HEAD)"
+            echo "receipt=$RUNNER_TEMP/mpfs-serve-image-receipt-${{ needs.release-please.outputs.tag_name }}.txt"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish the release image to GHCR
+        id: publish
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          nix shell --inputs-from . nixpkgs#skopeo nixpkgs#jq -c \
+            scripts/publish-mpfs-serve-image \
+            --source-sha "${{ steps.source.outputs.sha }}" \
+            --tag "sha-${{ steps.source.outputs.sha }}" \
+            --tag "${{ needs.release-please.outputs.tag_name }}" \
+            --receipt "${{ steps.source.outputs.receipt }}"
+
+      - name: Verify the published image starts
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! command -v docker >/dev/null 2>&1; then
+            echo "::error::no container runtime on this runner; startup cannot be proved"
+            exit 1
+          fi
+          docker --version
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+          scripts/check-mpfs-serve-image-startup "${{ steps.publish.outputs.image }}"
+
+      # Uploaded, never clobbered: the receipt for an existing release tag is
+      # immutable, and the release itself is neither deleted nor recreated.
+      - name: Attach the immutable digest receipt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          nix shell --inputs-from . nixpkgs#gh -c gh release upload \
+            "${{ needs.release-please.outputs.tag_name }}" \
+            "${{ steps.source.outputs.receipt }}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ result-docker
 .claude/
 .orch/
 .playwright-mcp/
+/gate.sh
 
 # MkDocs build output
 site/

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,13 @@
     , iohkNix, CHaP, cardano-node, cardano-mpfs-onchain, cardano-node-clients
     , cardano-ledger-wasm, ghc-wasm-meta, ... }:
     let
-      version = self.dirtyShortRev or self.shortRev;
+      # Publishable identity is the exact clean revision. A dirty or
+      # revision-less evaluation yields an unmistakably non-qualifying value
+      # that the publish gate rejects rather than a shortened lookalike.
+      version = self.rev or (if self ? dirtyRev then
+        "dirty-${self.dirtyRev}"
+      else
+        "unknown");
       parts = flake-parts.lib.mkFlake { inherit inputs; } {
         systems = [ "x86_64-linux" "aarch64-darwin" ];
         perSystem = { system, ... }:

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -8,7 +8,17 @@ let
 in pkgs.dockerTools.buildImage {
   name = "ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve";
   tag = version;
-  config = { EntryPoint = [ "mpfs-serve" ]; };
+  config = {
+    # Docker and the OCI image spec read `Entrypoint`; any other spelling is
+    # silently ignored and yields an image with no entrypoint at all.
+    Entrypoint = [ "mpfs-serve" ];
+    Labels = {
+      "org.opencontainers.image.revision" = version;
+      "org.opencontainers.image.version" = version;
+      "org.opencontainers.image.source" =
+        "https://github.com/lambdasistemi/cardano-mpfs-offchain";
+    };
+  };
   copyToRoot = pkgs.buildEnv {
     name = "image-root";
     paths = [

--- a/scripts/check-mpfs-serve-image-startup
+++ b/scripts/check-mpfs-serve-image-startup
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Prove a published mpfs-serve image starts, by immutable digest.
+#
+# mpfs-serve has no --help or --version mode, so the only observable startup
+# signal is its required-argument rejection. Success therefore means a non-zero
+# exit carrying exactly that diagnostic: a zero exit, an unrelated failure, a
+# mutable tag, or a failed pull are all rejections.
+set -uo pipefail
+
+EXPECTED_DIAGNOSTIC='--socket is required'
+
+die() {
+  printf 'check-mpfs-serve-image-startup: %s\n' "$*" >&2
+  exit 1
+}
+
+(($# == 1)) || die "usage: check-mpfs-serve-image-startup <repository>@sha256:<64 hex>"
+image=$1
+[[ "$image" =~ ^[^[:space:]@]+@sha256:[0-9a-f]{64}$ ]] \
+  || die "not an immutable digest reference: '$image'"
+
+runtime=${CONTAINER_RUNTIME:-}
+if [[ -z "$runtime" ]]; then
+  for candidate in docker podman; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      runtime=$candidate
+      break
+    fi
+  done
+fi
+[[ -n "$runtime" ]] || die "no container runtime available to exercise the image"
+command -v "$runtime" >/dev/null 2>&1 \
+  || die "container runtime is not executable: '$runtime'"
+
+"$runtime" pull "$image" >/dev/null 2>&1 \
+  || die "could not pull $image with $runtime"
+
+# No --entrypoint override: the point is to exercise the configured one.
+output=$("$runtime" run --rm "$image" 2>&1)
+status=$?
+
+((status != 0)) \
+  || die "entrypoint exited 0; expected the missing-required-argument failure"
+case "$output" in
+  *"$EXPECTED_DIAGNOSTIC"*) ;;
+  *) die "exit $status is not the expected startup failure: $output" ;;
+esac
+
+printf 'image=%s\nexit=%s\nruntime=%s\noutput=%s\n' \
+  "$image" "$status" "$runtime" "$output"

--- a/scripts/publish-mpfs-serve-image
+++ b/scripts/publish-mpfs-serve-image
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Publish the pipeline-built mpfs-serve OCI image to GHCR.
+#
+# Publishable source identity is the exact clean commit and nothing else. The
+# archive is always built from the checked-out source — there is no way to hand
+# this command a prebuilt image — actual publication additionally requires a
+# GitHub Actions run URL of this repository, and every alias is read back from
+# the registry and reconciled before any receipt is written.
+set -euo pipefail
+
+REPOSITORY=ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve
+SOURCE_URL=https://github.com/lambdasistemi/cardano-mpfs-offchain
+REPOSITORY_SLUG=lambdasistemi/cardano-mpfs-offchain
+MAX_TAG_LENGTH=128
+# "branch-" + slug + "-sha-" + 40 hex must stay within MAX_TAG_LENGTH.
+MAX_SLUG_LENGTH=76
+
+die() {
+  printf 'publish-mpfs-serve-image: %s\n' "$*" >&2
+  exit 1
+}
+need_value() { [[ $# -ge 2 ]] || die "missing value for $1"; }
+
+validate_only=0
+alias_event=
+ref_name=
+source_sha=
+receipt=
+run_url=
+tags=()
+
+while (($#)); do
+  case $1 in
+    --validate-only) validate_only=1; shift ;;
+    --source-sha) need_value "$@"; source_sha=$2; shift 2 ;;
+    --tag) need_value "$@"; tags+=("$2"); shift 2 ;;
+    --receipt) need_value "$@"; receipt=$2; shift 2 ;;
+    --alias-for-event) need_value "$@"; alias_event=$2; shift 2 ;;
+    --ref-name) need_value "$@"; ref_name=$2; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] \
+  || die "source revision is not an exact 40-character lowercase commit SHA: '$source_sha'"
+
+# Deterministic lowercase OCI-safe representation of a full Git ref name.
+slugify() {
+  local slug
+  slug=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-*//; s/-*$//')
+  printf '%s' "${slug:0:MAX_SLUG_LENGTH}" | sed 's/-*$//'
+}
+
+valid_tag() {
+  local tag=$1
+  [[ -n "$tag" && ${#tag} -le $MAX_TAG_LENGTH && "$tag" != latest ]] || return 1
+  case $tag in
+    sha-*) [[ "$tag" == "sha-$source_sha" ]] ;;
+    branch-*)
+      [[ "$tag" =~ ^branch-[a-z0-9]([a-z0-9._-]*[a-z0-9])?-sha-[0-9a-f]{40}$ ]] \
+        && [[ "$tag" == *"-sha-$source_sha" ]] ;;
+    v*) [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] ;;
+    *) return 1 ;;
+  esac
+}
+
+# The event-to-alias mapping lives here so a workflow cannot name a tag this
+# command would refuse, and so publication is unreachable for a pull request.
+if [[ -n "$alias_event" ]]; then
+  case $alias_event in
+    push)
+      [[ "$ref_name" == main ]] || die "push publication is limited to main, got '$ref_name'"
+      selected="sha-$source_sha" ;;
+    workflow_dispatch)
+      slug=$(slugify "$ref_name")
+      [[ -n "$slug" ]] || die "ref name '$ref_name' has no OCI-safe slug"
+      selected="branch-$slug-sha-$source_sha" ;;
+    *) die "no publication alias is defined for event '$alias_event'" ;;
+  esac
+  valid_tag "$selected" || die "selected alias is not a valid tag: $selected"
+  printf '%s\n' "$selected"
+  exit 0
+fi
+
+((${#tags[@]})) || die "no registry alias requested; pass at least one --tag"
+for tag in "${tags[@]}"; do
+  valid_tag "$tag" || die "alias does not match the settled tag policy for $source_sha: '$tag'"
+done
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || die "publication must run from a Git checkout of the source"
+[[ -z "$(git status --porcelain)" ]] \
+  || die "source tree is dirty; publication requires a clean checkout"
+head_sha=$(git rev-parse HEAD)
+[[ "$head_sha" == "$source_sha" ]] \
+  || die "source revision is not the checked-out commit: sha=$source_sha head=$head_sha"
+
+if ((validate_only)); then
+  printf 'validated repository=%s revision=%s aliases=%s\n' \
+    "$REPOSITORY" "$source_sha" "${tags[*]}"
+  exit 0
+fi
+
+# ------------------------------------------------------------- publication
+# Provenance is read from the runner environment and bound to this request; it
+# is never a caller-supplied string, because an operator checkout can type any
+# string it likes. The receipt URL is constructed from those fields.
+[[ "${GITHUB_ACTIONS:-}" == true ]] \
+  || die "publication requires a GitHub Actions runner (GITHUB_ACTIONS=true)"
+[[ "${GITHUB_REPOSITORY:-}" == "$REPOSITORY_SLUG" ]] \
+  || die "publication is limited to $REPOSITORY_SLUG, got '${GITHUB_REPOSITORY:-}'"
+[[ "${GITHUB_SERVER_URL:-}" == https://github.com ]] \
+  || die "unexpected GitHub server: '${GITHUB_SERVER_URL:-}'"
+[[ "${GITHUB_SHA:-}" == "$source_sha" ]] \
+  || die "runner commit '${GITHUB_SHA:-}' is not the requested revision $source_sha"
+[[ "${GITHUB_RUN_ID:-}" =~ ^[0-9]+$ ]] \
+  || die "GITHUB_RUN_ID is not a run identifier: '${GITHUB_RUN_ID:-}'"
+run_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+command -v skopeo >/dev/null 2>&1 || die "skopeo is required for registry copy"
+command -v jq >/dev/null 2>&1 || die "jq is required to read image configs"
+[[ -n "${GHCR_USER:-}" && -n "${GHCR_TOKEN:-}" ]] \
+  || die "GHCR_USER and GHCR_TOKEN must be set for registry authentication"
+
+# The archive is built here, from the checked-out pipeline source. A prebuilt
+# or caller-supplied image is not a publication input.
+archive=$(nix build --quiet --no-link --print-out-paths .#docker-image)
+[[ -f "$archive" ]] || die "docker-image output is not an archive file: $archive"
+
+# Every source-derived identity field is reconciled before the first copy, so a
+# mislabelled archive never reaches the registry under any alias.
+config=$(skopeo inspect --config "docker-archive:$archive")
+label() { printf '%s' "$1" | jq -r --arg k "$2" '.config.Labels[$k] // ""'; }
+[[ "$(label "$config" org.opencontainers.image.revision)" == "$source_sha" ]] \
+  || die "archive revision label is not the source revision $source_sha"
+[[ "$(label "$config" org.opencontainers.image.version)" == "$source_sha" ]] \
+  || die "archive version label is not the source revision $source_sha"
+[[ "$(label "$config" org.opencontainers.image.source)" == "$SOURCE_URL" ]] \
+  || die "archive source label is not $SOURCE_URL"
+[[ "$(printf '%s' "$config" | jq -r '(.config.Entrypoint // []) | join(" ")')" == "mpfs-serve" ]] \
+  || die "archive entrypoint is not mpfs-serve"
+
+digest=
+revision=
+for tag in "${tags[@]}"; do
+  skopeo copy --dest-creds "$GHCR_USER:$GHCR_TOKEN" \
+    "docker-archive:$archive" "docker://$REPOSITORY:$tag"
+  seen_digest=$(skopeo inspect --creds "$GHCR_USER:$GHCR_TOKEN" \
+    --format '{{.Digest}}' "docker://$REPOSITORY:$tag")
+  [[ "$seen_digest" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || die "registry returned a malformed digest for '$tag': $seen_digest"
+  # Read the published config back for this alias. The receipt reports what the
+  # registry says it is holding, never an echo of what was requested.
+  seen_revision=$(label "$(skopeo inspect --creds "$GHCR_USER:$GHCR_TOKEN" \
+    --config "docker://$REPOSITORY:$tag")" org.opencontainers.image.revision)
+  [[ "$seen_revision" == "$source_sha" ]] \
+    || die "published '$tag' reports revision '$seen_revision', not $source_sha"
+  if [[ -z "$digest" ]]; then
+    digest=$seen_digest
+    revision=$seen_revision
+  else
+    [[ "$digest" == "$seen_digest" ]] \
+      || die "aliases resolve to different content: $digest vs $seen_digest for '$tag'"
+    [[ "$revision" == "$seen_revision" ]] \
+      || die "aliases report different revisions: $revision vs $seen_revision for '$tag'"
+  fi
+done
+
+emit() {
+  printf 'repository=%s\ndigest=%s\nrevision=%s\naliases=%s\nrun_url=%s\n' \
+    "$REPOSITORY" "$digest" "$revision" "${tags[*]}" "$run_url"
+}
+emit
+[[ -z "$receipt" ]] || emit >"$receipt"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    printf 'digest=%s\n' "$digest"
+    printf 'image=%s@%s\n' "$REPOSITORY" "$digest"
+  } >>"$GITHUB_OUTPUT"
+fi

--- a/scripts/test-mpfs-serve-image-pipeline
+++ b/scripts/test-mpfs-serve-image-pipeline
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# Executable proof for the pipeline-published mpfs-serve image contract (S1).
+#
+# Comparators judging repository source are paired with a mutated copy proving
+# they can fail, and each mutant verifies its own application. The publication
+# boundary runs against a fake registry whose positive control is asserted
+# first: if that control fails, every rejection below it would be vacuous.
+set -uo pipefail
+root=$(git rev-parse --show-toplevel)
+cd "$root" || exit 1
+publish=$root/scripts/publish-mpfs-serve-image
+startup=$root/scripts/check-mpfs-serve-image-startup
+image_nix=$root/nix/docker-image.nix
+serve_hs=$root/cardano-mpfs-offchain/exe/Serve.hs
+ci_yml=$root/.github/workflows/ci.yml
+release_yml=$root/.github/workflows/release.yml
+source_url=https://github.com/lambdasistemi/cardano-mpfs-offchain
+repository=ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve
+failures=0
+pass() { printf 'PROOF-PASS  %s\n' "$*"; }
+fail() { printf 'PROOF-FAIL  %s\n' "$*" >&2; failures=$((failures + 1)); }
+# The property holds when the command succeeds / when it fails.
+assert() { local l=$1; shift; if "$@" >/dev/null 2>&1; then pass "$l"; else fail "$l"; fi; }
+refute() { local l=$1; shift; if "$@" >/dev/null 2>&1; then fail "$l"; else pass "$l"; fi; }
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1 (wanted '$2', got '$3')"; fi
+}
+# A mutant is only evidence if the edit actually landed.
+mutate() {
+  local src=$1 dst=$2
+  shift 2
+  sed "$@" "$src" >"$dst"
+  if cmp -s "$src" "$dst"; then
+    fail "mutation did not apply to ${src##*/}: $*"
+    return 1
+  fi
+}
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+have_scripts=1
+for required in "$publish" "$startup"; do
+  if [[ -x "$required" ]]; then
+    pass "present and executable: ${required#"$root"/}"
+  else
+    fail "missing or non-executable production script: ${required#"$root"/}"
+    have_scripts=0
+  fi
+done
+# I1/I2 — M-IMAGE against M-PUBLISH. The flake identity is publishable if and
+# only if the tree is clean; the branch taken is reported so neither world is
+# a vacuous pass.
+version=$(nix eval --raw .#version 2>/dev/null)
+head_sha=$(git rev-parse HEAD)
+if [[ -z "$version" ]]; then
+  fail "flake .#version did not evaluate"
+elif [[ -n "$(git status --porcelain)" ]]; then
+  if [[ "$version" == "$head_sha" ]]; then
+    fail "dirty tree yielded a publishable identity: $version"
+  else
+    pass "dirty tree yields non-qualifying identity: $version"
+  fi
+elif [[ "$version" == "$head_sha" ]]; then
+  pass "clean tree yields exact full revision: $version"
+else
+  fail "clean tree identity is not exact HEAD: version=$version head=$head_sha"
+fi
+if ((have_scripts)); then
+  repo=$tmp/repo
+  mkdir -p "$repo"
+  cp "$publish" "$repo/publish"
+  (
+    cd "$repo" || exit 1
+    git init -q && git config user.name proof && git config user.email p@example.invalid
+    git add publish && git commit -qm seed
+  ) >/dev/null 2>&1
+  sha=$(git -C "$repo" rev-parse HEAD)
+  other=$(printf 'b%.0s' {1..40})
+  p() { env -C "$repo" ./publish "$@"; }
+  # I1/I2 — the exact clean commit is the only publishable source.
+  assert "main sha alias accepted" p --validate-only --source-sha "$sha" --tag "sha-$sha"
+  assert "several valid aliases accepted" p --validate-only --source-sha "$sha" --tag "sha-$sha" --tag v1.2.3
+  refute "foreign 40-hex source refused" p --validate-only --source-sha "$other" --tag "sha-$other"
+  refute "alias naming a foreign commit refused" p --validate-only --source-sha "$sha" --tag "sha-$other"
+  refute "branch alias naming a foreign commit refused" p --validate-only --source-sha "$sha" --tag "branch-feat-x-sha-$other"
+  refute "uppercase source sha refused" p --validate-only --source-sha "${sha^^}" --tag "sha-${sha^^}"
+  refute "publication without an alias refused" p --validate-only --source-sha "$sha"
+  refute "unknown flag refused" p --validate-only --source-sha "$sha" --tag "sha-$sha" --push-anyway
+  # One forbidden alias must sink the whole publication, not merely itself.
+  refute "latest among valid aliases refused" p --validate-only --source-sha "$sha" --tag "sha-$sha" --tag latest
+  # F-CI-TAGS — one owner for the event-to-alias mapping.
+  main_alias=$(p --alias-for-event push --ref-name main --source-sha "$sha" 2>/dev/null)
+  assert_eq "push/main alias is sha-<sha>" "sha-$sha" "$main_alias"
+  branch_alias=$(p --alias-for-event workflow_dispatch --ref-name feat/publish-mpfs-serve-image --source-sha "$sha" 2>/dev/null)
+  assert_eq "dispatch alias is branch-<slug>-sha-<sha>" "branch-feat-publish-mpfs-serve-image-sha-$sha" "$branch_alias"
+  slugged=$(p --alias-for-event workflow_dispatch --ref-name 'Feat/Weird_Ref.v2' --source-sha "$sha" 2>/dev/null)
+  assert_eq "ref slug is deterministic, lowercase and OCI-safe" "branch-feat-weird-ref-v2-sha-$sha" "$slugged"
+  bounded=$(p --alias-for-event workflow_dispatch --ref-name "$(printf 'x%.0s' {1..200})" --source-sha "$sha" 2>/dev/null)
+  if [[ -n "$bounded" && ${#bounded} -le 128 ]]; then
+    pass "overlong ref bounded to a valid OCI tag (${#bounded} chars)"
+  else
+    fail "overlong ref produced an invalid tag of ${#bounded} chars"
+  fi
+  # Round-trip: an alias the mapping emits must be one the validator accepts.
+  for emitted in "$main_alias" "$branch_alias" "$slugged" "$bounded"; do
+    assert "emitted alias round-trips: ${emitted:0:18}…" p --validate-only --source-sha "$sha" --tag "$emitted"
+  done
+  refute "pull_request cannot select an alias" p --alias-for-event pull_request --ref-name main --source-sha "$sha"
+fi
+
+# ---------------------------------------------------------------------------
+# Publication boundary (F-S1-001/002/003) against a fake registry. The fakes
+# are reached by PATH, so production carries no test seam.
+# ---------------------------------------------------------------------------
+if ((have_scripts)); then
+  fakebin=$tmp/bin
+  mkdir -p "$fakebin"
+  mocklog=$tmp/registry.log
+  fakearchive=$tmp/image.tar
+  : >"$fakearchive"
+  cat >"$fakebin/nix" <<'FAKENIX'
+#!/usr/bin/env bash
+printf 'nix %s\n' "$*" >>"$MOCK_LOG"
+printf '%s\n' "$MOCK_ARCHIVE"
+FAKENIX
+  cat >"$fakebin/skopeo" <<'FAKESKOPEO'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >>"$MOCK_LOG"
+emit_config() {
+  printf '{"config":{"Labels":{"org.opencontainers.image.revision":"%s","org.opencontainers.image.version":"%s","org.opencontainers.image.source":"%s"},"Entrypoint":["mpfs-serve"]}}\n' "$1" "$2" "$3"
+}
+[[ ${1:-} == copy ]] && exit "${MOCK_COPY_EXIT:-0}"
+if [[ " $* " == *" docker-archive:"* ]]; then
+  emit_config "${MOCK_ARCHIVE_REV:-$MOCK_SHA}" "${MOCK_ARCHIVE_VER:-$MOCK_SHA}" \
+    "${MOCK_ARCHIVE_SRC:-https://github.com/lambdasistemi/cardano-mpfs-offchain}"
+  exit 0
+fi
+args="$*"
+alias_tag=${args##*:}
+if [[ " $* " == *" --config "* ]]; then
+  revision=$MOCK_SHA
+  if [[ -n "${MOCK_BAD_ALIAS:-}" && "$alias_tag" == "$MOCK_BAD_ALIAS" ]]; then
+    revision=${MOCK_BAD_REV:-0000000000000000000000000000000000000000}
+  fi
+  emit_config "$revision" "$MOCK_SHA" "https://github.com/lambdasistemi/cardano-mpfs-offchain"
+  exit 0
+fi
+digest=${MOCK_DIGEST:-sha256:$(printf 'a%.0s' {1..64})}
+if [[ -n "${MOCK_DIGEST2_ALIAS:-}" && "$alias_tag" == "$MOCK_DIGEST2_ALIAS" ]]; then
+  digest=sha256:$(printf 'b%.0s' {1..64})
+fi
+printf '%s\n' "$digest"
+FAKESKOPEO
+  chmod +x "$fakebin/nix" "$fakebin/skopeo"
+  run_url=$source_url/actions/runs/42
+  receipt=$tmp/receipt.txt
+  # The runner identity a real GitHub Actions publication job would carry.
+  ci_env=(GITHUB_ACTIONS=true "GITHUB_REPOSITORY=lambdasistemi/cardano-mpfs-offchain"
+    GITHUB_SERVER_URL=https://github.com "GITHUB_SHA=$sha" GITHUB_RUN_ID=42)
+  pub_env=(MOCK_UNUSED=1)
+  pub() {
+    : >"$mocklog"
+    env -C "$repo" "PATH=$fakebin:$PATH" "MOCK_LOG=$mocklog" "MOCK_SHA=$sha" \
+      "MOCK_ARCHIVE=$fakearchive" GHCR_USER=proof GHCR_TOKEN=not-a-secret \
+      "${ci_env[@]}" "${pub_env[@]}" ./publish --source-sha "$sha" "$@"
+  }
+  copied() { grep -q '^copy ' "$mocklog"; }
+  # Positive control FIRST: without it every rejection below proves nothing.
+  if pub --tag "sha-$sha" --receipt "$receipt" >/dev/null 2>&1 \
+    && grep -q '^nix build' "$mocklog" && copied \
+    && grep -qE '^inspect .*--config .*docker://' "$mocklog" \
+    && grep -qx "revision=$sha" "$receipt" && grep -qx "run_url=$run_url" "$receipt"; then
+    pass "publication reaches source build, copy, remote digest and config readback, receipt"
+  else
+    fail "publication positive control never reached the boundary; the rejections below are vacuous"
+  fi
+  # F-S1-001 — no prebuilt archive, no caller-supplied provenance, and a runner
+  # identity bound to this request. Each spoof keeps the clean checkout, built
+  # archive, tags and auth of the passing run, so only the CI identity differs.
+  refute "prebuilt --archive input refused" pub --tag "sha-$sha" --archive "$fakearchive"
+  refute "caller-supplied --run-url refused" pub --tag "sha-$sha" --run-url "$run_url"
+  for spoof in GITHUB_ACTIONS= GITHUB_REPOSITORY=other/repo "GITHUB_SHA=$other" \
+    GITHUB_RUN_ID=not-a-run GITHUB_SERVER_URL=https://evil.example; do
+    pub_env=("$spoof")
+    refute "publication refused without a bound ${spoof%%=*}" pub --tag "sha-$sha"
+    refute "${spoof%%=*} spoof reached no copy" copied
+  done
+  pub_env=(MOCK_UNUSED=1)
+  # F-S1-002 — every source-derived label, version included, is reconciled
+  # to the source revision before the first copy.
+  for mutant in MOCK_ARCHIVE_REV=1111111111111111111111111111111111111111 \
+    MOCK_ARCHIVE_VER=foreign-version MOCK_ARCHIVE_SRC=https://evil.example/x; do
+    pub_env=("$mutant")
+    refute "archive ${mutant%%=*} mutant refused" pub --tag "sha-$sha"
+    refute "archive ${mutant%%=*} mutant reached no copy" copied
+  done
+  pub_env=(MOCK_UNUSED=1)
+  # F-S1-003 — every alias is read back from the registry and reconciled, and
+  # the receipt reports the observed revision rather than the requested one.
+  pub_env=(MOCK_DIGEST2_ALIAS=v9.9.9)
+  refute "divergent alias digests refused" pub --tag "sha-$sha" --tag v9.9.9
+  pub_env=(MOCK_BAD_ALIAS=v9.9.9)
+  refute "second alias reporting a foreign revision refused" pub --tag "sha-$sha" --tag v9.9.9
+  pub_env=(MOCK_BAD_ALIAS="sha-$sha")
+  refute "first alias reporting a foreign revision refused" pub --tag "sha-$sha"
+  pub_env=(MOCK_DIGEST=sha256:tooshort)
+  refute "malformed remote digest refused" pub --tag "sha-$sha"
+  pub_env=(MOCK_COPY_EXIT=1)
+  refute "failed registry copy refused" pub --tag "sha-$sha"
+  pub_env=(MOCK_UNUSED=1)
+  # Two aliases must produce two remote config reads: what a checker that
+  # inspects only the first alias fails.
+  pub --tag "sha-$sha" --tag v9.9.9 >/dev/null 2>&1
+  assert_eq "every alias config is read back" 2 "$(grep -cE '^inspect .*--config .*docker://' "$mocklog")"
+fi
+
+# I3/I4 — startup checker.
+if ((have_scripts)); then
+  runtime=$tmp/runtime
+  cat >"$runtime" <<'MOCK'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >>"$MOCK_LOG"
+case "${1:-}" in
+  pull)
+    if [[ "${MOCK_MODE:-expected}" == pull-fail ]]; then exit 7; fi
+    exit 0 ;;
+  run)
+    case "${MOCK_MODE:-expected}" in
+      expected) echo 'mpfs-serve: --socket is required' >&2; exit 1 ;;
+      unrelated) echo 'oci runtime create failed: exec format error' >&2; exit 125 ;;
+      # Expected text AND a zero exit: proves the checker requires both a
+      # non-zero exit and the diagnostic, not either one alone.
+      zero) echo 'mpfs-serve: --socket is required'; exit 0 ;;
+    esac ;;
+esac
+exit 64
+MOCK
+  chmod +x "$runtime"
+  ref="$repository@sha256:$(printf 'c%.0s' {1..64})"
+  log=$tmp/mock.log
+  : >"$log"
+  ck() { env CONTAINER_RUNTIME="$runtime" MOCK_LOG="$log" "$@"; }
+  assert "expected startup diagnostic accepted" ck MOCK_MODE=expected "$startup" "$ref"
+  # That acceptance must have come from actually driving the runtime.
+  assert "checker pulled the immutable reference" grep -qE "^pull .*$ref" "$log"
+  assert "checker ran the pulled reference" grep -qE "^run .*$ref" "$log"
+  refute "checker did not override the configured entrypoint" grep -q -- '--entrypoint' "$log"
+  refute "zero exit carrying the expected text refused" ck MOCK_MODE=zero "$startup" "$ref"
+  refute "failed pull refused" ck MOCK_MODE=pull-fail "$startup" "$ref"
+  refute "short digest refused" ck MOCK_MODE=expected "$startup" "$repository@sha256:$(printf 'c%.0s' {1..63})"
+  refute "uppercase digest refused" ck MOCK_MODE=expected "$startup" "$repository@sha256:$(printf 'C%.0s' {1..64})"
+  refute "absent container runtime refused" env CONTAINER_RUNTIME="$tmp/nope" MOCK_LOG="$log" "$startup" "$ref"
+  refute "missing image argument refused" ck MOCK_MODE=expected "$startup"
+fi
+
+# I3 seam — the checker's oracle against the diagnostic the binary emits.
+diagnostic_present() { grep -qF -- "$1" "$2"; }
+if ((have_scripts)); then
+  oracle=$(sed -n 's/^EXPECTED_DIAGNOSTIC=//p' "$startup" | tr -d "'\"" | head -1)
+  if [[ -z "$oracle" ]]; then
+    fail "startup checker does not declare EXPECTED_DIAGNOSTIC"
+  elif diagnostic_present "$oracle" "$serve_hs"; then
+    pass "checker oracle '$oracle' is the diagnostic Serve.hs emits"
+    if mutate "$serve_hs" "$tmp/serve.hs" "/$oracle/d"; then
+      refute "oracle comparator rejects a source that cannot emit it" diagnostic_present "$oracle" "$tmp/serve.hs"
+    fi
+  else
+    fail "checker oracle '$oracle' is absent from ${serve_hs#"$root"/}"
+  fi
+fi
+
+# I5 seam — the config key a runtime actually reads.
+entrypoint_key_ok() {
+  grep -qE '\bEntrypoint[[:space:]]*=' "$1" && ! grep -qE '\bEntryPoint\b' "$1"
+}
+if entrypoint_key_ok "$image_nix"; then
+  pass "image config uses the Entrypoint key a runtime reads"
+  if mutate "$image_nix" "$tmp/ep.nix" 's/Entrypoint/EntryPoint/'; then
+    refute "entrypoint comparator rejects the ignored EntryPoint spelling" entrypoint_key_ok "$tmp/ep.nix"
+  fi
+else
+  fail "image config sets no runtime-readable Entrypoint (${image_nix#"$root"/})"
+fi
+
+# R-PUB-003 — OCI provenance.
+labels_ok() {
+  grep -qF 'org.opencontainers.image.revision' "$1" \
+    && grep -qF 'org.opencontainers.image.version' "$1" \
+    && grep -qF 'org.opencontainers.image.source' "$1" && grep -qF "$source_url" "$1"
+}
+if labels_ok "$image_nix"; then
+  pass "image declares the three OCI provenance labels and the mandated source"
+  if mutate "$image_nix" "$tmp/src.nix" "s|$source_url|https://example.invalid/x|"; then
+    refute "label comparator rejects a foreign source URL" labels_ok "$tmp/src.nix"
+  fi
+  if mutate "$image_nix" "$tmp/rev.nix" '/org.opencontainers.image.revision/d'; then
+    refute "label comparator rejects a missing revision label" labels_ok "$tmp/rev.nix"
+  fi
+else
+  fail "image does not declare the required OCI provenance labels"
+fi
+
+# M-CI / M-RELEASE — the workflows must delegate to the owned commands, or
+# every proof above judges code the pipeline never runs.
+for wf in "$ci_yml" "$release_yml"; do
+  name=${wf#"$root"/}
+  assert "$name invokes the owned publication command" grep -q 'scripts/publish-mpfs-serve-image' "$wf"
+  assert "$name invokes the owned startup checker" grep -q 'scripts/check-mpfs-serve-image-startup' "$wf"
+  refute "$name passes no caller-supplied run URL" grep -q -- '--run-url' "$wf"
+done
+refute "workflows do not re-implement registry copy inline" grep -qE 'skopeo[[:space:]]+copy' "$ci_yml" "$release_yml"
+assert "CI publication is guarded against pull_request" grep -q "github.event_name != 'pull_request'" "$ci_yml"
+refute "release workflow neither deletes nor recreates a tag or release" grep -qE 'gh release (delete|create)|--delete' "$release_yml"
+if grep -q 'mpfs-serve-image-receipt' "$release_yml"; then
+  pass "release workflow uploads a uniquely named digest receipt"
+  # The accepted base carries exactly two --clobber uploads (the mpfs-cli
+  # tarballs). Pinning that count is what makes "the receipt upload does not
+  # clobber" falsifiable: adding one anywhere moves the count to three.
+  assert_eq "no --clobber added to the release workflow" 2 "$(grep -c -- '--clobber' "$release_yml")"
+else
+  fail "release workflow uploads no mpfs-serve-image-receipt artifact"
+fi
+if ((failures)); then
+  printf 'PROOF-RED   %d failing check(s)\n' "$failures" >&2
+  exit 1
+fi
+printf 'PROOF-GREEN all checks passed\n'

--- a/specs/m2-e-publish-pipeline/data-model.md
+++ b/specs/m2-e-publish-pipeline/data-model.md
@@ -1,0 +1,47 @@
+# Data model
+
+Artifact ceiling: 3,500 bytes / 80 lines.
+
+## D-SOURCE — source identity
+
+| Field | Type | Constraint |
+|---|---|---|
+| `revision` | clean lowercase hexadecimal string or local placeholder | A publishable value is exactly 40 characters and equal to the checked-out clean Git commit. A local value is unmistakably non-qualifying, such as `unknown` or `dirty-<revision>`. |
+| `source` | HTTPS repository URL | Exactly `https://github.com/lambdasistemi/cardano-mpfs-offchain`. |
+| `version` | OCI label string | Stable non-empty image version derived for the same source. |
+
+No publishable D-SOURCE exists for a dirty tree, a placeholder, or an absent
+full revision. Placeholder identity cannot be normalized into a SHA by the
+publication boundary.
+
+## D-ALIAS — registry tag
+
+| Field | Type | Constraint |
+|---|---|---|
+| `kind` | `main-sha` \| `branch-sha` \| `release` | Determined by the authorized workflow event. |
+| `tag` | OCI tag string | Matches the settled shape for its kind; never `latest`. |
+| `revision` | D-SOURCE reference | The same full revision the archive labels carry. |
+
+Branch slugs are deterministic lowercase OCI-safe representations of the full
+branch ref name and are length-bounded so the complete tag is valid.
+
+## D-PUBLICATION — immutable publication result
+
+| Field | Type | Constraint |
+|---|---|---|
+| `repository` | image repository | The mandated GHCR repository. |
+| `digest` | OCI digest | `sha256:` followed by exactly 64 lowercase hexadecimal characters. |
+| `aliases` | non-empty set of D-ALIAS | Every alias resolves to `digest`. |
+| `revision` | D-SOURCE reference | Equals the revision label returned by registry inspection. |
+| `run_url` | HTTPS URL | Identifies the pipeline run that built and copied the image. |
+
+## D-STARTUP — startup observation
+
+| Field | Type | Constraint |
+|---|---|---|
+| `image` | repository plus immutable digest | Never only a mutable tag. |
+| `exit` | integer | Non-zero because required server arguments are intentionally absent. |
+| `output` | captured text | Contains the expected `mpfs-serve` missing-argument diagnostic. |
+| `runtime` | runtime identity | Names the executable that pulled/started the image. |
+
+A different non-zero failure is not a successful D-STARTUP observation.

--- a/specs/m2-e-publish-pipeline/functions-model.md
+++ b/specs/m2-e-publish-pipeline/functions-model.md
@@ -1,0 +1,12 @@
+# Functions model
+
+Artifact ceiling: 3,500 bytes / 80 lines.
+
+| ID | Interface | Arguments | Result / effects | Constraints |
+|---|---|---|---|---|
+| F-IMAGE | Docker image derivation | `pkgs`, `project`, `revision: String`, `version: String`, `mpfs-blueprint` | Docker archive derivation | Embeds D-SOURCE labels and a stable internal tag; dirty/local identity is visibly non-qualifying. |
+| F-PUBLISH | `scripts/publish-mpfs-serve-image` | `source_sha: String`, one or more `tag: String` | Copies one pipeline-built archive to each GHCR alias and writes D-PUBLICATION fields | Fails before copy on dirty/placeholder/invalid source, invalid tag, label mismatch, absent auth, malformed digest, or differing alias digests. No daemon requirement. |
+| F-STARTUP | `scripts/check-mpfs-serve-image-startup` | `image_digest_ref: String` | Writes D-STARTUP observation; exit 0 only for expected startup diagnostic | Pulls/runs the configured entrypoint; rejects an unrelated non-zero failure and a zero exit. |
+| F-CI-TAGS | CI event-to-alias mapping | `event_name`, `ref_name`, `source_sha` | One D-ALIAS | Main push selects `sha-<SHA>`; dispatch selects `branch-<slug>-sha-<SHA>`. |
+| F-RELEASE-TAGS | release output-to-alias mapping | `tag_name`, `source_sha` | SHA alias plus release D-ALIAS | Release alias is exactly the release-please `v<version>` output and shares the digest. |
+| F-RECEIPT | release receipt generation | D-PUBLICATION plus release tag | Immutable text artifact uploaded to the existing release | Contains commit, digest, repository, run URL, and aliases; upload does not delete/recreate or clobber. |

--- a/specs/m2-e-publish-pipeline/modules-model.md
+++ b/specs/m2-e-publish-pipeline/modules-model.md
@@ -1,0 +1,14 @@
+# Modules model
+
+Artifact ceiling: 3,500 bytes / 80 lines.
+
+| ID | Component | Responsibility | Dependency direction |
+|---|---|---|---|
+| M-IMAGE | Flake image output and `nix/docker-image.nix` | Distinguish clean full source identity from unmistakable local placeholders and embed standard OCI provenance. | Depends on flake-provided source identity and existing `mpfs-serve`/blueprint derivations only. |
+| M-PUBLISH | Repository-owned image publication command | Require clean full source identity, validate source/tag inputs, build the repository image archive, copy it daemonlessly to GHCR aliases, and emit validated immutable digest/receipt fields. | Depends on M-IMAGE and registry tools; knows no workflow event syntax. |
+| M-STARTUP | Repository-owned pulled-image startup checker | Exercise the configured entrypoint by digest and distinguish the expected missing-required-argument failure from unrelated failure. | Depends on a container runtime and an immutable image reference; does not build or publish. |
+| M-CI | Existing `.github/workflows/ci.yml` | Preserve all current checks and artifact upload; publish only for main push or manual dispatch with settled tags and job-scoped package permission. | Converts GitHub event/ref data into validated M-PUBLISH inputs, then invokes M-STARTUP. |
+| M-RELEASE | Existing `.github/workflows/release.yml` | When release-please creates a release, publish SHA and `v<version>` aliases and upload a non-clobbering digest receipt to that release. | Depends on release-please outputs and the same M-PUBLISH/M-STARTUP contract. |
+
+M-CI and M-RELEASE may select aliases but cannot invent source identity; the
+full SHA comes from the checked-out source and must agree with M-IMAGE.

--- a/specs/m2-e-publish-pipeline/plan.md
+++ b/specs/m2-e-publish-pipeline/plan.md
@@ -1,0 +1,66 @@
+# Implementation plan
+
+Artifact ceiling: 6,000 bytes / 120 lines.
+
+## Strategy
+
+Use the existing `CI` workflow for main and branch publication because its
+`workflow_dispatch` definition already exists on the default branch; GitHub
+can therefore dispatch the feature branch before merge. Add the release alias
+to the existing release workflow, reusing repository-owned publication and
+verification commands. Keep build identity inside the flake/image derivation
+and registry mechanics outside the Nix sandbox.
+
+The publishable image archive has one stable internal identity based on the
+exact source SHA. A dirty local build instead receives an unmistakable
+non-qualifying placeholder. Registry aliases are applied during publication so
+a release alias and the immutable SHA alias can point at the same content. The
+release record is a small uploaded receipt rather than a recreated or replaced
+release.
+
+## Live boundaries
+
+- Nix evaluation makes dirty/local identity visibly non-qualifying; the
+  publication boundary fails closed without a clean full revision.
+- `skopeo` copies the Nix Docker archive to GHCR without assuming a Docker
+  daemon.
+- The container runtime is used only for post-publication startup proof. The
+  workflow records which runtime is available and fails if none can exercise
+  the pulled digest.
+- GHCR authorization uses the same-repository `GITHUB_TOKEN` with
+  `packages: write`. The GitHub App is not part of this boundary.
+
+## Ordered slices
+
+### S1 — Repository publication contract
+
+Produce one bisect-safe repository commit containing the image identity and
+labels, reusable publication/startup verification commands, focused negative
+controls, main/dispatch publication wiring, release alias wiring, and the
+release digest receipt. The commit is locally buildable and its static/focused
+gate is falsified on the accepted base before implementation.
+
+### S2 — Live branch evidence
+
+Push the accepted S1 commit, dispatch the existing `CI` workflow on the feature
+branch, and freeze the run URL, source SHA, immutable digest, external registry
+inspection, startup result, negative controls, and PR CI state. This slice
+changes no repository source and is admissible only from the exact accepted S1
+SHA.
+
+## Verification
+
+- Local focused gate proves workflow/tag/label/guard/startup-check structure,
+  YAML validity, and negative controls for dirty source, placeholder identity,
+  and broken startup input.
+- `nix build .#docker-image` succeeds from the clean candidate.
+- The normal repository CI command remains green.
+- A real branch-dispatch run publishes and verifies the digest.
+- An independent external `skopeo inspect` confirms the digest and full
+  revision label; an external runtime repeats the startup check.
+
+## Constraints
+
+No Haskell or route file is writable. Release-please files, deployment scripts,
+production, `latest`, package visibility, published tags/releases, existing CI
+jobs, and the existing artifact upload are outside the implementation fence.

--- a/specs/m2-e-publish-pipeline/spec.md
+++ b/specs/m2-e-publish-pipeline/spec.md
@@ -1,0 +1,68 @@
+# Pipeline-published `mpfs-serve` image
+
+Artifact ceiling: 6,500 bytes / 120 lines.
+
+## Outcome
+
+The repository pipeline publishes the `mpfs-serve` OCI image at
+`ghcr.io/lambdasistemi/cardano-mpfs-offchain/mpfs-serve`. Every published
+artifact is tied to the exact clean source commit, is addressable by immutable
+digest, and can be pulled and started without a repository checkout.
+
+## Requirements
+
+- **R-PUB-001 — Pipeline origin.** Publication builds from the checked-out
+  workflow source. Operator worktrees and pre-built local archives are not
+  publication inputs.
+- **R-PUB-002 — Immutable identity.** Each successful publication reports an
+  immutable `sha256:` digest and the exact 40-character source SHA.
+- **R-PUB-003 — OCI provenance.** The image config contains
+  `org.opencontainers.image.revision` equal to the exact 40-character source
+  SHA, `org.opencontainers.image.version`, and
+  `org.opencontainers.image.source` equal to the repository URL.
+- **R-PUB-004 — Clean publish source.** A dirty, missing, shortened,
+  placeholder, or malformed source revision prevents publication. A local
+  development build may use an unmistakably non-qualifying identity such as
+  `unknown` or `dirty-<revision>`, but it cannot pass the publish gate.
+- **R-PUB-005 — Tag policy.** A main push publishes
+  `sha-<40-character-SHA>`; a branch dispatch publishes
+  `branch-<slug>-sha-<40-character-SHA>`; a release additionally publishes
+  `v<version>`. No path publishes `latest`.
+- **R-PUB-006 — Immutable release record.** A release publication records the
+  release tag, exact commit, image repository, immutable digest, and published
+  aliases in a release artifact without deleting or recreating a tag or
+  release.
+- **R-PUB-007 — Real startup proof.** Publication pulls the registry artifact
+  by digest and exercises its configured entrypoint. Because `mpfs-serve` has
+  no help/version mode, success means observing its expected missing-required-
+  argument failure rather than treating any non-zero exit as success.
+- **R-PUB-008 — Falsifiable checks.** The clean-tree guard and startup checker
+  each have an executed negative control. A wrong failure mode or broken input
+  makes verification non-zero; no verification command is masked.
+- **R-PUB-009 — Existing CI retained.** Existing build, test, E2E,
+  version-sync, Docker build, and Docker artifact upload behavior remains
+  enabled.
+- **R-PUB-010 — Least privilege.** Same-repository GHCR publication uses the
+  workflow `GITHUB_TOKEN` with job-scoped `packages: write`; it does not mint
+  or expose the GitHub App private key.
+
+## Invariants
+
+| ID | Severity | Failure meaning | Success meaning |
+|---|---|---|---|
+| I1-SOURCE-IDENTITY | ADVISORY | A tag or revision label can name a source other than the exact built commit. | The tag input and revision label both derive from and equal the clean full SHA. |
+| I2-CLEAN-TREE | ADVISORY | Dirty, ambiguous, or placeholder source can pass the publish gate or resemble a clean SHA. | Dirty source and an explicit placeholder are both rejected by publication, demonstrated by negative controls. |
+| I3-CHECKS-FAIL | ADVISORY | A broken startup input or wrong failure mode can leave verification green. | The same checker is observed rejecting a real broken input and accepts only the expected `mpfs-serve` startup failure. |
+| I4-IMAGE-STARTS | ADVISORY | Registry presence is mistaken for executable startup. | The pulled digest runs its configured entrypoint and reaches `mpfs-serve` argument validation. |
+
+## Rejections and non-goals
+
+Reject publication before any registry copy when the worktree is dirty, the
+identity is a placeholder, the SHA is not exactly 40 lowercase hexadecimal
+characters, the tag violates the settled policy, or the archive labels
+disagree with the source SHA. Reject a
+post-copy run when digest inspection or startup proof fails.
+
+This ticket does not change Haskell, add `--help`/`--version`, add HTTP routes,
+deploy, modify release-please configuration, make the GHCR package public,
+publish `latest`, or remove the existing workflow artifact upload.

--- a/specs/m2-e-publish-pipeline/tasks.md
+++ b/specs/m2-e-publish-pipeline/tasks.md
@@ -4,13 +4,13 @@ Artifact ceiling: 2,500 bytes / 80 lines.
 
 ## S1 — Repository publication contract
 
-- [ ] T-PUB-001 Make image identity distinguish a clean full revision from an unmistakable local placeholder.
-- [ ] T-PUB-002 Add OCI revision, version, and source labels.
-- [ ] T-PUB-003 Add daemonless GHCR publication with settled input/tag guards.
-- [ ] T-PUB-004 Add pulled-image startup verification and a real broken-input negative control.
-- [ ] T-PUB-005 Publish SHA/main and branch-dispatch aliases from existing CI while retaining all existing jobs and artifact upload.
-- [ ] T-PUB-006 Publish release SHA and `v<version>` aliases and upload the immutable digest receipt.
-- [ ] T-PUB-007 Prove dirty source, placeholder identity, and broken startup input are rejected.
+- [x] T-PUB-001 Make image identity distinguish a clean full revision from an unmistakable local placeholder.
+- [x] T-PUB-002 Add OCI revision, version, and source labels.
+- [x] T-PUB-003 Add daemonless GHCR publication with settled input/tag guards.
+- [x] T-PUB-004 Add pulled-image startup verification and a real broken-input negative control.
+- [x] T-PUB-005 Publish SHA/main and branch-dispatch aliases from existing CI while retaining all existing jobs and artifact upload.
+- [x] T-PUB-006 Publish release SHA and `v<version>` aliases and upload the immutable digest receipt.
+- [x] T-PUB-007 Prove dirty source, placeholder identity, and broken startup input are rejected.
 
 ## S2 — Live branch evidence
 

--- a/specs/m2-e-publish-pipeline/tasks.md
+++ b/specs/m2-e-publish-pipeline/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+Artifact ceiling: 2,500 bytes / 80 lines.
+
+## S1 — Repository publication contract
+
+- [ ] T-PUB-001 Make image identity distinguish a clean full revision from an unmistakable local placeholder.
+- [ ] T-PUB-002 Add OCI revision, version, and source labels.
+- [ ] T-PUB-003 Add daemonless GHCR publication with settled input/tag guards.
+- [ ] T-PUB-004 Add pulled-image startup verification and a real broken-input negative control.
+- [ ] T-PUB-005 Publish SHA/main and branch-dispatch aliases from existing CI while retaining all existing jobs and artifact upload.
+- [ ] T-PUB-006 Publish release SHA and `v<version>` aliases and upload the immutable digest receipt.
+- [ ] T-PUB-007 Prove dirty source, placeholder identity, and broken startup input are rejected.
+
+## S2 — Live branch evidence
+
+- [ ] T-PUB-008 Dispatch the feature branch and capture run URL, source SHA, digest, labels, and startup evidence.
+- [ ] T-PUB-009 Independently pull/inspect/start the digest outside CI and freeze raw output.
+- [ ] T-PUB-010 Verify all PR-head checks are green and the draft PR describes the factual change without issue linkage.


### PR DESCRIPTION
## Summary

- publishes the pipeline-built `mpfs-serve` OCI image to GHCR without a Docker daemon
- binds publication to the exact clean GitHub Actions checkout and records exact revision, version, source, digest, aliases, and run URL
- publishes immutable SHA/main, manual branch, and release aliases under the settled policy; no path publishes `latest`
- reads every alias back from the registry and verifies digest/revision agreement before emitting the receipt
- pulls the published digest and exercises the configured `mpfs-serve` entrypoint, accepting only its expected missing-argument diagnostic
- retains the existing CI/E2E/version-sync jobs and Docker artifact upload; release publication attaches a non-clobbering digest receipt

## Verification

- accepted-base `nix develop --quiet -c just ci`: pass
- focused publication/startup proof: 74 checks pass, with the audit repair properties demonstrated red against the rejected candidate
- independent final commit audit: pass
- independent frozen full gate at final commit `8407d3967fc78f986ff224b92447e05c1610d3ac`: pass; repository suites 447/0, 214/0, 36/0, and 10/0; E2E 37/0
- branch publication and independent external registry/runtime proof remain pending operator approval; this PR therefore remains draft

No GitHub issue exists for this internal ticket.
